### PR TITLE
sl-1-2: derived sync store + three-state header indicator

### DIFF
--- a/split/core.js
+++ b/split/core.js
@@ -297,6 +297,7 @@ function init() {
     else if (action === 'resetData') confirmAction('Reset ALL data to defaults? A backup will be downloaded automatically before resetting.', resetAllData, 'Reset');
     else if (action === 'toggleVisitFormShow') toggleVisitForm(true);
     else if (action === 'toggleVisitFormHide') toggleVisitForm(false);
+    else if (action === 'syncReload' && typeof syncReload === 'function') syncReload();
     else if (action === 'dismissWelcomeGuide') dismissWelcomeGuide();
     else if (action === 'toggleHomeVitals') toggleHomeVitals();
     else if (action === 'openScorePopupStop') { e.stopPropagation(); openScorePopup(arg); }

--- a/split/start.js
+++ b/split/start.js
@@ -11,3 +11,6 @@ _bugInit();
 if (window.location.search.indexOf('nosync') === -1) {
   try { initFirebase(); } catch(e) { console.error('[sync] initFirebase crashed:', e); }
 }
+// Sync visibility indicator (Phase 1 — sl-1-2). Runs even under ?nosync so
+// the header still reflects true network state from navigator.onLine alone.
+try { initSyncVisibility(); } catch(e) { console.error('[sync-vis] init crashed:', e); }

--- a/split/styles.css
+++ b/split/styles.css
@@ -8636,3 +8636,45 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 [data-theme="dark"] .sync-code-row { border-top-color:rgba(51,101,128,0.15); }
 [data-theme="dark"] .sync-modal { background:var(--surface); }
 [data-theme="dark"] .sync-modal-input { background:rgba(255,255,255,0.05); border-color:rgba(51,101,128,0.25); }
+
+/* ═══ Sync Visibility Indicator (Phase 1 — sl-1-2) ═══
+   Three-state header pill. Color is derived from [data-state] and driven
+   entirely by CSS custom properties so nothing in the UI is hardcoded. */
+.sync-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-6);
+  padding: var(--sp-2) var(--sp-8);
+  border: 1px solid transparent;
+  border-radius: var(--r-full);
+  background: transparent;
+  color: var(--light);
+  font: inherit;
+  font-size: var(--fs-xs);
+  line-height: 1.1;
+  cursor: default;
+  transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+.sync-indicator[hidden] { display: none !important; }
+.sync-indicator:focus-visible { outline: 2px solid var(--tc-sky); outline-offset: 2px; }
+.sync-indicator__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--r-full);
+  background: currentColor;
+  flex-shrink: 0;
+}
+.sync-indicator__label { white-space: nowrap; font-weight: 600; }
+.sync-indicator[data-state="online"]  { color: var(--tc-sage); }
+.sync-indicator[data-state="pending"] { color: var(--tc-amber); }
+.sync-indicator[data-state="offline"] { color: var(--tc-danger); }
+.sync-indicator[data-state="pending"] .sync-indicator__dot {
+  animation: sync-indicator-pulse 1.4s ease-in-out infinite;
+}
+@keyframes sync-indicator-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.35; transform: scale(0.85); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .sync-indicator[data-state="pending"] .sync-indicator__dot { animation: none; }
+}

--- a/split/styles.css
+++ b/split/styles.css
@@ -8637,9 +8637,9 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 [data-theme="dark"] .sync-modal { background:var(--surface); }
 [data-theme="dark"] .sync-modal-input { background:rgba(255,255,255,0.05); border-color:rgba(51,101,128,0.25); }
 
-/* ═══ Sync Visibility Indicator (Phase 1 — sl-1-2) ═══
-   Three-state header pill. Color is derived from [data-state] and driven
-   entirely by CSS custom properties so nothing in the UI is hardcoded. */
+/* ═══ Sync Visibility Indicator (Phase 1 — sl-1-2, r2) ═══
+   Five logical states mapped to three visual colors per the gap audit.
+   Copy + aria-label disambiguate the two reds (offline vs halted) for AT. */
 .sync-indicator {
   display: inline-flex;
   align-items: center;
@@ -8665,10 +8665,13 @@ body.ql-locked .dark-toggle { pointer-events:none; }
   flex-shrink: 0;
 }
 .sync-indicator__label { white-space: nowrap; font-weight: 600; }
-.sync-indicator[data-state="online"]  { color: var(--tc-sage); }
-.sync-indicator[data-state="pending"] { color: var(--tc-amber); }
-.sync-indicator[data-state="offline"] { color: var(--tc-danger); }
-.sync-indicator[data-state="pending"] .sync-indicator__dot {
+.sync-indicator[data-state="connecting"] { color: var(--tc-amber); }
+.sync-indicator[data-state="online"]     { color: var(--tc-sage); }
+.sync-indicator[data-state="syncing"]    { color: var(--tc-amber); }
+.sync-indicator[data-state="offline"]    { color: var(--tc-danger); }
+.sync-indicator[data-state="halted"]     { color: var(--tc-danger); cursor: pointer; }
+.sync-indicator[data-state="connecting"] .sync-indicator__dot,
+.sync-indicator[data-state="syncing"]    .sync-indicator__dot {
   animation: sync-indicator-pulse 1.4s ease-in-out infinite;
 }
 @keyframes sync-indicator-pulse {
@@ -8676,5 +8679,6 @@ body.ql-locked .dark-toggle { pointer-events:none; }
   50%      { opacity: 0.35; transform: scale(0.85); }
 }
 @media (prefers-reduced-motion: reduce) {
-  .sync-indicator[data-state="pending"] .sync-indicator__dot { animation: none; }
+  .sync-indicator[data-state="connecting"] .sync-indicator__dot,
+  .sync-indicator[data-state="syncing"]    .sync-indicator__dot { animation: none; }
 }

--- a/split/sync.js
+++ b/split/sync.js
@@ -65,6 +65,13 @@ function _syncArmReadyFallback(collection) {
 function _syncMarkReady(collection) {
   if (_syncReady[collection]) return;
   _syncReady[collection] = true;
+  // Visibility store r2: first listener-ready is proof of Firestore activity
+  // — collapses the 'connecting' state even if onSnapshotsInSync is not yet
+  // available or has not yet landed.
+  if (typeof _syncHasEverFired !== 'undefined' && !_syncHasEverFired) {
+    _syncHasEverFired = true;
+    if (typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
+  }
   if (_syncReadyTimers[collection]) {
     clearTimeout(_syncReadyTimers[collection]);
     _syncReadyTimers[collection] = null;
@@ -100,8 +107,12 @@ function _syncRecordCrash(source, err) {
       _syncDebounceTimers[k] = null;
     });
     console.error('[sync] Auto-disabled after ' + _syncCrashCount + ' crashes. App is local-only.');
+    // Cipher blocker #5 (r2): the 'Sync paused' toast is retired. The halted
+    // state is now surfaced persistently in the header indicator + offline
+    // badge, with a reload affordance. Transient toast on top would be the
+    // three-surfaces-for-one-state redundancy the derived store is meant
+    // to eliminate.
     if (typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
-    showQLToast('Sync paused — too many errors. Reload to retry.');
   }
 }
 
@@ -448,6 +459,12 @@ function _syncDetachListeners() {
   });
   _syncReadyTimers = {};
   _syncPendingFlush = {};
+  // Visibility store r2: re-attach is a fresh session — wipe per-key pending
+  // state and the has-ever-fired gate so the indicator honestly returns to
+  // 'connecting' until the new listeners confirm activity.
+  if (typeof _syncPendingByKey !== 'undefined') _syncPendingByKey = {};
+  if (typeof _syncHasEverFired !== 'undefined') _syncHasEverFired = false;
+  if (typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
 }
 
 // ═══════════════════════════════════════════
@@ -642,7 +659,7 @@ function _syncWritePerEntry(hRef, collection, key, oldVal, newVal) {
     var data = Object.assign({}, entry, syncMeta, {
       __sync_createdBy: { uid: _syncUser.uid, name: _syncUser.displayName || 'Parent' }
     });
-    _syncTrackWrite(colRef.doc(entry.id).set(data)).catch(function(e) {
+    colRef.doc(entry.id).set(data).catch(function(e) {
       console.error('[sync] Add ' + collection + '/' + entry.id + ' failed:', e);
     });
   });
@@ -650,14 +667,14 @@ function _syncWritePerEntry(hRef, collection, key, oldVal, newVal) {
   // Edited entries — field-level updates
   diff.edited.forEach(function(change) {
     var payload = Object.assign({}, change.updates, change.deletes, syncMeta);
-    _syncTrackWrite(colRef.doc(change.id).update(payload)).catch(function(e) {
+    colRef.doc(change.id).update(payload).catch(function(e) {
       console.error('[sync] Update ' + collection + '/' + change.id + ' failed:', e);
     });
   });
 
   // Deleted entries
   diff.deleted.forEach(function(id) {
-    _syncTrackWrite(colRef.doc(id).delete()).catch(function(e) {
+    colRef.doc(id).delete().catch(function(e) {
       console.error('[sync] Delete ' + collection + '/' + id + ' failed:', e);
     });
   });
@@ -734,13 +751,13 @@ function _syncFlushSingleDoc(hRef, collection) {
   if (hasUpdates) {
     var nested = _syncNestDottedPaths(diff.updates);
     var updatePayload = Object.assign({}, nested, syncMeta);
-    promises.push(_syncTrackWrite(docRef.set(updatePayload, { merge: true })));
+    promises.push(docRef.set(updatePayload, { merge: true }));
   }
   if (hasDeletes) {
     // Deletes go through update() which DOES support dotted paths correctly,
     // so leave diff.deletes flat.
     var deletePayload = Object.assign({}, diff.deletes, syncMeta);
-    promises.push(_syncTrackWrite(docRef.update(deletePayload)));
+    promises.push(docRef.update(deletePayload));
   }
 
   Promise.all(promises).catch(function(e) {
@@ -777,9 +794,12 @@ function _syncAttachListeners(hId) {
   var perEntryCollections = Object.keys(_peSet);
   var singleDocNames = Object.keys(_sdSet);
 
-  // Per-entry collections — each handler wrapped in try/catch for isolation
+  // Per-entry collections — each handler wrapped in try/catch for isolation.
+  // {includeMetadataChanges:true} so pending→ACK transitions fire the handler
+  // and the visibility store can read snapshot.metadata.hasPendingWrites.
+  // Data-equality checks inside the handler short-circuit metadata-only fires.
   perEntryCollections.forEach(function(col) {
-    var unsub = hRef.collection(col).onSnapshot(function(snapshot) {
+    var unsub = hRef.collection(col).onSnapshot({ includeMetadataChanges: true }, function(snapshot) {
       try { if (!_syncDisabled) _syncHandlePerEntrySnapshot(col, snapshot); }
       catch(e) { _syncRecordCrash('per-entry/' + col, e); }
     }, function(err) {
@@ -793,7 +813,7 @@ function _syncAttachListeners(hId) {
 
   // Single-doc collections (in /singles/{docName})
   singleDocNames.forEach(function(docName) {
-    var unsub = hRef.collection('singles').doc(docName).onSnapshot(function(doc) {
+    var unsub = hRef.collection('singles').doc(docName).onSnapshot({ includeMetadataChanges: true }, function(doc) {
       try { if (!_syncDisabled) _syncHandleSingleDocSnapshot(docName, doc); }
       catch(e) { _syncRecordCrash('single-doc/' + docName, e); }
     }, function(err) {
@@ -817,6 +837,11 @@ function _syncAttachListeners(hId) {
 
 // ─── Handle Per-Entry Snapshot ───
 function _syncHandlePerEntrySnapshot(collection, snapshot) {
+  // Cipher r2: record post-submit pending-write state for this collection
+  // before any early return. Listener fires with {includeMetadataChanges:true}
+  // so this catches pending→ACK transitions even when no data changed.
+  _syncRecordPending(collection, !!(snapshot.metadata && snapshot.metadata.hasPendingWrites));
+
   // C0 Cipher C2: mark-ready in finally so defer paths don't suppress it.
   try {
     // Find which localStorage key maps to this collection
@@ -894,6 +919,10 @@ function _syncHandlePerEntrySnapshot(collection, snapshot) {
 
 // ─── Handle Single-Doc Snapshot ───
 function _syncHandleSingleDocSnapshot(docName, doc) {
+  // Cipher r2: record post-submit pending-write state for this doc before
+  // any early return. Listener fires with {includeMetadataChanges:true}.
+  _syncRecordPending(docName, !!(doc && doc.metadata && doc.metadata.hasPendingWrites));
+
   // C0 Cipher C2: _syncMarkReady MUST run on every exit path, including
   // early returns and defer paths, so the collection's ready-state is
   // confirmed even when no save happens. Wrap in try/finally.
@@ -1259,60 +1288,86 @@ function _syncConfirmJoin() {
   syncJoinByCode(code.trim());
 }
 
-// ─── Sync Visibility (Phase 1 — sl-1-2) ───
-// Derived store fusing navigator.onLine, the Firestore drain signal
-// (onSnapshotsInSync when available), and local WAL depth
-// (in-flight writes + debounce timers + deferred flushes).
-// Nothing is hardcoded: the header indicator reads only from syncVisibilityState().
-var _syncPendingWriteCount = 0;          // in-flight Firestore promises
+// ─── Sync Visibility (Phase 1 — sl-1-2, r2) ───
+// Derived store fusing four signals:
+//   (a) navigator.onLine + window online/offline events
+//   (b) Firestore drain via db.onSnapshotsInSync — definitive ACK that local
+//       cache + IDB persistence queue + server are all in sync
+//   (c) Post-submit pending-writes from snapshot.metadata.hasPendingWrites
+//       (recorded per collection/doc by the existing listener handlers, which
+//       now subscribe with {includeMetadataChanges:true})
+//   (d) Pre-submit queue: _syncDebounceTimers (active count) + _syncPendingFlush
+//
+// Five logical states, three visual colors (color mapping lives in CSS):
+//   connecting — cold boot: no listener has fired, no drain event yet, pending===0
+//   online     — network up, fully drained
+//   syncing    — network up, pending > 0
+//   offline    — !navigator.onLine
+//   halted     — _syncDisabled === true (circuit breaker tripped; reload-required)
+//
+// Disjointness contract:
+//   pre-submit (our maps) and post-submit (hasPendingWrites map) are phases
+//   of a write's life. A write is in _syncDebounceTimers until the timer
+//   fires; the fire callback nulls the entry and calls .set(), whose
+//   snapshot.metadata.hasPendingWrites then reflects the submission.
+//   Mutually exclusive at any instant — counts are additive by construction.
+
+var _syncPendingByKey = {};              // collection/docName → bool (last-seen hasPendingWrites)
 var _syncVisibilityListeners = [];       // subscriber callbacks
 var _syncLastVisibility = null;          // last emitted snapshot (for change-detect)
 var _syncVisibilityNotifyTimer = null;   // coalesces burst notifies
 var _syncSnapshotsInSyncUnsub = null;    // Firestore drain listener unsub
 var _syncVisibilityInitDone = false;
+var _syncHasEverFired = false;           // any listener (per-entry/single-doc) first-fired OR onSnapshotsInSync landed
+var _syncVisibilityClickBound = false;   // guard for #syncStatus click binding
 
-function _syncTrackWrite(promise) {
-  if (!promise || typeof promise.then !== 'function') return promise;
-  _syncPendingWriteCount++;
+function _syncRecordPending(key, isPending) {
+  var prev = !!_syncPendingByKey[key];
+  if (prev === !!isPending) return;
+  if (isPending) _syncPendingByKey[key] = true;
+  else delete _syncPendingByKey[key];
   _syncNotifyVisibility();
-  var settle = function() {
-    if (_syncPendingWriteCount > 0) _syncPendingWriteCount--;
-    _syncNotifyVisibility();
-  };
-  promise.then(settle, settle);
-  return promise;
 }
 
-function _syncCountActiveDebounces() {
+function _syncCountPreSubmit() {
   var n = 0;
   for (var k in _syncDebounceTimers) {
     if (Object.prototype.hasOwnProperty.call(_syncDebounceTimers, k) && _syncDebounceTimers[k]) n++;
   }
-  return n;
-}
-
-function _syncCountDeferredFlushes() {
-  var n = 0;
   for (var c in _syncPendingFlush) {
     if (Object.prototype.hasOwnProperty.call(_syncPendingFlush, c) && _syncPendingFlush[c]) n++;
   }
   return n;
 }
 
+function _syncCountPostSubmit() {
+  var n = 0;
+  for (var k in _syncPendingByKey) {
+    if (Object.prototype.hasOwnProperty.call(_syncPendingByKey, k) && _syncPendingByKey[k]) n++;
+  }
+  return n;
+}
+
 function syncVisibilityState() {
   var online = (typeof navigator !== 'undefined' && 'onLine' in navigator) ? navigator.onLine !== false : true;
-  var pending = _syncPendingWriteCount + _syncCountActiveDebounces() + _syncCountDeferredFlushes();
+  var preSubmit  = _syncCountPreSubmit();
+  var postSubmit = _syncCountPostSubmit();
+  var pending = preSubmit + postSubmit;  // disjoint by construction (see header comment)
   var state, reason;
-  if (!online) {
-    state = 'offline'; reason = 'no-network';
-  } else if (_syncDisabled) {
-    // Crash-killed sync: local-only until reload. Honest to show as offline;
-    // reason distinguishes it from a true network drop for diagnostics/UI copy.
-    state = 'offline'; reason = 'sync-disabled';
+
+  // Evaluation order matters: halted is a local fault independent of network,
+  // so it wins over offline. connecting is only valid before any proof of
+  // Firestore activity; it collapses to syncing the moment pending > 0.
+  if (_syncDisabled) {
+    state = 'halted';     reason = 'sync-disabled';
+  } else if (!online) {
+    state = 'offline';    reason = 'no-network';
+  } else if (!_syncHasEverFired && pending === 0) {
+    state = 'connecting'; reason = 'no-listener-yet';
   } else if (pending > 0) {
-    state = 'pending'; reason = 'writes-pending';
+    state = 'syncing';    reason = 'writes-pending';
   } else {
-    state = 'online'; reason = 'synced';
+    state = 'online';     reason = 'synced';
   }
   return { state: state, pending: pending, reason: reason };
 }
@@ -1346,19 +1401,48 @@ function _syncUpdateStatusIndicator(snap) {
   if (!btn) return;
   if (btn.hasAttribute('hidden')) btn.removeAttribute('hidden');
   btn.setAttribute('data-state', snap.state);
-  var label = snap.state === 'online'  ? 'Synced'
-            : snap.state === 'pending' ? 'Syncing' + (snap.pending > 0 ? ' (' + snap.pending + ')' : '…')
-            :                            'Offline';
-  var nPending = snap.pending > 0 ? ' (' + snap.pending + ' pending)' : '';
-  var title = snap.state === 'online'  ? 'All changes synced.'
-            : snap.state === 'pending' ? (snap.pending + ' change' + (snap.pending === 1 ? '' : 's') + ' pending sync.')
-            : snap.reason === 'sync-disabled'
-              ? 'Sync paused after errors — changes will sync on reload.' + nPending
-              : 'Offline — changes will sync when back online.' + nPending;
+
+  // Copy table — one source of truth per logical state; CSS handles color.
+  // aria-label is the long form so screen readers distinguish the two red
+  // states (offline vs halted) that share --tc-danger.
+  var label, title;
+  switch (snap.state) {
+    case 'connecting':
+      label = 'Connecting…';
+      title = 'Connecting to sync…';
+      break;
+    case 'online':
+      label = 'Synced';
+      title = 'All changes synced.';
+      break;
+    case 'syncing':
+      label = 'Syncing' + (snap.pending > 0 ? ' (' + snap.pending + ')' : '…');
+      title = snap.pending + ' change' + (snap.pending === 1 ? '' : 's') + ' pending sync.';
+      break;
+    case 'offline':
+      label = 'Offline';
+      title = 'Offline — changes will sync when back online.' + (snap.pending > 0 ? ' (' + snap.pending + ' pending)' : '');
+      break;
+    case 'halted':
+      label = 'Sync paused';
+      title = 'Sync paused after errors — tap to reload.' + (snap.pending > 0 ? ' (' + snap.pending + ' pending)' : '');
+      break;
+    default:
+      label = ''; title = '';
+  }
+
   var labEl = btn.querySelector('.sync-indicator__label');
   if (labEl) labEl.textContent = label;
   btn.setAttribute('title', title);
   btn.setAttribute('aria-label', title);
+}
+
+function _syncOnIndicatorClick(e) {
+  var btn = e && e.target && e.target.closest ? e.target.closest('#syncStatus') : null;
+  if (!btn) return;
+  if (btn.getAttribute('data-state') !== 'halted') return;
+  // Halted is the only state where a tap has an affordance — reload retries sync.
+  window.location.reload();
 }
 
 function initSyncVisibility() {
@@ -1372,10 +1456,22 @@ function initSyncVisibility() {
       if (typeof firebase !== 'undefined' && firebase.firestore) {
         var db = firebase.firestore();
         if (typeof db.onSnapshotsInSync === 'function') {
-          _syncSnapshotsInSyncUnsub = db.onSnapshotsInSync(bump);
+          _syncSnapshotsInSyncUnsub = db.onSnapshotsInSync(function() {
+            // First drain event = definitive proof of Firestore activity.
+            // Collapses 'connecting' to 'online' (or 'syncing' if writes are
+            // queued — ordering in syncVisibilityState handles that).
+            _syncHasEverFired = true;
+            _syncNotifyVisibility();
+          });
         }
       }
-    } catch(e) { /* non-fatal — derived store still works via counter */ }
+    } catch(e) { /* non-fatal — derived store still works from counters */ }
+  }
+  // Bind click-to-reload once. Uses event delegation on document so it
+  // survives template re-renders.
+  if (!_syncVisibilityClickBound && typeof document !== 'undefined') {
+    document.addEventListener('click', _syncOnIndicatorClick);
+    _syncVisibilityClickBound = true;
   }
   onSyncVisibilityChange(_syncUpdateStatusIndicator);
 }

--- a/split/sync.js
+++ b/split/sync.js
@@ -72,6 +72,7 @@ function _syncMarkReady(collection) {
   // Fire any pending flush that was deferred waiting for this listener.
   if (_syncPendingFlush[collection]) {
     _syncPendingFlush[collection] = false;
+    if (typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
     // Cipher C3: breaker interaction
     if (_syncWriteCount >= CIRCUIT_BREAKER_LIMIT) {
       console.warn('[sync] Skipping ready-pending-flush for ' + collection +
@@ -99,6 +100,7 @@ function _syncRecordCrash(source, err) {
       _syncDebounceTimers[k] = null;
     });
     console.error('[sync] Auto-disabled after ' + _syncCrashCount + ' crashes. App is local-only.');
+    if (typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
     showQLToast('Sync paused — too many errors. Reload to retry.');
   }
 }
@@ -640,7 +642,7 @@ function _syncWritePerEntry(hRef, collection, key, oldVal, newVal) {
     var data = Object.assign({}, entry, syncMeta, {
       __sync_createdBy: { uid: _syncUser.uid, name: _syncUser.displayName || 'Parent' }
     });
-    colRef.doc(entry.id).set(data).catch(function(e) {
+    _syncTrackWrite(colRef.doc(entry.id).set(data)).catch(function(e) {
       console.error('[sync] Add ' + collection + '/' + entry.id + ' failed:', e);
     });
   });
@@ -648,14 +650,14 @@ function _syncWritePerEntry(hRef, collection, key, oldVal, newVal) {
   // Edited entries — field-level updates
   diff.edited.forEach(function(change) {
     var payload = Object.assign({}, change.updates, change.deletes, syncMeta);
-    colRef.doc(change.id).update(payload).catch(function(e) {
+    _syncTrackWrite(colRef.doc(change.id).update(payload)).catch(function(e) {
       console.error('[sync] Update ' + collection + '/' + change.id + ' failed:', e);
     });
   });
 
   // Deleted entries
   diff.deleted.forEach(function(id) {
-    colRef.doc(id).delete().catch(function(e) {
+    _syncTrackWrite(colRef.doc(id).delete()).catch(function(e) {
       console.error('[sync] Delete ' + collection + '/' + id + ' failed:', e);
     });
   });
@@ -664,10 +666,12 @@ function _syncWritePerEntry(hRef, collection, key, oldVal, newVal) {
 // ─── Single-Doc Write (debounced) ───
 function _syncDebounceSingleDoc(hRef, collection, key, oldVal, newVal) {
   var timerKey = collection; // debounce per collection, not per key
-  if (_syncDebounceTimers[timerKey]) clearTimeout(_syncDebounceTimers[timerKey]);
+  var wasQueued = !!_syncDebounceTimers[timerKey];
+  if (wasQueued) clearTimeout(_syncDebounceTimers[timerKey]);
 
   _syncDebounceTimers[timerKey] = setTimeout(function() {
     _syncDebounceTimers[timerKey] = null;
+    if (typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
     // Re-check state at flush time (guards against stale hRef from debounce delay)
     if (_syncDisabled || !_syncHouseholdId || !_syncUser) return;
     try {
@@ -676,6 +680,7 @@ function _syncDebounceSingleDoc(hRef, collection, key, oldVal, newVal) {
       _syncFlushSingleDoc(freshRef, collection);
     } catch(e) { _syncRecordCrash('debounce-flush/' + collection, e); }
   }, DEBOUNCE_MS);
+  if (!wasQueued && typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
 }
 
 function _syncFlushSingleDoc(hRef, collection) {
@@ -689,6 +694,7 @@ function _syncFlushSingleDoc(hRef, collection) {
   // retry once the listener (or fallback timer) confirms remote state.
   if (!_syncReady[collection]) {
     _syncPendingFlush[collection] = true;
+    if (typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
     console.warn('[sync] Flush deferred for ' + collection +
       ' — listener not ready. Will retry on listener-ready.');
     return;
@@ -728,13 +734,13 @@ function _syncFlushSingleDoc(hRef, collection) {
   if (hasUpdates) {
     var nested = _syncNestDottedPaths(diff.updates);
     var updatePayload = Object.assign({}, nested, syncMeta);
-    promises.push(docRef.set(updatePayload, { merge: true }));
+    promises.push(_syncTrackWrite(docRef.set(updatePayload, { merge: true })));
   }
   if (hasDeletes) {
     // Deletes go through update() which DOES support dotted paths correctly,
     // so leave diff.deletes flat.
     var deletePayload = Object.assign({}, diff.deletes, syncMeta);
-    promises.push(docRef.update(deletePayload));
+    promises.push(_syncTrackWrite(docRef.update(deletePayload)));
   }
 
   Promise.all(promises).catch(function(e) {
@@ -1252,3 +1258,125 @@ function _syncConfirmJoin() {
   if (!code.trim()) { showQLToast('Enter invite code'); return; }
   syncJoinByCode(code.trim());
 }
+
+// ─── Sync Visibility (Phase 1 — sl-1-2) ───
+// Derived store fusing navigator.onLine, the Firestore drain signal
+// (onSnapshotsInSync when available), and local WAL depth
+// (in-flight writes + debounce timers + deferred flushes).
+// Nothing is hardcoded: the header indicator reads only from syncVisibilityState().
+var _syncPendingWriteCount = 0;          // in-flight Firestore promises
+var _syncVisibilityListeners = [];       // subscriber callbacks
+var _syncLastVisibility = null;          // last emitted snapshot (for change-detect)
+var _syncVisibilityNotifyTimer = null;   // coalesces burst notifies
+var _syncSnapshotsInSyncUnsub = null;    // Firestore drain listener unsub
+var _syncVisibilityInitDone = false;
+
+function _syncTrackWrite(promise) {
+  if (!promise || typeof promise.then !== 'function') return promise;
+  _syncPendingWriteCount++;
+  _syncNotifyVisibility();
+  var settle = function() {
+    if (_syncPendingWriteCount > 0) _syncPendingWriteCount--;
+    _syncNotifyVisibility();
+  };
+  promise.then(settle, settle);
+  return promise;
+}
+
+function _syncCountActiveDebounces() {
+  var n = 0;
+  for (var k in _syncDebounceTimers) {
+    if (Object.prototype.hasOwnProperty.call(_syncDebounceTimers, k) && _syncDebounceTimers[k]) n++;
+  }
+  return n;
+}
+
+function _syncCountDeferredFlushes() {
+  var n = 0;
+  for (var c in _syncPendingFlush) {
+    if (Object.prototype.hasOwnProperty.call(_syncPendingFlush, c) && _syncPendingFlush[c]) n++;
+  }
+  return n;
+}
+
+function syncVisibilityState() {
+  var online = (typeof navigator !== 'undefined' && 'onLine' in navigator) ? navigator.onLine !== false : true;
+  var pending = _syncPendingWriteCount + _syncCountActiveDebounces() + _syncCountDeferredFlushes();
+  var state, reason;
+  if (!online) {
+    state = 'offline'; reason = 'no-network';
+  } else if (_syncDisabled) {
+    // Crash-killed sync: local-only until reload. Honest to show as offline;
+    // reason distinguishes it from a true network drop for diagnostics/UI copy.
+    state = 'offline'; reason = 'sync-disabled';
+  } else if (pending > 0) {
+    state = 'pending'; reason = 'writes-pending';
+  } else {
+    state = 'online'; reason = 'synced';
+  }
+  return { state: state, pending: pending, reason: reason };
+}
+
+function onSyncVisibilityChange(listener) {
+  if (typeof listener !== 'function') return function(){};
+  _syncVisibilityListeners.push(listener);
+  try { listener(syncVisibilityState()); } catch(e) { console.error('[sync-vis] listener threw on subscribe', e); }
+  return function unsubscribe() {
+    var i = _syncVisibilityListeners.indexOf(listener);
+    if (i >= 0) _syncVisibilityListeners.splice(i, 1);
+  };
+}
+
+function _syncNotifyVisibility() {
+  if (_syncVisibilityNotifyTimer) return;
+  _syncVisibilityNotifyTimer = setTimeout(function() {
+    _syncVisibilityNotifyTimer = null;
+    var snap = syncVisibilityState();
+    var prev = _syncLastVisibility;
+    if (prev && prev.state === snap.state && prev.pending === snap.pending && prev.reason === snap.reason) return;
+    _syncLastVisibility = snap;
+    for (var i = 0; i < _syncVisibilityListeners.length; i++) {
+      try { _syncVisibilityListeners[i](snap); } catch(e) { console.error('[sync-vis] listener threw', e); }
+    }
+  }, 120);
+}
+
+function _syncUpdateStatusIndicator(snap) {
+  var btn = document.getElementById('syncStatus');
+  if (!btn) return;
+  if (btn.hasAttribute('hidden')) btn.removeAttribute('hidden');
+  btn.setAttribute('data-state', snap.state);
+  var label = snap.state === 'online'  ? 'Synced'
+            : snap.state === 'pending' ? 'Syncing' + (snap.pending > 0 ? ' (' + snap.pending + ')' : '…')
+            :                            'Offline';
+  var nPending = snap.pending > 0 ? ' (' + snap.pending + ' pending)' : '';
+  var title = snap.state === 'online'  ? 'All changes synced.'
+            : snap.state === 'pending' ? (snap.pending + ' change' + (snap.pending === 1 ? '' : 's') + ' pending sync.')
+            : snap.reason === 'sync-disabled'
+              ? 'Sync paused after errors — changes will sync on reload.' + nPending
+              : 'Offline — changes will sync when back online.' + nPending;
+  var labEl = btn.querySelector('.sync-indicator__label');
+  if (labEl) labEl.textContent = label;
+  btn.setAttribute('title', title);
+  btn.setAttribute('aria-label', title);
+}
+
+function initSyncVisibility() {
+  if (_syncVisibilityInitDone) return;
+  _syncVisibilityInitDone = true;
+  if (typeof window !== 'undefined') {
+    var bump = function() { _syncNotifyVisibility(); };
+    window.addEventListener('online',  bump);
+    window.addEventListener('offline', bump);
+    try {
+      if (typeof firebase !== 'undefined' && firebase.firestore) {
+        var db = firebase.firestore();
+        if (typeof db.onSnapshotsInSync === 'function') {
+          _syncSnapshotsInSyncUnsub = db.onSnapshotsInSync(bump);
+        }
+      }
+    } catch(e) { /* non-fatal — derived store still works via counter */ }
+  }
+  onSyncVisibilityChange(_syncUpdateStatusIndicator);
+}
+

--- a/split/sync.js
+++ b/split/sync.js
@@ -1319,7 +1319,8 @@ var _syncVisibilityNotifyTimer = null;   // coalesces burst notifies
 var _syncSnapshotsInSyncUnsub = null;    // Firestore drain listener unsub
 var _syncVisibilityInitDone = false;
 var _syncHasEverFired = false;           // any listener (per-entry/single-doc) first-fired OR onSnapshotsInSync landed
-var _syncVisibilityClickBound = false;   // guard for #syncStatus click binding
+// (r3) Indicator click is routed through the data-action dispatcher (HR-3);
+// no bespoke document click handler is bound here.
 
 function _syncRecordPending(key, isPending) {
   var prev = !!_syncPendingByKey[key];
@@ -1435,14 +1436,22 @@ function _syncUpdateStatusIndicator(snap) {
   if (labEl) labEl.textContent = label;
   btn.setAttribute('title', title);
   btn.setAttribute('aria-label', title);
+
+  // HR-3 / HR-6 (r3): tap-to-reload is routed through the core.js data-action
+  // dispatcher. Only halted is tappable; other states are read-only pills.
+  // Toggle the attribute's presence — the dispatcher gates on its presence,
+  // so other states are non-interactive without any extra guard here.
+  if (snap.state === 'halted') btn.setAttribute('data-action', 'syncReload');
+  else btn.removeAttribute('data-action');
 }
 
-function _syncOnIndicatorClick(e) {
-  var btn = e && e.target && e.target.closest ? e.target.closest('#syncStatus') : null;
-  if (!btn) return;
-  if (btn.getAttribute('data-state') !== 'halted') return;
-  // Halted is the only state where a tap has an affordance — reload retries sync.
-  window.location.reload();
+// Dispatcher target for data-action="syncReload". Called from the indicator
+// pill when halted. Reloading re-bootstraps sync and clears the circuit
+// breaker's in-memory crash count.
+function syncReload() {
+  if (typeof window !== 'undefined' && window.location && window.location.reload) {
+    window.location.reload();
+  }
 }
 
 function initSyncVisibility() {
@@ -1466,12 +1475,6 @@ function initSyncVisibility() {
         }
       }
     } catch(e) { /* non-fatal — derived store still works from counters */ }
-  }
-  // Bind click-to-reload once. Uses event delegation on document so it
-  // survives template re-renders.
-  if (!_syncVisibilityClickBound && typeof document !== 'undefined') {
-    document.addEventListener('click', _syncOnIndicatorClick);
-    _syncVisibilityClickBound = true;
   }
   onSyncVisibilityChange(_syncUpdateStatusIndicator);
 }

--- a/split/sync.js
+++ b/split/sync.js
@@ -1312,7 +1312,22 @@ function _syncConfirmJoin() {
 //   snapshot.metadata.hasPendingWrites then reflects the submission.
 //   Mutually exclusive at any instant — counts are additive by construction.
 
-var _syncPendingByKey = {};              // collection/docName → bool (last-seen hasPendingWrites)
+// _syncPendingByKey — key = collection name for per-entry listeners (caretickets,
+//   etc.), key = docName for single-doc listeners (tracking, medical, etc.).
+// Value is the last-seen QuerySnapshot/DocumentSnapshot metadata.hasPendingWrites.
+//
+// SEMANTIC NOTE (Cipher PR #4 nit 2, r3 option b): Firestore's
+// QuerySnapshot.metadata.hasPendingWrites is a SINGLE boolean per collection
+// — true iff ANY doc in the collection has a pending write. Counting entries
+// in this map therefore yields the number of COLLECTIONS with one or more
+// pending writes, not the number of individual writes. Five queued meals in
+// `tracking` → badge reads "(1 pending)", not "(5 pending)". The direction
+// is honest (`pending > 0` correctly reports "something is queued") and the
+// copy "(N pending)" reads naturally at the user level. True per-write
+// precision would require iterating snapshot.docChanges() and keying by
+// `${collection}/${doc.id}` in _syncRecordPending — deferred to a phase-2
+// refinement if the count's user-visible granularity becomes a concern.
+var _syncPendingByKey = {};
 var _syncVisibilityListeners = [];       // subscriber callbacks
 var _syncLastVisibility = null;          // last emitted snapshot (for change-detect)
 var _syncVisibilityNotifyTimer = null;   // coalesces burst notifies

--- a/split/template.html
+++ b/split/template.html
@@ -105,6 +105,10 @@
       <div class="d-flex items-center gap-12 flex-wrap mt-6">
         <span class="t-md t-mid" id="headerDateTime">—</span>
         <span class="t-md t-mid" id="headerWeather">—</span>
+        <button id="syncStatus" type="button" class="sync-indicator" hidden aria-live="polite" aria-atomic="true">
+          <span class="sync-indicator__dot" aria-hidden="true"></span>
+          <span class="sync-indicator__label"></span>
+        </button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Task

`sl-1-2` — Derived sync-visibility store + header indicator. Ships as **r2 + r3 + r4** (see revision trail below). Approved by Cipher at `cd1d4d1` with three comment-level nits, all now addressed.

## Revision trail

| Rev | Commit | Scope |
|---|---|---|
| r1 | `9ea167e` | Initial draft — three-state model, `_syncTrackWrite` hand-rolled counter. Superseded. |
| r2 | `ce55827` | Cipher r1 blockers 1–5 resolved: five-state machine, `onSnapshotsInSync` drain, `hasPendingWrites`-based post-submit, `halted` state distinct from `offline`, legacy `'Sync paused'` toast retired. |
| r3 | `cd1d4d1` | HR-3 / HR-6 compliance: indicator tap-to-reload routed through the `core.js` data-action dispatcher. Bespoke `_syncOnIndicatorClick` + `document.addEventListener` removed; `syncReload()` + dispatcher clause introduced. Scope-split from the sl-1-3 draft. |
| r4 | `2566d55` | Cipher re-review nit 2 (option b): in-source precision comment on `_syncPendingByKey` naming the per-collection (not per-write) semantics. No behaviour change. |

## What ships

### Derived store (`syncVisibilityState`, `onSyncVisibilityChange`)

Fused signals:

- `navigator.onLine` + `window` `online`/`offline` events.
- Firestore `db.onSnapshotsInSync(cb)` — definitive drain ACK. First fire flips `_syncHasEverFired = true`, collapsing `connecting`.
- Per-listener `snapshot.metadata.hasPendingWrites` recorded into `_syncPendingByKey` (both listener shapes now subscribe with `{ includeMetadataChanges: true }`).
- Pre-submit queue: active `_syncDebounceTimers` + `_syncPendingFlush` entries.
- `_syncDisabled` (circuit-breaker kill).

### Five logical states → three visual colors

```
state = halted      if  _syncDisabled === true
      = offline     if  !navigator.onLine
      = connecting  if  !_syncHasEverFired && pending === 0
      = syncing     if  pending > 0
      = online      otherwise
```

`halted` evaluated before `offline` — local fault ≠ network fault. `connecting` collapses the moment `pending > 0` (proof of activity). `aria-label` distinguishes the two reds for AT; `--tc-sage / --tc-amber / --tc-danger` are the only colors used.

### Pending count — disjoint by construction

```
pre-submit  = |active _syncDebounceTimers| + |active _syncPendingFlush|
post-submit = |{k : _syncPendingByKey[k] === true}|
pending     = pre-submit + post-submit
```

**Disjointness:** a write is in `_syncDebounceTimers` until the timer fires; the fire callback nulls the entry **before** `.set()` is invoked, whose subsequent snapshot metadata flips post-submit. Mutually exclusive per-write, additive by construction.

**Precision note (r4):** `_syncPendingByKey` is keyed per collection (for per-entry listeners) or per docName (single-doc). `hasPendingWrites` is a single boolean per QuerySnapshot, so the post-submit count is "collections with any pending write," not "individual writes." Directionally honest, numerically understated when multiple writes queue into the same per-entry collection. Documented in-source; per-doc precision is deferred to phase-2 if warranted.

### Indicator markup

```html
<button id="syncStatus" type="button" class="sync-indicator" hidden
        aria-live="polite" aria-atomic="true">
  <span class="sync-indicator__dot" aria-hidden="true"></span>
  <span class="sync-indicator__label"></span>
</button>
```

Lives inside `#headerFull`. `data-state` drives color via CSS; `data-action="syncReload"` is toggled on when `state === 'halted'` (r3). Initial `hidden` removed on first notify — no lying initial pixel.

### Legacy toast decision (PR body section for Cipher nit 3)

- **`'Sync paused — too many errors.'`** toast in `_syncRecordCrash` is **retired** (r2). Halted state now surfaces persistently in the header indicator + offline badge (#5), with a reload affordance. Keeping the toast would be the three-surfaces-for-one-state redundancy the derived store exists to eliminate.
- **Remote-change toast** (`sync.js:1005–1045`) is **retained explicitly** as a *collaboration* signal: "another device wrote; refresh for the freshest view." This is a different event class than sync-state. The charter (sl-1-1 r2, PR #3) names this out-of-scope for the derived store; keeping it is not a Pillar II violation, it's a strictly additional orthogonal signal. Flagged in-audit so the next reader doesn't try to "clean it up" under the Phase 1 flag.

### HR compliance

- **HR-2** — no inline styles; all visual state via `--tc-*`, `--sp-*`, `--fs-*`, `--r-*` tokens.
- **HR-3 / HR-6** — indicator reload routed through `data-action="syncReload"` + `core.js` dispatcher (r3). No bespoke click handler bound by this PR.
- **HR-5** — every spacing/font/radius value via design tokens.
- **HR-7** — indicator uses inline `<span class="sync-indicator__dot">`; no `zi()` icon here (dot is a CSS shape, not a sprite symbol).

## Files changed

```
split/sync.js        (+ the Sync Visibility section; listener {includeMetadataChanges})
split/core.js        (+ 1 dispatcher clause for 'syncReload')
split/template.html  (+ #syncStatus markup)
split/styles.css     (+ .sync-indicator rules — 5 data-states → 3 color tokens)
split/start.js       (+ initSyncVisibility() call)
```

## Smoke plan (manual; no CI wired)

1. **Cold boot online** — pill shows `Connecting…` (amber pulse) until first listener fires, then `Synced` (green).
2. **Log a meal** — pill flips `Syncing (1)` amber during debounce (~2 s), back to `Synced` post-ACK.
3. **Offline + write** — pill `Offline` red; pending count increments as writes queue.
4. **Re-online** — `onSnapshotsInSync` fires, pill drains to `Synced` green.
5. **Circuit-breaker trip** — pill `Sync paused` red; tapping triggers reload via data-action.
6. **`?nosync`** — pill still tracks `navigator.onLine`; Firestore bypass clean.

## Review-ask reconciliation (from r1 → r2/r3/r4)

1. `_syncDisabled → halted` — not collapsed; `reason: 'sync-disabled'` preserved in snapshot.
2. Disjointness contract — in-source at `_syncCountPreSubmit`/`_syncCountPostSubmit`, verified at the debounce handoff.
3. `_syncTrackWrite` mechanism — removed; post-submit sources from `hasPendingWrites` scan.
4. Header-only indicator — correct split; always-visible offline badge lands in #5.

## Next

`sl-1-3` (#5) — offline badge, base = this branch. Approved at r1 (`3dbe32b`, now rebased to `8799df4` atop this r4). Sovereign merge order: #4 squash → #5 auto-retargets or rebases → #5 squash.
