### PR TITLE
sl-1-3: live offline badge driven by sync-visibility store

### DIFF
--- a/split/styles.css
+++ b/split/styles.css
@@ -8682,3 +8682,63 @@ body.ql-locked .dark-toggle { pointer-events:none; }
   .sync-indicator[data-state="connecting"] .sync-indicator__dot,
   .sync-indicator[data-state="syncing"]    .sync-indicator__dot { animation: none; }
 }
+
+/* ═══ Offline / Halted Persistent Badge (Phase 1 — sl-1-3) ═══
+   Matches the existing home-banner pattern (fe-home-banner etc.) — left
+   border accent via --tc-danger, tinted background, rounded corners,
+   single row on wide viewports, wraps on narrow. Tokens only (HR-5), no
+   inline styles (HR-2); reload routed through data-action (HR-3/HR-6). */
+.offline-badge {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-10);
+  padding: var(--sp-10) var(--sp-12);
+  margin: var(--sp-8) 0;
+  border-left: 4px solid var(--tc-danger);
+  border-radius: var(--r-lg);
+  background: rgba(224, 112, 112, 0.10);
+  color: var(--text);
+  font-size: var(--fs-sm);
+  line-height: 1.35;
+  flex-wrap: wrap;
+}
+.offline-badge[hidden] { display: none !important; }
+.offline-badge__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  color: var(--tc-danger);
+  flex-shrink: 0;
+}
+.offline-badge__icon .zi { width: 18px; height: 18px; }
+.offline-badge__copy {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-weight: 600;
+}
+.offline-badge__action {
+  flex-shrink: 0;
+  padding: var(--sp-4) var(--sp-10);
+  border: 1px solid var(--tc-danger);
+  border-radius: var(--r-md);
+  background: transparent;
+  color: var(--tc-danger);
+  font: inherit;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.offline-badge__action[hidden] { display: none !important; }
+.offline-badge__action:hover,
+.offline-badge__action:focus-visible {
+  background: var(--tc-danger);
+  color: var(--white);
+}
+.offline-badge__action:focus-visible {
+  outline: 2px solid var(--tc-sky);
+  outline-offset: 2px;
+}
+[data-theme="dark"] .offline-badge { background: rgba(224, 112, 112, 0.08); }

--- a/split/sync.js
+++ b/split/sync.js
@@ -1461,11 +1461,44 @@ function _syncUpdateStatusIndicator(snap) {
 }
 
 // Dispatcher target for data-action="syncReload". Called from the indicator
-// pill when halted. Reloading re-bootstraps sync and clears the circuit
-// breaker's in-memory crash count.
+// pill when halted (sl-1-2 r3) and the offline badge's reload button
+// (sl-1-3). Reloading re-bootstraps sync and clears the circuit breaker's
+// in-memory crash count.
 function syncReload() {
   if (typeof window !== 'undefined' && window.location && window.location.reload) {
     window.location.reload();
+  }
+}
+
+// ─── Offline Badge Renderer (Phase 1 — sl-1-3) ───
+// Subscribed to the sync-visibility store; shows the persistent badge
+// below the header in offline or halted state only. Copy and pending-count
+// come from the same snapshot the indicator consumes — no separate counter.
+function _syncUpdateOfflineBadge(snap) {
+  var badge = document.getElementById('offlineBadge');
+  if (!badge) return;
+  var visible = snap.state === 'offline' || snap.state === 'halted';
+  if (!visible) {
+    if (!badge.hasAttribute('hidden')) badge.setAttribute('hidden', '');
+    return;
+  }
+  if (badge.hasAttribute('hidden')) badge.removeAttribute('hidden');
+  badge.setAttribute('data-state', snap.state);
+
+  var nPending = snap.pending > 0 ? ' (' + snap.pending + ' pending)' : '';
+  var copy = snap.state === 'halted'
+    ? 'Sync paused after errors — reload to retry.' + nPending
+    : 'Offline — changes will sync when back online.' + nPending;
+
+  var copyEl = badge.querySelector('.offline-badge__copy');
+  if (copyEl) copyEl.textContent = copy;
+
+  // Reload surfaces only in halted (local fault); offline auto-resumes
+  // on network restore, no user action needed.
+  var reloadBtn = badge.querySelector('.offline-badge__action');
+  if (reloadBtn) {
+    if (snap.state === 'halted') reloadBtn.removeAttribute('hidden');
+    else reloadBtn.setAttribute('hidden', '');
   }
 }
 
@@ -1492,5 +1525,6 @@ function initSyncVisibility() {
     } catch(e) { /* non-fatal — derived store still works from counters */ }
   }
   onSyncVisibilityChange(_syncUpdateStatusIndicator);
+  onSyncVisibilityChange(_syncUpdateOfflineBadge);
 }
 

--- a/split/template.html
+++ b/split/template.html
@@ -113,6 +113,18 @@
     </div>
   </div>
 
+  <!-- Offline / halted persistent badge (Phase 1 — sl-1-3). Driven by the
+       sync-visibility store from sl-1-2; hidden in connecting/online/syncing
+       states. aria-live=polite so copy changes (including pending-count
+       updates) are announced by AT without interrupting. Reload button is
+       surfaced only in the halted state and routed through the data-action
+       dispatcher wired in sl-1-2 r3 (HR-3/HR-6). -->
+  <div id="offlineBadge" class="offline-badge" role="status" aria-live="polite" aria-atomic="true" hidden>
+    <span class="offline-badge__icon" aria-hidden="true"><svg class="zi"><use href="#zi-alert-circle"/></svg></span>
+    <span class="offline-badge__copy"></span>
+    <button type="button" class="offline-badge__action" data-action="syncReload" hidden>Reload</button>
+  </div>
+
   <!-- ══════════════ TAB 1: HOME ══════════════ -->
   <div class="tab-panel active" id="tab-home">
     <div class="grid">


### PR DESCRIPTION
## Task

`sl-1-3` — Live offline badge driven by the sync-visibility store. Stacked on `sl-1-2` (PR #4); base retargeted from `main` to that branch so this diff is **badge-only**.

## Gate order (held)

This PR draft is held pending Cipher's re-review of `sl-1-2` r2/r3. If Cipher surfaces a new blocker on the store shape in the re-review, the badge's renderer (`_syncUpdateOfflineBadge`) is the only dependent surface and is trivial to rebase. **Do not re-review this until `sl-1-2` r2/r3 clears.**

## Scope split

The indicator's HR-3 click-path refactor originally included in the first draft of this PR has been **split out to `sl-1-2` r3** (commit `cd1d4d1`) so sl-1-2's compliance fix stays in its own lane. sl-1-3 now carries only:

| File | Change |
|---|---|
| `split/template.html` | `#offlineBadge` row inserted between `#headerFull` and the first tab panel — visible on every tab. `role="status"`, `aria-live="polite"`, `aria-atomic="true"`. Reload button is `data-action="syncReload"` (the clause is in sl-1-2 r3). |
| `split/sync.js` | `_syncUpdateOfflineBadge(snap)` renderer + subscription. Consumes `syncReload()` introduced in sl-1-2 r3. |
| `split/styles.css` | `.offline-badge` + `__icon` / `__copy` / `__action` matching the existing `fe-home-banner` pattern. Dark-mode tint variant. |

`split/core.js` is **not** touched in this PR — the dispatcher clause lives in sl-1-2 r3.

## Behaviour (per sl-1-1 r2 charter)

| State | Badge visible? | Copy | Reload? |
|---|---|---|---|
| `connecting` / `online` / `syncing` | no | — | — |
| `offline` | yes | `Offline — changes will sync when back online.` + `(N pending)` when N > 0 | no — auto-resumes on network restore |
| `halted` | yes | `Sync paused after errors — reload to retry.` + `(N pending)` when N > 0 | yes — `data-action="syncReload"` |

## HR compliance

- **HR-2** (no inline styles) — class + CSS tokens only.
- **HR-3 / HR-6** (data-action delegation) — reload is `data-action="syncReload"`; the dispatcher handler was added in sl-1-2 r3.
- **HR-5** (design tokens) — `--sp-*`, `--fs-*`, `--r-*`, `--tc-danger`, `--tc-sky`, `--white`, `--text`. No ad-hoc hex.
- **HR-7** (`zi()`) — `<svg class="zi"><use href="#zi-alert-circle"/></svg>`.

## A11y

- `role="status"` + `aria-live="polite"` + `aria-atomic="true"` — transitions (including pending-count updates) announced without interrupting.
- Icon `aria-hidden`; copy carries semantics.
- Reload `:focus-visible` ring via `--tc-sky`.
- Dark mode drops tint alpha; left-border accent persists.

## Doctrine credit

Cipher's Hour-12 candidate carries through: "gap audits must use framework-provided ACK primitives (`onSnapshotsInSync` / `hasPendingWrites`) instead of hand-rolled counters when available." The badge's `N pending` comes from the same disjoint contract (pre-submit maps + `hasPendingWrites` post-submit) established in `sl-1-2` r2 — no regression.

## Smoke plan (manual; no CI wired)

1. **Offline** — DevTools → Network → Offline. Badge appears with "Offline — changes will sync when back online." No pending count, no reload button.
2. **Offline + writes** — log a meal while offline. Copy flips to "… (1 pending)" within ~120 ms; increments as more writes queue.
3. **Re-online** — flip Network back on. Badge disappears once `onSnapshotsInSync` fires.
4. **Halted** — force circuit-breaker trip. Badge switches to halted copy + Reload button. Tap → page reloads.
5. **A11y** — VoiceOver / NVDA on state transitions: copy announced politely.
6. **Dark mode** — toggle via settings; tint drops to 0.08.

## Out-of-scope (unchanged)

`.gitignore` hardening remains flagged in `sl-1-1`. Follow-up PR after Phase 1 closes.
