### PR TITLE
sl-2-arming: Playwright + chromium + 4-criterion smoke (R-4, R-15, CT-10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,15 @@
-
 .claude/
+
+# Node / Playwright dev dependencies (excluded from production build artifact;
+# build.sh emits index.html from split/* only and does not sweep these paths).
+node_modules/
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/
+
+# OS-trash patterns (file-manager rename-on-trash; CT-prefix `.trashed-{ms}-{name}`).
+.trashed-*
+.Trash-*
+.DS_Store
+Thumbs.db

--- a/index.html
+++ b/index.html
@@ -8643,6 +8643,112 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 [data-theme="dark"] .sync-code-row { border-top-color:rgba(51,101,128,0.15); }
 [data-theme="dark"] .sync-modal { background:var(--surface); }
 [data-theme="dark"] .sync-modal-input { background:rgba(255,255,255,0.05); border-color:rgba(51,101,128,0.25); }
+
+/* ═══ Sync Visibility Indicator (Phase 1 — sl-1-2, r2) ═══
+   Five logical states mapped to three visual colors per the gap audit.
+   Copy + aria-label disambiguate the two reds (offline vs halted) for AT. */
+.sync-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-6);
+  padding: var(--sp-2) var(--sp-8);
+  border: 1px solid transparent;
+  border-radius: var(--r-full);
+  background: transparent;
+  color: var(--light);
+  font: inherit;
+  font-size: var(--fs-xs);
+  line-height: 1.1;
+  cursor: default;
+  transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+.sync-indicator[hidden] { display: none !important; }
+.sync-indicator:focus-visible { outline: 2px solid var(--tc-sky); outline-offset: 2px; }
+.sync-indicator__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--r-full);
+  background: currentColor;
+  flex-shrink: 0;
+}
+.sync-indicator__label { white-space: nowrap; font-weight: 600; }
+.sync-indicator[data-state="connecting"] { color: var(--tc-amber); }
+.sync-indicator[data-state="online"]     { color: var(--tc-sage); }
+.sync-indicator[data-state="syncing"]    { color: var(--tc-amber); }
+.sync-indicator[data-state="offline"]    { color: var(--tc-danger); }
+.sync-indicator[data-state="halted"]     { color: var(--tc-danger); cursor: pointer; }
+.sync-indicator[data-state="connecting"] .sync-indicator__dot,
+.sync-indicator[data-state="syncing"]    .sync-indicator__dot {
+  animation: sync-indicator-pulse 1.4s ease-in-out infinite;
+}
+@keyframes sync-indicator-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.35; transform: scale(0.85); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .sync-indicator[data-state="connecting"] .sync-indicator__dot,
+  .sync-indicator[data-state="syncing"]    .sync-indicator__dot { animation: none; }
+}
+
+/* ═══ Offline / Halted Persistent Badge (Phase 1 — sl-1-3) ═══
+   Matches the existing home-banner pattern (fe-home-banner etc.) — left
+   border accent via --tc-danger, tinted background, rounded corners,
+   single row on wide viewports, wraps on narrow. Tokens only (HR-5), no
+   inline styles (HR-2); reload routed through data-action (HR-3/HR-6). */
+.offline-badge {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-10);
+  padding: var(--sp-10) var(--sp-12);
+  margin: var(--sp-8) 0;
+  border-left: 4px solid var(--tc-danger);
+  border-radius: var(--r-lg);
+  background: rgba(224, 112, 112, 0.10);
+  color: var(--text);
+  font-size: var(--fs-sm);
+  line-height: 1.35;
+  flex-wrap: wrap;
+}
+.offline-badge[hidden] { display: none !important; }
+.offline-badge__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  color: var(--tc-danger);
+  flex-shrink: 0;
+}
+.offline-badge__icon .zi { width: 18px; height: 18px; }
+.offline-badge__copy {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-weight: 600;
+}
+.offline-badge__action {
+  flex-shrink: 0;
+  padding: var(--sp-4) var(--sp-10);
+  border: 1px solid var(--tc-danger);
+  border-radius: var(--r-md);
+  background: transparent;
+  color: var(--tc-danger);
+  font: inherit;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.offline-badge__action[hidden] { display: none !important; }
+.offline-badge__action:hover,
+.offline-badge__action:focus-visible {
+  background: var(--tc-danger);
+  color: var(--white);
+}
+.offline-badge__action:focus-visible {
+  outline: 2px solid var(--tc-sky);
+  outline-offset: 2px;
+}
+[data-theme="dark"] .offline-badge { background: rgba(224, 112, 112, 0.08); }
   </style>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
@@ -8754,8 +8860,24 @@ body.ql-locked .dark-toggle { pointer-events:none; }
       <div class="d-flex items-center gap-12 flex-wrap mt-6">
         <span class="t-md t-mid" id="headerDateTime">—</span>
         <span class="t-md t-mid" id="headerWeather">—</span>
+        <button id="syncStatus" type="button" class="sync-indicator" hidden aria-live="polite" aria-atomic="true">
+          <span class="sync-indicator__dot" aria-hidden="true"></span>
+          <span class="sync-indicator__label"></span>
+        </button>
       </div>
     </div>
+  </div>
+
+  <!-- Offline / halted persistent badge (Phase 1 — sl-1-3). Driven by the
+       sync-visibility store from sl-1-2; hidden in connecting/online/syncing
+       states. aria-live=polite so copy changes (including pending-count
+       updates) are announced by AT without interrupting. Reload button is
+       surfaced only in the halted state and routed through the data-action
+       dispatcher wired in sl-1-2 r3 (HR-3/HR-6). -->
+  <div id="offlineBadge" class="offline-badge" role="status" aria-live="polite" aria-atomic="true" hidden>
+    <span class="offline-badge__icon" aria-hidden="true"><svg class="zi"><use href="#zi-alert-circle"/></svg></span>
+    <span class="offline-badge__copy"></span>
+    <button type="button" class="offline-badge__action" data-action="syncReload" hidden>Reload</button>
   </div>
 
   <!-- ══════════════ TAB 1: HOME ══════════════ -->
@@ -15374,6 +15496,7 @@ function init() {
     else if (action === 'resetData') confirmAction('Reset ALL data to defaults? A backup will be downloaded automatically before resetting.', resetAllData, 'Reset');
     else if (action === 'toggleVisitFormShow') toggleVisitForm(true);
     else if (action === 'toggleVisitFormHide') toggleVisitForm(false);
+    else if (action === 'syncReload' && typeof syncReload === 'function') syncReload();
     else if (action === 'dismissWelcomeGuide') dismissWelcomeGuide();
     else if (action === 'toggleHomeVitals') toggleHomeVitals();
     else if (action === 'openScorePopupStop') { e.stopPropagation(); openScorePopup(arg); }
@@ -60743,6 +60866,13 @@ function _syncArmReadyFallback(collection) {
 function _syncMarkReady(collection) {
   if (_syncReady[collection]) return;
   _syncReady[collection] = true;
+  // Visibility store r2: first listener-ready is proof of Firestore activity
+  // — collapses the 'connecting' state even if onSnapshotsInSync is not yet
+  // available or has not yet landed.
+  if (typeof _syncHasEverFired !== 'undefined' && !_syncHasEverFired) {
+    _syncHasEverFired = true;
+    if (typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
+  }
   if (_syncReadyTimers[collection]) {
     clearTimeout(_syncReadyTimers[collection]);
     _syncReadyTimers[collection] = null;
@@ -60750,6 +60880,7 @@ function _syncMarkReady(collection) {
   // Fire any pending flush that was deferred waiting for this listener.
   if (_syncPendingFlush[collection]) {
     _syncPendingFlush[collection] = false;
+    if (typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
     // Cipher C3: breaker interaction
     if (_syncWriteCount >= CIRCUIT_BREAKER_LIMIT) {
       console.warn('[sync] Skipping ready-pending-flush for ' + collection +
@@ -60777,7 +60908,12 @@ function _syncRecordCrash(source, err) {
       _syncDebounceTimers[k] = null;
     });
     console.error('[sync] Auto-disabled after ' + _syncCrashCount + ' crashes. App is local-only.');
-    showQLToast('Sync paused — too many errors. Reload to retry.');
+    // Cipher blocker #5 (r2): the 'Sync paused' toast is retired. The halted
+    // state is now surfaced persistently in the header indicator + offline
+    // badge, with a reload affordance. Transient toast on top would be the
+    // three-surfaces-for-one-state redundancy the derived store is meant
+    // to eliminate.
+    if (typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
   }
 }
 
@@ -61124,6 +61260,12 @@ function _syncDetachListeners() {
   });
   _syncReadyTimers = {};
   _syncPendingFlush = {};
+  // Visibility store r2: re-attach is a fresh session — wipe per-key pending
+  // state and the has-ever-fired gate so the indicator honestly returns to
+  // 'connecting' until the new listeners confirm activity.
+  if (typeof _syncPendingByKey !== 'undefined') _syncPendingByKey = {};
+  if (typeof _syncHasEverFired !== 'undefined') _syncHasEverFired = false;
+  if (typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
 }
 
 // ═══════════════════════════════════════════
@@ -61342,10 +61484,12 @@ function _syncWritePerEntry(hRef, collection, key, oldVal, newVal) {
 // ─── Single-Doc Write (debounced) ───
 function _syncDebounceSingleDoc(hRef, collection, key, oldVal, newVal) {
   var timerKey = collection; // debounce per collection, not per key
-  if (_syncDebounceTimers[timerKey]) clearTimeout(_syncDebounceTimers[timerKey]);
+  var wasQueued = !!_syncDebounceTimers[timerKey];
+  if (wasQueued) clearTimeout(_syncDebounceTimers[timerKey]);
 
   _syncDebounceTimers[timerKey] = setTimeout(function() {
     _syncDebounceTimers[timerKey] = null;
+    if (typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
     // Re-check state at flush time (guards against stale hRef from debounce delay)
     if (_syncDisabled || !_syncHouseholdId || !_syncUser) return;
     try {
@@ -61354,6 +61498,7 @@ function _syncDebounceSingleDoc(hRef, collection, key, oldVal, newVal) {
       _syncFlushSingleDoc(freshRef, collection);
     } catch(e) { _syncRecordCrash('debounce-flush/' + collection, e); }
   }, DEBOUNCE_MS);
+  if (!wasQueued && typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
 }
 
 function _syncFlushSingleDoc(hRef, collection) {
@@ -61367,6 +61512,7 @@ function _syncFlushSingleDoc(hRef, collection) {
   // retry once the listener (or fallback timer) confirms remote state.
   if (!_syncReady[collection]) {
     _syncPendingFlush[collection] = true;
+    if (typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
     console.warn('[sync] Flush deferred for ' + collection +
       ' — listener not ready. Will retry on listener-ready.');
     return;
@@ -61449,9 +61595,12 @@ function _syncAttachListeners(hId) {
   var perEntryCollections = Object.keys(_peSet);
   var singleDocNames = Object.keys(_sdSet);
 
-  // Per-entry collections — each handler wrapped in try/catch for isolation
+  // Per-entry collections — each handler wrapped in try/catch for isolation.
+  // {includeMetadataChanges:true} so pending→ACK transitions fire the handler
+  // and the visibility store can read snapshot.metadata.hasPendingWrites.
+  // Data-equality checks inside the handler short-circuit metadata-only fires.
   perEntryCollections.forEach(function(col) {
-    var unsub = hRef.collection(col).onSnapshot(function(snapshot) {
+    var unsub = hRef.collection(col).onSnapshot({ includeMetadataChanges: true }, function(snapshot) {
       try { if (!_syncDisabled) _syncHandlePerEntrySnapshot(col, snapshot); }
       catch(e) { _syncRecordCrash('per-entry/' + col, e); }
     }, function(err) {
@@ -61465,7 +61614,7 @@ function _syncAttachListeners(hId) {
 
   // Single-doc collections (in /singles/{docName})
   singleDocNames.forEach(function(docName) {
-    var unsub = hRef.collection('singles').doc(docName).onSnapshot(function(doc) {
+    var unsub = hRef.collection('singles').doc(docName).onSnapshot({ includeMetadataChanges: true }, function(doc) {
       try { if (!_syncDisabled) _syncHandleSingleDocSnapshot(docName, doc); }
       catch(e) { _syncRecordCrash('single-doc/' + docName, e); }
     }, function(err) {
@@ -61489,6 +61638,11 @@ function _syncAttachListeners(hId) {
 
 // ─── Handle Per-Entry Snapshot ───
 function _syncHandlePerEntrySnapshot(collection, snapshot) {
+  // Cipher r2: record post-submit pending-write state for this collection
+  // before any early return. Listener fires with {includeMetadataChanges:true}
+  // so this catches pending→ACK transitions even when no data changed.
+  _syncRecordPending(collection, !!(snapshot.metadata && snapshot.metadata.hasPendingWrites));
+
   // C0 Cipher C2: mark-ready in finally so defer paths don't suppress it.
   try {
     // Find which localStorage key maps to this collection
@@ -61566,6 +61720,10 @@ function _syncHandlePerEntrySnapshot(collection, snapshot) {
 
 // ─── Handle Single-Doc Snapshot ───
 function _syncHandleSingleDocSnapshot(docName, doc) {
+  // Cipher r2: record post-submit pending-write state for this doc before
+  // any early return. Listener fires with {includeMetadataChanges:true}.
+  _syncRecordPending(docName, !!(doc && doc.metadata && doc.metadata.hasPendingWrites));
+
   // C0 Cipher C2: _syncMarkReady MUST run on every exit path, including
   // early returns and defer paths, so the collection's ready-state is
   // confirmed even when no save happens. Wrap in try/finally.
@@ -61930,6 +62088,247 @@ function _syncConfirmJoin() {
   if (!code.trim()) { showQLToast('Enter invite code'); return; }
   syncJoinByCode(code.trim());
 }
+
+// ─── Sync Visibility (Phase 1 — sl-1-2, r2) ───
+// Derived store fusing four signals:
+//   (a) navigator.onLine + window online/offline events
+//   (b) Firestore drain via db.onSnapshotsInSync — definitive ACK that local
+//       cache + IDB persistence queue + server are all in sync
+//   (c) Post-submit pending-writes from snapshot.metadata.hasPendingWrites
+//       (recorded per collection/doc by the existing listener handlers, which
+//       now subscribe with {includeMetadataChanges:true})
+//   (d) Pre-submit queue: _syncDebounceTimers (active count) + _syncPendingFlush
+//
+// Five logical states, three visual colors (color mapping lives in CSS):
+//   connecting — cold boot: no listener has fired, no drain event yet, pending===0
+//   online     — network up, fully drained
+//   syncing    — network up, pending > 0
+//   offline    — !navigator.onLine
+//   halted     — _syncDisabled === true (circuit breaker tripped; reload-required)
+//
+// Disjointness contract:
+//   pre-submit (our maps) and post-submit (hasPendingWrites map) are phases
+//   of a write's life. A write is in _syncDebounceTimers until the timer
+//   fires; the fire callback nulls the entry and calls .set(), whose
+//   snapshot.metadata.hasPendingWrites then reflects the submission.
+//   Mutually exclusive at any instant — counts are additive by construction.
+
+// _syncPendingByKey — key = collection name for per-entry listeners (caretickets,
+//   etc.), key = docName for single-doc listeners (tracking, medical, etc.).
+// Value is the last-seen QuerySnapshot/DocumentSnapshot metadata.hasPendingWrites.
+//
+// SEMANTIC NOTE (Cipher PR #4 nit 2, r3 option b): Firestore's
+// QuerySnapshot.metadata.hasPendingWrites is a SINGLE boolean per collection
+// — true iff ANY doc in the collection has a pending write. Counting entries
+// in this map therefore yields the number of COLLECTIONS with one or more
+// pending writes, not the number of individual writes. Five queued meals in
+// `tracking` → badge reads "(1 pending)", not "(5 pending)". The direction
+// is honest (`pending > 0` correctly reports "something is queued") and the
+// copy "(N pending)" reads naturally at the user level. True per-write
+// precision would require iterating snapshot.docChanges() and keying by
+// `${collection}/${doc.id}` in _syncRecordPending — deferred to a phase-2
+// refinement if the count's user-visible granularity becomes a concern.
+var _syncPendingByKey = {};
+var _syncVisibilityListeners = [];       // subscriber callbacks
+var _syncLastVisibility = null;          // last emitted snapshot (for change-detect)
+var _syncVisibilityNotifyTimer = null;   // coalesces burst notifies
+var _syncSnapshotsInSyncUnsub = null;    // Firestore drain listener unsub
+var _syncVisibilityInitDone = false;
+var _syncHasEverFired = false;           // any listener (per-entry/single-doc) first-fired OR onSnapshotsInSync landed
+// (r3) Indicator click is routed through the data-action dispatcher (HR-3);
+// no bespoke document click handler is bound here.
+
+function _syncRecordPending(key, isPending) {
+  var prev = !!_syncPendingByKey[key];
+  if (prev === !!isPending) return;
+  if (isPending) _syncPendingByKey[key] = true;
+  else delete _syncPendingByKey[key];
+  _syncNotifyVisibility();
+}
+
+function _syncCountPreSubmit() {
+  var n = 0;
+  for (var k in _syncDebounceTimers) {
+    if (Object.prototype.hasOwnProperty.call(_syncDebounceTimers, k) && _syncDebounceTimers[k]) n++;
+  }
+  for (var c in _syncPendingFlush) {
+    if (Object.prototype.hasOwnProperty.call(_syncPendingFlush, c) && _syncPendingFlush[c]) n++;
+  }
+  return n;
+}
+
+function _syncCountPostSubmit() {
+  var n = 0;
+  for (var k in _syncPendingByKey) {
+    if (Object.prototype.hasOwnProperty.call(_syncPendingByKey, k) && _syncPendingByKey[k]) n++;
+  }
+  return n;
+}
+
+function syncVisibilityState() {
+  var online = (typeof navigator !== 'undefined' && 'onLine' in navigator) ? navigator.onLine !== false : true;
+  var preSubmit  = _syncCountPreSubmit();
+  var postSubmit = _syncCountPostSubmit();
+  var pending = preSubmit + postSubmit;  // disjoint by construction (see header comment)
+  var state, reason;
+
+  // Evaluation order matters: halted is a local fault independent of network,
+  // so it wins over offline. connecting is only valid before any proof of
+  // Firestore activity; it collapses to syncing the moment pending > 0.
+  if (_syncDisabled) {
+    state = 'halted';     reason = 'sync-disabled';
+  } else if (!online) {
+    state = 'offline';    reason = 'no-network';
+  } else if (!_syncHasEverFired && pending === 0) {
+    state = 'connecting'; reason = 'no-listener-yet';
+  } else if (pending > 0) {
+    state = 'syncing';    reason = 'writes-pending';
+  } else {
+    state = 'online';     reason = 'synced';
+  }
+  return { state: state, pending: pending, reason: reason };
+}
+
+function onSyncVisibilityChange(listener) {
+  if (typeof listener !== 'function') return function(){};
+  _syncVisibilityListeners.push(listener);
+  try { listener(syncVisibilityState()); } catch(e) { console.error('[sync-vis] listener threw on subscribe', e); }
+  return function unsubscribe() {
+    var i = _syncVisibilityListeners.indexOf(listener);
+    if (i >= 0) _syncVisibilityListeners.splice(i, 1);
+  };
+}
+
+function _syncNotifyVisibility() {
+  if (_syncVisibilityNotifyTimer) return;
+  _syncVisibilityNotifyTimer = setTimeout(function() {
+    _syncVisibilityNotifyTimer = null;
+    var snap = syncVisibilityState();
+    var prev = _syncLastVisibility;
+    if (prev && prev.state === snap.state && prev.pending === snap.pending && prev.reason === snap.reason) return;
+    _syncLastVisibility = snap;
+    for (var i = 0; i < _syncVisibilityListeners.length; i++) {
+      try { _syncVisibilityListeners[i](snap); } catch(e) { console.error('[sync-vis] listener threw', e); }
+    }
+  }, 120);
+}
+
+function _syncUpdateStatusIndicator(snap) {
+  var btn = document.getElementById('syncStatus');
+  if (!btn) return;
+  if (btn.hasAttribute('hidden')) btn.removeAttribute('hidden');
+  btn.setAttribute('data-state', snap.state);
+
+  // Copy table — one source of truth per logical state; CSS handles color.
+  // aria-label is the long form so screen readers distinguish the two red
+  // states (offline vs halted) that share --tc-danger.
+  var label, title;
+  switch (snap.state) {
+    case 'connecting':
+      label = 'Connecting…';
+      title = 'Connecting to sync…';
+      break;
+    case 'online':
+      label = 'Synced';
+      title = 'All changes synced.';
+      break;
+    case 'syncing':
+      label = 'Syncing' + (snap.pending > 0 ? ' (' + snap.pending + ')' : '…');
+      title = snap.pending + ' change' + (snap.pending === 1 ? '' : 's') + ' pending sync.';
+      break;
+    case 'offline':
+      label = 'Offline';
+      title = 'Offline — changes will sync when back online.' + (snap.pending > 0 ? ' (' + snap.pending + ' pending)' : '');
+      break;
+    case 'halted':
+      label = 'Sync paused';
+      title = 'Sync paused after errors — tap to reload.' + (snap.pending > 0 ? ' (' + snap.pending + ' pending)' : '');
+      break;
+    default:
+      label = ''; title = '';
+  }
+
+  var labEl = btn.querySelector('.sync-indicator__label');
+  if (labEl) labEl.textContent = label;
+  btn.setAttribute('title', title);
+  btn.setAttribute('aria-label', title);
+
+  // HR-3 / HR-6 (r3): tap-to-reload is routed through the core.js data-action
+  // dispatcher. Only halted is tappable; other states are read-only pills.
+  // Toggle the attribute's presence — the dispatcher gates on its presence,
+  // so other states are non-interactive without any extra guard here.
+  if (snap.state === 'halted') btn.setAttribute('data-action', 'syncReload');
+  else btn.removeAttribute('data-action');
+}
+
+// Dispatcher target for data-action="syncReload". Called from the indicator
+// pill when halted (sl-1-2 r3) and the offline badge's reload button
+// (sl-1-3). Reloading re-bootstraps sync and clears the circuit breaker's
+// in-memory crash count.
+function syncReload() {
+  if (typeof window !== 'undefined' && window.location && window.location.reload) {
+    window.location.reload();
+  }
+}
+
+// ─── Offline Badge Renderer (Phase 1 — sl-1-3) ───
+// Subscribed to the sync-visibility store; shows the persistent badge
+// below the header in offline or halted state only. Copy and pending-count
+// come from the same snapshot the indicator consumes — no separate counter.
+function _syncUpdateOfflineBadge(snap) {
+  var badge = document.getElementById('offlineBadge');
+  if (!badge) return;
+  var visible = snap.state === 'offline' || snap.state === 'halted';
+  if (!visible) {
+    if (!badge.hasAttribute('hidden')) badge.setAttribute('hidden', '');
+    return;
+  }
+  if (badge.hasAttribute('hidden')) badge.removeAttribute('hidden');
+  badge.setAttribute('data-state', snap.state);
+
+  var nPending = snap.pending > 0 ? ' (' + snap.pending + ' pending)' : '';
+  var copy = snap.state === 'halted'
+    ? 'Sync paused after errors — reload to retry.' + nPending
+    : 'Offline — changes will sync when back online.' + nPending;
+
+  var copyEl = badge.querySelector('.offline-badge__copy');
+  if (copyEl) copyEl.textContent = copy;
+
+  // Reload surfaces only in halted (local fault); offline auto-resumes
+  // on network restore, no user action needed.
+  var reloadBtn = badge.querySelector('.offline-badge__action');
+  if (reloadBtn) {
+    if (snap.state === 'halted') reloadBtn.removeAttribute('hidden');
+    else reloadBtn.setAttribute('hidden', '');
+  }
+}
+
+function initSyncVisibility() {
+  if (_syncVisibilityInitDone) return;
+  _syncVisibilityInitDone = true;
+  if (typeof window !== 'undefined') {
+    var bump = function() { _syncNotifyVisibility(); };
+    window.addEventListener('online',  bump);
+    window.addEventListener('offline', bump);
+    try {
+      if (typeof firebase !== 'undefined' && firebase.firestore) {
+        var db = firebase.firestore();
+        if (typeof db.onSnapshotsInSync === 'function') {
+          _syncSnapshotsInSyncUnsub = db.onSnapshotsInSync(function() {
+            // First drain event = definitive proof of Firestore activity.
+            // Collapses 'connecting' to 'online' (or 'syncing' if writes are
+            // queued — ordering in syncVisibilityState handles that).
+            _syncHasEverFired = true;
+            _syncNotifyVisibility();
+          });
+        }
+      }
+    } catch(e) { /* non-fatal — derived store still works from counters */ }
+  }
+  onSyncVisibilityChange(_syncUpdateStatusIndicator);
+  onSyncVisibilityChange(_syncUpdateOfflineBadge);
+}
+
 // ─────────────────────────────────────────
 // START — must be last in concat order
 // ─────────────────────────────────────────
@@ -61943,6 +62342,9 @@ _bugInit();
 if (window.location.search.indexOf('nosync') === -1) {
   try { initFirebase(); } catch(e) { console.error('[sync] initFirebase crashed:', e); }
 }
+// Sync visibility indicator (Phase 1 — sl-1-2). Runs even under ?nosync so
+// the header still reflects true network state from navigator.onLine alone.
+try { initSyncVisibility(); } catch(e) { console.error('[sync-vis] init crashed:', e); }
 </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "sproutlab-tests",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Dev-only test harness for SproutLab (Playwright + zero-dep static server). Not part of the production build artifact.",
+  "scripts": {
+    "test:e2e": "playwright test",
+    "test:e2e:stress": "playwright test --repeat-each=5",
+    "test:e2e:ci": "CI=1 playwright test --repeat-each=5",
+    "serve": "node tests/e2e/server.mjs"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.48.2"
+  },
+  "packageManager": "pnpm@10.33.0"
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// SproutLab Phase 2 arming — hermetic local serve, chromium only, retries: 0 (R-6).
+// CT-10 lesson: bundled chromium does not trust sandbox MITM CAs, so we serve locally
+// rather than pointing at the live deploy.
+const PORT = process.env.PORT ? Number(process.env.PORT) : 5173;
+const baseURL = `http://127.0.0.1:${PORT}`;
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'list' : [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    actionTimeout: 8_000,
+    navigationTimeout: 15_000,
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    command: `node tests/e2e/server.mjs ${PORT}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 10_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,52 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: 1.48.2
+        version: 1.48.2
+
+packages:
+
+  '@playwright/test@1.48.2':
+    resolution: {integrity: sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  playwright-core@1.48.2:
+    resolution: {integrity: sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.48.2:
+    resolution: {integrity: sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+snapshots:
+
+  '@playwright/test@1.48.2':
+    dependencies:
+      playwright: 1.48.2
+
+  fsevents@2.3.2:
+    optional: true
+
+  playwright-core@1.48.2: {}
+
+  playwright@1.48.2:
+    dependencies:
+      playwright-core: 1.48.2
+    optionalDependencies:
+      fsevents: 2.3.2

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -8643,6 +8643,112 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 [data-theme="dark"] .sync-code-row { border-top-color:rgba(51,101,128,0.15); }
 [data-theme="dark"] .sync-modal { background:var(--surface); }
 [data-theme="dark"] .sync-modal-input { background:rgba(255,255,255,0.05); border-color:rgba(51,101,128,0.25); }
+
+/* ═══ Sync Visibility Indicator (Phase 1 — sl-1-2, r2) ═══
+   Five logical states mapped to three visual colors per the gap audit.
+   Copy + aria-label disambiguate the two reds (offline vs halted) for AT. */
+.sync-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-6);
+  padding: var(--sp-2) var(--sp-8);
+  border: 1px solid transparent;
+  border-radius: var(--r-full);
+  background: transparent;
+  color: var(--light);
+  font: inherit;
+  font-size: var(--fs-xs);
+  line-height: 1.1;
+  cursor: default;
+  transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+.sync-indicator[hidden] { display: none !important; }
+.sync-indicator:focus-visible { outline: 2px solid var(--tc-sky); outline-offset: 2px; }
+.sync-indicator__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--r-full);
+  background: currentColor;
+  flex-shrink: 0;
+}
+.sync-indicator__label { white-space: nowrap; font-weight: 600; }
+.sync-indicator[data-state="connecting"] { color: var(--tc-amber); }
+.sync-indicator[data-state="online"]     { color: var(--tc-sage); }
+.sync-indicator[data-state="syncing"]    { color: var(--tc-amber); }
+.sync-indicator[data-state="offline"]    { color: var(--tc-danger); }
+.sync-indicator[data-state="halted"]     { color: var(--tc-danger); cursor: pointer; }
+.sync-indicator[data-state="connecting"] .sync-indicator__dot,
+.sync-indicator[data-state="syncing"]    .sync-indicator__dot {
+  animation: sync-indicator-pulse 1.4s ease-in-out infinite;
+}
+@keyframes sync-indicator-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.35; transform: scale(0.85); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .sync-indicator[data-state="connecting"] .sync-indicator__dot,
+  .sync-indicator[data-state="syncing"]    .sync-indicator__dot { animation: none; }
+}
+
+/* ═══ Offline / Halted Persistent Badge (Phase 1 — sl-1-3) ═══
+   Matches the existing home-banner pattern (fe-home-banner etc.) — left
+   border accent via --tc-danger, tinted background, rounded corners,
+   single row on wide viewports, wraps on narrow. Tokens only (HR-5), no
+   inline styles (HR-2); reload routed through data-action (HR-3/HR-6). */
+.offline-badge {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-10);
+  padding: var(--sp-10) var(--sp-12);
+  margin: var(--sp-8) 0;
+  border-left: 4px solid var(--tc-danger);
+  border-radius: var(--r-lg);
+  background: rgba(224, 112, 112, 0.10);
+  color: var(--text);
+  font-size: var(--fs-sm);
+  line-height: 1.35;
+  flex-wrap: wrap;
+}
+.offline-badge[hidden] { display: none !important; }
+.offline-badge__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  color: var(--tc-danger);
+  flex-shrink: 0;
+}
+.offline-badge__icon .zi { width: 18px; height: 18px; }
+.offline-badge__copy {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-weight: 600;
+}
+.offline-badge__action {
+  flex-shrink: 0;
+  padding: var(--sp-4) var(--sp-10);
+  border: 1px solid var(--tc-danger);
+  border-radius: var(--r-md);
+  background: transparent;
+  color: var(--tc-danger);
+  font: inherit;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.offline-badge__action[hidden] { display: none !important; }
+.offline-badge__action:hover,
+.offline-badge__action:focus-visible {
+  background: var(--tc-danger);
+  color: var(--white);
+}
+.offline-badge__action:focus-visible {
+  outline: 2px solid var(--tc-sky);
+  outline-offset: 2px;
+}
+[data-theme="dark"] .offline-badge { background: rgba(224, 112, 112, 0.08); }
   </style>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
@@ -8754,8 +8860,24 @@ body.ql-locked .dark-toggle { pointer-events:none; }
       <div class="d-flex items-center gap-12 flex-wrap mt-6">
         <span class="t-md t-mid" id="headerDateTime">—</span>
         <span class="t-md t-mid" id="headerWeather">—</span>
+        <button id="syncStatus" type="button" class="sync-indicator" hidden aria-live="polite" aria-atomic="true">
+          <span class="sync-indicator__dot" aria-hidden="true"></span>
+          <span class="sync-indicator__label"></span>
+        </button>
       </div>
     </div>
+  </div>
+
+  <!-- Offline / halted persistent badge (Phase 1 — sl-1-3). Driven by the
+       sync-visibility store from sl-1-2; hidden in connecting/online/syncing
+       states. aria-live=polite so copy changes (including pending-count
+       updates) are announced by AT without interrupting. Reload button is
+       surfaced only in the halted state and routed through the data-action
+       dispatcher wired in sl-1-2 r3 (HR-3/HR-6). -->
+  <div id="offlineBadge" class="offline-badge" role="status" aria-live="polite" aria-atomic="true" hidden>
+    <span class="offline-badge__icon" aria-hidden="true"><svg class="zi"><use href="#zi-alert-circle"/></svg></span>
+    <span class="offline-badge__copy"></span>
+    <button type="button" class="offline-badge__action" data-action="syncReload" hidden>Reload</button>
   </div>
 
   <!-- ══════════════ TAB 1: HOME ══════════════ -->
@@ -15374,6 +15496,7 @@ function init() {
     else if (action === 'resetData') confirmAction('Reset ALL data to defaults? A backup will be downloaded automatically before resetting.', resetAllData, 'Reset');
     else if (action === 'toggleVisitFormShow') toggleVisitForm(true);
     else if (action === 'toggleVisitFormHide') toggleVisitForm(false);
+    else if (action === 'syncReload' && typeof syncReload === 'function') syncReload();
     else if (action === 'dismissWelcomeGuide') dismissWelcomeGuide();
     else if (action === 'toggleHomeVitals') toggleHomeVitals();
     else if (action === 'openScorePopupStop') { e.stopPropagation(); openScorePopup(arg); }
@@ -60743,6 +60866,13 @@ function _syncArmReadyFallback(collection) {
 function _syncMarkReady(collection) {
   if (_syncReady[collection]) return;
   _syncReady[collection] = true;
+  // Visibility store r2: first listener-ready is proof of Firestore activity
+  // — collapses the 'connecting' state even if onSnapshotsInSync is not yet
+  // available or has not yet landed.
+  if (typeof _syncHasEverFired !== 'undefined' && !_syncHasEverFired) {
+    _syncHasEverFired = true;
+    if (typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
+  }
   if (_syncReadyTimers[collection]) {
     clearTimeout(_syncReadyTimers[collection]);
     _syncReadyTimers[collection] = null;
@@ -60750,6 +60880,7 @@ function _syncMarkReady(collection) {
   // Fire any pending flush that was deferred waiting for this listener.
   if (_syncPendingFlush[collection]) {
     _syncPendingFlush[collection] = false;
+    if (typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
     // Cipher C3: breaker interaction
     if (_syncWriteCount >= CIRCUIT_BREAKER_LIMIT) {
       console.warn('[sync] Skipping ready-pending-flush for ' + collection +
@@ -60777,7 +60908,12 @@ function _syncRecordCrash(source, err) {
       _syncDebounceTimers[k] = null;
     });
     console.error('[sync] Auto-disabled after ' + _syncCrashCount + ' crashes. App is local-only.');
-    showQLToast('Sync paused — too many errors. Reload to retry.');
+    // Cipher blocker #5 (r2): the 'Sync paused' toast is retired. The halted
+    // state is now surfaced persistently in the header indicator + offline
+    // badge, with a reload affordance. Transient toast on top would be the
+    // three-surfaces-for-one-state redundancy the derived store is meant
+    // to eliminate.
+    if (typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
   }
 }
 
@@ -61124,6 +61260,12 @@ function _syncDetachListeners() {
   });
   _syncReadyTimers = {};
   _syncPendingFlush = {};
+  // Visibility store r2: re-attach is a fresh session — wipe per-key pending
+  // state and the has-ever-fired gate so the indicator honestly returns to
+  // 'connecting' until the new listeners confirm activity.
+  if (typeof _syncPendingByKey !== 'undefined') _syncPendingByKey = {};
+  if (typeof _syncHasEverFired !== 'undefined') _syncHasEverFired = false;
+  if (typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
 }
 
 // ═══════════════════════════════════════════
@@ -61342,10 +61484,12 @@ function _syncWritePerEntry(hRef, collection, key, oldVal, newVal) {
 // ─── Single-Doc Write (debounced) ───
 function _syncDebounceSingleDoc(hRef, collection, key, oldVal, newVal) {
   var timerKey = collection; // debounce per collection, not per key
-  if (_syncDebounceTimers[timerKey]) clearTimeout(_syncDebounceTimers[timerKey]);
+  var wasQueued = !!_syncDebounceTimers[timerKey];
+  if (wasQueued) clearTimeout(_syncDebounceTimers[timerKey]);
 
   _syncDebounceTimers[timerKey] = setTimeout(function() {
     _syncDebounceTimers[timerKey] = null;
+    if (typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
     // Re-check state at flush time (guards against stale hRef from debounce delay)
     if (_syncDisabled || !_syncHouseholdId || !_syncUser) return;
     try {
@@ -61354,6 +61498,7 @@ function _syncDebounceSingleDoc(hRef, collection, key, oldVal, newVal) {
       _syncFlushSingleDoc(freshRef, collection);
     } catch(e) { _syncRecordCrash('debounce-flush/' + collection, e); }
   }, DEBOUNCE_MS);
+  if (!wasQueued && typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
 }
 
 function _syncFlushSingleDoc(hRef, collection) {
@@ -61367,6 +61512,7 @@ function _syncFlushSingleDoc(hRef, collection) {
   // retry once the listener (or fallback timer) confirms remote state.
   if (!_syncReady[collection]) {
     _syncPendingFlush[collection] = true;
+    if (typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
     console.warn('[sync] Flush deferred for ' + collection +
       ' — listener not ready. Will retry on listener-ready.');
     return;
@@ -61449,9 +61595,12 @@ function _syncAttachListeners(hId) {
   var perEntryCollections = Object.keys(_peSet);
   var singleDocNames = Object.keys(_sdSet);
 
-  // Per-entry collections — each handler wrapped in try/catch for isolation
+  // Per-entry collections — each handler wrapped in try/catch for isolation.
+  // {includeMetadataChanges:true} so pending→ACK transitions fire the handler
+  // and the visibility store can read snapshot.metadata.hasPendingWrites.
+  // Data-equality checks inside the handler short-circuit metadata-only fires.
   perEntryCollections.forEach(function(col) {
-    var unsub = hRef.collection(col).onSnapshot(function(snapshot) {
+    var unsub = hRef.collection(col).onSnapshot({ includeMetadataChanges: true }, function(snapshot) {
       try { if (!_syncDisabled) _syncHandlePerEntrySnapshot(col, snapshot); }
       catch(e) { _syncRecordCrash('per-entry/' + col, e); }
     }, function(err) {
@@ -61465,7 +61614,7 @@ function _syncAttachListeners(hId) {
 
   // Single-doc collections (in /singles/{docName})
   singleDocNames.forEach(function(docName) {
-    var unsub = hRef.collection('singles').doc(docName).onSnapshot(function(doc) {
+    var unsub = hRef.collection('singles').doc(docName).onSnapshot({ includeMetadataChanges: true }, function(doc) {
       try { if (!_syncDisabled) _syncHandleSingleDocSnapshot(docName, doc); }
       catch(e) { _syncRecordCrash('single-doc/' + docName, e); }
     }, function(err) {
@@ -61489,6 +61638,11 @@ function _syncAttachListeners(hId) {
 
 // ─── Handle Per-Entry Snapshot ───
 function _syncHandlePerEntrySnapshot(collection, snapshot) {
+  // Cipher r2: record post-submit pending-write state for this collection
+  // before any early return. Listener fires with {includeMetadataChanges:true}
+  // so this catches pending→ACK transitions even when no data changed.
+  _syncRecordPending(collection, !!(snapshot.metadata && snapshot.metadata.hasPendingWrites));
+
   // C0 Cipher C2: mark-ready in finally so defer paths don't suppress it.
   try {
     // Find which localStorage key maps to this collection
@@ -61566,6 +61720,10 @@ function _syncHandlePerEntrySnapshot(collection, snapshot) {
 
 // ─── Handle Single-Doc Snapshot ───
 function _syncHandleSingleDocSnapshot(docName, doc) {
+  // Cipher r2: record post-submit pending-write state for this doc before
+  // any early return. Listener fires with {includeMetadataChanges:true}.
+  _syncRecordPending(docName, !!(doc && doc.metadata && doc.metadata.hasPendingWrites));
+
   // C0 Cipher C2: _syncMarkReady MUST run on every exit path, including
   // early returns and defer paths, so the collection's ready-state is
   // confirmed even when no save happens. Wrap in try/finally.
@@ -61930,6 +62088,247 @@ function _syncConfirmJoin() {
   if (!code.trim()) { showQLToast('Enter invite code'); return; }
   syncJoinByCode(code.trim());
 }
+
+// ─── Sync Visibility (Phase 1 — sl-1-2, r2) ───
+// Derived store fusing four signals:
+//   (a) navigator.onLine + window online/offline events
+//   (b) Firestore drain via db.onSnapshotsInSync — definitive ACK that local
+//       cache + IDB persistence queue + server are all in sync
+//   (c) Post-submit pending-writes from snapshot.metadata.hasPendingWrites
+//       (recorded per collection/doc by the existing listener handlers, which
+//       now subscribe with {includeMetadataChanges:true})
+//   (d) Pre-submit queue: _syncDebounceTimers (active count) + _syncPendingFlush
+//
+// Five logical states, three visual colors (color mapping lives in CSS):
+//   connecting — cold boot: no listener has fired, no drain event yet, pending===0
+//   online     — network up, fully drained
+//   syncing    — network up, pending > 0
+//   offline    — !navigator.onLine
+//   halted     — _syncDisabled === true (circuit breaker tripped; reload-required)
+//
+// Disjointness contract:
+//   pre-submit (our maps) and post-submit (hasPendingWrites map) are phases
+//   of a write's life. A write is in _syncDebounceTimers until the timer
+//   fires; the fire callback nulls the entry and calls .set(), whose
+//   snapshot.metadata.hasPendingWrites then reflects the submission.
+//   Mutually exclusive at any instant — counts are additive by construction.
+
+// _syncPendingByKey — key = collection name for per-entry listeners (caretickets,
+//   etc.), key = docName for single-doc listeners (tracking, medical, etc.).
+// Value is the last-seen QuerySnapshot/DocumentSnapshot metadata.hasPendingWrites.
+//
+// SEMANTIC NOTE (Cipher PR #4 nit 2, r3 option b): Firestore's
+// QuerySnapshot.metadata.hasPendingWrites is a SINGLE boolean per collection
+// — true iff ANY doc in the collection has a pending write. Counting entries
+// in this map therefore yields the number of COLLECTIONS with one or more
+// pending writes, not the number of individual writes. Five queued meals in
+// `tracking` → badge reads "(1 pending)", not "(5 pending)". The direction
+// is honest (`pending > 0` correctly reports "something is queued") and the
+// copy "(N pending)" reads naturally at the user level. True per-write
+// precision would require iterating snapshot.docChanges() and keying by
+// `${collection}/${doc.id}` in _syncRecordPending — deferred to a phase-2
+// refinement if the count's user-visible granularity becomes a concern.
+var _syncPendingByKey = {};
+var _syncVisibilityListeners = [];       // subscriber callbacks
+var _syncLastVisibility = null;          // last emitted snapshot (for change-detect)
+var _syncVisibilityNotifyTimer = null;   // coalesces burst notifies
+var _syncSnapshotsInSyncUnsub = null;    // Firestore drain listener unsub
+var _syncVisibilityInitDone = false;
+var _syncHasEverFired = false;           // any listener (per-entry/single-doc) first-fired OR onSnapshotsInSync landed
+// (r3) Indicator click is routed through the data-action dispatcher (HR-3);
+// no bespoke document click handler is bound here.
+
+function _syncRecordPending(key, isPending) {
+  var prev = !!_syncPendingByKey[key];
+  if (prev === !!isPending) return;
+  if (isPending) _syncPendingByKey[key] = true;
+  else delete _syncPendingByKey[key];
+  _syncNotifyVisibility();
+}
+
+function _syncCountPreSubmit() {
+  var n = 0;
+  for (var k in _syncDebounceTimers) {
+    if (Object.prototype.hasOwnProperty.call(_syncDebounceTimers, k) && _syncDebounceTimers[k]) n++;
+  }
+  for (var c in _syncPendingFlush) {
+    if (Object.prototype.hasOwnProperty.call(_syncPendingFlush, c) && _syncPendingFlush[c]) n++;
+  }
+  return n;
+}
+
+function _syncCountPostSubmit() {
+  var n = 0;
+  for (var k in _syncPendingByKey) {
+    if (Object.prototype.hasOwnProperty.call(_syncPendingByKey, k) && _syncPendingByKey[k]) n++;
+  }
+  return n;
+}
+
+function syncVisibilityState() {
+  var online = (typeof navigator !== 'undefined' && 'onLine' in navigator) ? navigator.onLine !== false : true;
+  var preSubmit  = _syncCountPreSubmit();
+  var postSubmit = _syncCountPostSubmit();
+  var pending = preSubmit + postSubmit;  // disjoint by construction (see header comment)
+  var state, reason;
+
+  // Evaluation order matters: halted is a local fault independent of network,
+  // so it wins over offline. connecting is only valid before any proof of
+  // Firestore activity; it collapses to syncing the moment pending > 0.
+  if (_syncDisabled) {
+    state = 'halted';     reason = 'sync-disabled';
+  } else if (!online) {
+    state = 'offline';    reason = 'no-network';
+  } else if (!_syncHasEverFired && pending === 0) {
+    state = 'connecting'; reason = 'no-listener-yet';
+  } else if (pending > 0) {
+    state = 'syncing';    reason = 'writes-pending';
+  } else {
+    state = 'online';     reason = 'synced';
+  }
+  return { state: state, pending: pending, reason: reason };
+}
+
+function onSyncVisibilityChange(listener) {
+  if (typeof listener !== 'function') return function(){};
+  _syncVisibilityListeners.push(listener);
+  try { listener(syncVisibilityState()); } catch(e) { console.error('[sync-vis] listener threw on subscribe', e); }
+  return function unsubscribe() {
+    var i = _syncVisibilityListeners.indexOf(listener);
+    if (i >= 0) _syncVisibilityListeners.splice(i, 1);
+  };
+}
+
+function _syncNotifyVisibility() {
+  if (_syncVisibilityNotifyTimer) return;
+  _syncVisibilityNotifyTimer = setTimeout(function() {
+    _syncVisibilityNotifyTimer = null;
+    var snap = syncVisibilityState();
+    var prev = _syncLastVisibility;
+    if (prev && prev.state === snap.state && prev.pending === snap.pending && prev.reason === snap.reason) return;
+    _syncLastVisibility = snap;
+    for (var i = 0; i < _syncVisibilityListeners.length; i++) {
+      try { _syncVisibilityListeners[i](snap); } catch(e) { console.error('[sync-vis] listener threw', e); }
+    }
+  }, 120);
+}
+
+function _syncUpdateStatusIndicator(snap) {
+  var btn = document.getElementById('syncStatus');
+  if (!btn) return;
+  if (btn.hasAttribute('hidden')) btn.removeAttribute('hidden');
+  btn.setAttribute('data-state', snap.state);
+
+  // Copy table — one source of truth per logical state; CSS handles color.
+  // aria-label is the long form so screen readers distinguish the two red
+  // states (offline vs halted) that share --tc-danger.
+  var label, title;
+  switch (snap.state) {
+    case 'connecting':
+      label = 'Connecting…';
+      title = 'Connecting to sync…';
+      break;
+    case 'online':
+      label = 'Synced';
+      title = 'All changes synced.';
+      break;
+    case 'syncing':
+      label = 'Syncing' + (snap.pending > 0 ? ' (' + snap.pending + ')' : '…');
+      title = snap.pending + ' change' + (snap.pending === 1 ? '' : 's') + ' pending sync.';
+      break;
+    case 'offline':
+      label = 'Offline';
+      title = 'Offline — changes will sync when back online.' + (snap.pending > 0 ? ' (' + snap.pending + ' pending)' : '');
+      break;
+    case 'halted':
+      label = 'Sync paused';
+      title = 'Sync paused after errors — tap to reload.' + (snap.pending > 0 ? ' (' + snap.pending + ' pending)' : '');
+      break;
+    default:
+      label = ''; title = '';
+  }
+
+  var labEl = btn.querySelector('.sync-indicator__label');
+  if (labEl) labEl.textContent = label;
+  btn.setAttribute('title', title);
+  btn.setAttribute('aria-label', title);
+
+  // HR-3 / HR-6 (r3): tap-to-reload is routed through the core.js data-action
+  // dispatcher. Only halted is tappable; other states are read-only pills.
+  // Toggle the attribute's presence — the dispatcher gates on its presence,
+  // so other states are non-interactive without any extra guard here.
+  if (snap.state === 'halted') btn.setAttribute('data-action', 'syncReload');
+  else btn.removeAttribute('data-action');
+}
+
+// Dispatcher target for data-action="syncReload". Called from the indicator
+// pill when halted (sl-1-2 r3) and the offline badge's reload button
+// (sl-1-3). Reloading re-bootstraps sync and clears the circuit breaker's
+// in-memory crash count.
+function syncReload() {
+  if (typeof window !== 'undefined' && window.location && window.location.reload) {
+    window.location.reload();
+  }
+}
+
+// ─── Offline Badge Renderer (Phase 1 — sl-1-3) ───
+// Subscribed to the sync-visibility store; shows the persistent badge
+// below the header in offline or halted state only. Copy and pending-count
+// come from the same snapshot the indicator consumes — no separate counter.
+function _syncUpdateOfflineBadge(snap) {
+  var badge = document.getElementById('offlineBadge');
+  if (!badge) return;
+  var visible = snap.state === 'offline' || snap.state === 'halted';
+  if (!visible) {
+    if (!badge.hasAttribute('hidden')) badge.setAttribute('hidden', '');
+    return;
+  }
+  if (badge.hasAttribute('hidden')) badge.removeAttribute('hidden');
+  badge.setAttribute('data-state', snap.state);
+
+  var nPending = snap.pending > 0 ? ' (' + snap.pending + ' pending)' : '';
+  var copy = snap.state === 'halted'
+    ? 'Sync paused after errors — reload to retry.' + nPending
+    : 'Offline — changes will sync when back online.' + nPending;
+
+  var copyEl = badge.querySelector('.offline-badge__copy');
+  if (copyEl) copyEl.textContent = copy;
+
+  // Reload surfaces only in halted (local fault); offline auto-resumes
+  // on network restore, no user action needed.
+  var reloadBtn = badge.querySelector('.offline-badge__action');
+  if (reloadBtn) {
+    if (snap.state === 'halted') reloadBtn.removeAttribute('hidden');
+    else reloadBtn.setAttribute('hidden', '');
+  }
+}
+
+function initSyncVisibility() {
+  if (_syncVisibilityInitDone) return;
+  _syncVisibilityInitDone = true;
+  if (typeof window !== 'undefined') {
+    var bump = function() { _syncNotifyVisibility(); };
+    window.addEventListener('online',  bump);
+    window.addEventListener('offline', bump);
+    try {
+      if (typeof firebase !== 'undefined' && firebase.firestore) {
+        var db = firebase.firestore();
+        if (typeof db.onSnapshotsInSync === 'function') {
+          _syncSnapshotsInSyncUnsub = db.onSnapshotsInSync(function() {
+            // First drain event = definitive proof of Firestore activity.
+            // Collapses 'connecting' to 'online' (or 'syncing' if writes are
+            // queued — ordering in syncVisibilityState handles that).
+            _syncHasEverFired = true;
+            _syncNotifyVisibility();
+          });
+        }
+      }
+    } catch(e) { /* non-fatal — derived store still works from counters */ }
+  }
+  onSyncVisibilityChange(_syncUpdateStatusIndicator);
+  onSyncVisibilityChange(_syncUpdateOfflineBadge);
+}
+
 // ─────────────────────────────────────────
 // START — must be last in concat order
 // ─────────────────────────────────────────
@@ -61943,6 +62342,9 @@ _bugInit();
 if (window.location.search.indexOf('nosync') === -1) {
   try { initFirebase(); } catch(e) { console.error('[sync] initFirebase crashed:', e); }
 }
+// Sync visibility indicator (Phase 1 — sl-1-2). Runs even under ?nosync so
+// the header still reflects true network state from navigator.onLine alone.
+try { initSyncVisibility(); } catch(e) { console.error('[sync-vis] init crashed:', e); }
 </script>
 </body>
 </html>

--- a/tests/e2e/server.mjs
+++ b/tests/e2e/server.mjs
@@ -1,0 +1,46 @@
+// Zero-dep static server for Playwright (CT-10 mitigation: hermetic local serve).
+// Serves the repo root so /index.html, /manifest.json, /icon-*.png, and /lib/firebase-*-compat.js
+// resolve at the same paths the production GitHub Pages deploy uses.
+//
+// Usage: node tests/e2e/server.mjs [port]
+
+import http from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import { extname, join, normalize, resolve } from 'node:path';
+
+const PORT = Number(process.argv[2] || process.env.PORT || 5173);
+const ROOT = resolve(new URL('../..', import.meta.url).pathname);
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js':   'application/javascript; charset=utf-8',
+  '.mjs':  'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.css':  'text/css; charset=utf-8',
+  '.png':  'image/png',
+  '.svg':  'image/svg+xml',
+  '.ico':  'image/x-icon',
+  '.txt':  'text/plain; charset=utf-8',
+};
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
+    const safe = normalize(urlPath).replace(/^(\.\.[/\\])+/, '');
+    let filePath = join(ROOT, safe);
+    if (!filePath.startsWith(ROOT)) { res.writeHead(403); res.end('forbidden'); return; }
+    let s;
+    try { s = await stat(filePath); } catch { res.writeHead(404); res.end('not found'); return; }
+    if (s.isDirectory()) filePath = join(filePath, 'index.html');
+    const buf = await readFile(filePath);
+    const type = MIME[extname(filePath).toLowerCase()] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': type, 'Cache-Control': 'no-store' });
+    res.end(buf);
+  } catch (err) {
+    res.writeHead(500); res.end(String(err));
+  }
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`[sl-arming] static server on http://127.0.0.1:${PORT} (root=${ROOT})`);
+});

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -63,32 +63,91 @@ test.describe('SproutLab smoke (Phase 2 arming)', () => {
     expect(errors, errors.join('\n')).toEqual([]);
   });
 
-  test('2 — all six primary tabs transition without throwing', async ({ page }) => {
+  // Test 2 ships as a triad (R-7) covering both modes of the simple-mode contract.
+  // Cipher r2 surfaced that simple-mode is opt-OUT (split/core.js:3711–3717:
+  // saved !== 'false' → simple-mode added on init), so a fresh browserContext
+  // with empty localStorage gets simple-mode ON, which CSS-hides Insights + Info.
+  // The triad documents the two-mode contract on-record:
+  //   2a — simple-mode default renders four tabs (positive, default state)
+  //   2b — full mode (opt-out) renders all six (positive, opt-out state)
+  //   2c — simple-mode hides exactly Insights + Info, nothing more (regression-guard)
+
+  const SIMPLE_VISIBLE = ['home', 'growth', 'track', 'history'] as const;
+  const SIMPLE_HIDDEN = ['insights', 'info'] as const;
+
+  test('2a — simple-mode default renders four tabs (Insights + Info hidden)', async ({ page }) => {
     await stubChartJs(page);
     const { errors } = attachConsoleCollector(page);
     await page.goto('/index.html?nosync');
     await expect(page.locator('.tab-bar')).toBeVisible();
 
-    // Pre-condition: simple-mode hides Insights + Info tabs. The smoke spec
-    // exercises full mode; assert simple-mode is not active before iterating.
+    // Default: no localStorage entry → simple-mode ON.
+    await expect(page.locator('body')).toHaveClass(/\bsimple-mode\b/);
+
+    for (const tab of SIMPLE_VISIBLE) {
+      const btn = page.locator(`.tab-bar .tab-btn[data-tab="${tab}"]`);
+      await expect(btn, `tab "${tab}" present`).toHaveCount(1);
+      await btn.scrollIntoViewIfNeeded();
+      await expect(btn, `tab "${tab}" visible`).toBeVisible();
+      await btn.click();
+      await expect(btn).toHaveClass(/\bactive\b/);
+      await expect(page.locator(`#tab-${tab}`)).toHaveClass(/\bactive\b/);
+    }
+
+    for (const tab of SIMPLE_HIDDEN) {
+      const btn = page.locator(`.tab-bar .tab-btn[data-tab="${tab}"]`);
+      await expect(btn, `tab "${tab}" present in DOM`).toHaveCount(1);
+      await expect(btn, `tab "${tab}" hidden under simple-mode`).toBeHidden();
+    }
+
+    expect(errors, errors.join('\n')).toEqual([]);
+  });
+
+  test('2b — full mode (simple-mode opted out) renders all six tabs', async ({ page }) => {
+    await stubChartJs(page);
+    const { errors } = attachConsoleCollector(page);
+
+    // Opt out of simple-mode before init runs (split/core.js:3711 reads localStorage
+    // synchronously during initSimpleMode). addInitScript fires before page scripts.
+    await page.addInitScript(() => {
+      try { window.localStorage.setItem('ziva_simple_mode', 'false'); } catch {}
+    });
+
+    await page.goto('/index.html?nosync');
+    await expect(page.locator('.tab-bar')).toBeVisible();
     await expect(page.locator('body')).not.toHaveClass(/\bsimple-mode\b/);
 
     for (const tab of PRIMARY_TABS) {
       const btn = page.locator(`.tab-bar .tab-btn[data-tab="${tab}"]`);
-      await expect(btn, `tab button for "${tab}" present`).toHaveCount(1);
-      // The .tab-bar is overflow-x:auto; tabs to the right of the viewport
-      // report hidden to toBeVisible() at default Desktop Chrome 1280×720
-      // even though they're rendered. Scroll into view first (matches actual
-      // user behaviour on the responsive surface).
+      await expect(btn, `tab "${tab}" present`).toHaveCount(1);
       await btn.scrollIntoViewIfNeeded();
-      await expect(btn, `tab button for "${tab}" visible`).toBeVisible();
+      await expect(btn, `tab "${tab}" visible`).toBeVisible();
       await btn.click();
-      // Active tab gets .active on both the button and the corresponding panel.
       await expect(btn).toHaveClass(/\bactive\b/);
       await expect(page.locator(`#tab-${tab}`)).toHaveClass(/\bactive\b/);
     }
 
     expect(errors, errors.join('\n')).toEqual([]);
+  });
+
+  test('2c — simple-mode hides exactly Insights + Info, nothing else', async ({ page }) => {
+    await stubChartJs(page);
+    await page.goto('/index.html?nosync');
+    await expect(page.locator('body')).toHaveClass(/\bsimple-mode\b/);
+
+    // Regression-guard for the simple-mode contract: if styles.css ever drops
+    // a tab from the .simple-mode hide rule (or adds another), this fails.
+    for (const tab of PRIMARY_TABS) {
+      const btn = page.locator(`.tab-bar .tab-btn[data-tab="${tab}"]`);
+      await expect(btn, `tab "${tab}" present in DOM`).toHaveCount(1);
+      const shouldBeHidden = (SIMPLE_HIDDEN as readonly string[]).includes(tab);
+      if (shouldBeHidden) {
+        await expect(btn, `simple-mode hides "${tab}"`).toBeHidden();
+      } else {
+        await btn.scrollIntoViewIfNeeded();
+        await expect(btn, `simple-mode keeps "${tab}" visible`).toBeVisible();
+      }
+    }
   });
 
   test('3 — manifest.json parses with required PWA keys', async ({ request }) => {

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -10,12 +10,36 @@ const PRIMARY_TABS = ['home', 'growth', 'track', 'insights', 'history', 'info'] 
 
 // Console errors we treat as benign on cold boot. CDN flakes for Chart.js or
 // Firebase background warm-up shouldn't fail the smoke run; province-specific
-// renderer errors must.
+// renderer errors must. Network/cert errors from the sandbox environment are
+// also filtered (CT-10 lesson extended to console layer — bundled chromium may
+// not trust sandbox MITM CAs, producing console errors with no URL substring;
+// Cipher r1 review on PR #9 surfaced this empirically).
 const BENIGN_CONSOLE = [
   /chart\.js/i,
   /firebase/i,
   /favicon/i,
+  /Failed to load resource: net::/i,
+  /ERR_CERT_/i,
 ];
+
+// Hermetic stub for the Chart.js CDN. The smoke spec doesn't exercise chart
+// rendering; stubbing the CDN at the route layer means cert / egress posture
+// in any sandbox cannot produce false-positive console errors. Cipher Path B
+// from the PR #9 r1 review.
+async function stubChartJs(page: Page): Promise<void> {
+  await page.route('https://cdn.jsdelivr.net/**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/javascript; charset=utf-8',
+      body:
+        'window.Chart = class { constructor(){ this.data={datasets:[]}; this.options={}; }' +
+        ' update(){} destroy(){} resize(){} };' +
+        'window.Chart.register = function(){};' +
+        'window.Chart.defaults = { plugins:{} };' +
+        'window.Chart.helpers = {};',
+    }),
+  );
+}
 
 function attachConsoleCollector(page: Page): { errors: string[] } {
   const errors: string[] = [];
@@ -31,6 +55,7 @@ function attachConsoleCollector(page: Page): { errors: string[] } {
 
 test.describe('SproutLab smoke (Phase 2 arming)', () => {
   test('1 — index loads with no fatal console.error or pageerror', async ({ page }) => {
+    await stubChartJs(page);
     const { errors } = attachConsoleCollector(page);
     await page.goto('/index.html?nosync');
     await expect(page.locator('.tab-bar')).toBeVisible();
@@ -39,13 +64,24 @@ test.describe('SproutLab smoke (Phase 2 arming)', () => {
   });
 
   test('2 — all six primary tabs transition without throwing', async ({ page }) => {
+    await stubChartJs(page);
     const { errors } = attachConsoleCollector(page);
     await page.goto('/index.html?nosync');
     await expect(page.locator('.tab-bar')).toBeVisible();
 
+    // Pre-condition: simple-mode hides Insights + Info tabs. The smoke spec
+    // exercises full mode; assert simple-mode is not active before iterating.
+    await expect(page.locator('body')).not.toHaveClass(/\bsimple-mode\b/);
+
     for (const tab of PRIMARY_TABS) {
       const btn = page.locator(`.tab-bar .tab-btn[data-tab="${tab}"]`);
-      await expect(btn, `tab button for "${tab}"`).toBeVisible();
+      await expect(btn, `tab button for "${tab}" present`).toHaveCount(1);
+      // The .tab-bar is overflow-x:auto; tabs to the right of the viewport
+      // report hidden to toBeVisible() at default Desktop Chrome 1280×720
+      // even though they're rendered. Scroll into view first (matches actual
+      // user behaviour on the responsive surface).
+      await btn.scrollIntoViewIfNeeded();
+      await expect(btn, `tab button for "${tab}" visible`).toBeVisible();
       await btn.click();
       // Active tab gets .active on both the button and the corresponding panel.
       await expect(btn).toHaveClass(/\bactive\b/);
@@ -67,6 +103,7 @@ test.describe('SproutLab smoke (Phase 2 arming)', () => {
   });
 
   test('4 — Phase 1 surfaces intact under offline simulation', async ({ page, context }) => {
+    await stubChartJs(page);
     await page.goto('/index.html?nosync');
 
     // syncStatus indicator exists in DOM (sl-1-2). It starts hidden until the

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect, type ConsoleMessage, type Page } from '@playwright/test';
+
+// SproutLab Phase 2 arming — province-specific smoke (R-15: surveyed against actual
+// surface, NOT copied from sep-dashboard or sep-invoicing).
+//
+// `?nosync` skips Firebase init in start.js but keeps initSyncVisibility() running,
+// so the indicator + offline badge still wire up to navigator.onLine.
+
+const PRIMARY_TABS = ['home', 'growth', 'track', 'insights', 'history', 'info'] as const;
+
+// Console errors we treat as benign on cold boot. CDN flakes for Chart.js or
+// Firebase background warm-up shouldn't fail the smoke run; province-specific
+// renderer errors must.
+const BENIGN_CONSOLE = [
+  /chart\.js/i,
+  /firebase/i,
+  /favicon/i,
+];
+
+function attachConsoleCollector(page: Page): { errors: string[] } {
+  const errors: string[] = [];
+  page.on('console', (msg: ConsoleMessage) => {
+    if (msg.type() !== 'error') return;
+    const text = msg.text();
+    if (BENIGN_CONSOLE.some((rx) => rx.test(text))) return;
+    errors.push(text);
+  });
+  page.on('pageerror', (err) => { errors.push(`pageerror: ${err.message}`); });
+  return { errors };
+}
+
+test.describe('SproutLab smoke (Phase 2 arming)', () => {
+  test('1 — index loads with no fatal console.error or pageerror', async ({ page }) => {
+    const { errors } = attachConsoleCollector(page);
+    await page.goto('/index.html?nosync');
+    await expect(page.locator('.tab-bar')).toBeVisible();
+    await page.waitForTimeout(500); // settle: let init() and initSyncVisibility() flush
+    expect(errors, errors.join('\n')).toEqual([]);
+  });
+
+  test('2 — all six primary tabs transition without throwing', async ({ page }) => {
+    const { errors } = attachConsoleCollector(page);
+    await page.goto('/index.html?nosync');
+    await expect(page.locator('.tab-bar')).toBeVisible();
+
+    for (const tab of PRIMARY_TABS) {
+      const btn = page.locator(`.tab-bar .tab-btn[data-tab="${tab}"]`);
+      await expect(btn, `tab button for "${tab}"`).toBeVisible();
+      await btn.click();
+      // Active tab gets .active on both the button and the corresponding panel.
+      await expect(btn).toHaveClass(/\bactive\b/);
+      await expect(page.locator(`#tab-${tab}`)).toHaveClass(/\bactive\b/);
+    }
+
+    expect(errors, errors.join('\n')).toEqual([]);
+  });
+
+  test('3 — manifest.json parses with required PWA keys', async ({ request }) => {
+    const res = await request.get('/manifest.json');
+    expect(res.ok()).toBe(true);
+    const m = await res.json();
+    expect(m).toHaveProperty('name');
+    expect(m).toHaveProperty('start_url');
+    expect(m).toHaveProperty('display');
+    expect(Array.isArray(m.icons)).toBe(true);
+    expect(m.icons.length).toBeGreaterThan(0);
+  });
+
+  test('4 — Phase 1 surfaces intact under offline simulation', async ({ page, context }) => {
+    await page.goto('/index.html?nosync');
+
+    // syncStatus indicator exists in DOM (sl-1-2). It starts hidden until the
+    // visibility store fires its first notify; we assert presence, not visibility.
+    await expect(page.locator('#syncStatus')).toHaveCount(1);
+
+    // Offline badge exists; starts hidden (sl-1-3).
+    const badge = page.locator('#offlineBadge');
+    await expect(badge).toHaveCount(1);
+    await expect(badge).toBeHidden();
+
+    // Flip the network offline at the BrowserContext level. The window
+    // 'offline' event fires; the visibility store transitions to `offline`.
+    await context.setOffline(true);
+    await expect(badge).toBeVisible({ timeout: 5_000 });
+
+    // Restore. Once `onSnapshotsInSync` would have fired (no-op under ?nosync),
+    // the offline branch evaluates to false and the badge hides again. The
+    // sl-1-2/r2 audit defines the transition as ~120 ms debounced.
+    await context.setOffline(false);
+    await expect(badge).toBeHidden({ timeout: 5_000 });
+  });
+});


### PR DESCRIPTION
## sl-2-arming — Playwright + chromium + zero-dep server + 4-criterion smoke

First non-doc PR of Phase 2. Atomic per R-3: arming only, no feature surface. Cleared by Aurelius/Sovereign on PR #7 charter ratification (Option B) and PR #8 cleanup merge.

## Files

| Path | Purpose | Source LOC |
|---|---|---|
| `package.json` | `@playwright/test@1.48.2` dev dep + `pnpm@10.33.0` packageManager + four test scripts | 16 |
| `pnpm-lock.yaml` | Lockfile generated via `pnpm install --lockfile-only` | (generated) |
| `playwright.config.ts` | chromium-only, `retries: 0` (R-6), hermetic `webServer` config, html report off in CI | 33 |
| `tests/e2e/server.mjs` | Zero-dep Node static server serving repo root (CT-10 mitigation) | 46 |
| `tests/e2e/smoke.spec.ts` | Four-criterion province-specific smoke (R-15) | 92 |
| `.gitignore` | Extended from bare `.claude/` to also ignore `node_modules/`, test artifacts, OS-trash patterns | +13 |

**Authored source: 200 LOC.** Right at the R-9 threshold; per Sovereign-this-turn ("LOC budget can be extended if there's a need; quality should not be compromised for LOC"), framed here as appropriately right-sized for the four criteria — splitting would fragment a single arming concern. Builder discretion exercised; disclosed for the record.

## Test criteria (R-15 — surveyed against actual SproutLab surface, not copy-pasted)

| # | Criterion | Selector evidence |
|---|---|---|
| 1 | Index loads with no fatal `console.error` / `pageerror`. Benign Chart.js / Firebase / favicon noise filtered (regex allowlist in spec). | `.tab-bar` visible after `goto('/index.html?nosync')` |
| 2 | All **six** primary tabs transition without throwing. | `.tab-bar .tab-btn[data-tab=...]` for each of `home, growth, track, insights, history, info`; assert `.active` flips on button + matching `#tab-{name}` panel. |
| 3 | `manifest.json` parses; required PWA keys present (`name`, `start_url`, `display`, `icons[]`). | direct `request.get('/manifest.json')` — no browser involvement |
| 4 | Phase 1 surfaces intact under offline simulation. | `#syncStatus` present (sl-1-2); `#offlineBadge` exists, hidden initially, becomes visible under `context.setOffline(true)`, hidden again under `setOffline(false)`. |

## In-flight charter correction (R-15 / D8 disclosure)

Charter PR #7 §4 (PR-2 row) listed "five primary tabs (Home, Diet, Medical, Intelligence, Settings)". The actual surface in `split/template.html:71–90` has **six** primary tabs: `home`, `growth`, `track`, `insights`, `history`, `info`. `Diet` and `Medical` are **sub-panels** under the `track` tab (per `track-sub-panel` markup at `split/template.html:516+`); `Settings` is a sidebar button (`data-action="toggleSettingsSidebar"` at line 90), not a tab.

Spec implements the actual surface (six). The charter's tab list was a Lyra-side scout slip — caught now rather than later, before tests could ossify against a wrong surface. Mirrors D8 / CT-4 ("substance-right-number-wrong" pattern) and D3 (catch → iterate → ratify → next surface) at the charter→arming hop.

No charter r2 — the correction lives here in the spec and PR body. Future readers of the charter find this PR cross-linked.

## Hermetic strategy

- **`?nosync` query param** — `start.js:9–11` skips Firebase init when `window.location.search.indexOf('nosync') !== -1`, but `initSyncVisibility()` still runs (per `start.js:13–15` comment), so test 4's `navigator.onLine` paths exercise faithfully.
- **Chart.js CDN allowed through** — `https://cdn.jsdelivr.net/npm/chart.js` loads from public CDN. Bundled chromium fetches it directly. If a CI environment blocks egress to jsdelivr, test 1 becomes the canary; mitigation would be a route-stub (deferred unless empirically needed). Logged to hygiene queue.
- **No live deploy hits.** CT-10 lesson: `baseURL` is `http://127.0.0.1:5173`, never the GitHub Pages URL. Bundled chromium does not trust sandbox MITM CAs.

## Stress-config plan (per `02-habits.md`)

To run locally before Cipher review:

```
pnpm install
pnpm exec playwright install chromium
pnpm test:e2e               # default workers, single pass
pnpm test:e2e:stress        # default workers, --repeat-each=5 (parallel stress)
pnpm test:e2e:ci            # CI=1 → workers=1, --repeat-each=5 (sequential stress)
```

Cipher independent re-run: same three configs in own sandbox.

**LOC budget note:** I did NOT run the suite myself in this PR — the harness sandbox can generate a lockfile but I have not exercised browser-level execution here. The spec is authored against verified DOM selectors (`split/template.html` lines cited above). Cipher's independent re-run is the verification floor (R-4 expansion / `02-habits.md` "Independent re-run as Cipher's verification floor"). If something flakes on first execution, that's the Builder-pass / Cipher-fail divergence pattern (CT-8) and I will iterate.

## Build Rule check (R-12 application question)

`CLAUDE.md` does not state an explicit "single-file no build tools" rule the way `sep-dashboard`'s `PROJECT_REFERENCE.md` did. The province's Build §says "NEVER use raw cat. Always build.sh." — that rule constrains the *production* build, not dev tooling. `node_modules/`, Playwright artifacts, and `tests/e2e/` are gitignored and never read by `split/build.sh` (which only `cat`s `split/*.{css,html,js}` in a fixed order — verified at `split/build.sh:1–35`).

**No formal R-12 amendment doc shipped.** If Cipher reads this differently, request-changes and I'll add `docs/PWA_BUILD_RULE_AMENDMENT.md` retroactively.

## Hygiene queue (carry-forward; flush at 3–5 per R-10)

1. **Charter §4 PR-2 tab-count slip** — captured in this PR body (D8 / CT-4). Not requeued.
2. **Chart.js CDN egress dependency in tests** — if CI sandbox blocks jsdelivr, route-stub becomes mandatory. Currently latent.
3. **`docs/PWA_BUILD_RULE_AMENDMENT.md`** — not shipped this PR; pending Cipher's call.
4. *(carried from PR #7)* The three D8 catches (precache list 5→8, module count framing, PR-4a D1 framing) fold into PR-3 / PR-4a / PR-4b bodies.
5. *(latent)* `beta/` frozen per Sovereign — no Phase 2 work touches it.

## Acceptance for this PR

- All four spec tests pass at `retries: 0` across single + `--repeat-each=5` + `CI=1 --repeat-each=5` (Cipher's verification floor).
- Cipher independent re-run matches Builder result counts.
- No regressions to Phase 1 surfaces (the spec exists to prevent them going forward).
- Lockfile + `package.json` consistent (`pnpm install --lockfile-only` clean).

## Review path

- **Cipher (advisory):** Independent re-run per R-4. Verify DOM selectors against `split/template.html` (lines cited above). Empirical probe on test 4's offline timing — the 5s timeout should be plenty; if it flakes under stress reps, that's a CT-8-shaped catch for the visibility store's debounce.
- **Aurelius + Sovereign (merge gate):** R-14 structural change (first dev-dependency tree in repo). Aurelius has standing context; Sovereign nod expected.

→ **Cipher:** advisory review + independent re-run requested.
→ **Aurelius / Sovereign:** structural arming — merge gate.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SrMUpJ6h3BCNcYNpsEboMo)_