### PR TITLE
sl-3-pnpm-build (PR-8): pnpm build automation — closes Phase 2 hygiene-queue item 2

### DIFF
--- a/docs/SPROUTLAB_QUICK_REFERENCE.md
+++ b/docs/SPROUTLAB_QUICK_REFERENCE.md
@@ -36,12 +36,12 @@ Output: `sproutlab.html` → copy to `index.html` for GitHub Pages
 ### Deploy Workflow
 
 ```bash
-cd ~/SproutLab/split
-bash build.sh > ../sproutlab.html
-cp ../sproutlab.html ../index.html
-cd ..
+cd ~/SproutLab
+pnpm build              # bumps manifest version + builds sproutlab.html + copies to index.html
 git add -A && git commit -m "message" && git push
 ```
+
+`pnpm build` is the canonical entry; `bash split/build.sh > sproutlab.html && cp sproutlab.html index.html` is the same steps written out (PR-8 wired the script + made build.sh self-locating so `pnpm build` works from any cwd). The manifest version bump runs first (`split/bump-version.mjs`); errors go to stderr so the stdout HTML stream stays clean.
 
 ---
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.04.27-4",
+  "version": "2026.04.27-5",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "sproutlab-tests",
   "version": "0.0.0",
   "private": true,
-  "description": "Dev-only test harness for SproutLab (Playwright + zero-dep static server). Not part of the production build artifact.",
+  "description": "Dev-only test harness + build script for SproutLab. Production artifact (sproutlab.html / index.html) is built by `pnpm build`; this package.json itself is not part of the runtime bundle.",
   "scripts": {
+    "build": "bash split/build.sh > sproutlab.html && cp sproutlab.html index.html",
     "test:e2e": "playwright test",
     "test:e2e:stress": "playwright test --repeat-each=5",
     "test:e2e:ci": "CI=1 playwright test --repeat-each=5",

--- a/split/build.sh
+++ b/split/build.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# PR-8 (sl-3-pnpm-build): cd to script dir so the build can be invoked from any
+# cwd (e.g. `pnpm build` from repo root). Internal cat/node calls remain
+# relative to split/ as before; this just makes the cwd discipline implicit.
+cd "$(dirname "$0")"
 # Phase 2 PR-3: bump manifest.json version (date-stamp + same-day counter)
 # before HTML concat. Errors here go to stderr so stdout (HTML) stays clean.
 node bump-version.mjs ../manifest.json

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -689,3 +689,31 @@ test.describe('Update-detection toast (Phase 2 PR-5)', () => {
     await expect(page.locator('#updateToast'), 'toast reveals under full-mode').toBeVisible();
   });
 });
+
+// ───────────────────────────────────────────────────────────────────────────
+// Build script contract (Phase 3 PR-8)
+// ───────────────────────────────────────────────────────────────────────────
+//
+// PR-8 mechanizes the rebuild step the Phase 1 ship-gap surfaced (manifest
+// `version` advanced but the compiled artifact wasn't regenerated). The
+// `pnpm build` entry runs `bash split/build.sh` (which now self-locates via
+// `cd "$(dirname "$0")"` so it works from any cwd) and copies the result to
+// both sproutlab.html and index.html. This describe block regression-guards
+// the `package.json` "scripts.build" entry against accidental drop. The
+// existing PR-3 manifest-version triad (above, lines ~290–365) covers the
+// build-output side; this just guards the entry point.
+
+test.describe('Build script contract (Phase 3 PR-8)', () => {
+  test('positive — package.json declares a `build` script that invokes split/build.sh', async ({ request }) => {
+    const res = await request.get('/package.json');
+    expect(res.ok(), 'package.json fetchable').toBeTruthy();
+    const pkg = await res.json();
+    expect(pkg.scripts, 'package.json has scripts block').toBeTruthy();
+    expect(pkg.scripts.build, 'scripts.build entry present').toBeTruthy();
+    // Substring match — exact wording can iterate (e.g. future prepush hook),
+    // but the entry must drive split/build.sh, not bypass it.
+    expect(pkg.scripts.build, 'build script invokes split/build.sh').toContain('split/build.sh');
+    expect(pkg.scripts.build, 'build script writes sproutlab.html').toContain('sproutlab.html');
+    expect(pkg.scripts.build, 'build script copies to index.html').toContain('index.html');
+  });
+});


### PR DESCRIPTION
**PR-8 of Phase 3 sequence — `pnpm build` automation.** Closes Phase 2 hygiene-queue item 2 (Cipher's "land-before-PR-9" recommendation). Cut off `main@978766d` (post-charter-merge) per R-2.

Sovereign-ratified at charter merge (#15, ruling 2): "PR-8 (pnpm build automation) — fold-in. Lands between charter and PR-9. Cipher's Phase 2 close note honored: mechanize rebuild before feature work to narrow Phase-1-style ship-gap recurrence window."

---

## Changes (5 files, +39 / -6)

| File | Change |
|---|---|
| `split/build.sh` | `cd "$(dirname "$0")"` at top — script self-locates so `pnpm build` works from repo root. Internal `cat`/`node` calls remain relative to `split/` as before. |
| `package.json` | Add `"build": "bash split/build.sh > sproutlab.html && cp sproutlab.html index.html"`. Description updated to reflect dual role (test harness + build entry). |
| `docs/SPROUTLAB_QUICK_REFERENCE.md` | Deploy Workflow block: three-command sequence → `pnpm build` + git commit/push. |
| `tests/e2e/smoke.spec.ts` | New `Build script contract (Phase 3 PR-8)` describe block with one regression-guard test (`scripts.build` exists; substring-matches `split/build.sh` + `sproutlab.html` + `index.html`). Substring discipline so the entry can iterate (e.g. future `prepush` hook) without test churn but cannot bypass `split/build.sh`. |
| `manifest.json` | `2026.04.27-4` → `2026.04.27-5` (single bump per PR; produced by the verification build run). |

---

## R-4 floor (Cipher-mandated)

| Stage | Result |
|---|---|
| Single-pass | **23/23** (25.3s) |
| Parallel `--repeat-each=5` | **115/115** (1.9m) |
| `CI=1` sequential `--repeat-each=5` | **115/115** (2.8m) |
| **Total** | **253 stable executions, 0 flakes** at `retries: 0` |

The existing PR-3 manifest-version triad (smoke.spec.ts:290–365) re-exercises the build-output side; verified passing on this branch.

---

## Byte-identity verification (instance 6 of the doctrine)

| State | sproutlab.html md5 | index.html md5 | manifest version |
|---|---|---|---|
| Pre-build | `6700fe8b...` | `6700fe8b...` | `2026.04.27-4` |
| Post-build | `6700fe8b...` | `6700fe8b...` | `2026.04.27-5` |

HTML md5 stable across the build (manifest version lives in `manifest.json`, not embedded in HTML; runtime-fetched by `displayAppVersion`). Two output paths, one stream — both written from the same `bash split/build.sh` stdout via `cp` after the redirect.

---

## Cipher's four build-phase surfacings — carry forward to PR-9, NOT addressed here

Per the charter merge commit, Cipher's surfacings sit at the PR-9 author phase. Logging on-record so PR-9 inherits them cleanly:

1. **`medChecks` belongs in `SYNC_RENDER_DEPS`** — `KEYS.medChecks` is single-doc (`sync.js:134`); needs its renderer dependency declared.
2. **`SYNC_RENDER_DEPS` shape permits `{ global: null, renderers: [...] }`** for non-globaled keys (`vaccBooked`, `episodes` family); writer-shim case-table covers globaled keys; dispatch-only path for `null`.
3. **Per-entry attribution composition** — aggregate / generic / count-only branches per `__sync_updatedBy` uniformity.
4. **Per-entry strip cross-reference** — `sync.js:862–868` (per-entry handler) parallel to single-doc `:938`.

---

## Files explicitly NOT touched in PR-8

- `split/sync.js` (Phase 3 feature surface; PR-9).
- `core.js`, `medical.js`, `intelligence.js` (renderer surfaces; PR-9).
- `node_modules/`, `test-results/`, `playwright-report/` (gitignored per existing `.gitignore`).

---

## Rulings requested

- **Cipher:** advisory review (relay-only). R-4 floor numbers above; recommend independent rerun for byte-identity confirmation.
- **Aurelius / Sovereign:** R-14 — touches build infra → Sovereign's nod requested. Squash-merge on ratification keeps PR-9 cleanly cut from main@<post-merge-sha>.

→ **Cipher:** advisory review requested.
→ **Aurelius / Sovereign:** ratify; merge gate on Sovereign nod.

— Lyra (The Weaver)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTVgKBRHzPRzYHP5tTkpcK)_