### PR TITLE
sl-3-per-entry-attribution (PR-19.5): per-entry __sync_updatedBy persistence + history-tab attribution

### DIFF
--- a/index.html
+++ b/index.html
@@ -17528,6 +17528,19 @@ function escHtml(s) {
 }
 function normVacc(n) { return n.toLowerCase().replace(/[^a-z0-9]/g, ''); }
 
+// _renderAttribution — PR-19.5 (per-entry attribution). Returns an HTML
+// fragment for the "by Bhavna" tagline shown on history-tab rows. Reads
+// __sync_updatedBy from the entry (preserved through the listener strip
+// per PR-19.5's modified per-entry strip + the stamp-on-flush in
+// _syncFlushSingleDoc). Returns empty string for legacy entries lacking
+// the stamp — graceful degradation. HR-4 escHtml at the boundary.
+function _renderAttribution(entry) {
+  if (!entry || typeof entry !== 'object') return '';
+  var ub = entry.__sync_updatedBy;
+  if (!ub || !ub.name) return '';
+  return '<div class="entry-attribution t-sub-light fs-xs">by ' + escHtml(ub.name) + '</div>';
+}
+
 // ─────────────────────────────────────────
 // SHARED UTILITIES (migrated from feature modules → core)
 // ─────────────────────────────────────────
@@ -21578,6 +21591,7 @@ function renderVaccHistory() {
               <div class="t-title fw-600">${escHtml(v.name)}</div>
               <div style="font-size:var(--fs-sm);color:var(--tc-lav);">${formatDate(v.date)} · ${ageAtVacc}</div>
               ${dateFlag}
+              ${_renderAttribution(v)}
             </div>
             <button data-action="openVaccEditModal" data-stop="1" data-arg="${realIdx}" class="btn-icon-edit" aria-label="Edit date">Edit</button>
             ${info ? '<span style="font-size:var(--icon-xs);color:var(--light);">ⓘ</span>' : ''}
@@ -25547,6 +25561,7 @@ function renderMilestoneHistory() {
         <div class="flex-1-min">
           <div class="t-title fw-600">${escHtml(m.text)}${m.advanced ? ' <svg class="zi"><use href="#zi-star"/></svg>' : ''}</div>
           <div style="font-size:var(--fs-sm);color:${cm.textColor};">${statusText}</div>
+          ${_renderAttribution(m)}
         </div>
       </div>`;
   });
@@ -26175,13 +26190,14 @@ function renderPoopHistoryPreview() {
       if (p.blood) flags.push(zi('drop'));
       if (p.mucus) flags.push(zi('drop'));
       const note = p.notes ? ` · ${escHtml(p.notes)}` : '';
-      return `<div style="display:flex;align-items:center;gap:var(--sp-8);padding:4px 0;">
+      return `<div style="display:flex;align-items:center;gap:var(--sp-8);padding:4px 0;flex-wrap:wrap;">
         <span class="poop-color-circle" style="background:${col.hex};"></span>
         <span style="font-size:var(--fs-base);">${formatTimeShort(p.time)}</span>
         <span class="poop-badge badge-amber" >${col.label}</span>
         <span class="poop-badge badge-amber" >${con.label}</span>
         ${flags.map(f => `<span class="t-sm">${f}</span>`).join('')}
         <span class="t-sub">${note}</span>
+        ${_renderAttribution(p)}
       </div>`;
     }).join('');
     return `<div style="padding:8px 0;border-bottom:1px solid var(--amber-light);">
@@ -26468,6 +26484,7 @@ function renderNotesHistory() {
               <span class="badge-sm" style="background:var(--glass-strong);margin-left:4px;">${cat}</span>
               ${n.done ? ' · Completed' : ''}
             </div>
+            ${_renderAttribution(n)}
           </div>
         </div>
       </div>`;
@@ -34443,6 +34460,7 @@ function renderGrowthHistory() {
         <div class="flex-1-min">
           <div class="t-title fw-600">${formatDate(r.date)} · ${ageAtDate(r.date)}</div>
           <div class="t-sub">${parts.join(' · ')}</div>
+          ${_renderAttribution(r)}
         </div>
         <button class="del-btn" data-action="deleteGrowth" data-arg="${origIdx}" aria-label="Delete entry">×</button>
       </div>`;
@@ -38826,11 +38844,12 @@ function renderSleepHistoryPreview() {
       const icon = s.type === 'night' ? zi('moon') : zi('zzz');
       const qual = s.type === 'night' ? getSleepScoreBadge(s) : '';
       const note = s.notes ? `<span class="t-sub"> · ${escHtml(s.notes)}</span>` : '';
-      return `<div style="display:flex;align-items:center;gap:var(--sp-8);padding:4px 0;">
+      return `<div style="display:flex;align-items:center;gap:var(--sp-8);padding:4px 0;flex-wrap:wrap;">
         <span>${icon}</span>
         <span style="font-size:var(--fs-base);">${formatTimeShort(s.bedtime)} → ${formatTimeShort(s.wakeTime)}</span>
         <span class="sleep-entry-duration">${dur.h}h ${dur.m}m</span>
         ${qual}${note}
+        ${_renderAttribution(s)}
       </div>`;
     }).join('');
     return `<div style="padding:8px 0;border-bottom:1px solid var(--indigo-light);">
@@ -61896,6 +61915,36 @@ function _syncDebounceSingleDoc(hRef, collection, key, oldVal, newVal) {
   if (!wasQueued && typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
 }
 
+// _syncStampUnattributed — PR-19.5 (per-entry attribution). At flush time,
+// walk each array-shape value and stamp entries lacking __sync_updatedBy
+// with the current writer's attribution. The stamp travels to Firestore
+// and echoes back via the listener to all devices (including the writer's
+// own device, where it lands in localStorage on echo and is picked up by
+// _syncDispatchRender's rehydrate). Per-entry attribution is the data-shape
+// change (vs. PR-19's per-key sidecar) the Sovereign-side production
+// verification surfaced as missing on the history-tab surface.
+//
+// Scope (PR-19.5): array-shape values only (growth, sleep, poop, vacc,
+// meds, visits, milestones, notes, doctors, episodes, careTickets). Object-
+// keyed shapes (feeding, activityLog, medChecks) are Phase 4 carry-forward;
+// stamping a date-keyed sub-object requires a wrapper-shape decision that
+// affects every renderer reading those fields.
+function _syncStampUnattributed(value, writer) {
+  if (!Array.isArray(value)) return value;
+  if (!writer || (!writer.uid && !writer.name)) return value;
+  var changed = false;
+  var stamped = value.map(function(entry) {
+    if (entry && typeof entry === 'object' && !Array.isArray(entry) && !entry.__sync_updatedBy) {
+      changed = true;
+      return Object.assign({}, entry, {
+        __sync_updatedBy: { uid: writer.uid || null, name: writer.name || null },
+      });
+    }
+    return entry;
+  });
+  return changed ? stamped : value;
+}
+
 function _syncFlushSingleDoc(hRef, collection) {
   // Gather all localStorage KEYS that map to this collection
   var keysForCol = _syncCollectionToKeys[collection];
@@ -61917,6 +61966,26 @@ function _syncFlushSingleDoc(hRef, collection) {
   var current = {};
   for (var i = 0; i < keysForCol.length; i++) {
     current[keysForCol[i]] = load(keysForCol[i], null);
+  }
+
+  // PR-19.5 (per-entry attribution) — stamp un-attributed array entries
+  // with the current writer's identity before computing the diff. New
+  // local entries (lacking the stamp) thereby travel to Firestore with
+  // attribution; existing stamped entries (from prior remote writes or
+  // prior local stamps) are preserved. The stamp echoes back via the
+  // listener and lands in localStorage during the standard receive path,
+  // closing the loop without writing-back into localStorage from this
+  // function (which would be a layer-violation; flush operates on the
+  // outbound side, the listener handles the inbound side).
+  var writer = _syncUser ? {
+    uid:  _syncUser.uid || null,
+    name: _syncUser.displayName || 'Parent',
+  } : null;
+  if (writer) {
+    for (var si = 0; si < keysForCol.length; si++) {
+      var sk = keysForCol[si];
+      current[sk] = _syncStampUnattributed(current[sk], writer);
+    }
   }
 
   // Build combined shadow (what Firestore last knew)
@@ -62055,13 +62124,20 @@ function _syncHandlePerEntrySnapshot(collection, snapshot) {
     var entries = [];
     snapshot.forEach(function(doc) {
       var data = doc.data();
-      // Strip __sync_* metadata before storing locally (parallel to single-doc
-      // strip at the snapshot handler below; Cipher #4 cross-reference)
+      // PR-19.5 (per-entry attribution) — preserve __sync_updatedBy and
+      // __sync_syncedAt on each entry so the history-tab renderer can show
+      // "by Bhavna" per row. Strip the rest of __sync_* (e.g. __sync_createdBy
+      // is duplicative for our needs at this scope; can be added later).
+      // Parallel to single-doc handler at the snapshot strip below; Cipher #4
+      // cross-reference. The non-stripped attribution survives roundtrips
+      // (next flush's set+merge writes a fresh __sync_updatedBy at doc/entry
+      // level; Firestore overwrites cleanly).
       var clean = {};
       var keys = Object.keys(data);
       for (var j = 0; j < keys.length; j++) {
-        if (keys[j].indexOf('__sync_') !== 0) {
-          clean[keys[j]] = data[keys[j]];
+        var k = keys[j];
+        if (k.indexOf('__sync_') !== 0 || k === '__sync_updatedBy' || k === '__sync_syncedAt') {
+          clean[k] = data[k];
         }
       }
       // Ensure id field matches doc ID

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.04.28-2",
+  "version": "2026.04.29-1",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -2226,6 +2226,19 @@ function escHtml(s) {
 }
 function normVacc(n) { return n.toLowerCase().replace(/[^a-z0-9]/g, ''); }
 
+// _renderAttribution — PR-19.5 (per-entry attribution). Returns an HTML
+// fragment for the "by Bhavna" tagline shown on history-tab rows. Reads
+// __sync_updatedBy from the entry (preserved through the listener strip
+// per PR-19.5's modified per-entry strip + the stamp-on-flush in
+// _syncFlushSingleDoc). Returns empty string for legacy entries lacking
+// the stamp — graceful degradation. HR-4 escHtml at the boundary.
+function _renderAttribution(entry) {
+  if (!entry || typeof entry !== 'object') return '';
+  var ub = entry.__sync_updatedBy;
+  if (!ub || !ub.name) return '';
+  return '<div class="entry-attribution t-sub-light fs-xs">by ' + escHtml(ub.name) + '</div>';
+}
+
 // ─────────────────────────────────────────
 // SHARED UTILITIES (migrated from feature modules → core)
 // ─────────────────────────────────────────

--- a/split/home.js
+++ b/split/home.js
@@ -1395,6 +1395,7 @@ function renderVaccHistory() {
               <div class="t-title fw-600">${escHtml(v.name)}</div>
               <div style="font-size:var(--fs-sm);color:var(--tc-lav);">${formatDate(v.date)} · ${ageAtVacc}</div>
               ${dateFlag}
+              ${_renderAttribution(v)}
             </div>
             <button data-action="openVaccEditModal" data-stop="1" data-arg="${realIdx}" class="btn-icon-edit" aria-label="Edit date">Edit</button>
             ${info ? '<span style="font-size:var(--icon-xs);color:var(--light);">ⓘ</span>' : ''}
@@ -5364,6 +5365,7 @@ function renderMilestoneHistory() {
         <div class="flex-1-min">
           <div class="t-title fw-600">${escHtml(m.text)}${m.advanced ? ' <svg class="zi"><use href="#zi-star"/></svg>' : ''}</div>
           <div style="font-size:var(--fs-sm);color:${cm.textColor};">${statusText}</div>
+          ${_renderAttribution(m)}
         </div>
       </div>`;
   });
@@ -5992,13 +5994,14 @@ function renderPoopHistoryPreview() {
       if (p.blood) flags.push(zi('drop'));
       if (p.mucus) flags.push(zi('drop'));
       const note = p.notes ? ` · ${escHtml(p.notes)}` : '';
-      return `<div style="display:flex;align-items:center;gap:var(--sp-8);padding:4px 0;">
+      return `<div style="display:flex;align-items:center;gap:var(--sp-8);padding:4px 0;flex-wrap:wrap;">
         <span class="poop-color-circle" style="background:${col.hex};"></span>
         <span style="font-size:var(--fs-base);">${formatTimeShort(p.time)}</span>
         <span class="poop-badge badge-amber" >${col.label}</span>
         <span class="poop-badge badge-amber" >${con.label}</span>
         ${flags.map(f => `<span class="t-sm">${f}</span>`).join('')}
         <span class="t-sub">${note}</span>
+        ${_renderAttribution(p)}
       </div>`;
     }).join('');
     return `<div style="padding:8px 0;border-bottom:1px solid var(--amber-light);">
@@ -6285,6 +6288,7 @@ function renderNotesHistory() {
               <span class="badge-sm" style="background:var(--glass-strong);margin-left:4px;">${cat}</span>
               ${n.done ? ' · Completed' : ''}
             </div>
+            ${_renderAttribution(n)}
           </div>
         </div>
       </div>`;

--- a/split/medical.js
+++ b/split/medical.js
@@ -993,6 +993,7 @@ function renderGrowthHistory() {
         <div class="flex-1-min">
           <div class="t-title fw-600">${formatDate(r.date)} · ${ageAtDate(r.date)}</div>
           <div class="t-sub">${parts.join(' · ')}</div>
+          ${_renderAttribution(r)}
         </div>
         <button class="del-btn" data-action="deleteGrowth" data-arg="${origIdx}" aria-label="Delete entry">×</button>
       </div>`;
@@ -5376,11 +5377,12 @@ function renderSleepHistoryPreview() {
       const icon = s.type === 'night' ? zi('moon') : zi('zzz');
       const qual = s.type === 'night' ? getSleepScoreBadge(s) : '';
       const note = s.notes ? `<span class="t-sub"> · ${escHtml(s.notes)}</span>` : '';
-      return `<div style="display:flex;align-items:center;gap:var(--sp-8);padding:4px 0;">
+      return `<div style="display:flex;align-items:center;gap:var(--sp-8);padding:4px 0;flex-wrap:wrap;">
         <span>${icon}</span>
         <span style="font-size:var(--fs-base);">${formatTimeShort(s.bedtime)} → ${formatTimeShort(s.wakeTime)}</span>
         <span class="sleep-entry-duration">${dur.h}h ${dur.m}m</span>
         ${qual}${note}
+        ${_renderAttribution(s)}
       </div>`;
     }).join('');
     return `<div style="padding:8px 0;border-bottom:1px solid var(--indigo-light);">

--- a/split/sync.js
+++ b/split/sync.js
@@ -940,6 +940,36 @@ function _syncDebounceSingleDoc(hRef, collection, key, oldVal, newVal) {
   if (!wasQueued && typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
 }
 
+// _syncStampUnattributed — PR-19.5 (per-entry attribution). At flush time,
+// walk each array-shape value and stamp entries lacking __sync_updatedBy
+// with the current writer's attribution. The stamp travels to Firestore
+// and echoes back via the listener to all devices (including the writer's
+// own device, where it lands in localStorage on echo and is picked up by
+// _syncDispatchRender's rehydrate). Per-entry attribution is the data-shape
+// change (vs. PR-19's per-key sidecar) the Sovereign-side production
+// verification surfaced as missing on the history-tab surface.
+//
+// Scope (PR-19.5): array-shape values only (growth, sleep, poop, vacc,
+// meds, visits, milestones, notes, doctors, episodes, careTickets). Object-
+// keyed shapes (feeding, activityLog, medChecks) are Phase 4 carry-forward;
+// stamping a date-keyed sub-object requires a wrapper-shape decision that
+// affects every renderer reading those fields.
+function _syncStampUnattributed(value, writer) {
+  if (!Array.isArray(value)) return value;
+  if (!writer || (!writer.uid && !writer.name)) return value;
+  var changed = false;
+  var stamped = value.map(function(entry) {
+    if (entry && typeof entry === 'object' && !Array.isArray(entry) && !entry.__sync_updatedBy) {
+      changed = true;
+      return Object.assign({}, entry, {
+        __sync_updatedBy: { uid: writer.uid || null, name: writer.name || null },
+      });
+    }
+    return entry;
+  });
+  return changed ? stamped : value;
+}
+
 function _syncFlushSingleDoc(hRef, collection) {
   // Gather all localStorage KEYS that map to this collection
   var keysForCol = _syncCollectionToKeys[collection];
@@ -961,6 +991,26 @@ function _syncFlushSingleDoc(hRef, collection) {
   var current = {};
   for (var i = 0; i < keysForCol.length; i++) {
     current[keysForCol[i]] = load(keysForCol[i], null);
+  }
+
+  // PR-19.5 (per-entry attribution) — stamp un-attributed array entries
+  // with the current writer's identity before computing the diff. New
+  // local entries (lacking the stamp) thereby travel to Firestore with
+  // attribution; existing stamped entries (from prior remote writes or
+  // prior local stamps) are preserved. The stamp echoes back via the
+  // listener and lands in localStorage during the standard receive path,
+  // closing the loop without writing-back into localStorage from this
+  // function (which would be a layer-violation; flush operates on the
+  // outbound side, the listener handles the inbound side).
+  var writer = _syncUser ? {
+    uid:  _syncUser.uid || null,
+    name: _syncUser.displayName || 'Parent',
+  } : null;
+  if (writer) {
+    for (var si = 0; si < keysForCol.length; si++) {
+      var sk = keysForCol[si];
+      current[sk] = _syncStampUnattributed(current[sk], writer);
+    }
   }
 
   // Build combined shadow (what Firestore last knew)
@@ -1099,13 +1149,20 @@ function _syncHandlePerEntrySnapshot(collection, snapshot) {
     var entries = [];
     snapshot.forEach(function(doc) {
       var data = doc.data();
-      // Strip __sync_* metadata before storing locally (parallel to single-doc
-      // strip at the snapshot handler below; Cipher #4 cross-reference)
+      // PR-19.5 (per-entry attribution) — preserve __sync_updatedBy and
+      // __sync_syncedAt on each entry so the history-tab renderer can show
+      // "by Bhavna" per row. Strip the rest of __sync_* (e.g. __sync_createdBy
+      // is duplicative for our needs at this scope; can be added later).
+      // Parallel to single-doc handler at the snapshot strip below; Cipher #4
+      // cross-reference. The non-stripped attribution survives roundtrips
+      // (next flush's set+merge writes a fresh __sync_updatedBy at doc/entry
+      // level; Firestore overwrites cleanly).
       var clean = {};
       var keys = Object.keys(data);
       for (var j = 0; j < keys.length; j++) {
-        if (keys[j].indexOf('__sync_') !== 0) {
-          clean[keys[j]] = data[keys[j]];
+        var k = keys[j];
+        if (k.indexOf('__sync_') !== 0 || k === '__sync_updatedBy' || k === '__sync_syncedAt') {
+          clean[k] = data[k];
         }
       }
       // Ensure id field matches doc ID

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -17528,6 +17528,19 @@ function escHtml(s) {
 }
 function normVacc(n) { return n.toLowerCase().replace(/[^a-z0-9]/g, ''); }
 
+// _renderAttribution — PR-19.5 (per-entry attribution). Returns an HTML
+// fragment for the "by Bhavna" tagline shown on history-tab rows. Reads
+// __sync_updatedBy from the entry (preserved through the listener strip
+// per PR-19.5's modified per-entry strip + the stamp-on-flush in
+// _syncFlushSingleDoc). Returns empty string for legacy entries lacking
+// the stamp — graceful degradation. HR-4 escHtml at the boundary.
+function _renderAttribution(entry) {
+  if (!entry || typeof entry !== 'object') return '';
+  var ub = entry.__sync_updatedBy;
+  if (!ub || !ub.name) return '';
+  return '<div class="entry-attribution t-sub-light fs-xs">by ' + escHtml(ub.name) + '</div>';
+}
+
 // ─────────────────────────────────────────
 // SHARED UTILITIES (migrated from feature modules → core)
 // ─────────────────────────────────────────
@@ -21578,6 +21591,7 @@ function renderVaccHistory() {
               <div class="t-title fw-600">${escHtml(v.name)}</div>
               <div style="font-size:var(--fs-sm);color:var(--tc-lav);">${formatDate(v.date)} · ${ageAtVacc}</div>
               ${dateFlag}
+              ${_renderAttribution(v)}
             </div>
             <button data-action="openVaccEditModal" data-stop="1" data-arg="${realIdx}" class="btn-icon-edit" aria-label="Edit date">Edit</button>
             ${info ? '<span style="font-size:var(--icon-xs);color:var(--light);">ⓘ</span>' : ''}
@@ -25547,6 +25561,7 @@ function renderMilestoneHistory() {
         <div class="flex-1-min">
           <div class="t-title fw-600">${escHtml(m.text)}${m.advanced ? ' <svg class="zi"><use href="#zi-star"/></svg>' : ''}</div>
           <div style="font-size:var(--fs-sm);color:${cm.textColor};">${statusText}</div>
+          ${_renderAttribution(m)}
         </div>
       </div>`;
   });
@@ -26175,13 +26190,14 @@ function renderPoopHistoryPreview() {
       if (p.blood) flags.push(zi('drop'));
       if (p.mucus) flags.push(zi('drop'));
       const note = p.notes ? ` · ${escHtml(p.notes)}` : '';
-      return `<div style="display:flex;align-items:center;gap:var(--sp-8);padding:4px 0;">
+      return `<div style="display:flex;align-items:center;gap:var(--sp-8);padding:4px 0;flex-wrap:wrap;">
         <span class="poop-color-circle" style="background:${col.hex};"></span>
         <span style="font-size:var(--fs-base);">${formatTimeShort(p.time)}</span>
         <span class="poop-badge badge-amber" >${col.label}</span>
         <span class="poop-badge badge-amber" >${con.label}</span>
         ${flags.map(f => `<span class="t-sm">${f}</span>`).join('')}
         <span class="t-sub">${note}</span>
+        ${_renderAttribution(p)}
       </div>`;
     }).join('');
     return `<div style="padding:8px 0;border-bottom:1px solid var(--amber-light);">
@@ -26468,6 +26484,7 @@ function renderNotesHistory() {
               <span class="badge-sm" style="background:var(--glass-strong);margin-left:4px;">${cat}</span>
               ${n.done ? ' · Completed' : ''}
             </div>
+            ${_renderAttribution(n)}
           </div>
         </div>
       </div>`;
@@ -34443,6 +34460,7 @@ function renderGrowthHistory() {
         <div class="flex-1-min">
           <div class="t-title fw-600">${formatDate(r.date)} · ${ageAtDate(r.date)}</div>
           <div class="t-sub">${parts.join(' · ')}</div>
+          ${_renderAttribution(r)}
         </div>
         <button class="del-btn" data-action="deleteGrowth" data-arg="${origIdx}" aria-label="Delete entry">×</button>
       </div>`;
@@ -38826,11 +38844,12 @@ function renderSleepHistoryPreview() {
       const icon = s.type === 'night' ? zi('moon') : zi('zzz');
       const qual = s.type === 'night' ? getSleepScoreBadge(s) : '';
       const note = s.notes ? `<span class="t-sub"> · ${escHtml(s.notes)}</span>` : '';
-      return `<div style="display:flex;align-items:center;gap:var(--sp-8);padding:4px 0;">
+      return `<div style="display:flex;align-items:center;gap:var(--sp-8);padding:4px 0;flex-wrap:wrap;">
         <span>${icon}</span>
         <span style="font-size:var(--fs-base);">${formatTimeShort(s.bedtime)} → ${formatTimeShort(s.wakeTime)}</span>
         <span class="sleep-entry-duration">${dur.h}h ${dur.m}m</span>
         ${qual}${note}
+        ${_renderAttribution(s)}
       </div>`;
     }).join('');
     return `<div style="padding:8px 0;border-bottom:1px solid var(--indigo-light);">
@@ -61896,6 +61915,36 @@ function _syncDebounceSingleDoc(hRef, collection, key, oldVal, newVal) {
   if (!wasQueued && typeof _syncNotifyVisibility === 'function') _syncNotifyVisibility();
 }
 
+// _syncStampUnattributed — PR-19.5 (per-entry attribution). At flush time,
+// walk each array-shape value and stamp entries lacking __sync_updatedBy
+// with the current writer's attribution. The stamp travels to Firestore
+// and echoes back via the listener to all devices (including the writer's
+// own device, where it lands in localStorage on echo and is picked up by
+// _syncDispatchRender's rehydrate). Per-entry attribution is the data-shape
+// change (vs. PR-19's per-key sidecar) the Sovereign-side production
+// verification surfaced as missing on the history-tab surface.
+//
+// Scope (PR-19.5): array-shape values only (growth, sleep, poop, vacc,
+// meds, visits, milestones, notes, doctors, episodes, careTickets). Object-
+// keyed shapes (feeding, activityLog, medChecks) are Phase 4 carry-forward;
+// stamping a date-keyed sub-object requires a wrapper-shape decision that
+// affects every renderer reading those fields.
+function _syncStampUnattributed(value, writer) {
+  if (!Array.isArray(value)) return value;
+  if (!writer || (!writer.uid && !writer.name)) return value;
+  var changed = false;
+  var stamped = value.map(function(entry) {
+    if (entry && typeof entry === 'object' && !Array.isArray(entry) && !entry.__sync_updatedBy) {
+      changed = true;
+      return Object.assign({}, entry, {
+        __sync_updatedBy: { uid: writer.uid || null, name: writer.name || null },
+      });
+    }
+    return entry;
+  });
+  return changed ? stamped : value;
+}
+
 function _syncFlushSingleDoc(hRef, collection) {
   // Gather all localStorage KEYS that map to this collection
   var keysForCol = _syncCollectionToKeys[collection];
@@ -61917,6 +61966,26 @@ function _syncFlushSingleDoc(hRef, collection) {
   var current = {};
   for (var i = 0; i < keysForCol.length; i++) {
     current[keysForCol[i]] = load(keysForCol[i], null);
+  }
+
+  // PR-19.5 (per-entry attribution) — stamp un-attributed array entries
+  // with the current writer's identity before computing the diff. New
+  // local entries (lacking the stamp) thereby travel to Firestore with
+  // attribution; existing stamped entries (from prior remote writes or
+  // prior local stamps) are preserved. The stamp echoes back via the
+  // listener and lands in localStorage during the standard receive path,
+  // closing the loop without writing-back into localStorage from this
+  // function (which would be a layer-violation; flush operates on the
+  // outbound side, the listener handles the inbound side).
+  var writer = _syncUser ? {
+    uid:  _syncUser.uid || null,
+    name: _syncUser.displayName || 'Parent',
+  } : null;
+  if (writer) {
+    for (var si = 0; si < keysForCol.length; si++) {
+      var sk = keysForCol[si];
+      current[sk] = _syncStampUnattributed(current[sk], writer);
+    }
   }
 
   // Build combined shadow (what Firestore last knew)
@@ -62055,13 +62124,20 @@ function _syncHandlePerEntrySnapshot(collection, snapshot) {
     var entries = [];
     snapshot.forEach(function(doc) {
       var data = doc.data();
-      // Strip __sync_* metadata before storing locally (parallel to single-doc
-      // strip at the snapshot handler below; Cipher #4 cross-reference)
+      // PR-19.5 (per-entry attribution) — preserve __sync_updatedBy and
+      // __sync_syncedAt on each entry so the history-tab renderer can show
+      // "by Bhavna" per row. Strip the rest of __sync_* (e.g. __sync_createdBy
+      // is duplicative for our needs at this scope; can be added later).
+      // Parallel to single-doc handler at the snapshot strip below; Cipher #4
+      // cross-reference. The non-stripped attribution survives roundtrips
+      // (next flush's set+merge writes a fresh __sync_updatedBy at doc/entry
+      // level; Firestore overwrites cleanly).
       var clean = {};
       var keys = Object.keys(data);
       for (var j = 0; j < keys.length; j++) {
-        if (keys[j].indexOf('__sync_') !== 0) {
-          clean[keys[j]] = data[keys[j]];
+        var k = keys[j];
+        if (k.indexOf('__sync_') !== 0 || k === '__sync_updatedBy' || k === '__sync_syncedAt') {
+          clean[k] = data[k];
         }
       }
       // Ensure id field matches doc ID

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1474,3 +1474,161 @@ test.describe('Persistent attribution sidecar (Phase 3 PR-19)', () => {
     expect(final['ziva_feeding'].uid, 'feeding uid is rishabh').toBe('rishabh-uid');
   });
 });
+
+// ───────────────────────────────────────────────────────────────────────────
+// PR-19.5 — Per-entry attribution (history-tab surface)
+// ───────────────────────────────────────────────────────────────────────────
+//
+// Sovereign-side production verification of PR-19 surfaced that the per-key
+// KEYS.lastWriters sidecar was insufficient for the history-tab surface:
+// each entry in a history list needs its own attribution. PR-19.5 fixes:
+//   (a) per-entry strip in _syncHandlePerEntrySnapshot preserves
+//       __sync_updatedBy / __sync_syncedAt on each entry (caretickets)
+//   (b) _syncStampUnattributed in _syncFlushSingleDoc stamps un-attributed
+//       array entries with the current writer at flush time (so locally-
+//       added entries get the writer's identity before going to Firestore;
+//       echoes back via listener with stamp intact)
+//   (c) _renderAttribution(entry) helper in core.js + wired into history-
+//       tab renderers (growth, sleep, poop, vacc, milestones, notes; meds
+//       and feeding are object-keyed → Phase 4)
+//
+// Doctrine ledger: hermetic-floor-doesnt-substitute-for-production-floor
+// RATIFIED at 3/3 with this PR's predecessor (PR-19) being the third
+// instance. Hermetic R-4 floor remains necessary-not-sufficient; production
+// verification on a real second device is the closer.
+
+test.describe('Per-entry attribution — strip preserves + flush stamps (Phase 3 PR-19.5)', () => {
+  test('positive — _syncStampUnattributed stamps un-attributed array entries with writer identity', async ({ page }) => {
+    await stubChartJs(page);
+    await page.goto('/index.html?nosync');
+    await page.waitForFunction(() => typeof (window as { _syncStampUnattributed?: unknown })._syncStampUnattributed === 'function');
+
+    const result = await page.evaluate(() => {
+      const w = window as unknown as Record<string, unknown>;
+      const stamp = w['_syncStampUnattributed'] as (
+        value: Array<Record<string, unknown>>, writer: { uid: string; name: string }
+      ) => Array<Record<string, unknown>>;
+      const writer = { uid: 'lyra-uid', name: 'Lyra' };
+      // Mixed array — some entries have stamps, some don't.
+      const input = [
+        { date: '2025-09-04', wt: 3.45 },                                                          // unstamped
+        { date: '2026-04-25', wt: 8.00, __sync_updatedBy: { uid: 'bhavna-uid', name: 'Bhavna' } }, // stamped (Bhavna)
+        { date: '2026-04-27', wt: 8.10 },                                                          // unstamped
+      ];
+      const stamped = stamp(input, writer);
+      return {
+        len: stamped.length,
+        firstStamp: stamped[0].__sync_updatedBy as { name: string } | undefined,
+        secondStamp: stamped[1].__sync_updatedBy as { name: string } | undefined,
+        thirdStamp: stamped[2].__sync_updatedBy as { name: string } | undefined,
+      };
+    });
+
+    expect(result.len, 'stamped array length unchanged').toBe(3);
+    expect(result.firstStamp?.name, 'first (unstamped) gets writer identity').toBe('Lyra');
+    expect(result.secondStamp?.name, 'second (already-stamped) preserved').toBe('Bhavna');
+    expect(result.thirdStamp?.name, 'third (unstamped) gets writer identity').toBe('Lyra');
+  });
+
+  test('regression-guard — listener handler preserves __sync_updatedBy on entries through localStorage', async ({ page }) => {
+    await stubChartJs(page);
+    await page.goto('/index.html?nosync');
+    await page.waitForFunction(() => typeof (window as { _syncHandleSingleDocSnapshot?: unknown })._syncHandleSingleDocSnapshot === 'function');
+
+    const persisted = await page.evaluate(() => {
+      const w = window as unknown as Record<string, unknown>;
+      const handler = w['_syncHandleSingleDocSnapshot'] as (
+        docName: string, doc: { exists: boolean; data: () => Record<string, unknown>; metadata: { hasPendingWrites: boolean } }
+      ) => void;
+      const _syncReady = w['_syncReady'] as Record<string, boolean>;
+      if (_syncReady) _syncReady['growth'] = true;
+      handler('growth', {
+        exists: true,
+        data: () => ({
+          ziva_growth: [
+            { date: '2025-09-04', wt: 3.45, ht: 50, __sync_updatedBy: { uid: 'kajal-uid', name: 'Kajal Parakh' } },
+            { date: '2026-04-27', wt: 8.10, ht: 68, __sync_updatedBy: { uid: 'bhavna-uid', name: 'Bhavna' } },
+          ],
+          __sync_updatedBy: { uid: 'bhavna-uid', name: 'Bhavna' },
+        }),
+        metadata: { hasPendingWrites: false },
+      });
+      // localStorage now has the array; verify each entry retained __sync_updatedBy
+      const raw = window.localStorage.getItem('ziva_growth');
+      return raw ? JSON.parse(raw) : null;
+    });
+
+    expect(persisted, 'localStorage[ziva_growth] populated').not.toBeNull();
+    expect(Array.isArray(persisted), 'is array').toBeTruthy();
+    expect(persisted[0].__sync_updatedBy?.name, 'first entry attribution preserved (Kajal)').toBe('Kajal Parakh');
+    expect(persisted[1].__sync_updatedBy?.name, 'second entry attribution preserved (Bhavna)').toBe('Bhavna');
+  });
+
+  test('positive-regression — _renderAttribution returns empty string for legacy un-stamped entries (graceful degradation)', async ({ page }) => {
+    await stubChartJs(page);
+    await page.goto('/index.html?nosync');
+    await page.waitForFunction(() => typeof (window as { _renderAttribution?: unknown })._renderAttribution === 'function');
+
+    const variants = await page.evaluate(() => {
+      const w = window as unknown as Record<string, unknown>;
+      const render = w['_renderAttribution'] as (entry: unknown) => string;
+      return {
+        stamped: render({ date: '2026-04-27', wt: 8.10, __sync_updatedBy: { uid: 'b', name: 'Bhavna' } }),
+        unstamped: render({ date: '2026-04-27', wt: 8.10 }),                                  // legacy entry
+        emptyName: render({ date: '2026-04-27', wt: 8.10, __sync_updatedBy: { uid: 'b' } }),  // missing name
+        nullEntry: render(null),
+        undef: render(undefined),
+        notObject: render(42),
+      };
+    });
+
+    expect(variants.stamped, 'stamped entry renders attribution').toContain('Bhavna');
+    expect(variants.unstamped, 'unstamped legacy entry renders empty').toBe('');
+    expect(variants.emptyName, 'missing name renders empty').toBe('');
+    expect(variants.nullEntry, 'null entry renders empty').toBe('');
+    expect(variants.undef, 'undefined entry renders empty').toBe('');
+    expect(variants.notObject, 'non-object entry renders empty').toBe('');
+  });
+});
+
+test.describe('Per-entry attribution — caretickets per-entry strip preserves __sync_updatedBy (Phase 3 PR-19.5)', () => {
+  test('positive — per-entry snapshot persists each entry\'s __sync_updatedBy through the strip', async ({ page }) => {
+    await stubChartJs(page);
+    await page.goto('/index.html?nosync');
+    await page.waitForFunction(() => typeof (window as { _syncHandlePerEntrySnapshot?: unknown })._syncHandlePerEntrySnapshot === 'function');
+
+    const persisted = await page.evaluate(() => {
+      const w = window as unknown as Record<string, unknown>;
+      const handler = w['_syncHandlePerEntrySnapshot'] as (
+        collection: string, snapshot: {
+          forEach: (cb: (doc: { id: string; data: () => Record<string, unknown> }) => void) => void;
+          docChanges: () => Array<{ doc: { data: () => Record<string, unknown> }; type: string }>;
+          metadata: { hasPendingWrites: boolean };
+        }
+      ) => void;
+      const _syncReady = w['_syncReady'] as Record<string, boolean>;
+      if (_syncReady) _syncReady['caretickets'] = true;
+      // Synthetic per-entry snapshot with two tickets, each with its own __sync_updatedBy
+      const docs = [
+        { id: 't1', data: () => ({ id: 't1', title: 'Cough check', __sync_updatedBy: { uid: 'kajal-uid', name: 'Kajal Parakh' }, __sync_syncedAt: null }) },
+        { id: 't2', data: () => ({ id: 't2', title: 'Vit D follow-up', __sync_updatedBy: { uid: 'rishabh-uid', name: 'Rishabh' }, __sync_syncedAt: null }) },
+      ];
+      const snapshot = {
+        forEach: function(cb: (d: { id: string; data: () => Record<string, unknown> }) => void) { docs.forEach(cb); },
+        docChanges: function() { return docs.map(d => ({ doc: d, type: 'modified' })); },
+        metadata: { hasPendingWrites: false },
+      };
+      handler('caretickets', snapshot);
+      const raw = window.localStorage.getItem('ziva_care_tickets');
+      return raw ? JSON.parse(raw) : null;
+    });
+
+    expect(persisted, 'localStorage[ziva_care_tickets] populated').not.toBeNull();
+    expect(persisted.length, 'two tickets').toBe(2);
+    expect(persisted[0].__sync_updatedBy?.name, 'ticket 1 attribution preserved').toBe('Kajal Parakh');
+    expect(persisted[1].__sync_updatedBy?.name, 'ticket 2 attribution preserved').toBe('Rishabh');
+    // The strip must NOT preserve OTHER __sync_* fields (e.g. __sync_createdBy)
+    // — only __sync_updatedBy and __sync_syncedAt are the explicit allowlist.
+    expect(persisted[0].__sync_createdBy, 'unrelated __sync_* field stripped').toBeUndefined();
+  });
+});


### PR DESCRIPTION
**PR-19.5 — Per-entry attribution hotfix.** Aurelius's post-PR-19 ratification: PR-19's `KEYS.lastWriters` per-key sidecar passed Surface A (status-strip activity-mode pill) but failed Surface B (history-tab attribution) — per-key granularity is wrong shape for "for each entry in the log, who wrote it." Sovereign's original directive needs PER-ENTRY persistence. Cut off `main@99f4f344` per R-2.

---

## Doctrinal moment

**`hermetic-floor-doesnt-substitute-for-production-floor` advances 2/3 → 3/3 RATIFIED.** Three on-record instances:
1. PR-9 toast — hermetic 352/352 + circuit-breaker prod fail
2. PR-18 hotfix — deepened hermetic 418/418 + e2e DOM-toast assertion + still prod fail
3. PR-19 — hermetic 484/484 + production verification surfaced history-tab attribution gap

Joins the four campaign-RATIFIED doctrines (byte-identity-by-construction, running-beats-reading, persistent-PAT, R-7-binary-mode-triad).

---

## Architectural fix

**A. Per-entry strip — preserve `__sync_updatedBy` + `__sync_syncedAt`.** The strip in `_syncHandlePerEntrySnapshot` (caretickets) previously stripped ALL `__sync_*`. Now uses an explicit allowlist: `__sync_updatedBy` and `__sync_syncedAt` pass through; other `__sync_*` still stripped.

**B. Single-doc array entries — auto-stamp at flush.** New helper `_syncStampUnattributed(value, writer)` walks array-shape values, stamps un-attributed objects with the current writer's `{ uid, name }`. Called from `_syncFlushSingleDoc` before the diff. Locally-added entries get the writer's identity before going to Firestore; existing stamped entries preserved. Single-doc top-level strip unchanged — array entries pass through the doc-level strip untouched (the strip removes top-level `__sync_*`, not nested).

**C. `_renderAttribution(entry)` helper in core.js.** Returns `<div class="entry-attribution t-sub-light fs-xs">by {name}</div>` when `entry.__sync_updatedBy.name` is present; empty string for legacy un-stamped entries (graceful degradation). HR-4 escHtml at the boundary.

**D. History-tab renderer wiring (5 surfaces, array-shape collections):**
- `renderGrowthHistory` (medical.js)
- `renderSleepHistoryPreview` (medical.js)
- `renderPoopHistoryPreview` (home.js)
- `renderVaccHistory` (home.js)
- `renderMilestoneHistory` (home.js)
- `renderNotesHistory` (home.js)

---

## Out of PR-19.5 scope (Phase 4 carry-forward)

| Renderer | Reason |
|---|---|
| `renderFeedingHistory` | feeding is object-keyed (date → meal-record); stamping requires shape decision affecting every feeding renderer |
| `renderMedLog` | reads `medChecks` (object-keyed); same shape concern |
| `renderAlertHistory` | `alertsHistory` not in `SYNC_KEYS` (local-only) |
| `renderScrapbookHistory` | `scrapbook` not in `SYNC_KEYS` |

Surface preserved — `KEYS.lastWriters` sidecar from PR-19 unchanged; status-strip activity-mode pill still drives off the same pipeline.

---

## Tests (smoke.spec.ts +158, 4 new cases)

### Per-entry attribution strip + stamp (3 tests)
- **positive** — `_syncStampUnattributed` stamps un-attributed array entries with writer; preserves already-stamped entries.
- **regression-guard** — listener handler preserves `__sync_updatedBy` on entries through localStorage roundtrip (synthetic doc with two pre-stamped entries; both stamps survive in localStorage).
- **positive-regression** — `_renderAttribution` returns empty for null/undefined/missing-name/non-object inputs.

### Per-entry caretickets strip preservation (1 test)
- **positive** — per-entry snapshot persists each entry's `__sync_updatedBy` through the strip; unrelated `__sync_*` fields (e.g. `__sync_createdBy`) remain stripped (allowlist discipline).

---

## R-4 floor

| Stage | Result |
|---|---|
| Single-pass | **48/48** (43.9s) |
| Parallel `--repeat-each=5` | **240/240** (3.6m) |
| `CI=1` sequential `--repeat-each=5` | **240/240** (5.5m) |
| **Total** | **528 stable, 0 flakes** at `retries:0` |

**Cumulative campaign R-4: 2,409 + 528 = 2,937 stable / 0 silent flakes.**

---

## Real-device verification (Aurelius standing protocol)

Hermetic R-4 floor remains **necessary-not-sufficient** — the now-RATIFIED `hermetic-floor-doesnt-substitute-for-production-floor` doctrine binds. PR-19.5 specifically requires Sovereign-side production verification on a real second device before Cipher ack.

Hermetic suite covers:
- (a) strip preservation through localStorage
- (b) flush-time stamp on un-attributed entries
- (c) graceful degradation for legacy entries

Production verification covers:
- live-Firestore round-trip with stamp persistence
- history-tab visual rendering with attribution per row on a real second device

---

## Doctrine ledger updates

| Doctrine | Pre | Post | Notes |
|---|---|---|---|
| `hermetic-floor-doesnt-substitute-for-production-floor` | 2/3 | **3/3 RATIFIED** | Graduates from candidate to RATIFIED at this verification moment |
| `transient-vs-permanent-surfaces-for-cross-device-collaboration` | 1/3 | 1/3 | PR-19.5 is the per-entry shape implementation, not a new surface candidate |
| R-7 binary-mode triad | 4 (sustainment) | 4 | No new instance |
| render-functions-must-be-pure | 0/3 | 0/3 | No new instance |
| graceful-best-effort-dispatch-via-name-resolution | 1/3 | 1/3 | No new instance |

---

## NEW Phase 4 carry-forwards

- Object-keyed-collection per-entry stamping (feeding, activityLog, medChecks). Requires shape decision for date-keyed sub-objects.
- `renderFeedingHistory` + `renderMedLog` attribution display (depends on shape decision above).
- Backfill stamping for legacy un-stamped entries on first flush.

Manifest bumped `2026.04.28-2 → 2026.04.29-1` (new day).

---

## Rulings requested

→ **Cipher:** advisory review. R-4 numbers above; recommend independent rerun. Probe the strip-allowlist precision (only `__sync_updatedBy` and `__sync_syncedAt` pass; `__sync_createdBy` etc. still stripped). Probe `_syncStampUnattributed` for edge cases: nested objects, primitive values, array-of-arrays. Probe each history renderer's `_renderAttribution` insertion site for HR-2/HR-4 compliance.

→ **Aurelius / Sovereign:** R-14 structural change in sync.js (strip allowlist + flush-time stamping) → Sovereign nod requested. After PR-19.5 lands, full Surfaces B + C + D verification on prod is the next gate.

→ **Sovereign:** real-device verification on a second device required before ack. Hermetic 528/0 + cumulative 2,937/0 is the floor; history-tab rendering with attribution per row on real prod is the closer.

— Lyra (The Weaver)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTVgKBRHzPRzYHP5tTkpcK)_