### PR TITLE
sl-3-renderer-coverage (PR-19.6): audit-and-close pass on history-tab attribution + 10 newly-wired renderers

### DIFF
--- a/index.html
+++ b/index.html
@@ -17285,6 +17285,7 @@ function renderNotes(filterCat) {
             ${n.photo ? zi('camera') + ' ' : ''}${n.voice ? zi('camera') + ' ' : ''}
             <span class="note-cat-badge ${noteCategory}">${catIcon} ${noteCategory}</span>
           </div>
+          ${_renderAttribution(n)}
         </div>
         <div class="note-actions">
           <button class="note-btn complete-btn" data-action="toggleNote" data-arg="${n._i}">${n.done ? '↩' : zi('check')}</button>
@@ -22364,6 +22365,7 @@ function renderVisits() {
           <div class="visit-date">${formatDate(v.date)}</div>
           ${v.doctor ? `<div class="visit-doctor">${zi('steth')} ${escHtml(v.doctor)}</div>` : ''}
           ${v.reason ? `<div class="visit-doctor">${zi('list')} ${escHtml(v.reason)}</div>` : ''}
+          ${_renderAttribution(v)}
         </div>
         <div class="visit-actions">
           <button class="note-btn del-note-btn" data-action="deleteVisit" data-arg="${v._i}">&times;</button>
@@ -25908,6 +25910,7 @@ function renderPoopLog() {
               <span class="poop-badge badge-amber" >${amtLabel}</span>
               ${flagBadges.join('')}
             </div>
+            ${_renderAttribution(p)}
           </div>
           <div class="d-flex items-center gap-4">
             <button data-action="editPoopEntry" data-arg="${realIdx}" class="btn-icon-amber" aria-label="Edit entry">Edit</button>
@@ -33779,6 +33782,7 @@ function renderActiveMilestones() {
           '<div class="ms-active-name">' + escHtml(m.text) + '</div>' +
           '<div class="ms-active-stage" style="color:' + stageMeta.color + ';">' + stageMeta.icon + ' ' + stageMeta.label + ' · ' + m.evidenceCount + ' observations' + (confPct > 0 ? ' · ' + confPct + '% high-conf' : '') + '</div>' +
           (dateRange ? '<div class="ms-active-dates">' + dateRange + '</div>' : '') +
+          _renderAttribution(m) +
         '</div>' +
         overrideHtml +
       '</div>' +
@@ -37215,6 +37219,7 @@ function renderMeds() {
         </div>
         ${m.brand ? `<div class="med-brand">${zi('target')} ${escHtml(m.brand)}</div>` : ''}
         ${m.notes ? `<div class="med-detail" style="margin-top:4px;font-style:italic;">${escHtml(m.notes)}</div>` : ''}
+        ${_renderAttribution(m)}
       </div>
       <div class="med-actions">
         <button class="med-btn toggle-btn" data-action="toggleMed" data-arg="${m._i}">${m.active ? '⏸ Stop' : '▶ Resume'}</button>
@@ -38464,6 +38469,7 @@ function renderSleepLog() {
               ${qualBadge}
               ${wakeBadge}
             </div>
+            ${_renderAttribution(s)}
           </div>
           <div class="d-flex items-center gap-4">
             <div class="sleep-entry-duration" style="background:${durBg};color:${durColor};">${dur.h}h ${dur.m}m</div>
@@ -50349,6 +50355,7 @@ function renderFeverHistory() {
     if (doseCount > 0) html += ' · Crocin ×' + doseCount;
     html += '</div>';
     if (ep.resolvedNotes) html += '<div class="fe-history-detail">' + escHtml(ep.resolvedNotes) + '</div>';
+    html += _renderAttribution(ep);
     html += '</div>';
   });
   body.innerHTML = html;
@@ -51015,6 +51022,7 @@ function renderDiarrhoeaHistory() {
     html += '<div class="fe-history-date">' + startD + (endD && endD !== startD ? ' — ' + endD : '') + '</div>';
     html += '<div class="fe-history-detail">Duration: ' + dur + ' · ' + ep.stools.length + ' stools · ' + ep.fluids.length + ' fluid entries · ' + ep.wetDiapers.length + ' wet diapers logged</div>';
     if (ep.resolvedNotes) html += '<div class="fe-history-detail">' + escHtml(ep.resolvedNotes) + '</div>';
+    html += _renderAttribution(ep);
     html += '</div>';
   });
   body.innerHTML = html;
@@ -51385,7 +51393,9 @@ function renderVomitingHistory() {
   let html = '';
   resolved.slice().reverse().forEach(ep => {
     html += '<div class="fe-history-entry"><div class="fe-history-date">' + formatDate(ep.startedAt.split('T')[0]) + ' · ' + _feverDurationStr(ep) + '</div>';
-    html += '<div class="fe-history-detail">' + ep.episodes.length + ' episodes · ' + ep.fluids.length + ' fluids logged</div></div>';
+    html += '<div class="fe-history-detail">' + ep.episodes.length + ' episodes · ' + ep.fluids.length + ' fluids logged</div>';
+    html += _renderAttribution(ep);
+    html += '</div>';
   });
   body.innerHTML = html;
 }
@@ -51645,7 +51655,9 @@ function renderColdHistory() {
   resolved.slice().reverse().forEach(ep => {
     const days = Math.ceil((new Date(ep.resolvedAt || Date.now()).getTime() - new Date(ep.startedAt).getTime()) / 86400000);
     html += '<div class="fe-history-entry"><div class="fe-history-date">' + formatDate(ep.startedAt.split('T')[0]) + ' · ' + days + ' day' + (days !== 1 ? 's' : '') + '</div>';
-    html += '<div class="fe-history-detail">' + ep.dailyLogs.length + ' daily logs · ' + ep.actions.length + ' actions</div></div>';
+    html += '<div class="fe-history-detail">' + ep.dailyLogs.length + ' daily logs · ' + ep.actions.length + ' actions</div>';
+    html += _renderAttribution(ep);
+    html += '</div>';
   });
   body.innerHTML = html;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.04.29-1",
+  "version": "2026.04.29-2",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -1983,6 +1983,7 @@ function renderNotes(filterCat) {
             ${n.photo ? zi('camera') + ' ' : ''}${n.voice ? zi('camera') + ' ' : ''}
             <span class="note-cat-badge ${noteCategory}">${catIcon} ${noteCategory}</span>
           </div>
+          ${_renderAttribution(n)}
         </div>
         <div class="note-actions">
           <button class="note-btn complete-btn" data-action="toggleNote" data-arg="${n._i}">${n.done ? '↩' : zi('check')}</button>

--- a/split/home.js
+++ b/split/home.js
@@ -2168,6 +2168,7 @@ function renderVisits() {
           <div class="visit-date">${formatDate(v.date)}</div>
           ${v.doctor ? `<div class="visit-doctor">${zi('steth')} ${escHtml(v.doctor)}</div>` : ''}
           ${v.reason ? `<div class="visit-doctor">${zi('list')} ${escHtml(v.reason)}</div>` : ''}
+          ${_renderAttribution(v)}
         </div>
         <div class="visit-actions">
           <button class="note-btn del-note-btn" data-action="deleteVisit" data-arg="${v._i}">&times;</button>
@@ -5712,6 +5713,7 @@ function renderPoopLog() {
               <span class="poop-badge badge-amber" >${amtLabel}</span>
               ${flagBadges.join('')}
             </div>
+            ${_renderAttribution(p)}
           </div>
           <div class="d-flex items-center gap-4">
             <button data-action="editPoopEntry" data-arg="${realIdx}" class="btn-icon-amber" aria-label="Edit entry">Edit</button>

--- a/split/intelligence.js
+++ b/split/intelligence.js
@@ -7507,6 +7507,7 @@ function renderFeverHistory() {
     if (doseCount > 0) html += ' · Crocin ×' + doseCount;
     html += '</div>';
     if (ep.resolvedNotes) html += '<div class="fe-history-detail">' + escHtml(ep.resolvedNotes) + '</div>';
+    html += _renderAttribution(ep);
     html += '</div>';
   });
   body.innerHTML = html;
@@ -8173,6 +8174,7 @@ function renderDiarrhoeaHistory() {
     html += '<div class="fe-history-date">' + startD + (endD && endD !== startD ? ' — ' + endD : '') + '</div>';
     html += '<div class="fe-history-detail">Duration: ' + dur + ' · ' + ep.stools.length + ' stools · ' + ep.fluids.length + ' fluid entries · ' + ep.wetDiapers.length + ' wet diapers logged</div>';
     if (ep.resolvedNotes) html += '<div class="fe-history-detail">' + escHtml(ep.resolvedNotes) + '</div>';
+    html += _renderAttribution(ep);
     html += '</div>';
   });
   body.innerHTML = html;
@@ -8543,7 +8545,9 @@ function renderVomitingHistory() {
   let html = '';
   resolved.slice().reverse().forEach(ep => {
     html += '<div class="fe-history-entry"><div class="fe-history-date">' + formatDate(ep.startedAt.split('T')[0]) + ' · ' + _feverDurationStr(ep) + '</div>';
-    html += '<div class="fe-history-detail">' + ep.episodes.length + ' episodes · ' + ep.fluids.length + ' fluids logged</div></div>';
+    html += '<div class="fe-history-detail">' + ep.episodes.length + ' episodes · ' + ep.fluids.length + ' fluids logged</div>';
+    html += _renderAttribution(ep);
+    html += '</div>';
   });
   body.innerHTML = html;
 }
@@ -8803,7 +8807,9 @@ function renderColdHistory() {
   resolved.slice().reverse().forEach(ep => {
     const days = Math.ceil((new Date(ep.resolvedAt || Date.now()).getTime() - new Date(ep.startedAt).getTime()) / 86400000);
     html += '<div class="fe-history-entry"><div class="fe-history-date">' + formatDate(ep.startedAt.split('T')[0]) + ' · ' + days + ' day' + (days !== 1 ? 's' : '') + '</div>';
-    html += '<div class="fe-history-detail">' + ep.dailyLogs.length + ' daily logs · ' + ep.actions.length + ' actions</div></div>';
+    html += '<div class="fe-history-detail">' + ep.dailyLogs.length + ' daily logs · ' + ep.actions.length + ' actions</div>';
+    html += _renderAttribution(ep);
+    html += '</div>';
   });
   body.innerHTML = html;
 }

--- a/split/medical.js
+++ b/split/medical.js
@@ -312,6 +312,7 @@ function renderActiveMilestones() {
           '<div class="ms-active-name">' + escHtml(m.text) + '</div>' +
           '<div class="ms-active-stage" style="color:' + stageMeta.color + ';">' + stageMeta.icon + ' ' + stageMeta.label + ' · ' + m.evidenceCount + ' observations' + (confPct > 0 ? ' · ' + confPct + '% high-conf' : '') + '</div>' +
           (dateRange ? '<div class="ms-active-dates">' + dateRange + '</div>' : '') +
+          _renderAttribution(m) +
         '</div>' +
         overrideHtml +
       '</div>' +
@@ -3748,6 +3749,7 @@ function renderMeds() {
         </div>
         ${m.brand ? `<div class="med-brand">${zi('target')} ${escHtml(m.brand)}</div>` : ''}
         ${m.notes ? `<div class="med-detail" style="margin-top:4px;font-style:italic;">${escHtml(m.notes)}</div>` : ''}
+        ${_renderAttribution(m)}
       </div>
       <div class="med-actions">
         <button class="med-btn toggle-btn" data-action="toggleMed" data-arg="${m._i}">${m.active ? '⏸ Stop' : '▶ Resume'}</button>
@@ -4997,6 +4999,7 @@ function renderSleepLog() {
               ${qualBadge}
               ${wakeBadge}
             </div>
+            ${_renderAttribution(s)}
           </div>
           <div class="d-flex items-center gap-4">
             <div class="sleep-entry-duration" style="background:${durBg};color:${durColor};">${dur.h}h ${dur.m}m</div>

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -17285,6 +17285,7 @@ function renderNotes(filterCat) {
             ${n.photo ? zi('camera') + ' ' : ''}${n.voice ? zi('camera') + ' ' : ''}
             <span class="note-cat-badge ${noteCategory}">${catIcon} ${noteCategory}</span>
           </div>
+          ${_renderAttribution(n)}
         </div>
         <div class="note-actions">
           <button class="note-btn complete-btn" data-action="toggleNote" data-arg="${n._i}">${n.done ? '↩' : zi('check')}</button>
@@ -22364,6 +22365,7 @@ function renderVisits() {
           <div class="visit-date">${formatDate(v.date)}</div>
           ${v.doctor ? `<div class="visit-doctor">${zi('steth')} ${escHtml(v.doctor)}</div>` : ''}
           ${v.reason ? `<div class="visit-doctor">${zi('list')} ${escHtml(v.reason)}</div>` : ''}
+          ${_renderAttribution(v)}
         </div>
         <div class="visit-actions">
           <button class="note-btn del-note-btn" data-action="deleteVisit" data-arg="${v._i}">&times;</button>
@@ -25908,6 +25910,7 @@ function renderPoopLog() {
               <span class="poop-badge badge-amber" >${amtLabel}</span>
               ${flagBadges.join('')}
             </div>
+            ${_renderAttribution(p)}
           </div>
           <div class="d-flex items-center gap-4">
             <button data-action="editPoopEntry" data-arg="${realIdx}" class="btn-icon-amber" aria-label="Edit entry">Edit</button>
@@ -33779,6 +33782,7 @@ function renderActiveMilestones() {
           '<div class="ms-active-name">' + escHtml(m.text) + '</div>' +
           '<div class="ms-active-stage" style="color:' + stageMeta.color + ';">' + stageMeta.icon + ' ' + stageMeta.label + ' · ' + m.evidenceCount + ' observations' + (confPct > 0 ? ' · ' + confPct + '% high-conf' : '') + '</div>' +
           (dateRange ? '<div class="ms-active-dates">' + dateRange + '</div>' : '') +
+          _renderAttribution(m) +
         '</div>' +
         overrideHtml +
       '</div>' +
@@ -37215,6 +37219,7 @@ function renderMeds() {
         </div>
         ${m.brand ? `<div class="med-brand">${zi('target')} ${escHtml(m.brand)}</div>` : ''}
         ${m.notes ? `<div class="med-detail" style="margin-top:4px;font-style:italic;">${escHtml(m.notes)}</div>` : ''}
+        ${_renderAttribution(m)}
       </div>
       <div class="med-actions">
         <button class="med-btn toggle-btn" data-action="toggleMed" data-arg="${m._i}">${m.active ? '⏸ Stop' : '▶ Resume'}</button>
@@ -38464,6 +38469,7 @@ function renderSleepLog() {
               ${qualBadge}
               ${wakeBadge}
             </div>
+            ${_renderAttribution(s)}
           </div>
           <div class="d-flex items-center gap-4">
             <div class="sleep-entry-duration" style="background:${durBg};color:${durColor};">${dur.h}h ${dur.m}m</div>
@@ -50349,6 +50355,7 @@ function renderFeverHistory() {
     if (doseCount > 0) html += ' · Crocin ×' + doseCount;
     html += '</div>';
     if (ep.resolvedNotes) html += '<div class="fe-history-detail">' + escHtml(ep.resolvedNotes) + '</div>';
+    html += _renderAttribution(ep);
     html += '</div>';
   });
   body.innerHTML = html;
@@ -51015,6 +51022,7 @@ function renderDiarrhoeaHistory() {
     html += '<div class="fe-history-date">' + startD + (endD && endD !== startD ? ' — ' + endD : '') + '</div>';
     html += '<div class="fe-history-detail">Duration: ' + dur + ' · ' + ep.stools.length + ' stools · ' + ep.fluids.length + ' fluid entries · ' + ep.wetDiapers.length + ' wet diapers logged</div>';
     if (ep.resolvedNotes) html += '<div class="fe-history-detail">' + escHtml(ep.resolvedNotes) + '</div>';
+    html += _renderAttribution(ep);
     html += '</div>';
   });
   body.innerHTML = html;
@@ -51385,7 +51393,9 @@ function renderVomitingHistory() {
   let html = '';
   resolved.slice().reverse().forEach(ep => {
     html += '<div class="fe-history-entry"><div class="fe-history-date">' + formatDate(ep.startedAt.split('T')[0]) + ' · ' + _feverDurationStr(ep) + '</div>';
-    html += '<div class="fe-history-detail">' + ep.episodes.length + ' episodes · ' + ep.fluids.length + ' fluids logged</div></div>';
+    html += '<div class="fe-history-detail">' + ep.episodes.length + ' episodes · ' + ep.fluids.length + ' fluids logged</div>';
+    html += _renderAttribution(ep);
+    html += '</div>';
   });
   body.innerHTML = html;
 }
@@ -51645,7 +51655,9 @@ function renderColdHistory() {
   resolved.slice().reverse().forEach(ep => {
     const days = Math.ceil((new Date(ep.resolvedAt || Date.now()).getTime() - new Date(ep.startedAt).getTime()) / 86400000);
     html += '<div class="fe-history-entry"><div class="fe-history-date">' + formatDate(ep.startedAt.split('T')[0]) + ' · ' + days + ' day' + (days !== 1 ? 's' : '') + '</div>';
-    html += '<div class="fe-history-detail">' + ep.dailyLogs.length + ' daily logs · ' + ep.actions.length + ' actions</div></div>';
+    html += '<div class="fe-history-detail">' + ep.dailyLogs.length + ' daily logs · ' + ep.actions.length + ' actions</div>';
+    html += _renderAttribution(ep);
+    html += '</div>';
   });
   body.innerHTML = html;
 }

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1632,3 +1632,103 @@ test.describe('Per-entry attribution — caretickets per-entry strip preserves _
     expect(persisted[0].__sync_createdBy, 'unrelated __sync_* field stripped').toBeUndefined();
   });
 });
+
+// ───────────────────────────────────────────────────────────────────────────
+// PR-19.6 — Renderer-coverage extension (history-tab attribution audit close)
+// ───────────────────────────────────────────────────────────────────────────
+//
+// Sovereign-side production verification of PR-19.5 surfaced renderer-coverage
+// gaps: PR-19.5 wired 6 history-shape renderers (growth, sleep history-preview,
+// poop history-preview, vacc, milestones, notes) but missed the active-list
+// renderers (sleep-log, poop-log, meds, visits, active-milestones, notes-list)
+// AND the episode history cards (fever, diarrhoea, vomiting, cold). PR-19.6
+// is the audit-and-close pass per the new doctrine candidate
+// `architectural-surfacing-must-enumerate-axis-of-resolution` (currently 2/3).
+//
+// Audit table (full list in PR body); newly-wired renderers tested below via
+// a parameterized grep — built sproutlab.html must contain the
+// _renderAttribution(<entry-var>) call site for each declared renderer name.
+
+test.describe('PR-19.6 — renderer-coverage audit close (parameterized grep)', () => {
+  // Each entry: renderer function name + the entry variable expected in the
+  // _renderAttribution() call. The grep targets the BUILT sproutlab.html so
+  // we verify the wire-up survives the build pipeline (split → concat).
+  const NEWLY_WIRED: Array<{ renderer: string; entryVar: string; surface: string }> = [
+    { renderer: 'renderSleepLog',         entryVar: 's',  surface: 'track:sleep — sleep entries log' },
+    { renderer: 'renderPoopLog',          entryVar: 'p',  surface: 'track:poop — poop entries log' },
+    { renderer: 'renderMeds',             entryVar: 'm',  surface: 'track:medical — meds list' },
+    { renderer: 'renderVisits',           entryVar: 'v',  surface: 'track:medical — doctor visits list' },
+    { renderer: 'renderActiveMilestones', entryVar: 'm',  surface: 'track:milestones — active milestones (evidence)' },
+    { renderer: 'renderNotes',            entryVar: 'n',  surface: 'history — notes list' },
+    { renderer: 'renderFeverHistory',     entryVar: 'ep', surface: 'track:medical — fever episode history' },
+    { renderer: 'renderDiarrhoeaHistory', entryVar: 'ep', surface: 'track:medical — diarrhoea episode history' },
+    { renderer: 'renderVomitingHistory',  entryVar: 'ep', surface: 'track:medical — vomiting episode history' },
+    { renderer: 'renderColdHistory',      entryVar: 'ep', surface: 'track:medical — cold episode history' },
+  ];
+
+  // Sanity: PR-19.5 already-wired renderers — their wire-up MUST survive
+  // PR-19.6 (no regression on the prior coverage).
+  const PRE_WIRED_PR195: Array<{ renderer: string; entryVar: string }> = [
+    { renderer: 'renderGrowthHistory',         entryVar: 'r' },
+    { renderer: 'renderSleepHistoryPreview',   entryVar: 's' },
+    { renderer: 'renderPoopHistoryPreview',    entryVar: 'p' },
+    { renderer: 'renderVaccHistory',           entryVar: 'v' },
+    { renderer: 'renderMilestoneHistory',      entryVar: 'm' },
+    { renderer: 'renderNotesHistory',          entryVar: 'n' },
+  ];
+
+  test('positive — every newly-wired renderer in audit calls _renderAttribution(entry)', async ({ request }) => {
+    const res = await request.get('/sproutlab.html');
+    expect(res.ok(), 'sproutlab.html fetchable').toBeTruthy();
+    const html = await res.text();
+    for (const { renderer, entryVar, surface } of NEWLY_WIRED) {
+      // Each renderer must appear (function declaration) AND a
+      // _renderAttribution(<entryVar>) call must appear in the built bundle.
+      // The function-declaration grep prevents the test passing in a state
+      // where the renderer was renamed/removed but our audit list went stale.
+      const fnDecl = new RegExp('function\\s+' + renderer + '\\s*\\(');
+      const callSite = new RegExp('_renderAttribution\\s*\\(\\s*' + entryVar + '\\s*\\)');
+      expect(fnDecl.test(html), `${renderer} declared in built bundle (${surface})`).toBeTruthy();
+      expect(callSite.test(html), `${renderer} (${surface}) wires _renderAttribution(${entryVar})`).toBeTruthy();
+    }
+  });
+
+  test('regression-guard — every PR-19.5 already-wired renderer remains wired (no regression)', async ({ request }) => {
+    const res = await request.get('/sproutlab.html');
+    const html = await res.text();
+    for (const { renderer, entryVar } of PRE_WIRED_PR195) {
+      const fnDecl = new RegExp('function\\s+' + renderer + '\\s*\\(');
+      const callSite = new RegExp('_renderAttribution\\s*\\(\\s*' + entryVar + '\\s*\\)');
+      expect(fnDecl.test(html), `${renderer} still in built bundle`).toBeTruthy();
+      expect(callSite.test(html), `${renderer} still wires _renderAttribution(${entryVar})`).toBeTruthy();
+    }
+  });
+
+  test('positive-regression — explicitly-deferred renderers (Phase 4) are NOT wired (object-keyed-shape disposition documented in PR body)', async ({ request }) => {
+    const res = await request.get('/sproutlab.html');
+    const html = await res.text();
+    // These two are object-keyed (date → sub-object) and require a shape
+    // decision affecting every consumer of those fields. Per the audit
+    // disposition, they remain unwired in PR-19.6 and carry forward to
+    // Phase 4. The test asserts the explicit non-wire so a future drift-by-
+    // accident is caught: if someone wires renderMedLog without making the
+    // object-keyed shape decision, this guard fails and forces a re-discuss.
+    const DEFERRED: Array<{ renderer: string; reason: string }> = [
+      { renderer: 'renderMedLog',         reason: 'medChecks is object-keyed (date → medName→status string); per-entry attribution requires object-shape decision' },
+      { renderer: 'renderFeedingHistory', reason: 'feedingData is object-keyed (date → meal-record); per-entry attribution requires object-shape decision' },
+    ];
+    for (const { renderer, reason } of DEFERRED) {
+      // The renderer function MUST exist in the bundle (we're not pretending
+      // it doesn't) — but it must NOT have an _renderAttribution call site
+      // wired into its body. We check by extracting a window around the
+      // function declaration and grepping inside.
+      const re = new RegExp('function\\s+' + renderer + '\\s*\\(([\\s\\S]*?)\\n\\}', 'm');
+      const match = html.match(re);
+      expect(match, `${renderer} function body found in bundle`).toBeTruthy();
+      if (match) {
+        expect(match[1].includes('_renderAttribution'),
+          `${renderer} explicitly NOT wired per Phase 4 deferral: ${reason}`).toBeFalsy();
+      }
+    }
+  });
+});


### PR DESCRIPTION
**PR-19.6 — Renderer-coverage audit-and-close pass.** Aurelius's post-PR-19.5 ratification: PR-19.5 wired 6 history-shape renderers but missed the active-list renderers AND the 4 episode history cards. PR-19.6 is the audit-and-close. Cut off `main@f247b260` per R-2.

**Doctrine candidate at 3/3 RATIFIED:** `architectural-surfacing-must-enumerate-axis-of-resolution`. Three on-record instances (PR-19 per-key-vs-per-entry granularity not enumerated, PR-19.5 per-entry shape addressed but renderer-coverage axis not enumerated, PR-19.6 full audit table enumerates EVERY renderer with wire/defer disposition). Doctrine prescription: every architectural-decisions surfacing must enumerate the axes-of-resolution explicitly, with each axis having either a chosen value OR an explicit non-decision reason.

---

## Renderer audit table

### Already-wired in PR-19.5 (regression-guarded by parameterized test)

| Renderer | File:Line | Data | Surface |
|---|---|---|---|
| `renderGrowthHistory` | medical.js:968 | `growthData` | history — growth |
| `renderSleepHistoryPreview` | medical.js:5331 | `sleepData` | history — sleep portion |
| `renderPoopHistoryPreview` | home.js:5953 | `poopData` | history — poop portion |
| `renderVaccHistory` | home.js:1337 | `vaccData` | history — vaccinations |
| `renderMilestoneHistory` | home.js:5290 | `milestones` | history — milestone timeline |
| `renderNotesHistory` | home.js:6253 | `notes` | history — notes |

### Newly wired in PR-19.6 (10 renderers)

| Renderer | File:Line | Data | Surface |
|---|---|---|---|
| `renderSleepLog` | medical.js:4926 | `sleepData` | track:sleep — sleep entries log |
| `renderPoopLog` | home.js:5654 | `poopData` | track:poop — poop entries log |
| `renderMeds` | medical.js:3726 | `meds` | track:medical — meds list |
| `renderVisits` | home.js:2153 | `visits` | track:medical — doctor visits list |
| `renderActiveMilestones` | medical.js:238 | `milestones` | track:milestones — active milestones |
| `renderNotes` | core.js:1926 | `notes` | history — notes filtered list |
| `renderFeverHistory` | intelligence.js:7479 | `feverEpisodes` | track:medical — fever episode history |
| `renderDiarrhoeaHistory` | intelligence.js:8154 | `diarrhoeaEpisodes` | track:medical — diarrhoea episode history |
| `renderVomitingHistory` | intelligence.js:8535 | `vomitingEpisodes` | track:medical — vomiting episode history |
| `renderColdHistory` | intelligence.js:8796 | `coldEpisodes` | track:medical — cold episode history |

### Explicitly DEFERRED to Phase 4 (object-keyed shape; documented per audit discipline)

| Renderer | File:Line | Data | Reason |
|---|---|---|---|
| `renderMedLog` | home.js:2215 | `medChecks` | `medChecks` is object-keyed (date → medName→status string); per-entry attribution requires object-shape decision affecting every consumer |
| `renderFeedingHistory` | home.js:2381 | `feedingData` | `feedingData` is object-keyed (date → meal-record); same shape concern |

### Out of scope (not in `SYNC_KEYS` — local-only)

`renderScrapbookHistory`, `renderAlertHistory`, `renderScrapbook`

### Out of scope (preview/single-record cards, not list renderers)

`renderHomeSleep`, `renderHomePoop`, `renderHomeFeverBanner` et al; `renderFeverEpisodeCard` / `renderDiarrhoeaEpisodeCard` / `renderVomitingEpisodeCard` / `renderColdEpisodeCard` (active episode cards, one episode at a time); `renderDoctorPrep`, `renderDoctorContact`; `renderGrowthFacts`, `renderGrowthHero`; `renderHomeVacc`

### Out of scope (stats cards already dispatched via `SYNC_RENDER_DEPS`)

`renderDietStats`, `renderMilestoneStats`, `renderMedicalStats`, `renderGrowthStats`, `renderHome` composite

---

## Tests (smoke.spec.ts +100 — parameterized grep against the BUILT bundle)

1. **positive** — every newly-wired renderer in audit calls `_renderAttribution(entry)`. Iterates 10-renderer array; asserts (a) function declaration in built `sproutlab.html` AND (b) `_renderAttribution(<entryVar>)` call site exists. Function-declaration check prevents stale audit list from passing silently.
2. **regression-guard** — every PR-19.5 already-wired renderer remains wired (no regression on prior coverage).
3. **positive-regression** — explicitly-deferred renderers (`renderMedLog`, `renderFeedingHistory`) are NOT wired. Catches drift-by-accident: if someone wires `renderMedLog` without making the object-keyed shape decision, this guard fails and forces a re-discuss.

---

## R-4 floor

| Stage | Result |
|---|---|
| Single-pass | **51/51** (44.7s) |
| Parallel `--repeat-each=5` | **255/255** (3.8m) |
| `CI=1` sequential `--repeat-each=5` | **255/255** (5.6m) |
| **Total** | **561 stable, 0 flakes** at `retries:0` |

**Cumulative campaign R-4: 2,937 + 561 = 3,498 stable / 0 silent flakes.**

---

## Real-device verification

Hermetic 561/0 + cumulative 3,498/0 is **necessary-not-sufficient** per the now-RATIFIED `hermetic-floor-doesnt-substitute-for-production-floor`. Sovereign-side re-verification on the failed screenshots required before Cipher ack.

**Note for Sovereign:** `renderMedLog` remains explicitly UNWIRED (Phase 4 carry-forward) — Medication Log should still show no attribution. The other surfaces (sleep log, poop log, meds list, visits, active milestones, notes, episode histories) should now show per-row attribution where `__sync_updatedBy` is present on entries.

---

## Doctrine ledger updates

| Doctrine | Pre | Post | Notes |
|---|---|---|---|
| `architectural-surfacing-must-enumerate-axis-of-resolution` | 2/3 | **3/3 RATIFIED** | Third instance: full audit table enumerates EVERY renderer |
| `hermetic-floor-doesnt-substitute-for-production-floor` | 3/3 RATIFIED | 3/3 RATIFIED | Carries; binds via real-device verification |
| `transient-vs-permanent-surfaces-for-cross-device-collaboration` | 1/3 | 1/3 | Carries |
| R-7 binary-mode triad | 4 (sustainment) | 4 | No new instance |

---

## Files NOT touched

- `split/sync.js` — strip allowlist + flush-time stamping preserved unchanged from PR-19.5.
- `_syncDispatchRender` path (PR-9 + PR-18 + PR-19) — preserved.
- `split/styles.css` — no new styles (entry-attribution class shipped in PR-19.5).
- `split/template.html` — no new DOM elements.
- `KEYS.lastWriters` sidecar (PR-19) — preserved.
- `#syncActivity` activity-mode pill (PR-19) — preserved.
- Phase 2 carry-forwards items 1, 5, 8 — deferred per charter §6.

Manifest bumped `2026.04.29-1 → 2026.04.29-2`.

---

## Rulings requested

→ **Cipher:** advisory review. R-4 numbers above; recommend independent rerun. The audit table IS the deliverable from Lyra's side — verify "every full-list renderer either is wired OR has an explicit non-wire reason." Probe each of the 10 newly-wired insertion sites for HR-2/HR-4 compliance.

→ **Aurelius / Sovereign:** PR-19.6 closes the renderer-coverage gap from PR-19.5. R-14: hygiene-class wire-up changes (no new architectural surfaces) spanning 4 source files → Sovereign nod requested.

→ **Sovereign:** re-run the verification on the screenshots that failed. `renderMedLog` will still show no attribution (Phase 4 carry-forward); the rest should now render per-row attribution.

— Lyra (The Weaver)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTVgKBRHzPRzYHP5tTkpcK)_