### PR TITLE
sl-4-polish-10b-hr3-onclick-care-home (PR-35/Polish-10b): HR-3 onclick batch — Care + Home (24 sites)

### DIFF
--- a/index.html
+++ b/index.html
@@ -15746,6 +15746,32 @@ function init() {
       const el = document.getElementById(arg);
       if (el) el.style.display = el.style.display === 'none' ? 'block' : 'none';
     }
+    else if (action === 'toggleDisplayBlock') {
+      // Polish-10b: HR-3 cleanup — generic toggle between display:block and display:none.
+      // arg = elementId. Pair with data-stop="1" for stopPropagation behavior.
+      const el = document.getElementById(arg);
+      if (el) el.style.display = el.style.display === 'none' ? 'block' : 'none';
+    }
+    else if (action === 'toggleDisplayFlex') {
+      // Polish-10b: HR-3 cleanup — generic toggle between display:flex and display:none.
+      // arg = elementId. Pair with data-stop="1" for stopPropagation behavior.
+      const el = document.getElementById(arg);
+      if (el) el.style.display = el.style.display === 'none' ? 'flex' : 'none';
+    }
+    else if (action === 'resolveMissedMedDone' && typeof resolveMissedMed === 'function') resolveMissedMed(arg, arg2, 'done');
+    else if (action === 'resolveMissedMedSkipped' && typeof resolveMissedMed === 'function') resolveMissedMed(arg, arg2, 'skipped');
+    else if (action === 'markMedDone' && typeof markMedDone === 'function') markMedDone(arg, Number(arg2));
+    else if (action === 'markMedSkipped' && typeof markMedSkipped === 'function') markMedSkipped(arg, Number(arg2));
+    else if (action === 'deleteFeedingEntry' && typeof deleteFeedingEntry === 'function') deleteFeedingEntry(arg);
+    else if (action === 'switchFoodCatSub' && typeof switchFoodCatSub === 'function') switchFoodCatSub(arg, arg2);
+    else if (action === 'expandMilestoneByIdx' && typeof expandMilestoneByIdx === 'function') expandMilestoneByIdx(Number(arg));
+    else if (action === 'expandUpcomingItem' && typeof expandUpcomingItem === 'function') expandUpcomingItem(arg);
+    else if (action === 'fillDietMeal' && typeof fillDietMeal === 'function') fillDietMeal(arg, arg2);
+    else if (action === 'insertDietFood' && typeof insertDietFood === 'function') insertDietFood(arg, arg2);
+    else if (action === 'toggleAlertTip' && typeof toggleAlertTip === 'function') toggleAlertTip(arg);
+    else if (action === 'execAlertAction' && typeof execAlertAction === 'function') execAlertAction(arg);
+    else if (action === 'switchTab' && typeof switchTab === 'function') switchTab(arg);
+    else if (action === 'toggleUpcomingSubcat' && typeof toggleUpcomingSubcat === 'function') toggleUpcomingSubcat(arg);
     else if (action === 'editUpcomingVaccDate') editUpcomingVaccDate();
     else if (action === 'openMedModal') openMedModal();
     else if (action === 'toggleVisitForm') toggleVisitForm();
@@ -20961,8 +20987,8 @@ function renderRemindersAndAlerts() {
               <div class="supp-alert-icon">${zi('dot-red')}</div>
               <div class="supp-alert-title">Missed — ${escHtml(m.name)}</div>
               <div class="supp-alert-action">
-                <button class="supp-check-btn" onclick="resolveMissedMed('${escAttr(m.name)}', '${ds}', 'done')">Was given</button>
-                <button class="supp-skip-btn" onclick="resolveMissedMed('${escAttr(m.name)}', '${ds}', 'skipped')">Not given</button>
+                <button class="supp-check-btn" data-action="resolveMissedMedDone" data-arg="${escAttr(m.name)}" data-arg2="${ds}">Was given</button>
+                <button class="supp-skip-btn" data-action="resolveMissedMedSkipped" data-arg="${escAttr(m.name)}" data-arg2="${ds}">Not given</button>
               </div>
             </div>
             <div class="supp-alert-detail">${escHtml(m.dose || '')} · ${formatDate(ds)}</div>
@@ -21001,8 +21027,8 @@ function renderRemindersAndAlerts() {
           <div class="supp-alert-icon">${zi('warn')}</div>
           <div class="supp-alert-title">Reminder — ${escHtml(m.name)}</div>
           <div class="supp-alert-action">
-            <button class="supp-check-btn" onclick="markMedDone('${escAttr(m.name)}', ${idx})">Done</button>
-            <button class="supp-skip-btn" onclick="markMedSkipped('${escAttr(m.name)}', ${idx})">Skip</button>
+            <button class="supp-check-btn" data-action="markMedDone" data-arg="${escAttr(m.name)}" data-arg2="${idx}">Done</button>
+            <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escAttr(m.name)}" data-arg2="${idx}">Skip</button>
           </div>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${escHtml(m.freq || 'As prescribed')}</div>
@@ -21909,7 +21935,7 @@ function renderMilestones() {
             return `<div class="al-evid-item">${ev.date} — "${escHtml((ev.text||'').substring(0, 40))}" ${confDot} ${ev.confidence}</div>`;
           }).join('');
           if (m.evidenceCount > 5) evItems += `<div class="al-evid-more">+${m.evidenceCount - 5} more</div>`;
-          evidHtml = `<button class="ms-tidbit-toggle" onclick="event.stopPropagation();document.getElementById('${evidId}').style.display=document.getElementById('${evidId}').style.display==='none'?'block':'none'">${zi('chart')} View evidence ▾</button>
+          evidHtml = `<button class="ms-tidbit-toggle" data-action="toggleDisplayBlock" data-arg="${evidId}" data-stop="1">${zi('chart')} View evidence ▾</button>
             <div id="${evidId}" class="al-evid-box" style="display:none;">${evItems}</div>`;
         }
       }
@@ -21922,7 +21948,7 @@ function renderMilestones() {
                 <strong>${escHtml(m.text)}</strong>
                 ${metaHtml}
                 ${evidHtml}
-                ${tidbitData ? `<button class="ms-tidbit-toggle" onclick="event.stopPropagation();document.getElementById('${tidbitId}').style.display=document.getElementById('${tidbitId}').style.display==='none'?'flex':'none'"><svg class="zi"><use href="#zi-bulb"/></svg> Learn more ▾</button>` : ''}
+                ${tidbitData ? `<button class="ms-tidbit-toggle" data-action="toggleDisplayFlex" data-arg="${tidbitId}" data-stop="1"><svg class="zi"><use href="#zi-bulb"/></svg> Learn more ▾</button>` : ''}
               </div>
               ${m.advanced ? '<span class="badge-adv"><svg class="zi"><use href="#zi-star"/></svg> Advanced</span>' : ''}
               <div class="milestone-actions">
@@ -22462,7 +22488,7 @@ function renderRecentEvidence() {
     const isToday = dateStr === todayStr;
 
     html += '<div class="al-feed-day">';
-    html += '<div class="al-feed-day-header ptr" onclick="document.getElementById(\'' + dayBodyId + '\').style.display=document.getElementById(\'' + dayBodyId + '\').style.display===\'none\'?\'block\':\'none\'" >' +
+    html += '<div class="al-feed-day-header ptr" data-action="toggleDisplayBlock" data-arg="' + dayBodyId + '">' +
       dayLabel + ' — ' + entries.length + ' activit' + (entries.length === 1 ? 'y' : 'ies') + ' · ' + totalEvidence + ' evidence' +
       '<span style="float:right;">▾</span></div>';
     html += '<div class="al-feed-summary">' + summaryChips + '</div>';
@@ -22842,7 +22868,7 @@ function renderFeedingHistory() {
             ${sInsight ? `<div class="history-meal-insight"><span class="hmi-icon">${zi('sparkle')}</span><span>${sInsight}</span></div>` : ''}
             <div class="fx g8 fx-end mt-8">
               <button class="ms-action-btn" data-action="navFeedDay" data-stop="1" data-arg="${dateKey}">Edit</button>
-              <button class="ms-action-btn del-ms" onclick="event.stopPropagation();deleteFeedingEntry('${dateKey}')">&times; Delete</button>
+              <button class="ms-action-btn del-ms" data-action="deleteFeedingEntry" data-arg="${dateKey}" data-stop="1">&times; Delete</button>
             </div>
           </div>
         </div>`;
@@ -23074,7 +23100,7 @@ function openFoodCatModal(pid) {
     const sub = parent.subs[sid];
     const count = grouped[pid][sid].length;
     const total = sub.keys.length;
-    return `<button class="settings-tab${i===0?' active-st':''}" id="fct-${sid}" onclick="switchFoodCatSub('${pid}','${sid}')" style="font-size:var(--fs-xs);padding:6px 8px;gap:var(--sp-4);">
+    return `<button class="settings-tab${i===0?' active-st':''}" id="fct-${sid}" data-action="switchFoodCatSub" data-arg="${pid}" data-arg2="${sid}" style="font-size:var(--fs-xs);padding:6px 8px;gap:var(--sp-4);">
       ${sub.icon} ${sub.label} <span style="opacity:0.6;font-size:var(--fs-xs);">${count}/${total}</span>
     </button>`;
   }).join('');
@@ -23557,7 +23583,7 @@ function renderMilestoneStats() {
     const dateInfo = latestMs.doneAt ? formatDate(latestMs.doneAt.split('T')[0]) + ' · ' + ageAtDate(latestMs.doneAt) : '';
     const latestIdx = milestones.indexOf(latestMs);
     hlHtml += `
-      <div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:var(--sp-12) 14px;border-radius:var(--r-lg);background:var(--sage-light);cursor:pointer;" onclick="expandMilestoneByIdx(${latestIdx})">
+      <div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:var(--sp-12) 14px;border-radius:var(--r-lg);background:var(--sage-light);cursor:pointer;" data-action="expandMilestoneByIdx" data-arg="${latestIdx}">
         <span class="info-strip-icon">${ci}</span>
         <div class="flex-1-min">
           <div class="micro-label">Latest achieved</div>
@@ -23569,7 +23595,7 @@ function renderMilestoneStats() {
 
   if (nextMilestone) {
     hlHtml += `
-      <div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:var(--sp-12) 14px;border-radius:var(--r-lg);background:var(--lav-light);cursor:pointer;" onclick="expandUpcomingItem('${escAttr(nextMilestone.text)}')">
+      <div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:var(--sp-12) 14px;border-radius:var(--r-lg);background:var(--lav-light);cursor:pointer;" data-action="expandUpcomingItem" data-arg="${escAttr(nextMilestone.text)}">
         <span class="info-strip-icon">${nextMilestone.icon}</span>
         <div class="flex-1-min">
           <div class="micro-label">Coming up next</div>
@@ -23817,7 +23843,7 @@ function renderDietQuickPicker() {
       if (!val || val === '—skipped—') return;
       const short = val.length > 22 ? val.substring(0, 20) + '…' : val;
       const label = DAY_LABELS[pd.offset] || pd.offset + 'd';
-      pills.push(`<div class="dqp-same" onclick="fillDietMeal('${meal}','${escHtml(val).replace(/'/g, "\\\\'")}')" title="${escHtml(val)}">${label} <span class="op-60">${escHtml(short)}</span></div>`);
+      pills.push(`<div class="dqp-same" data-action="fillDietMeal" data-arg="${escAttr(meal)}" data-arg2="${escAttr(val)}" title="${escAttr(val)}">${label} <span class="op-60">${escHtml(short)}</span></div>`);
     });
 
     // 2. Same-as: today's OTHER meal slots that already have content
@@ -23828,19 +23854,19 @@ function renderDietQuickPicker() {
       const val = document.getElementById('meal-' + otherMeal)?.value || todayEntry[otherMeal] || '';
       if (!val || val === '—skipped—') return;
       const short = val.length > 20 ? val.substring(0, 18) + '…' : val;
-      pills.push(`<div class="dqp-same" onclick="fillDietMeal('${meal}','${escHtml(val).replace(/'/g, "\\\\'")}')" title="${escHtml(val)}">${MEAL_EMOJI[otherMeal]} ${MEAL_LABELS[otherMeal]} <span class="op-60">${escHtml(short)}</span></div>`);
+      pills.push(`<div class="dqp-same" data-action="fillDietMeal" data-arg="${escAttr(meal)}" data-arg2="${escAttr(val)}" title="${escAttr(val)}">${MEAL_EMOJI[otherMeal]} ${MEAL_LABELS[otherMeal]} <span class="op-60">${escHtml(short)}</span></div>`);
     });
 
     // 2. Top frequent foods for this meal slot (from meal-specific history)
     const mealFreq = getMealSlotTopFoods(meal, 4);
     mealFreq.forEach(f => {
-      pills.push(`<div class="dqp-pill" onclick="insertDietFood('${meal}','${escHtml(f.name).replace(/'/g, "\\\\'")}')" title="${f.count}× in ${MEAL_LABELS[meal]}">${escHtml(f.name)}</div>`);
+      pills.push(`<div class="dqp-pill" data-action="insertDietFood" data-arg="${escAttr(meal)}" data-arg2="${escAttr(f.name)}" title="${f.count}× in ${MEAL_LABELS[meal]}">${escHtml(f.name)}</div>`);
     });
 
     // 3. If no meal-specific foods, show general top foods
     if (mealFreq.length === 0 && topFoods.length > 0) {
       topFoods.slice(0, 3).forEach(f => {
-        pills.push(`<div class="dqp-pill" onclick="insertDietFood('${meal}','${escHtml(f.name).replace(/'/g, "\\\\'")}')" title="${f.count}× logged">${escHtml(f.name)}</div>`);
+        pills.push(`<div class="dqp-pill" data-action="insertDietFood" data-arg="${escAttr(meal)}" data-arg2="${escAttr(f.name)}" title="${f.count}× logged">${escHtml(f.name)}</div>`);
       });
     }
 
@@ -23937,8 +23963,7 @@ function renderDietIntelBanner() {
         html += '<div style="font-weight:600;margin-bottom:6px;">\u{1F4A1} ' + capitalize(MEAL_LABELS_FULL[nextMeal]) + ' ideas from Ziva\'s favorites</div>';
         best.forEach(function(t, idx) {
           var comboStr = t.foods.map(function(f){ return capitalize(f); }).join(', ');
-          var escapedCombo = escHtml(comboStr).replace(/'/g, "\\'");
-          html += '<div class="dib-combo-row" onclick="fillDietMeal(\'' + nextMeal + '\',\'' + escapedCombo + '\')" style="cursor:pointer;display:flex;align-items:center;gap:var(--sp-8);padding:6px 0;' + (idx > 0 ? 'border-top:1px solid rgba(0,0,0,0.05);' : '') + '">';
+          html += '<div class="dib-combo-row" data-action="fillDietMeal" data-arg="' + escAttr(nextMeal) + '" data-arg2="' + escAttr(comboStr) + '" style="cursor:pointer;display:flex;align-items:center;gap:var(--sp-8);padding:6px 0;' + (idx > 0 ? 'border-top:1px solid rgba(0,0,0,0.05);' : '') + '">';
           html += '<div class="flex-1-min0">';
           html += '<span class="t-sm" style="font-weight:600;color:var(--text);">' + escHtml(t.label) + '</span>';
           html += '<div style="display:flex;flex-wrap:wrap;gap:3px;margin-top:3px;">';
@@ -23981,7 +24006,7 @@ function renderDietIntelBanner() {
         html += '<div class="dib-card dib-synergy">\u{1F517} For ' + MEAL_LABELS_FULL[nextMeal] + ', try pairing with today\'s meals: ';
         top.forEach(function(s) {
           var emoji = s.type === 'absorption' ? '\u{1F517}' : s.type === 'complete' ? '\u2728' : '\u{1F33F}';
-          html += '<span class="dib-synergy-pill" onclick="insertDietFood(\'' + nextMeal + '\',\'' + escHtml(s.partner).replace(/'/g, "\\'") + '\')" title="' + escHtml(s.reason) + '">' + emoji + ' ' + escHtml(s.partner) + '</span> ';
+          html += '<span class="dib-synergy-pill" data-action="insertDietFood" data-arg="' + escAttr(nextMeal) + '" data-arg2="' + escAttr(s.partner) + '" title="' + escAttr(s.reason) + '">' + emoji + ' ' + escHtml(s.partner) + '</span> ';
         });
         html += '</div>';
       }
@@ -27885,11 +27910,11 @@ function renderAlertCardHTML(a, scope) {
       <div class="ctx-alert-body">
         <div class="ctx-alert-title">${escHtml(a.title)} <span class="ctx-alert-sev ${sevBadge}">${sevLabel}</span></div>
         <div class="ctx-alert-msg">${escHtml(a.body)}</div>
-        ${a.tip ? `<div class="ctx-alert-tip-toggle" onclick="event.stopPropagation();toggleAlertTip('${safeKey}')">${zi('bulb')} Tips & advice ▾</div>
+        ${a.tip ? `<div class="ctx-alert-tip-toggle" data-action="toggleAlertTip" data-arg="${safeKey}" data-stop="1">${zi('bulb')} Tips & advice ▾</div>
         <div class="ctx-alert-tip" id="ca-tip-${safeKey}">${escHtml(a.tip)}</div>` : ''}
         <div class="ctx-alert-actions">
-          ${a.action ? `<button class="ctx-alert-btn cab-primary" onclick="event.stopPropagation();execAlertAction('${safeKey}')">${escHtml(a.action.label)}</button>` : ''}
-          ${a.tab ? `<button class="ctx-alert-btn cab-secondary" onclick="event.stopPropagation();switchTab('${escAttr(a.tab)}')">View details</button>` : ''}
+          ${a.action ? `<button class="ctx-alert-btn cab-primary" data-action="execAlertAction" data-arg="${safeKey}" data-stop="1">${escHtml(a.action.label)}</button>` : ''}
+          ${a.tab ? `<button class="ctx-alert-btn cab-secondary" data-action="switchTab" data-arg="${escAttr(a.tab)}" data-stop="1">View details</button>` : ''}
         </div>
       </div>
     </div>
@@ -28586,7 +28611,7 @@ function renderTrendChips() {
 
   let html = '';
   chips.forEach((c, i) => {
-    html += `<div class="trend-chip" onclick="event.stopPropagation();switchTab('${c.tab}')">
+    html += `<div class="trend-chip" data-action="switchTab" data-arg="${escAttr(c.tab)}" data-stop="1">
       <span class="trend-chip-icon">${c.icon}</span>
       <div class="trend-chip-body">
         <div class="trend-chip-label">${c.label}</div>
@@ -33913,7 +33938,7 @@ function renderActiveMilestones() {
         return '<div class="al-evid-item">' + ev.date + ' — "' + escHtml((ev.text || '').substring(0, 40)) + '" ' + confDot + ' ' + ev.confidence + '</div>';
       }).join('');
       if (m.evidenceCount > 5) evItems += '<div class="al-evid-more">+' + (m.evidenceCount - 5) + ' more</div>';
-      evidHtml = '<button class="ms-tidbit-toggle" onclick="event.stopPropagation();document.getElementById(\'' + evidId + '\').style.display=document.getElementById(\'' + evidId + '\').style.display===\'none\'?\'block\':\'none\'">' + zi('chart') + ' View evidence ▾</button>' +
+      evidHtml = '<button class="ms-tidbit-toggle" data-action="toggleDisplayBlock" data-arg="' + evidId + '" data-stop="1">' + zi('chart') + ' View evidence ▾</button>' +
         '<div id="' + evidId + '" class="al-evid-box" style="display:none;">' + evItems + '</div>';
     }
 
@@ -34406,7 +34431,7 @@ function renderUpcomingEvents() {
           ${ev.source === 'custom' ? `<button class="del-btn" data-action="deleteEvent" data-stop="1" data-arg="${ev._i}" title="Delete">×</button>` : ''}
         </div>
         ${activities ? `
-          <button class="ms-tidbit-toggle mt-6" onclick="const e=document.getElementById('${actId}');e.style.display=e.style.display==='none'?'flex':'none';">
+          <button class="ms-tidbit-toggle mt-6" data-action="toggleDisplayFlex" data-arg="${actId}">
             ${zi('star')} Ziva activity ideas ▾
           </button>
           <div id="${actId}" style="display:none;margin-top:6px;flex-direction:column;gap:var(--sp-4);">
@@ -37731,7 +37756,7 @@ function renderUpcomingMilestones() {
 
       html += `
           <div class="upc-subcat" id="${subcatId}">
-            <div class="upc-subcat-header ${cat}" onclick="event.stopPropagation();toggleUpcomingSubcat('${subcatId}')">
+            <div class="upc-subcat-header ${cat}" data-action="toggleUpcomingSubcat" data-arg="${subcatId}" data-stop="1">
               <div class="upc-subcat-icon">${cm.icon}</div>
               <div class="upc-subcat-label">${cm.label}</div>
               <div class="upc-subcat-count">${catItems.length}</div>

--- a/index.html
+++ b/index.html
@@ -20987,8 +20987,8 @@ function renderRemindersAndAlerts() {
               <div class="supp-alert-icon">${zi('dot-red')}</div>
               <div class="supp-alert-title">Missed — ${escHtml(m.name)}</div>
               <div class="supp-alert-action">
-                <button class="supp-check-btn" data-action="resolveMissedMedDone" data-arg="${escAttr(m.name)}" data-arg2="${ds}">Was given</button>
-                <button class="supp-skip-btn" data-action="resolveMissedMedSkipped" data-arg="${escAttr(m.name)}" data-arg2="${ds}">Not given</button>
+                <button class="supp-check-btn" data-action="resolveMissedMedDone" data-arg="${escHtml(m.name)}" data-arg2="${ds}">Was given</button>
+                <button class="supp-skip-btn" data-action="resolveMissedMedSkipped" data-arg="${escHtml(m.name)}" data-arg2="${ds}">Not given</button>
               </div>
             </div>
             <div class="supp-alert-detail">${escHtml(m.dose || '')} · ${formatDate(ds)}</div>
@@ -21027,8 +21027,8 @@ function renderRemindersAndAlerts() {
           <div class="supp-alert-icon">${zi('warn')}</div>
           <div class="supp-alert-title">Reminder — ${escHtml(m.name)}</div>
           <div class="supp-alert-action">
-            <button class="supp-check-btn" data-action="markMedDone" data-arg="${escAttr(m.name)}" data-arg2="${idx}">Done</button>
-            <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escAttr(m.name)}" data-arg2="${idx}">Skip</button>
+            <button class="supp-check-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done</button>
+            <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Skip</button>
           </div>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${escHtml(m.freq || 'As prescribed')}</div>
@@ -23595,7 +23595,7 @@ function renderMilestoneStats() {
 
   if (nextMilestone) {
     hlHtml += `
-      <div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:var(--sp-12) 14px;border-radius:var(--r-lg);background:var(--lav-light);cursor:pointer;" data-action="expandUpcomingItem" data-arg="${escAttr(nextMilestone.text)}">
+      <div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:var(--sp-12) 14px;border-radius:var(--r-lg);background:var(--lav-light);cursor:pointer;" data-action="expandUpcomingItem" data-arg="${escHtml(nextMilestone.text)}">
         <span class="info-strip-icon">${nextMilestone.icon}</span>
         <div class="flex-1-min">
           <div class="micro-label">Coming up next</div>
@@ -23843,7 +23843,7 @@ function renderDietQuickPicker() {
       if (!val || val === '—skipped—') return;
       const short = val.length > 22 ? val.substring(0, 20) + '…' : val;
       const label = DAY_LABELS[pd.offset] || pd.offset + 'd';
-      pills.push(`<div class="dqp-same" data-action="fillDietMeal" data-arg="${escAttr(meal)}" data-arg2="${escAttr(val)}" title="${escAttr(val)}">${label} <span class="op-60">${escHtml(short)}</span></div>`);
+      pills.push(`<div class="dqp-same" data-action="fillDietMeal" data-arg="${escAttr(meal)}" data-arg2="${escHtml(val)}" title="${escAttr(val)}">${label} <span class="op-60">${escHtml(short)}</span></div>`);
     });
 
     // 2. Same-as: today's OTHER meal slots that already have content
@@ -23854,19 +23854,19 @@ function renderDietQuickPicker() {
       const val = document.getElementById('meal-' + otherMeal)?.value || todayEntry[otherMeal] || '';
       if (!val || val === '—skipped—') return;
       const short = val.length > 20 ? val.substring(0, 18) + '…' : val;
-      pills.push(`<div class="dqp-same" data-action="fillDietMeal" data-arg="${escAttr(meal)}" data-arg2="${escAttr(val)}" title="${escAttr(val)}">${MEAL_EMOJI[otherMeal]} ${MEAL_LABELS[otherMeal]} <span class="op-60">${escHtml(short)}</span></div>`);
+      pills.push(`<div class="dqp-same" data-action="fillDietMeal" data-arg="${escAttr(meal)}" data-arg2="${escHtml(val)}" title="${escAttr(val)}">${MEAL_EMOJI[otherMeal]} ${MEAL_LABELS[otherMeal]} <span class="op-60">${escHtml(short)}</span></div>`);
     });
 
     // 2. Top frequent foods for this meal slot (from meal-specific history)
     const mealFreq = getMealSlotTopFoods(meal, 4);
     mealFreq.forEach(f => {
-      pills.push(`<div class="dqp-pill" data-action="insertDietFood" data-arg="${escAttr(meal)}" data-arg2="${escAttr(f.name)}" title="${f.count}× in ${MEAL_LABELS[meal]}">${escHtml(f.name)}</div>`);
+      pills.push(`<div class="dqp-pill" data-action="insertDietFood" data-arg="${escAttr(meal)}" data-arg2="${escHtml(f.name)}" title="${f.count}× in ${MEAL_LABELS[meal]}">${escHtml(f.name)}</div>`);
     });
 
     // 3. If no meal-specific foods, show general top foods
     if (mealFreq.length === 0 && topFoods.length > 0) {
       topFoods.slice(0, 3).forEach(f => {
-        pills.push(`<div class="dqp-pill" data-action="insertDietFood" data-arg="${escAttr(meal)}" data-arg2="${escAttr(f.name)}" title="${f.count}× logged">${escHtml(f.name)}</div>`);
+        pills.push(`<div class="dqp-pill" data-action="insertDietFood" data-arg="${escAttr(meal)}" data-arg2="${escHtml(f.name)}" title="${f.count}× logged">${escHtml(f.name)}</div>`);
       });
     }
 
@@ -23963,7 +23963,7 @@ function renderDietIntelBanner() {
         html += '<div style="font-weight:600;margin-bottom:6px;">\u{1F4A1} ' + capitalize(MEAL_LABELS_FULL[nextMeal]) + ' ideas from Ziva\'s favorites</div>';
         best.forEach(function(t, idx) {
           var comboStr = t.foods.map(function(f){ return capitalize(f); }).join(', ');
-          html += '<div class="dib-combo-row" data-action="fillDietMeal" data-arg="' + escAttr(nextMeal) + '" data-arg2="' + escAttr(comboStr) + '" style="cursor:pointer;display:flex;align-items:center;gap:var(--sp-8);padding:6px 0;' + (idx > 0 ? 'border-top:1px solid rgba(0,0,0,0.05);' : '') + '">';
+          html += '<div class="dib-combo-row" data-action="fillDietMeal" data-arg="' + escAttr(nextMeal) + '" data-arg2="' + escHtml(comboStr) + '" style="cursor:pointer;display:flex;align-items:center;gap:var(--sp-8);padding:6px 0;' + (idx > 0 ? 'border-top:1px solid rgba(0,0,0,0.05);' : '') + '">';
           html += '<div class="flex-1-min0">';
           html += '<span class="t-sm" style="font-weight:600;color:var(--text);">' + escHtml(t.label) + '</span>';
           html += '<div style="display:flex;flex-wrap:wrap;gap:3px;margin-top:3px;">';
@@ -24006,7 +24006,7 @@ function renderDietIntelBanner() {
         html += '<div class="dib-card dib-synergy">\u{1F517} For ' + MEAL_LABELS_FULL[nextMeal] + ', try pairing with today\'s meals: ';
         top.forEach(function(s) {
           var emoji = s.type === 'absorption' ? '\u{1F517}' : s.type === 'complete' ? '\u2728' : '\u{1F33F}';
-          html += '<span class="dib-synergy-pill" data-action="insertDietFood" data-arg="' + escAttr(nextMeal) + '" data-arg2="' + escAttr(s.partner) + '" title="' + escAttr(s.reason) + '">' + emoji + ' ' + escHtml(s.partner) + '</span> ';
+          html += '<span class="dib-synergy-pill" data-action="insertDietFood" data-arg="' + escAttr(nextMeal) + '" data-arg2="' + escHtml(s.partner) + '" title="' + escAttr(s.reason) + '">' + emoji + ' ' + escHtml(s.partner) + '</span> ';
         });
         html += '</div>';
       }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.03-1",
+  "version": "2026.05.03-2",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.02-3",
+  "version": "2026.05.03-1",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -321,6 +321,32 @@ function init() {
       const el = document.getElementById(arg);
       if (el) el.style.display = el.style.display === 'none' ? 'block' : 'none';
     }
+    else if (action === 'toggleDisplayBlock') {
+      // Polish-10b: HR-3 cleanup — generic toggle between display:block and display:none.
+      // arg = elementId. Pair with data-stop="1" for stopPropagation behavior.
+      const el = document.getElementById(arg);
+      if (el) el.style.display = el.style.display === 'none' ? 'block' : 'none';
+    }
+    else if (action === 'toggleDisplayFlex') {
+      // Polish-10b: HR-3 cleanup — generic toggle between display:flex and display:none.
+      // arg = elementId. Pair with data-stop="1" for stopPropagation behavior.
+      const el = document.getElementById(arg);
+      if (el) el.style.display = el.style.display === 'none' ? 'flex' : 'none';
+    }
+    else if (action === 'resolveMissedMedDone' && typeof resolveMissedMed === 'function') resolveMissedMed(arg, arg2, 'done');
+    else if (action === 'resolveMissedMedSkipped' && typeof resolveMissedMed === 'function') resolveMissedMed(arg, arg2, 'skipped');
+    else if (action === 'markMedDone' && typeof markMedDone === 'function') markMedDone(arg, Number(arg2));
+    else if (action === 'markMedSkipped' && typeof markMedSkipped === 'function') markMedSkipped(arg, Number(arg2));
+    else if (action === 'deleteFeedingEntry' && typeof deleteFeedingEntry === 'function') deleteFeedingEntry(arg);
+    else if (action === 'switchFoodCatSub' && typeof switchFoodCatSub === 'function') switchFoodCatSub(arg, arg2);
+    else if (action === 'expandMilestoneByIdx' && typeof expandMilestoneByIdx === 'function') expandMilestoneByIdx(Number(arg));
+    else if (action === 'expandUpcomingItem' && typeof expandUpcomingItem === 'function') expandUpcomingItem(arg);
+    else if (action === 'fillDietMeal' && typeof fillDietMeal === 'function') fillDietMeal(arg, arg2);
+    else if (action === 'insertDietFood' && typeof insertDietFood === 'function') insertDietFood(arg, arg2);
+    else if (action === 'toggleAlertTip' && typeof toggleAlertTip === 'function') toggleAlertTip(arg);
+    else if (action === 'execAlertAction' && typeof execAlertAction === 'function') execAlertAction(arg);
+    else if (action === 'switchTab' && typeof switchTab === 'function') switchTab(arg);
+    else if (action === 'toggleUpcomingSubcat' && typeof toggleUpcomingSubcat === 'function') toggleUpcomingSubcat(arg);
     else if (action === 'editUpcomingVaccDate') editUpcomingVaccDate();
     else if (action === 'openMedModal') openMedModal();
     else if (action === 'toggleVisitForm') toggleVisitForm();

--- a/split/home.js
+++ b/split/home.js
@@ -619,8 +619,8 @@ function renderRemindersAndAlerts() {
               <div class="supp-alert-icon">${zi('dot-red')}</div>
               <div class="supp-alert-title">Missed — ${escHtml(m.name)}</div>
               <div class="supp-alert-action">
-                <button class="supp-check-btn" data-action="resolveMissedMedDone" data-arg="${escAttr(m.name)}" data-arg2="${ds}">Was given</button>
-                <button class="supp-skip-btn" data-action="resolveMissedMedSkipped" data-arg="${escAttr(m.name)}" data-arg2="${ds}">Not given</button>
+                <button class="supp-check-btn" data-action="resolveMissedMedDone" data-arg="${escHtml(m.name)}" data-arg2="${ds}">Was given</button>
+                <button class="supp-skip-btn" data-action="resolveMissedMedSkipped" data-arg="${escHtml(m.name)}" data-arg2="${ds}">Not given</button>
               </div>
             </div>
             <div class="supp-alert-detail">${escHtml(m.dose || '')} · ${formatDate(ds)}</div>
@@ -659,8 +659,8 @@ function renderRemindersAndAlerts() {
           <div class="supp-alert-icon">${zi('warn')}</div>
           <div class="supp-alert-title">Reminder — ${escHtml(m.name)}</div>
           <div class="supp-alert-action">
-            <button class="supp-check-btn" data-action="markMedDone" data-arg="${escAttr(m.name)}" data-arg2="${idx}">Done</button>
-            <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escAttr(m.name)}" data-arg2="${idx}">Skip</button>
+            <button class="supp-check-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done</button>
+            <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Skip</button>
           </div>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${escHtml(m.freq || 'As prescribed')}</div>
@@ -3227,7 +3227,7 @@ function renderMilestoneStats() {
 
   if (nextMilestone) {
     hlHtml += `
-      <div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:var(--sp-12) 14px;border-radius:var(--r-lg);background:var(--lav-light);cursor:pointer;" data-action="expandUpcomingItem" data-arg="${escAttr(nextMilestone.text)}">
+      <div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:var(--sp-12) 14px;border-radius:var(--r-lg);background:var(--lav-light);cursor:pointer;" data-action="expandUpcomingItem" data-arg="${escHtml(nextMilestone.text)}">
         <span class="info-strip-icon">${nextMilestone.icon}</span>
         <div class="flex-1-min">
           <div class="micro-label">Coming up next</div>
@@ -3475,7 +3475,7 @@ function renderDietQuickPicker() {
       if (!val || val === '—skipped—') return;
       const short = val.length > 22 ? val.substring(0, 20) + '…' : val;
       const label = DAY_LABELS[pd.offset] || pd.offset + 'd';
-      pills.push(`<div class="dqp-same" data-action="fillDietMeal" data-arg="${escAttr(meal)}" data-arg2="${escAttr(val)}" title="${escAttr(val)}">${label} <span class="op-60">${escHtml(short)}</span></div>`);
+      pills.push(`<div class="dqp-same" data-action="fillDietMeal" data-arg="${escAttr(meal)}" data-arg2="${escHtml(val)}" title="${escAttr(val)}">${label} <span class="op-60">${escHtml(short)}</span></div>`);
     });
 
     // 2. Same-as: today's OTHER meal slots that already have content
@@ -3486,19 +3486,19 @@ function renderDietQuickPicker() {
       const val = document.getElementById('meal-' + otherMeal)?.value || todayEntry[otherMeal] || '';
       if (!val || val === '—skipped—') return;
       const short = val.length > 20 ? val.substring(0, 18) + '…' : val;
-      pills.push(`<div class="dqp-same" data-action="fillDietMeal" data-arg="${escAttr(meal)}" data-arg2="${escAttr(val)}" title="${escAttr(val)}">${MEAL_EMOJI[otherMeal]} ${MEAL_LABELS[otherMeal]} <span class="op-60">${escHtml(short)}</span></div>`);
+      pills.push(`<div class="dqp-same" data-action="fillDietMeal" data-arg="${escAttr(meal)}" data-arg2="${escHtml(val)}" title="${escAttr(val)}">${MEAL_EMOJI[otherMeal]} ${MEAL_LABELS[otherMeal]} <span class="op-60">${escHtml(short)}</span></div>`);
     });
 
     // 2. Top frequent foods for this meal slot (from meal-specific history)
     const mealFreq = getMealSlotTopFoods(meal, 4);
     mealFreq.forEach(f => {
-      pills.push(`<div class="dqp-pill" data-action="insertDietFood" data-arg="${escAttr(meal)}" data-arg2="${escAttr(f.name)}" title="${f.count}× in ${MEAL_LABELS[meal]}">${escHtml(f.name)}</div>`);
+      pills.push(`<div class="dqp-pill" data-action="insertDietFood" data-arg="${escAttr(meal)}" data-arg2="${escHtml(f.name)}" title="${f.count}× in ${MEAL_LABELS[meal]}">${escHtml(f.name)}</div>`);
     });
 
     // 3. If no meal-specific foods, show general top foods
     if (mealFreq.length === 0 && topFoods.length > 0) {
       topFoods.slice(0, 3).forEach(f => {
-        pills.push(`<div class="dqp-pill" data-action="insertDietFood" data-arg="${escAttr(meal)}" data-arg2="${escAttr(f.name)}" title="${f.count}× logged">${escHtml(f.name)}</div>`);
+        pills.push(`<div class="dqp-pill" data-action="insertDietFood" data-arg="${escAttr(meal)}" data-arg2="${escHtml(f.name)}" title="${f.count}× logged">${escHtml(f.name)}</div>`);
       });
     }
 
@@ -3595,7 +3595,7 @@ function renderDietIntelBanner() {
         html += '<div style="font-weight:600;margin-bottom:6px;">\u{1F4A1} ' + capitalize(MEAL_LABELS_FULL[nextMeal]) + ' ideas from Ziva\'s favorites</div>';
         best.forEach(function(t, idx) {
           var comboStr = t.foods.map(function(f){ return capitalize(f); }).join(', ');
-          html += '<div class="dib-combo-row" data-action="fillDietMeal" data-arg="' + escAttr(nextMeal) + '" data-arg2="' + escAttr(comboStr) + '" style="cursor:pointer;display:flex;align-items:center;gap:var(--sp-8);padding:6px 0;' + (idx > 0 ? 'border-top:1px solid rgba(0,0,0,0.05);' : '') + '">';
+          html += '<div class="dib-combo-row" data-action="fillDietMeal" data-arg="' + escAttr(nextMeal) + '" data-arg2="' + escHtml(comboStr) + '" style="cursor:pointer;display:flex;align-items:center;gap:var(--sp-8);padding:6px 0;' + (idx > 0 ? 'border-top:1px solid rgba(0,0,0,0.05);' : '') + '">';
           html += '<div class="flex-1-min0">';
           html += '<span class="t-sm" style="font-weight:600;color:var(--text);">' + escHtml(t.label) + '</span>';
           html += '<div style="display:flex;flex-wrap:wrap;gap:3px;margin-top:3px;">';
@@ -3638,7 +3638,7 @@ function renderDietIntelBanner() {
         html += '<div class="dib-card dib-synergy">\u{1F517} For ' + MEAL_LABELS_FULL[nextMeal] + ', try pairing with today\'s meals: ';
         top.forEach(function(s) {
           var emoji = s.type === 'absorption' ? '\u{1F517}' : s.type === 'complete' ? '\u2728' : '\u{1F33F}';
-          html += '<span class="dib-synergy-pill" data-action="insertDietFood" data-arg="' + escAttr(nextMeal) + '" data-arg2="' + escAttr(s.partner) + '" title="' + escAttr(s.reason) + '">' + emoji + ' ' + escHtml(s.partner) + '</span> ';
+          html += '<span class="dib-synergy-pill" data-action="insertDietFood" data-arg="' + escAttr(nextMeal) + '" data-arg2="' + escHtml(s.partner) + '" title="' + escAttr(s.reason) + '">' + emoji + ' ' + escHtml(s.partner) + '</span> ';
         });
         html += '</div>';
       }

--- a/split/home.js
+++ b/split/home.js
@@ -619,8 +619,8 @@ function renderRemindersAndAlerts() {
               <div class="supp-alert-icon">${zi('dot-red')}</div>
               <div class="supp-alert-title">Missed — ${escHtml(m.name)}</div>
               <div class="supp-alert-action">
-                <button class="supp-check-btn" onclick="resolveMissedMed('${escAttr(m.name)}', '${ds}', 'done')">Was given</button>
-                <button class="supp-skip-btn" onclick="resolveMissedMed('${escAttr(m.name)}', '${ds}', 'skipped')">Not given</button>
+                <button class="supp-check-btn" data-action="resolveMissedMedDone" data-arg="${escAttr(m.name)}" data-arg2="${ds}">Was given</button>
+                <button class="supp-skip-btn" data-action="resolveMissedMedSkipped" data-arg="${escAttr(m.name)}" data-arg2="${ds}">Not given</button>
               </div>
             </div>
             <div class="supp-alert-detail">${escHtml(m.dose || '')} · ${formatDate(ds)}</div>
@@ -659,8 +659,8 @@ function renderRemindersAndAlerts() {
           <div class="supp-alert-icon">${zi('warn')}</div>
           <div class="supp-alert-title">Reminder — ${escHtml(m.name)}</div>
           <div class="supp-alert-action">
-            <button class="supp-check-btn" onclick="markMedDone('${escAttr(m.name)}', ${idx})">Done</button>
-            <button class="supp-skip-btn" onclick="markMedSkipped('${escAttr(m.name)}', ${idx})">Skip</button>
+            <button class="supp-check-btn" data-action="markMedDone" data-arg="${escAttr(m.name)}" data-arg2="${idx}">Done</button>
+            <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escAttr(m.name)}" data-arg2="${idx}">Skip</button>
           </div>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${escHtml(m.freq || 'As prescribed')}</div>
@@ -1567,7 +1567,7 @@ function renderMilestones() {
             return `<div class="al-evid-item">${ev.date} — "${escHtml((ev.text||'').substring(0, 40))}" ${confDot} ${ev.confidence}</div>`;
           }).join('');
           if (m.evidenceCount > 5) evItems += `<div class="al-evid-more">+${m.evidenceCount - 5} more</div>`;
-          evidHtml = `<button class="ms-tidbit-toggle" onclick="event.stopPropagation();document.getElementById('${evidId}').style.display=document.getElementById('${evidId}').style.display==='none'?'block':'none'">${zi('chart')} View evidence ▾</button>
+          evidHtml = `<button class="ms-tidbit-toggle" data-action="toggleDisplayBlock" data-arg="${evidId}" data-stop="1">${zi('chart')} View evidence ▾</button>
             <div id="${evidId}" class="al-evid-box" style="display:none;">${evItems}</div>`;
         }
       }
@@ -1580,7 +1580,7 @@ function renderMilestones() {
                 <strong>${escHtml(m.text)}</strong>
                 ${metaHtml}
                 ${evidHtml}
-                ${tidbitData ? `<button class="ms-tidbit-toggle" onclick="event.stopPropagation();document.getElementById('${tidbitId}').style.display=document.getElementById('${tidbitId}').style.display==='none'?'flex':'none'"><svg class="zi"><use href="#zi-bulb"/></svg> Learn more ▾</button>` : ''}
+                ${tidbitData ? `<button class="ms-tidbit-toggle" data-action="toggleDisplayFlex" data-arg="${tidbitId}" data-stop="1"><svg class="zi"><use href="#zi-bulb"/></svg> Learn more ▾</button>` : ''}
               </div>
               ${m.advanced ? '<span class="badge-adv"><svg class="zi"><use href="#zi-star"/></svg> Advanced</span>' : ''}
               <div class="milestone-actions">
@@ -2120,7 +2120,7 @@ function renderRecentEvidence() {
     const isToday = dateStr === todayStr;
 
     html += '<div class="al-feed-day">';
-    html += '<div class="al-feed-day-header ptr" onclick="document.getElementById(\'' + dayBodyId + '\').style.display=document.getElementById(\'' + dayBodyId + '\').style.display===\'none\'?\'block\':\'none\'" >' +
+    html += '<div class="al-feed-day-header ptr" data-action="toggleDisplayBlock" data-arg="' + dayBodyId + '">' +
       dayLabel + ' — ' + entries.length + ' activit' + (entries.length === 1 ? 'y' : 'ies') + ' · ' + totalEvidence + ' evidence' +
       '<span style="float:right;">▾</span></div>';
     html += '<div class="al-feed-summary">' + summaryChips + '</div>';
@@ -2500,7 +2500,7 @@ function renderFeedingHistory() {
             ${sInsight ? `<div class="history-meal-insight"><span class="hmi-icon">${zi('sparkle')}</span><span>${sInsight}</span></div>` : ''}
             <div class="fx g8 fx-end mt-8">
               <button class="ms-action-btn" data-action="navFeedDay" data-stop="1" data-arg="${dateKey}">Edit</button>
-              <button class="ms-action-btn del-ms" onclick="event.stopPropagation();deleteFeedingEntry('${dateKey}')">&times; Delete</button>
+              <button class="ms-action-btn del-ms" data-action="deleteFeedingEntry" data-arg="${dateKey}" data-stop="1">&times; Delete</button>
             </div>
           </div>
         </div>`;
@@ -2732,7 +2732,7 @@ function openFoodCatModal(pid) {
     const sub = parent.subs[sid];
     const count = grouped[pid][sid].length;
     const total = sub.keys.length;
-    return `<button class="settings-tab${i===0?' active-st':''}" id="fct-${sid}" onclick="switchFoodCatSub('${pid}','${sid}')" style="font-size:var(--fs-xs);padding:6px 8px;gap:var(--sp-4);">
+    return `<button class="settings-tab${i===0?' active-st':''}" id="fct-${sid}" data-action="switchFoodCatSub" data-arg="${pid}" data-arg2="${sid}" style="font-size:var(--fs-xs);padding:6px 8px;gap:var(--sp-4);">
       ${sub.icon} ${sub.label} <span style="opacity:0.6;font-size:var(--fs-xs);">${count}/${total}</span>
     </button>`;
   }).join('');
@@ -3215,7 +3215,7 @@ function renderMilestoneStats() {
     const dateInfo = latestMs.doneAt ? formatDate(latestMs.doneAt.split('T')[0]) + ' · ' + ageAtDate(latestMs.doneAt) : '';
     const latestIdx = milestones.indexOf(latestMs);
     hlHtml += `
-      <div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:var(--sp-12) 14px;border-radius:var(--r-lg);background:var(--sage-light);cursor:pointer;" onclick="expandMilestoneByIdx(${latestIdx})">
+      <div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:var(--sp-12) 14px;border-radius:var(--r-lg);background:var(--sage-light);cursor:pointer;" data-action="expandMilestoneByIdx" data-arg="${latestIdx}">
         <span class="info-strip-icon">${ci}</span>
         <div class="flex-1-min">
           <div class="micro-label">Latest achieved</div>
@@ -3227,7 +3227,7 @@ function renderMilestoneStats() {
 
   if (nextMilestone) {
     hlHtml += `
-      <div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:var(--sp-12) 14px;border-radius:var(--r-lg);background:var(--lav-light);cursor:pointer;" onclick="expandUpcomingItem('${escAttr(nextMilestone.text)}')">
+      <div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:var(--sp-12) 14px;border-radius:var(--r-lg);background:var(--lav-light);cursor:pointer;" data-action="expandUpcomingItem" data-arg="${escAttr(nextMilestone.text)}">
         <span class="info-strip-icon">${nextMilestone.icon}</span>
         <div class="flex-1-min">
           <div class="micro-label">Coming up next</div>
@@ -3475,7 +3475,7 @@ function renderDietQuickPicker() {
       if (!val || val === '—skipped—') return;
       const short = val.length > 22 ? val.substring(0, 20) + '…' : val;
       const label = DAY_LABELS[pd.offset] || pd.offset + 'd';
-      pills.push(`<div class="dqp-same" onclick="fillDietMeal('${meal}','${escHtml(val).replace(/'/g, "\\\\'")}')" title="${escHtml(val)}">${label} <span class="op-60">${escHtml(short)}</span></div>`);
+      pills.push(`<div class="dqp-same" data-action="fillDietMeal" data-arg="${escAttr(meal)}" data-arg2="${escAttr(val)}" title="${escAttr(val)}">${label} <span class="op-60">${escHtml(short)}</span></div>`);
     });
 
     // 2. Same-as: today's OTHER meal slots that already have content
@@ -3486,19 +3486,19 @@ function renderDietQuickPicker() {
       const val = document.getElementById('meal-' + otherMeal)?.value || todayEntry[otherMeal] || '';
       if (!val || val === '—skipped—') return;
       const short = val.length > 20 ? val.substring(0, 18) + '…' : val;
-      pills.push(`<div class="dqp-same" onclick="fillDietMeal('${meal}','${escHtml(val).replace(/'/g, "\\\\'")}')" title="${escHtml(val)}">${MEAL_EMOJI[otherMeal]} ${MEAL_LABELS[otherMeal]} <span class="op-60">${escHtml(short)}</span></div>`);
+      pills.push(`<div class="dqp-same" data-action="fillDietMeal" data-arg="${escAttr(meal)}" data-arg2="${escAttr(val)}" title="${escAttr(val)}">${MEAL_EMOJI[otherMeal]} ${MEAL_LABELS[otherMeal]} <span class="op-60">${escHtml(short)}</span></div>`);
     });
 
     // 2. Top frequent foods for this meal slot (from meal-specific history)
     const mealFreq = getMealSlotTopFoods(meal, 4);
     mealFreq.forEach(f => {
-      pills.push(`<div class="dqp-pill" onclick="insertDietFood('${meal}','${escHtml(f.name).replace(/'/g, "\\\\'")}')" title="${f.count}× in ${MEAL_LABELS[meal]}">${escHtml(f.name)}</div>`);
+      pills.push(`<div class="dqp-pill" data-action="insertDietFood" data-arg="${escAttr(meal)}" data-arg2="${escAttr(f.name)}" title="${f.count}× in ${MEAL_LABELS[meal]}">${escHtml(f.name)}</div>`);
     });
 
     // 3. If no meal-specific foods, show general top foods
     if (mealFreq.length === 0 && topFoods.length > 0) {
       topFoods.slice(0, 3).forEach(f => {
-        pills.push(`<div class="dqp-pill" onclick="insertDietFood('${meal}','${escHtml(f.name).replace(/'/g, "\\\\'")}')" title="${f.count}× logged">${escHtml(f.name)}</div>`);
+        pills.push(`<div class="dqp-pill" data-action="insertDietFood" data-arg="${escAttr(meal)}" data-arg2="${escAttr(f.name)}" title="${f.count}× logged">${escHtml(f.name)}</div>`);
       });
     }
 
@@ -3595,8 +3595,7 @@ function renderDietIntelBanner() {
         html += '<div style="font-weight:600;margin-bottom:6px;">\u{1F4A1} ' + capitalize(MEAL_LABELS_FULL[nextMeal]) + ' ideas from Ziva\'s favorites</div>';
         best.forEach(function(t, idx) {
           var comboStr = t.foods.map(function(f){ return capitalize(f); }).join(', ');
-          var escapedCombo = escHtml(comboStr).replace(/'/g, "\\'");
-          html += '<div class="dib-combo-row" onclick="fillDietMeal(\'' + nextMeal + '\',\'' + escapedCombo + '\')" style="cursor:pointer;display:flex;align-items:center;gap:var(--sp-8);padding:6px 0;' + (idx > 0 ? 'border-top:1px solid rgba(0,0,0,0.05);' : '') + '">';
+          html += '<div class="dib-combo-row" data-action="fillDietMeal" data-arg="' + escAttr(nextMeal) + '" data-arg2="' + escAttr(comboStr) + '" style="cursor:pointer;display:flex;align-items:center;gap:var(--sp-8);padding:6px 0;' + (idx > 0 ? 'border-top:1px solid rgba(0,0,0,0.05);' : '') + '">';
           html += '<div class="flex-1-min0">';
           html += '<span class="t-sm" style="font-weight:600;color:var(--text);">' + escHtml(t.label) + '</span>';
           html += '<div style="display:flex;flex-wrap:wrap;gap:3px;margin-top:3px;">';
@@ -3639,7 +3638,7 @@ function renderDietIntelBanner() {
         html += '<div class="dib-card dib-synergy">\u{1F517} For ' + MEAL_LABELS_FULL[nextMeal] + ', try pairing with today\'s meals: ';
         top.forEach(function(s) {
           var emoji = s.type === 'absorption' ? '\u{1F517}' : s.type === 'complete' ? '\u2728' : '\u{1F33F}';
-          html += '<span class="dib-synergy-pill" onclick="insertDietFood(\'' + nextMeal + '\',\'' + escHtml(s.partner).replace(/'/g, "\\'") + '\')" title="' + escHtml(s.reason) + '">' + emoji + ' ' + escHtml(s.partner) + '</span> ';
+          html += '<span class="dib-synergy-pill" data-action="insertDietFood" data-arg="' + escAttr(nextMeal) + '" data-arg2="' + escAttr(s.partner) + '" title="' + escAttr(s.reason) + '">' + emoji + ' ' + escHtml(s.partner) + '</span> ';
         });
         html += '</div>';
       }
@@ -7543,11 +7542,11 @@ function renderAlertCardHTML(a, scope) {
       <div class="ctx-alert-body">
         <div class="ctx-alert-title">${escHtml(a.title)} <span class="ctx-alert-sev ${sevBadge}">${sevLabel}</span></div>
         <div class="ctx-alert-msg">${escHtml(a.body)}</div>
-        ${a.tip ? `<div class="ctx-alert-tip-toggle" onclick="event.stopPropagation();toggleAlertTip('${safeKey}')">${zi('bulb')} Tips & advice ▾</div>
+        ${a.tip ? `<div class="ctx-alert-tip-toggle" data-action="toggleAlertTip" data-arg="${safeKey}" data-stop="1">${zi('bulb')} Tips & advice ▾</div>
         <div class="ctx-alert-tip" id="ca-tip-${safeKey}">${escHtml(a.tip)}</div>` : ''}
         <div class="ctx-alert-actions">
-          ${a.action ? `<button class="ctx-alert-btn cab-primary" onclick="event.stopPropagation();execAlertAction('${safeKey}')">${escHtml(a.action.label)}</button>` : ''}
-          ${a.tab ? `<button class="ctx-alert-btn cab-secondary" onclick="event.stopPropagation();switchTab('${escAttr(a.tab)}')">View details</button>` : ''}
+          ${a.action ? `<button class="ctx-alert-btn cab-primary" data-action="execAlertAction" data-arg="${safeKey}" data-stop="1">${escHtml(a.action.label)}</button>` : ''}
+          ${a.tab ? `<button class="ctx-alert-btn cab-secondary" data-action="switchTab" data-arg="${escAttr(a.tab)}" data-stop="1">View details</button>` : ''}
         </div>
       </div>
     </div>
@@ -8244,7 +8243,7 @@ function renderTrendChips() {
 
   let html = '';
   chips.forEach((c, i) => {
-    html += `<div class="trend-chip" onclick="event.stopPropagation();switchTab('${c.tab}')">
+    html += `<div class="trend-chip" data-action="switchTab" data-arg="${escAttr(c.tab)}" data-stop="1">
       <span class="trend-chip-icon">${c.icon}</span>
       <div class="trend-chip-body">
         <div class="trend-chip-label">${c.label}</div>

--- a/split/medical.js
+++ b/split/medical.js
@@ -298,7 +298,7 @@ function renderActiveMilestones() {
         return '<div class="al-evid-item">' + ev.date + ' — "' + escHtml((ev.text || '').substring(0, 40)) + '" ' + confDot + ' ' + ev.confidence + '</div>';
       }).join('');
       if (m.evidenceCount > 5) evItems += '<div class="al-evid-more">+' + (m.evidenceCount - 5) + ' more</div>';
-      evidHtml = '<button class="ms-tidbit-toggle" onclick="event.stopPropagation();document.getElementById(\'' + evidId + '\').style.display=document.getElementById(\'' + evidId + '\').style.display===\'none\'?\'block\':\'none\'">' + zi('chart') + ' View evidence ▾</button>' +
+      evidHtml = '<button class="ms-tidbit-toggle" data-action="toggleDisplayBlock" data-arg="' + evidId + '" data-stop="1">' + zi('chart') + ' View evidence ▾</button>' +
         '<div id="' + evidId + '" class="al-evid-box" style="display:none;">' + evItems + '</div>';
     }
 
@@ -791,7 +791,7 @@ function renderUpcomingEvents() {
           ${ev.source === 'custom' ? `<button class="del-btn" data-action="deleteEvent" data-stop="1" data-arg="${ev._i}" title="Delete">×</button>` : ''}
         </div>
         ${activities ? `
-          <button class="ms-tidbit-toggle mt-6" onclick="const e=document.getElementById('${actId}');e.style.display=e.style.display==='none'?'flex':'none';">
+          <button class="ms-tidbit-toggle mt-6" data-action="toggleDisplayFlex" data-arg="${actId}">
             ${zi('star')} Ziva activity ideas ▾
           </button>
           <div id="${actId}" style="display:none;margin-top:6px;flex-direction:column;gap:var(--sp-4);">
@@ -4116,7 +4116,7 @@ function renderUpcomingMilestones() {
 
       html += `
           <div class="upc-subcat" id="${subcatId}">
-            <div class="upc-subcat-header ${cat}" onclick="event.stopPropagation();toggleUpcomingSubcat('${subcatId}')">
+            <div class="upc-subcat-header ${cat}" data-action="toggleUpcomingSubcat" data-arg="${subcatId}" data-stop="1">
               <div class="upc-subcat-icon">${cm.icon}</div>
               <div class="upc-subcat-label">${cm.label}</div>
               <div class="upc-subcat-count">${catItems.length}</div>

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -15746,6 +15746,32 @@ function init() {
       const el = document.getElementById(arg);
       if (el) el.style.display = el.style.display === 'none' ? 'block' : 'none';
     }
+    else if (action === 'toggleDisplayBlock') {
+      // Polish-10b: HR-3 cleanup — generic toggle between display:block and display:none.
+      // arg = elementId. Pair with data-stop="1" for stopPropagation behavior.
+      const el = document.getElementById(arg);
+      if (el) el.style.display = el.style.display === 'none' ? 'block' : 'none';
+    }
+    else if (action === 'toggleDisplayFlex') {
+      // Polish-10b: HR-3 cleanup — generic toggle between display:flex and display:none.
+      // arg = elementId. Pair with data-stop="1" for stopPropagation behavior.
+      const el = document.getElementById(arg);
+      if (el) el.style.display = el.style.display === 'none' ? 'flex' : 'none';
+    }
+    else if (action === 'resolveMissedMedDone' && typeof resolveMissedMed === 'function') resolveMissedMed(arg, arg2, 'done');
+    else if (action === 'resolveMissedMedSkipped' && typeof resolveMissedMed === 'function') resolveMissedMed(arg, arg2, 'skipped');
+    else if (action === 'markMedDone' && typeof markMedDone === 'function') markMedDone(arg, Number(arg2));
+    else if (action === 'markMedSkipped' && typeof markMedSkipped === 'function') markMedSkipped(arg, Number(arg2));
+    else if (action === 'deleteFeedingEntry' && typeof deleteFeedingEntry === 'function') deleteFeedingEntry(arg);
+    else if (action === 'switchFoodCatSub' && typeof switchFoodCatSub === 'function') switchFoodCatSub(arg, arg2);
+    else if (action === 'expandMilestoneByIdx' && typeof expandMilestoneByIdx === 'function') expandMilestoneByIdx(Number(arg));
+    else if (action === 'expandUpcomingItem' && typeof expandUpcomingItem === 'function') expandUpcomingItem(arg);
+    else if (action === 'fillDietMeal' && typeof fillDietMeal === 'function') fillDietMeal(arg, arg2);
+    else if (action === 'insertDietFood' && typeof insertDietFood === 'function') insertDietFood(arg, arg2);
+    else if (action === 'toggleAlertTip' && typeof toggleAlertTip === 'function') toggleAlertTip(arg);
+    else if (action === 'execAlertAction' && typeof execAlertAction === 'function') execAlertAction(arg);
+    else if (action === 'switchTab' && typeof switchTab === 'function') switchTab(arg);
+    else if (action === 'toggleUpcomingSubcat' && typeof toggleUpcomingSubcat === 'function') toggleUpcomingSubcat(arg);
     else if (action === 'editUpcomingVaccDate') editUpcomingVaccDate();
     else if (action === 'openMedModal') openMedModal();
     else if (action === 'toggleVisitForm') toggleVisitForm();
@@ -20961,8 +20987,8 @@ function renderRemindersAndAlerts() {
               <div class="supp-alert-icon">${zi('dot-red')}</div>
               <div class="supp-alert-title">Missed — ${escHtml(m.name)}</div>
               <div class="supp-alert-action">
-                <button class="supp-check-btn" onclick="resolveMissedMed('${escAttr(m.name)}', '${ds}', 'done')">Was given</button>
-                <button class="supp-skip-btn" onclick="resolveMissedMed('${escAttr(m.name)}', '${ds}', 'skipped')">Not given</button>
+                <button class="supp-check-btn" data-action="resolveMissedMedDone" data-arg="${escAttr(m.name)}" data-arg2="${ds}">Was given</button>
+                <button class="supp-skip-btn" data-action="resolveMissedMedSkipped" data-arg="${escAttr(m.name)}" data-arg2="${ds}">Not given</button>
               </div>
             </div>
             <div class="supp-alert-detail">${escHtml(m.dose || '')} · ${formatDate(ds)}</div>
@@ -21001,8 +21027,8 @@ function renderRemindersAndAlerts() {
           <div class="supp-alert-icon">${zi('warn')}</div>
           <div class="supp-alert-title">Reminder — ${escHtml(m.name)}</div>
           <div class="supp-alert-action">
-            <button class="supp-check-btn" onclick="markMedDone('${escAttr(m.name)}', ${idx})">Done</button>
-            <button class="supp-skip-btn" onclick="markMedSkipped('${escAttr(m.name)}', ${idx})">Skip</button>
+            <button class="supp-check-btn" data-action="markMedDone" data-arg="${escAttr(m.name)}" data-arg2="${idx}">Done</button>
+            <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escAttr(m.name)}" data-arg2="${idx}">Skip</button>
           </div>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${escHtml(m.freq || 'As prescribed')}</div>
@@ -21909,7 +21935,7 @@ function renderMilestones() {
             return `<div class="al-evid-item">${ev.date} — "${escHtml((ev.text||'').substring(0, 40))}" ${confDot} ${ev.confidence}</div>`;
           }).join('');
           if (m.evidenceCount > 5) evItems += `<div class="al-evid-more">+${m.evidenceCount - 5} more</div>`;
-          evidHtml = `<button class="ms-tidbit-toggle" onclick="event.stopPropagation();document.getElementById('${evidId}').style.display=document.getElementById('${evidId}').style.display==='none'?'block':'none'">${zi('chart')} View evidence ▾</button>
+          evidHtml = `<button class="ms-tidbit-toggle" data-action="toggleDisplayBlock" data-arg="${evidId}" data-stop="1">${zi('chart')} View evidence ▾</button>
             <div id="${evidId}" class="al-evid-box" style="display:none;">${evItems}</div>`;
         }
       }
@@ -21922,7 +21948,7 @@ function renderMilestones() {
                 <strong>${escHtml(m.text)}</strong>
                 ${metaHtml}
                 ${evidHtml}
-                ${tidbitData ? `<button class="ms-tidbit-toggle" onclick="event.stopPropagation();document.getElementById('${tidbitId}').style.display=document.getElementById('${tidbitId}').style.display==='none'?'flex':'none'"><svg class="zi"><use href="#zi-bulb"/></svg> Learn more ▾</button>` : ''}
+                ${tidbitData ? `<button class="ms-tidbit-toggle" data-action="toggleDisplayFlex" data-arg="${tidbitId}" data-stop="1"><svg class="zi"><use href="#zi-bulb"/></svg> Learn more ▾</button>` : ''}
               </div>
               ${m.advanced ? '<span class="badge-adv"><svg class="zi"><use href="#zi-star"/></svg> Advanced</span>' : ''}
               <div class="milestone-actions">
@@ -22462,7 +22488,7 @@ function renderRecentEvidence() {
     const isToday = dateStr === todayStr;
 
     html += '<div class="al-feed-day">';
-    html += '<div class="al-feed-day-header ptr" onclick="document.getElementById(\'' + dayBodyId + '\').style.display=document.getElementById(\'' + dayBodyId + '\').style.display===\'none\'?\'block\':\'none\'" >' +
+    html += '<div class="al-feed-day-header ptr" data-action="toggleDisplayBlock" data-arg="' + dayBodyId + '">' +
       dayLabel + ' — ' + entries.length + ' activit' + (entries.length === 1 ? 'y' : 'ies') + ' · ' + totalEvidence + ' evidence' +
       '<span style="float:right;">▾</span></div>';
     html += '<div class="al-feed-summary">' + summaryChips + '</div>';
@@ -22842,7 +22868,7 @@ function renderFeedingHistory() {
             ${sInsight ? `<div class="history-meal-insight"><span class="hmi-icon">${zi('sparkle')}</span><span>${sInsight}</span></div>` : ''}
             <div class="fx g8 fx-end mt-8">
               <button class="ms-action-btn" data-action="navFeedDay" data-stop="1" data-arg="${dateKey}">Edit</button>
-              <button class="ms-action-btn del-ms" onclick="event.stopPropagation();deleteFeedingEntry('${dateKey}')">&times; Delete</button>
+              <button class="ms-action-btn del-ms" data-action="deleteFeedingEntry" data-arg="${dateKey}" data-stop="1">&times; Delete</button>
             </div>
           </div>
         </div>`;
@@ -23074,7 +23100,7 @@ function openFoodCatModal(pid) {
     const sub = parent.subs[sid];
     const count = grouped[pid][sid].length;
     const total = sub.keys.length;
-    return `<button class="settings-tab${i===0?' active-st':''}" id="fct-${sid}" onclick="switchFoodCatSub('${pid}','${sid}')" style="font-size:var(--fs-xs);padding:6px 8px;gap:var(--sp-4);">
+    return `<button class="settings-tab${i===0?' active-st':''}" id="fct-${sid}" data-action="switchFoodCatSub" data-arg="${pid}" data-arg2="${sid}" style="font-size:var(--fs-xs);padding:6px 8px;gap:var(--sp-4);">
       ${sub.icon} ${sub.label} <span style="opacity:0.6;font-size:var(--fs-xs);">${count}/${total}</span>
     </button>`;
   }).join('');
@@ -23557,7 +23583,7 @@ function renderMilestoneStats() {
     const dateInfo = latestMs.doneAt ? formatDate(latestMs.doneAt.split('T')[0]) + ' · ' + ageAtDate(latestMs.doneAt) : '';
     const latestIdx = milestones.indexOf(latestMs);
     hlHtml += `
-      <div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:var(--sp-12) 14px;border-radius:var(--r-lg);background:var(--sage-light);cursor:pointer;" onclick="expandMilestoneByIdx(${latestIdx})">
+      <div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:var(--sp-12) 14px;border-radius:var(--r-lg);background:var(--sage-light);cursor:pointer;" data-action="expandMilestoneByIdx" data-arg="${latestIdx}">
         <span class="info-strip-icon">${ci}</span>
         <div class="flex-1-min">
           <div class="micro-label">Latest achieved</div>
@@ -23569,7 +23595,7 @@ function renderMilestoneStats() {
 
   if (nextMilestone) {
     hlHtml += `
-      <div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:var(--sp-12) 14px;border-radius:var(--r-lg);background:var(--lav-light);cursor:pointer;" onclick="expandUpcomingItem('${escAttr(nextMilestone.text)}')">
+      <div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:var(--sp-12) 14px;border-radius:var(--r-lg);background:var(--lav-light);cursor:pointer;" data-action="expandUpcomingItem" data-arg="${escAttr(nextMilestone.text)}">
         <span class="info-strip-icon">${nextMilestone.icon}</span>
         <div class="flex-1-min">
           <div class="micro-label">Coming up next</div>
@@ -23817,7 +23843,7 @@ function renderDietQuickPicker() {
       if (!val || val === '—skipped—') return;
       const short = val.length > 22 ? val.substring(0, 20) + '…' : val;
       const label = DAY_LABELS[pd.offset] || pd.offset + 'd';
-      pills.push(`<div class="dqp-same" onclick="fillDietMeal('${meal}','${escHtml(val).replace(/'/g, "\\\\'")}')" title="${escHtml(val)}">${label} <span class="op-60">${escHtml(short)}</span></div>`);
+      pills.push(`<div class="dqp-same" data-action="fillDietMeal" data-arg="${escAttr(meal)}" data-arg2="${escAttr(val)}" title="${escAttr(val)}">${label} <span class="op-60">${escHtml(short)}</span></div>`);
     });
 
     // 2. Same-as: today's OTHER meal slots that already have content
@@ -23828,19 +23854,19 @@ function renderDietQuickPicker() {
       const val = document.getElementById('meal-' + otherMeal)?.value || todayEntry[otherMeal] || '';
       if (!val || val === '—skipped—') return;
       const short = val.length > 20 ? val.substring(0, 18) + '…' : val;
-      pills.push(`<div class="dqp-same" onclick="fillDietMeal('${meal}','${escHtml(val).replace(/'/g, "\\\\'")}')" title="${escHtml(val)}">${MEAL_EMOJI[otherMeal]} ${MEAL_LABELS[otherMeal]} <span class="op-60">${escHtml(short)}</span></div>`);
+      pills.push(`<div class="dqp-same" data-action="fillDietMeal" data-arg="${escAttr(meal)}" data-arg2="${escAttr(val)}" title="${escAttr(val)}">${MEAL_EMOJI[otherMeal]} ${MEAL_LABELS[otherMeal]} <span class="op-60">${escHtml(short)}</span></div>`);
     });
 
     // 2. Top frequent foods for this meal slot (from meal-specific history)
     const mealFreq = getMealSlotTopFoods(meal, 4);
     mealFreq.forEach(f => {
-      pills.push(`<div class="dqp-pill" onclick="insertDietFood('${meal}','${escHtml(f.name).replace(/'/g, "\\\\'")}')" title="${f.count}× in ${MEAL_LABELS[meal]}">${escHtml(f.name)}</div>`);
+      pills.push(`<div class="dqp-pill" data-action="insertDietFood" data-arg="${escAttr(meal)}" data-arg2="${escAttr(f.name)}" title="${f.count}× in ${MEAL_LABELS[meal]}">${escHtml(f.name)}</div>`);
     });
 
     // 3. If no meal-specific foods, show general top foods
     if (mealFreq.length === 0 && topFoods.length > 0) {
       topFoods.slice(0, 3).forEach(f => {
-        pills.push(`<div class="dqp-pill" onclick="insertDietFood('${meal}','${escHtml(f.name).replace(/'/g, "\\\\'")}')" title="${f.count}× logged">${escHtml(f.name)}</div>`);
+        pills.push(`<div class="dqp-pill" data-action="insertDietFood" data-arg="${escAttr(meal)}" data-arg2="${escAttr(f.name)}" title="${f.count}× logged">${escHtml(f.name)}</div>`);
       });
     }
 
@@ -23937,8 +23963,7 @@ function renderDietIntelBanner() {
         html += '<div style="font-weight:600;margin-bottom:6px;">\u{1F4A1} ' + capitalize(MEAL_LABELS_FULL[nextMeal]) + ' ideas from Ziva\'s favorites</div>';
         best.forEach(function(t, idx) {
           var comboStr = t.foods.map(function(f){ return capitalize(f); }).join(', ');
-          var escapedCombo = escHtml(comboStr).replace(/'/g, "\\'");
-          html += '<div class="dib-combo-row" onclick="fillDietMeal(\'' + nextMeal + '\',\'' + escapedCombo + '\')" style="cursor:pointer;display:flex;align-items:center;gap:var(--sp-8);padding:6px 0;' + (idx > 0 ? 'border-top:1px solid rgba(0,0,0,0.05);' : '') + '">';
+          html += '<div class="dib-combo-row" data-action="fillDietMeal" data-arg="' + escAttr(nextMeal) + '" data-arg2="' + escAttr(comboStr) + '" style="cursor:pointer;display:flex;align-items:center;gap:var(--sp-8);padding:6px 0;' + (idx > 0 ? 'border-top:1px solid rgba(0,0,0,0.05);' : '') + '">';
           html += '<div class="flex-1-min0">';
           html += '<span class="t-sm" style="font-weight:600;color:var(--text);">' + escHtml(t.label) + '</span>';
           html += '<div style="display:flex;flex-wrap:wrap;gap:3px;margin-top:3px;">';
@@ -23981,7 +24006,7 @@ function renderDietIntelBanner() {
         html += '<div class="dib-card dib-synergy">\u{1F517} For ' + MEAL_LABELS_FULL[nextMeal] + ', try pairing with today\'s meals: ';
         top.forEach(function(s) {
           var emoji = s.type === 'absorption' ? '\u{1F517}' : s.type === 'complete' ? '\u2728' : '\u{1F33F}';
-          html += '<span class="dib-synergy-pill" onclick="insertDietFood(\'' + nextMeal + '\',\'' + escHtml(s.partner).replace(/'/g, "\\'") + '\')" title="' + escHtml(s.reason) + '">' + emoji + ' ' + escHtml(s.partner) + '</span> ';
+          html += '<span class="dib-synergy-pill" data-action="insertDietFood" data-arg="' + escAttr(nextMeal) + '" data-arg2="' + escAttr(s.partner) + '" title="' + escAttr(s.reason) + '">' + emoji + ' ' + escHtml(s.partner) + '</span> ';
         });
         html += '</div>';
       }
@@ -27885,11 +27910,11 @@ function renderAlertCardHTML(a, scope) {
       <div class="ctx-alert-body">
         <div class="ctx-alert-title">${escHtml(a.title)} <span class="ctx-alert-sev ${sevBadge}">${sevLabel}</span></div>
         <div class="ctx-alert-msg">${escHtml(a.body)}</div>
-        ${a.tip ? `<div class="ctx-alert-tip-toggle" onclick="event.stopPropagation();toggleAlertTip('${safeKey}')">${zi('bulb')} Tips & advice ▾</div>
+        ${a.tip ? `<div class="ctx-alert-tip-toggle" data-action="toggleAlertTip" data-arg="${safeKey}" data-stop="1">${zi('bulb')} Tips & advice ▾</div>
         <div class="ctx-alert-tip" id="ca-tip-${safeKey}">${escHtml(a.tip)}</div>` : ''}
         <div class="ctx-alert-actions">
-          ${a.action ? `<button class="ctx-alert-btn cab-primary" onclick="event.stopPropagation();execAlertAction('${safeKey}')">${escHtml(a.action.label)}</button>` : ''}
-          ${a.tab ? `<button class="ctx-alert-btn cab-secondary" onclick="event.stopPropagation();switchTab('${escAttr(a.tab)}')">View details</button>` : ''}
+          ${a.action ? `<button class="ctx-alert-btn cab-primary" data-action="execAlertAction" data-arg="${safeKey}" data-stop="1">${escHtml(a.action.label)}</button>` : ''}
+          ${a.tab ? `<button class="ctx-alert-btn cab-secondary" data-action="switchTab" data-arg="${escAttr(a.tab)}" data-stop="1">View details</button>` : ''}
         </div>
       </div>
     </div>
@@ -28586,7 +28611,7 @@ function renderTrendChips() {
 
   let html = '';
   chips.forEach((c, i) => {
-    html += `<div class="trend-chip" onclick="event.stopPropagation();switchTab('${c.tab}')">
+    html += `<div class="trend-chip" data-action="switchTab" data-arg="${escAttr(c.tab)}" data-stop="1">
       <span class="trend-chip-icon">${c.icon}</span>
       <div class="trend-chip-body">
         <div class="trend-chip-label">${c.label}</div>
@@ -33913,7 +33938,7 @@ function renderActiveMilestones() {
         return '<div class="al-evid-item">' + ev.date + ' — "' + escHtml((ev.text || '').substring(0, 40)) + '" ' + confDot + ' ' + ev.confidence + '</div>';
       }).join('');
       if (m.evidenceCount > 5) evItems += '<div class="al-evid-more">+' + (m.evidenceCount - 5) + ' more</div>';
-      evidHtml = '<button class="ms-tidbit-toggle" onclick="event.stopPropagation();document.getElementById(\'' + evidId + '\').style.display=document.getElementById(\'' + evidId + '\').style.display===\'none\'?\'block\':\'none\'">' + zi('chart') + ' View evidence ▾</button>' +
+      evidHtml = '<button class="ms-tidbit-toggle" data-action="toggleDisplayBlock" data-arg="' + evidId + '" data-stop="1">' + zi('chart') + ' View evidence ▾</button>' +
         '<div id="' + evidId + '" class="al-evid-box" style="display:none;">' + evItems + '</div>';
     }
 
@@ -34406,7 +34431,7 @@ function renderUpcomingEvents() {
           ${ev.source === 'custom' ? `<button class="del-btn" data-action="deleteEvent" data-stop="1" data-arg="${ev._i}" title="Delete">×</button>` : ''}
         </div>
         ${activities ? `
-          <button class="ms-tidbit-toggle mt-6" onclick="const e=document.getElementById('${actId}');e.style.display=e.style.display==='none'?'flex':'none';">
+          <button class="ms-tidbit-toggle mt-6" data-action="toggleDisplayFlex" data-arg="${actId}">
             ${zi('star')} Ziva activity ideas ▾
           </button>
           <div id="${actId}" style="display:none;margin-top:6px;flex-direction:column;gap:var(--sp-4);">
@@ -37731,7 +37756,7 @@ function renderUpcomingMilestones() {
 
       html += `
           <div class="upc-subcat" id="${subcatId}">
-            <div class="upc-subcat-header ${cat}" onclick="event.stopPropagation();toggleUpcomingSubcat('${subcatId}')">
+            <div class="upc-subcat-header ${cat}" data-action="toggleUpcomingSubcat" data-arg="${subcatId}" data-stop="1">
               <div class="upc-subcat-icon">${cm.icon}</div>
               <div class="upc-subcat-label">${cm.label}</div>
               <div class="upc-subcat-count">${catItems.length}</div>

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -20987,8 +20987,8 @@ function renderRemindersAndAlerts() {
               <div class="supp-alert-icon">${zi('dot-red')}</div>
               <div class="supp-alert-title">Missed — ${escHtml(m.name)}</div>
               <div class="supp-alert-action">
-                <button class="supp-check-btn" data-action="resolveMissedMedDone" data-arg="${escAttr(m.name)}" data-arg2="${ds}">Was given</button>
-                <button class="supp-skip-btn" data-action="resolveMissedMedSkipped" data-arg="${escAttr(m.name)}" data-arg2="${ds}">Not given</button>
+                <button class="supp-check-btn" data-action="resolveMissedMedDone" data-arg="${escHtml(m.name)}" data-arg2="${ds}">Was given</button>
+                <button class="supp-skip-btn" data-action="resolveMissedMedSkipped" data-arg="${escHtml(m.name)}" data-arg2="${ds}">Not given</button>
               </div>
             </div>
             <div class="supp-alert-detail">${escHtml(m.dose || '')} · ${formatDate(ds)}</div>
@@ -21027,8 +21027,8 @@ function renderRemindersAndAlerts() {
           <div class="supp-alert-icon">${zi('warn')}</div>
           <div class="supp-alert-title">Reminder — ${escHtml(m.name)}</div>
           <div class="supp-alert-action">
-            <button class="supp-check-btn" data-action="markMedDone" data-arg="${escAttr(m.name)}" data-arg2="${idx}">Done</button>
-            <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escAttr(m.name)}" data-arg2="${idx}">Skip</button>
+            <button class="supp-check-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done</button>
+            <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Skip</button>
           </div>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${escHtml(m.freq || 'As prescribed')}</div>
@@ -23595,7 +23595,7 @@ function renderMilestoneStats() {
 
   if (nextMilestone) {
     hlHtml += `
-      <div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:var(--sp-12) 14px;border-radius:var(--r-lg);background:var(--lav-light);cursor:pointer;" data-action="expandUpcomingItem" data-arg="${escAttr(nextMilestone.text)}">
+      <div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:var(--sp-12) 14px;border-radius:var(--r-lg);background:var(--lav-light);cursor:pointer;" data-action="expandUpcomingItem" data-arg="${escHtml(nextMilestone.text)}">
         <span class="info-strip-icon">${nextMilestone.icon}</span>
         <div class="flex-1-min">
           <div class="micro-label">Coming up next</div>
@@ -23843,7 +23843,7 @@ function renderDietQuickPicker() {
       if (!val || val === '—skipped—') return;
       const short = val.length > 22 ? val.substring(0, 20) + '…' : val;
       const label = DAY_LABELS[pd.offset] || pd.offset + 'd';
-      pills.push(`<div class="dqp-same" data-action="fillDietMeal" data-arg="${escAttr(meal)}" data-arg2="${escAttr(val)}" title="${escAttr(val)}">${label} <span class="op-60">${escHtml(short)}</span></div>`);
+      pills.push(`<div class="dqp-same" data-action="fillDietMeal" data-arg="${escAttr(meal)}" data-arg2="${escHtml(val)}" title="${escAttr(val)}">${label} <span class="op-60">${escHtml(short)}</span></div>`);
     });
 
     // 2. Same-as: today's OTHER meal slots that already have content
@@ -23854,19 +23854,19 @@ function renderDietQuickPicker() {
       const val = document.getElementById('meal-' + otherMeal)?.value || todayEntry[otherMeal] || '';
       if (!val || val === '—skipped—') return;
       const short = val.length > 20 ? val.substring(0, 18) + '…' : val;
-      pills.push(`<div class="dqp-same" data-action="fillDietMeal" data-arg="${escAttr(meal)}" data-arg2="${escAttr(val)}" title="${escAttr(val)}">${MEAL_EMOJI[otherMeal]} ${MEAL_LABELS[otherMeal]} <span class="op-60">${escHtml(short)}</span></div>`);
+      pills.push(`<div class="dqp-same" data-action="fillDietMeal" data-arg="${escAttr(meal)}" data-arg2="${escHtml(val)}" title="${escAttr(val)}">${MEAL_EMOJI[otherMeal]} ${MEAL_LABELS[otherMeal]} <span class="op-60">${escHtml(short)}</span></div>`);
     });
 
     // 2. Top frequent foods for this meal slot (from meal-specific history)
     const mealFreq = getMealSlotTopFoods(meal, 4);
     mealFreq.forEach(f => {
-      pills.push(`<div class="dqp-pill" data-action="insertDietFood" data-arg="${escAttr(meal)}" data-arg2="${escAttr(f.name)}" title="${f.count}× in ${MEAL_LABELS[meal]}">${escHtml(f.name)}</div>`);
+      pills.push(`<div class="dqp-pill" data-action="insertDietFood" data-arg="${escAttr(meal)}" data-arg2="${escHtml(f.name)}" title="${f.count}× in ${MEAL_LABELS[meal]}">${escHtml(f.name)}</div>`);
     });
 
     // 3. If no meal-specific foods, show general top foods
     if (mealFreq.length === 0 && topFoods.length > 0) {
       topFoods.slice(0, 3).forEach(f => {
-        pills.push(`<div class="dqp-pill" data-action="insertDietFood" data-arg="${escAttr(meal)}" data-arg2="${escAttr(f.name)}" title="${f.count}× logged">${escHtml(f.name)}</div>`);
+        pills.push(`<div class="dqp-pill" data-action="insertDietFood" data-arg="${escAttr(meal)}" data-arg2="${escHtml(f.name)}" title="${f.count}× logged">${escHtml(f.name)}</div>`);
       });
     }
 
@@ -23963,7 +23963,7 @@ function renderDietIntelBanner() {
         html += '<div style="font-weight:600;margin-bottom:6px;">\u{1F4A1} ' + capitalize(MEAL_LABELS_FULL[nextMeal]) + ' ideas from Ziva\'s favorites</div>';
         best.forEach(function(t, idx) {
           var comboStr = t.foods.map(function(f){ return capitalize(f); }).join(', ');
-          html += '<div class="dib-combo-row" data-action="fillDietMeal" data-arg="' + escAttr(nextMeal) + '" data-arg2="' + escAttr(comboStr) + '" style="cursor:pointer;display:flex;align-items:center;gap:var(--sp-8);padding:6px 0;' + (idx > 0 ? 'border-top:1px solid rgba(0,0,0,0.05);' : '') + '">';
+          html += '<div class="dib-combo-row" data-action="fillDietMeal" data-arg="' + escAttr(nextMeal) + '" data-arg2="' + escHtml(comboStr) + '" style="cursor:pointer;display:flex;align-items:center;gap:var(--sp-8);padding:6px 0;' + (idx > 0 ? 'border-top:1px solid rgba(0,0,0,0.05);' : '') + '">';
           html += '<div class="flex-1-min0">';
           html += '<span class="t-sm" style="font-weight:600;color:var(--text);">' + escHtml(t.label) + '</span>';
           html += '<div style="display:flex;flex-wrap:wrap;gap:3px;margin-top:3px;">';
@@ -24006,7 +24006,7 @@ function renderDietIntelBanner() {
         html += '<div class="dib-card dib-synergy">\u{1F517} For ' + MEAL_LABELS_FULL[nextMeal] + ', try pairing with today\'s meals: ';
         top.forEach(function(s) {
           var emoji = s.type === 'absorption' ? '\u{1F517}' : s.type === 'complete' ? '\u2728' : '\u{1F33F}';
-          html += '<span class="dib-synergy-pill" data-action="insertDietFood" data-arg="' + escAttr(nextMeal) + '" data-arg2="' + escAttr(s.partner) + '" title="' + escAttr(s.reason) + '">' + emoji + ' ' + escHtml(s.partner) + '</span> ';
+          html += '<span class="dib-synergy-pill" data-action="insertDietFood" data-arg="' + escAttr(nextMeal) + '" data-arg2="' + escHtml(s.partner) + '" title="' + escAttr(s.reason) + '">' + emoji + ' ' + escHtml(s.partner) + '</span> ';
         });
         html += '</div>';
       }

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -3009,3 +3009,97 @@ test.describe('Polish-10a — SVG-in-data architectural shift + HR-1/HR-4 sweep'
       `intelligence.js: zero stethoscope-emoji glyphs in source. Found: ${stethEmojiInIntel}`).toBe(0);
   });
 });
+
+test.describe('Polish-10b — HR-3 onclick batch (Care + Home; ~24 sites)', () => {
+  // Polish-10b absorbs the inline-onclick HR-3 violations across the Care
+  // jurisdiction (medical.js doctor cards, vacc UI; home.js missed-med
+  // alerts, feeding day toggles, milestone expanders, diet pill fillers,
+  // contextual-alert tip toggles + actions). Two new generic dispatcher
+  // handlers introduced (toggleDisplayBlock, toggleDisplayFlex) for the
+  // common display-toggle pattern that previously inlined a 6-step DOM
+  // mutation chain.
+
+  test('positive — new dispatcher handlers wired in core.js (toggleDisplayBlock, toggleDisplayFlex, plus ~14 named function dispatchers)', async ({ request }) => {
+    const res = await request.get('/split/core.js');
+    expect(res.ok(), '/split/core.js fetchable').toBeTruthy();
+    const js = await res.text();
+
+    // Generic toggle handlers (Polish-10b new).
+    expect(js.includes("action === 'toggleDisplayBlock'"),
+      'core.js dispatcher includes toggleDisplayBlock').toBeTruthy();
+    expect(js.includes("action === 'toggleDisplayFlex'"),
+      'core.js dispatcher includes toggleDisplayFlex').toBeTruthy();
+
+    // Named function dispatchers.
+    const NAMED_HANDLERS = [
+      'resolveMissedMedDone', 'resolveMissedMedSkipped',
+      'markMedDone', 'markMedSkipped',
+      'deleteFeedingEntry', 'switchFoodCatSub',
+      'expandMilestoneByIdx', 'expandUpcomingItem',
+      'fillDietMeal', 'insertDietFood',
+      'toggleAlertTip', 'execAlertAction',
+      'switchTab', 'toggleUpcomingSubcat',
+    ];
+    for (const handler of NAMED_HANDLERS) {
+      expect(js.includes(`action === '${handler}'`),
+        `core.js dispatcher includes ${handler}`).toBeTruthy();
+    }
+  });
+
+  test('regression-guard — zero onclick=" attrs at converted Polish-10b ranges (medical.js + home.js)', async ({ request }) => {
+    const medRes = await request.get('/split/medical.js');
+    const med = await medRes.text();
+    const homeRes = await request.get('/split/home.js');
+    const home = await homeRes.text();
+
+    // Polish-10b: 3 medical.js conversions (lines were :301, :794, :4119).
+    // Verify the previously-inlined patterns are absent.
+    const buggyMedPatterns = [
+      // toggleDisplay*-style inlines that Polish-10b absorbed.
+      `onclick="event.stopPropagation();document.getElementById(\\'`,
+      `onclick="const e=document.getElementById('`,
+      `onclick="event.stopPropagation();toggleUpcomingSubcat('`,
+    ];
+    for (const pattern of buggyMedPatterns) {
+      expect(med.includes(pattern),
+        `medical.js: zero residual inlined onclick of pattern: ${pattern}`).toBeFalsy();
+    }
+
+    // Polish-10b: 21 home.js conversions across multiple pattern families.
+    const buggyHomePatterns = [
+      `onclick="resolveMissedMed(`,
+      `onclick="markMedDone(`,
+      `onclick="markMedSkipped(`,
+      `onclick="event.stopPropagation();deleteFeedingEntry(`,
+      `onclick="switchFoodCatSub(`,
+      `onclick="expandMilestoneByIdx(`,
+      `onclick="expandUpcomingItem(`,
+      `onclick="fillDietMeal(`,
+      `onclick="insertDietFood(`,
+      `onclick="event.stopPropagation();toggleAlertTip(`,
+      `onclick="event.stopPropagation();execAlertAction(`,
+      `onclick="event.stopPropagation();switchTab(`,
+    ];
+    for (const pattern of buggyHomePatterns) {
+      expect(home.includes(pattern),
+        `home.js: zero residual inlined onclick of pattern: ${pattern}`).toBeFalsy();
+    }
+
+    // Display-toggle inlines (the 6-step DOM mutation chain) — verify both
+    // medical.js and home.js no longer carry the literal pattern fragment.
+    const TOGGLE_FRAGMENT_BLOCK = `style.display==='none'?'block':'none'`;
+    const TOGGLE_FRAGMENT_FLEX = `style.display==='none'?'flex':'none'`;
+    expect(med.includes(TOGGLE_FRAGMENT_BLOCK) || med.includes(TOGGLE_FRAGMENT_FLEX),
+      'medical.js: zero residual display-toggle inlines (Polish-10b absorbs all)').toBeFalsy();
+
+    // home.js: only the SKIP-list site at home.js:637 may carry a display
+    // toggle fragment (compound chained-call inline; deferred to R-10).
+    // Other sites must be free of the pattern.
+    // For tractability we just check that the count is small.
+    const homeBlockMatches = (home.match(/style\.display=='none'\?'block':'none'/g) || []).length;
+    const homeFlexMatches = (home.match(/style\.display=='none'\?'flex':'none'/g) || []).length;
+    expect(homeBlockMatches + homeFlexMatches,
+      `home.js: at most 1 residual display-toggle inline (R-10 carry-forward at :637 chained-compound). Found: ${homeBlockMatches + homeFlexMatches}`)
+      .toBeLessThanOrEqual(1);
+  });
+});

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -3102,4 +3102,29 @@ test.describe('Polish-10b — HR-3 onclick batch (Care + Home; ~24 sites)', () =
       `home.js: at most 1 residual display-toggle inline (R-10 carry-forward at :637 chained-compound). Found: ${homeBlockMatches + homeFlexMatches}`)
       .toBeLessThanOrEqual(1);
   });
+
+  test('regression-guard r2 (Maren F-35-1) — escAttr-in-data-arg corrupts user-content via backslash-leak; user-content data-arg/data-arg2 positions must use escHtml not escAttr', async ({ request }) => {
+    // Maren's Polish-10b audit found that escAttr (core.js:2252) is
+    // `s.replace(/'/g, "\\'").replace(/"/g, '&quot;')` — designed for
+    // embedding inside a JS string literal within an attribute. When
+    // applied to data-arg="..." the HTML attribute parser does not decode
+    // \' as escape; backslash leaks through dataset.arg into the
+    // dispatcher's function call. Parent-facing failure: a food name like
+    // John's pasta saves to localStorage as John\'s pasta and syncs
+    // corrupted to Firestore. r2 fix: swap escAttr → escHtml at all
+    // user-content data-arg / data-arg2 positions; apostrophe in double-
+    // quoted HTML attribute is parser-safe; escHtml leaves apostrophe
+    // literal; dataset.arg returns clean string.
+    const homeRes = await request.get('/split/home.js');
+    const home = await homeRes.text();
+
+    // Affected fields: m.name (medication), nextMilestone.text (milestone),
+    // val (food meal value), f.name (food name), comboStr (combo string),
+    // s.partner (synergy partner food name).
+    const buggyPattern = /data-arg2?="\$\{escAttr\((m\.name|nextMilestone\.text|comboStr|s\.partner|f\.name|val)\b/g;
+    const violations = home.match(buggyPattern) || [];
+    expect(violations,
+      `Polish-10b r2: zero escAttr in user-content data-arg positions (Maren F-35-1 fix). Found: ${violations.join(' | ')}`)
+      .toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

Polish-10b absorbs the inline-onclick HR-3 violations across the Care jurisdiction (medical.js doctor cards + vacc UI; home.js missed-med alerts, feeding day toggles, milestone expanders, diet pill fillers, contextual-alert tip toggles + actions). Single fix-shape per atomic-canon discipline: function-call delegation via `data-action` + `data-arg` with optional `data-stop="1"` for `stopPropagation`.

## Architectural addition

Two new generic dispatcher handlers introduced (`toggleDisplayBlock`, `toggleDisplayFlex`) for the common 6-step display-toggle DOM mutation chain that previously inlined as:

```js
onclick="event.stopPropagation();document.getElementById('${id}')
  .style.display=document.getElementById('${id}')
  .style.display==='none'?'block':'none'"
```

Now collapses to:

```html
<element data-action="toggleDisplayBlock" data-arg="${id}" data-stop="1">
```

This pattern was repeated 5+ times across the Care surfaces and is a strong candidate for further use in Polish-10c + future R-10 sweeps.

## Sites converted (24)

### medical.js (3)
- `:301` view-evidence button → `toggleDisplayBlock` + `data-stop`
- `:794` activity-ideas toggle → `toggleDisplayFlex`
- `:4119` upcoming-subcat header → `toggleUpcomingSubcat` (1-arg) + `data-stop`

### home.js (21)
- `:622, :623` resolveMissedMed (split into `resolveMissedMedDone` / `resolveMissedMedSkipped` wrapper handlers since the 3rd arg is a fixed enum)
- `:662, :663` markMedDone / markMedSkipped (2 args)
- `:1570` view-evidence, `:1583` learn-more, `:2123` al-feed-day-header (toggleDisplay*)
- `:2503` deleteFeedingEntry (1 arg + stop)
- `:2735` switchFoodCatSub (2 args)
- `:3218` expandMilestoneByIdx (1 arg)
- `:3230` expandUpcomingItem (1 arg, escAttr-bearing)
- `:3478, :3489` fillDietMeal × 2 (2 args; eliminates the double-quote-escape pattern `escHtml(val).replace(/'/g, "\\\\'")` → straight `escAttr`)
- `:3495, :3501, :3642` insertDietFood × 3 (2 args; same simplification)
- `:3599` fillDietMeal (combo path)
- `:7546` toggleAlertTip, `:7549` execAlertAction, `:7550` switchTab (1 arg each + stop)
- `:8247` trend-chip switchTab (1 arg + stop)

## core.js dispatcher additions (~26 LOC)

- `toggleDisplayBlock` / `toggleDisplayFlex` (new generic handlers)
- 14 named function dispatchers (`resolveMissedMedDone` / `resolveMissedMedSkipped` wrap the 3-arg `resolveMissedMed`; rest dispatch to existing functions with `typeof function` guard)

## Tests (R-7 binary-mode duo per PR-18 precedent)

1. **positive** — dispatcher handlers wired in core.js (16 named entries including 2 generic toggles)
2. **regression-guard** — zero residual inlined onclick patterns at converted ranges in medical.js + home.js; ≤1 residual display-toggle inline in home.js (R-10 carry-forward at :637 chained-compound)

## Verification

```bash
# Source onclick count delta
medical.js: 11 → 8  (−3)
home.js:    31 → 10 (−21)
core.js:    2 → 2   (no change; existing inline JS in dispatcher itself)
```

## Carry-forwards (deferred per narrow-scope discipline)

Route to Polish-10c or R-10 at Polish-10 close artifact:

- **medical.js**: `:570/:572` (print-window context — separate document, doesn't share core.js dispatcher), `:2202` (compound input setValue + checkSymptoms), `:2317` (preventDefault — needs `data-prevent` dispatcher extension), `:4152/:4155/:4156` (4-arg upcomingToMilestone — needs `data-arg4` dispatcher extension), `:7215` (`this.nextElementSibling` DOM munging)
- **home.js**: `:637` (compound chained setValue+load+switchTab), `:2011` (compound call + `this.closest`), `:2955/:2961/:2966` (`this.classList.toggle` pattern → Polish-10c), `:2970/:2971` (`this.closest` patterns), `:5863` (`this.parentElement.classList` → Polish-10c), `:8140` (`item.action` template string injection — needs caller refactor)
- **intelligence.js + diet.js HR-3 sites** — Polish-10c scope

## Test plan

- [ ] Build verifies clean: `cd split && bash build.sh > sproutlab.html`
- [ ] Hermetic floor: load index.html in browser
- [ ] Tap "View evidence" on a milestone → evidence box toggles
- [ ] Tap "Learn more" on a milestone tidbit → tidbit content toggles
- [ ] Tap a missed-med "Was given" / "Not given" button → marks correctly + UI updates
- [ ] Tap a same-as diet pill → meal field populates
- [ ] Tap a contextual-alert "View details" → switches to target tab
- [ ] Tap an upcoming-subcat header → subcat collapses/expands
- [ ] Smoke spec duo passes: 2 new tests in `tests/e2e/smoke.spec.ts` Polish-10b describe block

→ **Cipher:** advisory review on dispatcher pattern (function-existence guard, generic toggleDisplay* handlers, escAttr application at 7 multi-arg sites)
→ **Maren:** Care-jurisdiction audit (3 medical.js conversions; 21 home.js conversions; 14 new dispatcher entries in core.js for Care-domain functions)
→ **Aurelius / Sovereign:** merge gate

— Lyra (The Weaver)

https://claude.ai/code/session_01CM2dJFnSvrR7FDkGXcn8ZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01CM2dJFnSvrR7FDkGXcn8ZA)_