### PR TITLE
sl-4-polish-10c-hr3-onclick-intel-diet (PR-36/Polish-10c): HR-3 onclick batch — Intelligence + Diet (15 sites)

### DIFF
--- a/index.html
+++ b/index.html
@@ -15772,6 +15772,20 @@ function init() {
     else if (action === 'execAlertAction' && typeof execAlertAction === 'function') execAlertAction(arg);
     else if (action === 'switchTab' && typeof switchTab === 'function') switchTab(arg);
     else if (action === 'toggleUpcomingSubcat' && typeof toggleUpcomingSubcat === 'function') toggleUpcomingSubcat(arg);
+    // Polish-10c: HR-3 onclick batch — Intelligence + Diet (15 sites).
+    // arg = elapsed-time selector ('feAction' | 'deHydra' | 'deAction' | 'voHydra' |
+    //   'voLog' | 'voAction' | 'ceAction'); arg2 = action label string.
+    else if (action === 'logFeverAction' && typeof logFeverAction === 'function') logFeverAction(arg2, _epGetSelectedTime(arg));
+    else if (action === 'logDiarrhoeaWetDiaper' && typeof logDiarrhoeaWetDiaper === 'function') logDiarrhoeaWetDiaper(_epGetSelectedTime(arg));
+    else if (action === 'logDiarrhoeaAction' && typeof logDiarrhoeaAction === 'function') logDiarrhoeaAction(arg2, _epGetSelectedTime(arg));
+    else if (action === 'logVomitingWetDiaper' && typeof logVomitingWetDiaper === 'function') logVomitingWetDiaper(_epGetSelectedTime(arg));
+    else if (action === 'logVomitingEpisodeEntry' && typeof logVomitingEpisodeEntry === 'function') logVomitingEpisodeEntry(arg2, _epGetSelectedTime(arg));
+    else if (action === 'logVomitingAction' && typeof logVomitingAction === 'function') logVomitingAction(arg2, _epGetSelectedTime(arg));
+    else if (action === 'ceToggleSymptom' && typeof ceToggleSymptom === 'function') ceToggleSymptom(arg);
+    else if (action === 'ceSetSeverity' && typeof ceSetSeverity === 'function') ceSetSeverity(Number(arg));
+    else if (action === 'logColdAction' && typeof logColdAction === 'function') logColdAction(arg2, _epGetSelectedTime(arg));
+    else if (action === 'showHeatmapDetail' && typeof showHeatmapDetail === 'function') showHeatmapDetail(arg, Number(arg2), arg3);
+    else if (action === 'toggleCorrEvidence' && typeof toggleCorrEvidence === 'function') toggleCorrEvidence(Number(arg));
     else if (action === 'editUpcomingVaccDate') editUpcomingVaccDate();
     else if (action === 'openMedModal') openMedModal();
     else if (action === 'toggleVisitForm') toggleVisitForm();
@@ -32969,7 +32983,7 @@ function renderCorrelationCard() {
         <span class="corr-rate ${rateClass}">${rpct}% (${r.abnormalAfter}/${r.totalOccurrences})</span>
       </div>
       <div class="corr-detail">${conList || 'Abnormal poop pattern'} · Confidence: ${r.confidence}</div>
-      <div class="corr-evidence" onclick="toggleCorrEvidence(${idx})"><span class="collapse-chevron" id="corrChev-${idx}">▾</span> View evidence (last ${r.dates.length})</div>
+      <div class="corr-evidence" data-action="toggleCorrEvidence" data-arg="${idx}"><span class="collapse-chevron" id="corrChev-${idx}">▾</span> View evidence (last ${r.dates.length})</div>
       <div class="corr-evidence-trail" id="corrEvidence-${idx}">
         ${r.dates.map(d => `<div class="corr-ev-row">${zi('bowl')} ${formatDate(d.ate)} → ${zi('diaper')} ${formatDate(d.poopDate)} · ${d.consistency}${d.abnormal ? ' ' + zi('warn') : ' ' + zi('check')}</div>`).join('')}
       </div>
@@ -50224,7 +50238,7 @@ function renderFeverEpisodeCard() {
   const ACTION_CHIPS = ['Lukewarm sponging', 'Breastfed', 'Fluids given', 'Changed clothes', 'Doctor called'];
   html += '<div class="fe-action-chips">';
   ACTION_CHIPS.forEach(a => {
-    html += '<span class="fe-action-chip" onclick="logFeverAction(\'' + a.replace(/'/g, "\\'") + '\', _epGetSelectedTime(\'feAction\'))">' + a + '</span>';
+    html += '<span class="fe-action-chip" data-action="logFeverAction" data-arg="feAction" data-arg2="' + escAttr(a) + '">' + escHtml(a) + '</span>';
   });
   html += '</div>';
   if (ep.actions.length > 0) {
@@ -50914,7 +50928,7 @@ function renderDiarrhoeaEpisodeCard() {
   html += '</div>';
   html += _epTimePickerHTML('deHydra');
   html += '<div class="kc-row-flex-wrap">';
-  html += '<span class="fe-action-chip" onclick="logDiarrhoeaWetDiaper(_epGetSelectedTime(\'deHydra\'))">' + zi('diaper') + ' Log wet diaper</span>';
+  html += '<span class="fe-action-chip" data-action="logDiarrhoeaWetDiaper" data-arg="deHydra">' + zi('diaper') + ' Log wet diaper</span>';
   html += '<span class="fe-action-chip" data-action="deLogFluidPrompt">'+zi('drop')+' Log fluid</span>';
   html += '</div>';
   if (ep.fluids.length > 0) {
@@ -50972,7 +50986,7 @@ function renderDiarrhoeaEpisodeCard() {
   const DE_ACTIONS = ['Breastfed', 'ORS given', 'Applied diaper cream', 'Changed diaper', 'Doctor called', 'Washed hands'];
   html += '<div class="fe-action-chips">';
   DE_ACTIONS.forEach(a => {
-    html += '<span class="fe-action-chip" onclick="logDiarrhoeaAction(\'' + a.replace(/'/g, "\\'") + '\', _epGetSelectedTime(\'deAction\'))">' + a + '</span>';
+    html += '<span class="fe-action-chip" data-action="logDiarrhoeaAction" data-arg="deAction" data-arg2="' + escAttr(a) + '">' + escHtml(a) + '</span>';
   });
   html += '</div>';
   if (ep.actions.length > 0) {
@@ -51415,16 +51429,16 @@ function renderVomitingEpisodeCard() {
   const hydColor = wetToday >= 6 ? 'var(--tc-sage)' : wetToday >= 4 ? 'var(--tc-amber)' : 'var(--tc-danger)';
   html += '<div class="de-hydra-bar"><div class="de-hydra-label">Wet diapers today</div><div class="de-hydra-track"><div class="de-hydra-fill" style="width:' + hydPct + '%;background:' + hydColor + ';"></div></div><div class="de-hydra-count" style="color:' + hydColor + ';">' + wetToday + '/6</div></div>';
   html += _epTimePickerHTML('voHydra');
-  html += '<div class="fe-action-chips"><span class="fe-action-chip" onclick="logVomitingWetDiaper(_epGetSelectedTime(\'voHydra\'))">'+zi('drop')+' Wet diaper</span><span class="fe-action-chip" data-action="voLogFluidPrompt">'+zi('drop')+' Log fluid</span></div>';
+  html += '<div class="fe-action-chips"><span class="fe-action-chip" data-action="logVomitingWetDiaper" data-arg="voHydra">'+zi('drop')+' Wet diaper</span><span class="fe-action-chip" data-action="voLogFluidPrompt">'+zi('drop')+' Log fluid</span></div>';
 
   // Log vomiting
   html += '<div class="fe-section-title">Vomiting Log</div>';
   html += _epTimePickerHTML('voLog');
   html += '<div class="fe-action-chips">';
-  html += '<span class="fe-action-chip" onclick="logVomitingEpisodeEntry(\'spit-up\', _epGetSelectedTime(\'voLog\'))">'+zi('warn')+' Spit-up</span>';
-  html += '<span class="fe-action-chip" onclick="logVomitingEpisodeEntry(\'vomit\', _epGetSelectedTime(\'voLog\'))">'+zi('siren')+' Vomit</span>';
-  html += '<span class="fe-action-chip" onclick="logVomitingEpisodeEntry(\'projectile\', _epGetSelectedTime(\'voLog\'))">'+zi('siren')+' Projectile</span>';
-  html += '<span class="fe-action-chip" onclick="logVomitingEpisodeEntry(\'bile\', _epGetSelectedTime(\'voLog\'))">'+zi('warn')+' Bile/green</span>';
+  html += '<span class="fe-action-chip" data-action="logVomitingEpisodeEntry" data-arg="voLog" data-arg2="spit-up">'+zi('warn')+' Spit-up</span>';
+  html += '<span class="fe-action-chip" data-action="logVomitingEpisodeEntry" data-arg="voLog" data-arg2="vomit">'+zi('siren')+' Vomit</span>';
+  html += '<span class="fe-action-chip" data-action="logVomitingEpisodeEntry" data-arg="voLog" data-arg2="projectile">'+zi('siren')+' Projectile</span>';
+  html += '<span class="fe-action-chip" data-action="logVomitingEpisodeEntry" data-arg="voLog" data-arg2="bile">'+zi('warn')+' Bile/green</span>';
   html += '</div>';
 
   if (ep.episodes.length > 0) {
@@ -51440,7 +51454,7 @@ function renderVomitingEpisodeCard() {
   html += _epTimePickerHTML('voAction');
   html += '<div class="fe-action-chips">';
   ['Kept upright 30min', 'Small feed given', 'Breastfed', 'Doctor called'].forEach(a => {
-    html += '<span class="fe-action-chip" onclick="logVomitingAction(\'' + a.replace(/'/g, "\\'") + '\', _epGetSelectedTime(\'voAction\'))">' + a + '</span>';
+    html += '<span class="fe-action-chip" data-action="logVomitingAction" data-arg="voAction" data-arg2="' + escAttr(a) + '">' + escHtml(a) + '</span>';
   });
   html += '</div>';
   if (ep.actions.length > 0) {
@@ -51691,7 +51705,7 @@ function renderColdEpisodeCard() {
   html += '<div class="fe-action-chips">';
   COLD_SYMPTOMS.forEach(s => {
     const active = todaySymptoms.has(s);
-    html += '<span class="fe-action-chip" style="' + (active ? 'background:var(--sage);color:white;' : '') + '" onclick="ceToggleSymptom(\'' + s.replace(/'/g, "\\'") + '\')">' + (active ? '✓ ' : '') + s + '</span>';
+    html += '<span class="fe-action-chip" style="' + (active ? 'background:var(--sage);color:white;' : '') + '" data-action="ceToggleSymptom" data-arg="' + escAttr(s) + '">' + (active ? '✓ ' : '') + escHtml(s) + '</span>';
   });
   html += '</div>';
 
@@ -51701,7 +51715,7 @@ function renderColdEpisodeCard() {
   for (let i = 1; i <= 5; i++) {
     const isActive = latestSeverity === i;
     const color = i <= 2 ? 'var(--tc-sage)' : i <= 3 ? 'var(--tc-amber)' : 'var(--tc-caution)';
-    html += '<span class="fe-action-chip" style="' + (isActive ? 'background:' + color + ';color:white;border-color:' + color + ';' : '') + 'min-width:32px;justify-content:center;" onclick="ceSetSeverity(' + i + ')">' + i + '</span>';
+    html += '<span class="fe-action-chip" style="' + (isActive ? 'background:' + color + ';color:white;border-color:' + color + ';' : '') + 'min-width:32px;justify-content:center;" data-action="ceSetSeverity" data-arg="' + i + '">' + i + '</span>';
   }
   html += '</div></div>';
 
@@ -51721,7 +51735,7 @@ function renderColdEpisodeCard() {
   html += _epTimePickerHTML('ceAction');
   html += '<div class="fe-action-chips">';
   ['Saline drops', 'Steam inhalation', 'Humidifier on', 'Elevated mattress', 'Breastfed', 'Doctor called'].forEach(a => {
-    html += '<span class="fe-action-chip" onclick="logColdAction(\'' + a.replace(/'/g, "\\'") + '\', _epGetSelectedTime(\'ceAction\'))">' + a + '</span>';
+    html += '<span class="fe-action-chip" data-action="logColdAction" data-arg="ceAction" data-arg2="' + escAttr(a) + '">' + escHtml(a) + '</span>';
   });
   html += '</div>';
   if (ep.actions.length > 0) {
@@ -57986,11 +58000,11 @@ function renderInfoNutrientHeatmap() {
         gridHtml += `<div class="nh-cell nh-nodata" title="No meals logged">–</div>`;
       } else if (count === 0) {
         // Meals logged but nutrient absent — real gap
-        gridHtml += `<div class="nh-cell nh-0 ${n.cssClass}" title="Gap" onclick="showHeatmapDetail('${n.key}',${dayIdx},'${data.days[dayIdx]}')">·</div>`;
+        gridHtml += `<div class="nh-cell nh-0 ${n.cssClass}" title="Gap" data-action="showHeatmapDetail" data-arg="${escAttr(n.key)}" data-arg2="${dayIdx}" data-arg3="${escAttr(data.days[dayIdx])}">·</div>`;
       } else {
         // Nutrient present — colored fill, tap to see sources
         const level = count <= 2 ? 1 : count <= 4 ? 2 : 3;
-        gridHtml += `<div class="nh-cell nh-${level} ${n.cssClass}" title="${escAttr(foods.join(', '))}" onclick="showHeatmapDetail('${n.key}',${dayIdx},'${data.days[dayIdx]}')"></div>`;
+        gridHtml += `<div class="nh-cell nh-${level} ${n.cssClass}" title="${escAttr(foods.join(', '))}" data-action="showHeatmapDetail" data-arg="${escAttr(n.key)}" data-arg2="${dayIdx}" data-arg3="${escAttr(data.days[dayIdx])}"></div>`;
       }
     });
   });

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.03-2",
+  "version": "2026.05.03-3",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -347,6 +347,20 @@ function init() {
     else if (action === 'execAlertAction' && typeof execAlertAction === 'function') execAlertAction(arg);
     else if (action === 'switchTab' && typeof switchTab === 'function') switchTab(arg);
     else if (action === 'toggleUpcomingSubcat' && typeof toggleUpcomingSubcat === 'function') toggleUpcomingSubcat(arg);
+    // Polish-10c: HR-3 onclick batch — Intelligence + Diet (15 sites).
+    // arg = elapsed-time selector ('feAction' | 'deHydra' | 'deAction' | 'voHydra' |
+    //   'voLog' | 'voAction' | 'ceAction'); arg2 = action label string.
+    else if (action === 'logFeverAction' && typeof logFeverAction === 'function') logFeverAction(arg2, _epGetSelectedTime(arg));
+    else if (action === 'logDiarrhoeaWetDiaper' && typeof logDiarrhoeaWetDiaper === 'function') logDiarrhoeaWetDiaper(_epGetSelectedTime(arg));
+    else if (action === 'logDiarrhoeaAction' && typeof logDiarrhoeaAction === 'function') logDiarrhoeaAction(arg2, _epGetSelectedTime(arg));
+    else if (action === 'logVomitingWetDiaper' && typeof logVomitingWetDiaper === 'function') logVomitingWetDiaper(_epGetSelectedTime(arg));
+    else if (action === 'logVomitingEpisodeEntry' && typeof logVomitingEpisodeEntry === 'function') logVomitingEpisodeEntry(arg2, _epGetSelectedTime(arg));
+    else if (action === 'logVomitingAction' && typeof logVomitingAction === 'function') logVomitingAction(arg2, _epGetSelectedTime(arg));
+    else if (action === 'ceToggleSymptom' && typeof ceToggleSymptom === 'function') ceToggleSymptom(arg);
+    else if (action === 'ceSetSeverity' && typeof ceSetSeverity === 'function') ceSetSeverity(Number(arg));
+    else if (action === 'logColdAction' && typeof logColdAction === 'function') logColdAction(arg2, _epGetSelectedTime(arg));
+    else if (action === 'showHeatmapDetail' && typeof showHeatmapDetail === 'function') showHeatmapDetail(arg, Number(arg2), arg3);
+    else if (action === 'toggleCorrEvidence' && typeof toggleCorrEvidence === 'function') toggleCorrEvidence(Number(arg));
     else if (action === 'editUpcomingVaccDate') editUpcomingVaccDate();
     else if (action === 'openMedModal') openMedModal();
     else if (action === 'toggleVisitForm') toggleVisitForm();

--- a/split/diet.js
+++ b/split/diet.js
@@ -3416,7 +3416,7 @@ function renderCorrelationCard() {
         <span class="corr-rate ${rateClass}">${rpct}% (${r.abnormalAfter}/${r.totalOccurrences})</span>
       </div>
       <div class="corr-detail">${conList || 'Abnormal poop pattern'} · Confidence: ${r.confidence}</div>
-      <div class="corr-evidence" onclick="toggleCorrEvidence(${idx})"><span class="collapse-chevron" id="corrChev-${idx}">▾</span> View evidence (last ${r.dates.length})</div>
+      <div class="corr-evidence" data-action="toggleCorrEvidence" data-arg="${idx}"><span class="collapse-chevron" id="corrChev-${idx}">▾</span> View evidence (last ${r.dates.length})</div>
       <div class="corr-evidence-trail" id="corrEvidence-${idx}">
         ${r.dates.map(d => `<div class="corr-ev-row">${zi('bowl')} ${formatDate(d.ate)} → ${zi('diaper')} ${formatDate(d.poopDate)} · ${d.consistency}${d.abnormal ? ' ' + zi('warn') : ' ' + zi('check')}</div>`).join('')}
       </div>

--- a/split/intelligence.js
+++ b/split/intelligence.js
@@ -7193,7 +7193,7 @@ function renderFeverEpisodeCard() {
   const ACTION_CHIPS = ['Lukewarm sponging', 'Breastfed', 'Fluids given', 'Changed clothes', 'Doctor called'];
   html += '<div class="fe-action-chips">';
   ACTION_CHIPS.forEach(a => {
-    html += '<span class="fe-action-chip" onclick="logFeverAction(\'' + a.replace(/'/g, "\\'") + '\', _epGetSelectedTime(\'feAction\'))">' + a + '</span>';
+    html += '<span class="fe-action-chip" data-action="logFeverAction" data-arg="feAction" data-arg2="' + escAttr(a) + '">' + escHtml(a) + '</span>';
   });
   html += '</div>';
   if (ep.actions.length > 0) {
@@ -7883,7 +7883,7 @@ function renderDiarrhoeaEpisodeCard() {
   html += '</div>';
   html += _epTimePickerHTML('deHydra');
   html += '<div class="kc-row-flex-wrap">';
-  html += '<span class="fe-action-chip" onclick="logDiarrhoeaWetDiaper(_epGetSelectedTime(\'deHydra\'))">' + zi('diaper') + ' Log wet diaper</span>';
+  html += '<span class="fe-action-chip" data-action="logDiarrhoeaWetDiaper" data-arg="deHydra">' + zi('diaper') + ' Log wet diaper</span>';
   html += '<span class="fe-action-chip" data-action="deLogFluidPrompt">'+zi('drop')+' Log fluid</span>';
   html += '</div>';
   if (ep.fluids.length > 0) {
@@ -7941,7 +7941,7 @@ function renderDiarrhoeaEpisodeCard() {
   const DE_ACTIONS = ['Breastfed', 'ORS given', 'Applied diaper cream', 'Changed diaper', 'Doctor called', 'Washed hands'];
   html += '<div class="fe-action-chips">';
   DE_ACTIONS.forEach(a => {
-    html += '<span class="fe-action-chip" onclick="logDiarrhoeaAction(\'' + a.replace(/'/g, "\\'") + '\', _epGetSelectedTime(\'deAction\'))">' + a + '</span>';
+    html += '<span class="fe-action-chip" data-action="logDiarrhoeaAction" data-arg="deAction" data-arg2="' + escAttr(a) + '">' + escHtml(a) + '</span>';
   });
   html += '</div>';
   if (ep.actions.length > 0) {
@@ -8384,16 +8384,16 @@ function renderVomitingEpisodeCard() {
   const hydColor = wetToday >= 6 ? 'var(--tc-sage)' : wetToday >= 4 ? 'var(--tc-amber)' : 'var(--tc-danger)';
   html += '<div class="de-hydra-bar"><div class="de-hydra-label">Wet diapers today</div><div class="de-hydra-track"><div class="de-hydra-fill" style="width:' + hydPct + '%;background:' + hydColor + ';"></div></div><div class="de-hydra-count" style="color:' + hydColor + ';">' + wetToday + '/6</div></div>';
   html += _epTimePickerHTML('voHydra');
-  html += '<div class="fe-action-chips"><span class="fe-action-chip" onclick="logVomitingWetDiaper(_epGetSelectedTime(\'voHydra\'))">'+zi('drop')+' Wet diaper</span><span class="fe-action-chip" data-action="voLogFluidPrompt">'+zi('drop')+' Log fluid</span></div>';
+  html += '<div class="fe-action-chips"><span class="fe-action-chip" data-action="logVomitingWetDiaper" data-arg="voHydra">'+zi('drop')+' Wet diaper</span><span class="fe-action-chip" data-action="voLogFluidPrompt">'+zi('drop')+' Log fluid</span></div>';
 
   // Log vomiting
   html += '<div class="fe-section-title">Vomiting Log</div>';
   html += _epTimePickerHTML('voLog');
   html += '<div class="fe-action-chips">';
-  html += '<span class="fe-action-chip" onclick="logVomitingEpisodeEntry(\'spit-up\', _epGetSelectedTime(\'voLog\'))">'+zi('warn')+' Spit-up</span>';
-  html += '<span class="fe-action-chip" onclick="logVomitingEpisodeEntry(\'vomit\', _epGetSelectedTime(\'voLog\'))">'+zi('siren')+' Vomit</span>';
-  html += '<span class="fe-action-chip" onclick="logVomitingEpisodeEntry(\'projectile\', _epGetSelectedTime(\'voLog\'))">'+zi('siren')+' Projectile</span>';
-  html += '<span class="fe-action-chip" onclick="logVomitingEpisodeEntry(\'bile\', _epGetSelectedTime(\'voLog\'))">'+zi('warn')+' Bile/green</span>';
+  html += '<span class="fe-action-chip" data-action="logVomitingEpisodeEntry" data-arg="voLog" data-arg2="spit-up">'+zi('warn')+' Spit-up</span>';
+  html += '<span class="fe-action-chip" data-action="logVomitingEpisodeEntry" data-arg="voLog" data-arg2="vomit">'+zi('siren')+' Vomit</span>';
+  html += '<span class="fe-action-chip" data-action="logVomitingEpisodeEntry" data-arg="voLog" data-arg2="projectile">'+zi('siren')+' Projectile</span>';
+  html += '<span class="fe-action-chip" data-action="logVomitingEpisodeEntry" data-arg="voLog" data-arg2="bile">'+zi('warn')+' Bile/green</span>';
   html += '</div>';
 
   if (ep.episodes.length > 0) {
@@ -8409,7 +8409,7 @@ function renderVomitingEpisodeCard() {
   html += _epTimePickerHTML('voAction');
   html += '<div class="fe-action-chips">';
   ['Kept upright 30min', 'Small feed given', 'Breastfed', 'Doctor called'].forEach(a => {
-    html += '<span class="fe-action-chip" onclick="logVomitingAction(\'' + a.replace(/'/g, "\\'") + '\', _epGetSelectedTime(\'voAction\'))">' + a + '</span>';
+    html += '<span class="fe-action-chip" data-action="logVomitingAction" data-arg="voAction" data-arg2="' + escAttr(a) + '">' + escHtml(a) + '</span>';
   });
   html += '</div>';
   if (ep.actions.length > 0) {
@@ -8660,7 +8660,7 @@ function renderColdEpisodeCard() {
   html += '<div class="fe-action-chips">';
   COLD_SYMPTOMS.forEach(s => {
     const active = todaySymptoms.has(s);
-    html += '<span class="fe-action-chip" style="' + (active ? 'background:var(--sage);color:white;' : '') + '" onclick="ceToggleSymptom(\'' + s.replace(/'/g, "\\'") + '\')">' + (active ? '✓ ' : '') + s + '</span>';
+    html += '<span class="fe-action-chip" style="' + (active ? 'background:var(--sage);color:white;' : '') + '" data-action="ceToggleSymptom" data-arg="' + escAttr(s) + '">' + (active ? '✓ ' : '') + escHtml(s) + '</span>';
   });
   html += '</div>';
 
@@ -8670,7 +8670,7 @@ function renderColdEpisodeCard() {
   for (let i = 1; i <= 5; i++) {
     const isActive = latestSeverity === i;
     const color = i <= 2 ? 'var(--tc-sage)' : i <= 3 ? 'var(--tc-amber)' : 'var(--tc-caution)';
-    html += '<span class="fe-action-chip" style="' + (isActive ? 'background:' + color + ';color:white;border-color:' + color + ';' : '') + 'min-width:32px;justify-content:center;" onclick="ceSetSeverity(' + i + ')">' + i + '</span>';
+    html += '<span class="fe-action-chip" style="' + (isActive ? 'background:' + color + ';color:white;border-color:' + color + ';' : '') + 'min-width:32px;justify-content:center;" data-action="ceSetSeverity" data-arg="' + i + '">' + i + '</span>';
   }
   html += '</div></div>';
 
@@ -8690,7 +8690,7 @@ function renderColdEpisodeCard() {
   html += _epTimePickerHTML('ceAction');
   html += '<div class="fe-action-chips">';
   ['Saline drops', 'Steam inhalation', 'Humidifier on', 'Elevated mattress', 'Breastfed', 'Doctor called'].forEach(a => {
-    html += '<span class="fe-action-chip" onclick="logColdAction(\'' + a.replace(/'/g, "\\'") + '\', _epGetSelectedTime(\'ceAction\'))">' + a + '</span>';
+    html += '<span class="fe-action-chip" data-action="logColdAction" data-arg="ceAction" data-arg2="' + escAttr(a) + '">' + escHtml(a) + '</span>';
   });
   html += '</div>';
   if (ep.actions.length > 0) {
@@ -14955,11 +14955,11 @@ function renderInfoNutrientHeatmap() {
         gridHtml += `<div class="nh-cell nh-nodata" title="No meals logged">–</div>`;
       } else if (count === 0) {
         // Meals logged but nutrient absent — real gap
-        gridHtml += `<div class="nh-cell nh-0 ${n.cssClass}" title="Gap" onclick="showHeatmapDetail('${n.key}',${dayIdx},'${data.days[dayIdx]}')">·</div>`;
+        gridHtml += `<div class="nh-cell nh-0 ${n.cssClass}" title="Gap" data-action="showHeatmapDetail" data-arg="${escAttr(n.key)}" data-arg2="${dayIdx}" data-arg3="${escAttr(data.days[dayIdx])}">·</div>`;
       } else {
         // Nutrient present — colored fill, tap to see sources
         const level = count <= 2 ? 1 : count <= 4 ? 2 : 3;
-        gridHtml += `<div class="nh-cell nh-${level} ${n.cssClass}" title="${escAttr(foods.join(', '))}" onclick="showHeatmapDetail('${n.key}',${dayIdx},'${data.days[dayIdx]}')"></div>`;
+        gridHtml += `<div class="nh-cell nh-${level} ${n.cssClass}" title="${escAttr(foods.join(', '))}" data-action="showHeatmapDetail" data-arg="${escAttr(n.key)}" data-arg2="${dayIdx}" data-arg3="${escAttr(data.days[dayIdx])}"></div>`;
       }
     });
   });

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -15772,6 +15772,20 @@ function init() {
     else if (action === 'execAlertAction' && typeof execAlertAction === 'function') execAlertAction(arg);
     else if (action === 'switchTab' && typeof switchTab === 'function') switchTab(arg);
     else if (action === 'toggleUpcomingSubcat' && typeof toggleUpcomingSubcat === 'function') toggleUpcomingSubcat(arg);
+    // Polish-10c: HR-3 onclick batch — Intelligence + Diet (15 sites).
+    // arg = elapsed-time selector ('feAction' | 'deHydra' | 'deAction' | 'voHydra' |
+    //   'voLog' | 'voAction' | 'ceAction'); arg2 = action label string.
+    else if (action === 'logFeverAction' && typeof logFeverAction === 'function') logFeverAction(arg2, _epGetSelectedTime(arg));
+    else if (action === 'logDiarrhoeaWetDiaper' && typeof logDiarrhoeaWetDiaper === 'function') logDiarrhoeaWetDiaper(_epGetSelectedTime(arg));
+    else if (action === 'logDiarrhoeaAction' && typeof logDiarrhoeaAction === 'function') logDiarrhoeaAction(arg2, _epGetSelectedTime(arg));
+    else if (action === 'logVomitingWetDiaper' && typeof logVomitingWetDiaper === 'function') logVomitingWetDiaper(_epGetSelectedTime(arg));
+    else if (action === 'logVomitingEpisodeEntry' && typeof logVomitingEpisodeEntry === 'function') logVomitingEpisodeEntry(arg2, _epGetSelectedTime(arg));
+    else if (action === 'logVomitingAction' && typeof logVomitingAction === 'function') logVomitingAction(arg2, _epGetSelectedTime(arg));
+    else if (action === 'ceToggleSymptom' && typeof ceToggleSymptom === 'function') ceToggleSymptom(arg);
+    else if (action === 'ceSetSeverity' && typeof ceSetSeverity === 'function') ceSetSeverity(Number(arg));
+    else if (action === 'logColdAction' && typeof logColdAction === 'function') logColdAction(arg2, _epGetSelectedTime(arg));
+    else if (action === 'showHeatmapDetail' && typeof showHeatmapDetail === 'function') showHeatmapDetail(arg, Number(arg2), arg3);
+    else if (action === 'toggleCorrEvidence' && typeof toggleCorrEvidence === 'function') toggleCorrEvidence(Number(arg));
     else if (action === 'editUpcomingVaccDate') editUpcomingVaccDate();
     else if (action === 'openMedModal') openMedModal();
     else if (action === 'toggleVisitForm') toggleVisitForm();
@@ -32969,7 +32983,7 @@ function renderCorrelationCard() {
         <span class="corr-rate ${rateClass}">${rpct}% (${r.abnormalAfter}/${r.totalOccurrences})</span>
       </div>
       <div class="corr-detail">${conList || 'Abnormal poop pattern'} · Confidence: ${r.confidence}</div>
-      <div class="corr-evidence" onclick="toggleCorrEvidence(${idx})"><span class="collapse-chevron" id="corrChev-${idx}">▾</span> View evidence (last ${r.dates.length})</div>
+      <div class="corr-evidence" data-action="toggleCorrEvidence" data-arg="${idx}"><span class="collapse-chevron" id="corrChev-${idx}">▾</span> View evidence (last ${r.dates.length})</div>
       <div class="corr-evidence-trail" id="corrEvidence-${idx}">
         ${r.dates.map(d => `<div class="corr-ev-row">${zi('bowl')} ${formatDate(d.ate)} → ${zi('diaper')} ${formatDate(d.poopDate)} · ${d.consistency}${d.abnormal ? ' ' + zi('warn') : ' ' + zi('check')}</div>`).join('')}
       </div>
@@ -50224,7 +50238,7 @@ function renderFeverEpisodeCard() {
   const ACTION_CHIPS = ['Lukewarm sponging', 'Breastfed', 'Fluids given', 'Changed clothes', 'Doctor called'];
   html += '<div class="fe-action-chips">';
   ACTION_CHIPS.forEach(a => {
-    html += '<span class="fe-action-chip" onclick="logFeverAction(\'' + a.replace(/'/g, "\\'") + '\', _epGetSelectedTime(\'feAction\'))">' + a + '</span>';
+    html += '<span class="fe-action-chip" data-action="logFeverAction" data-arg="feAction" data-arg2="' + escAttr(a) + '">' + escHtml(a) + '</span>';
   });
   html += '</div>';
   if (ep.actions.length > 0) {
@@ -50914,7 +50928,7 @@ function renderDiarrhoeaEpisodeCard() {
   html += '</div>';
   html += _epTimePickerHTML('deHydra');
   html += '<div class="kc-row-flex-wrap">';
-  html += '<span class="fe-action-chip" onclick="logDiarrhoeaWetDiaper(_epGetSelectedTime(\'deHydra\'))">' + zi('diaper') + ' Log wet diaper</span>';
+  html += '<span class="fe-action-chip" data-action="logDiarrhoeaWetDiaper" data-arg="deHydra">' + zi('diaper') + ' Log wet diaper</span>';
   html += '<span class="fe-action-chip" data-action="deLogFluidPrompt">'+zi('drop')+' Log fluid</span>';
   html += '</div>';
   if (ep.fluids.length > 0) {
@@ -50972,7 +50986,7 @@ function renderDiarrhoeaEpisodeCard() {
   const DE_ACTIONS = ['Breastfed', 'ORS given', 'Applied diaper cream', 'Changed diaper', 'Doctor called', 'Washed hands'];
   html += '<div class="fe-action-chips">';
   DE_ACTIONS.forEach(a => {
-    html += '<span class="fe-action-chip" onclick="logDiarrhoeaAction(\'' + a.replace(/'/g, "\\'") + '\', _epGetSelectedTime(\'deAction\'))">' + a + '</span>';
+    html += '<span class="fe-action-chip" data-action="logDiarrhoeaAction" data-arg="deAction" data-arg2="' + escAttr(a) + '">' + escHtml(a) + '</span>';
   });
   html += '</div>';
   if (ep.actions.length > 0) {
@@ -51415,16 +51429,16 @@ function renderVomitingEpisodeCard() {
   const hydColor = wetToday >= 6 ? 'var(--tc-sage)' : wetToday >= 4 ? 'var(--tc-amber)' : 'var(--tc-danger)';
   html += '<div class="de-hydra-bar"><div class="de-hydra-label">Wet diapers today</div><div class="de-hydra-track"><div class="de-hydra-fill" style="width:' + hydPct + '%;background:' + hydColor + ';"></div></div><div class="de-hydra-count" style="color:' + hydColor + ';">' + wetToday + '/6</div></div>';
   html += _epTimePickerHTML('voHydra');
-  html += '<div class="fe-action-chips"><span class="fe-action-chip" onclick="logVomitingWetDiaper(_epGetSelectedTime(\'voHydra\'))">'+zi('drop')+' Wet diaper</span><span class="fe-action-chip" data-action="voLogFluidPrompt">'+zi('drop')+' Log fluid</span></div>';
+  html += '<div class="fe-action-chips"><span class="fe-action-chip" data-action="logVomitingWetDiaper" data-arg="voHydra">'+zi('drop')+' Wet diaper</span><span class="fe-action-chip" data-action="voLogFluidPrompt">'+zi('drop')+' Log fluid</span></div>';
 
   // Log vomiting
   html += '<div class="fe-section-title">Vomiting Log</div>';
   html += _epTimePickerHTML('voLog');
   html += '<div class="fe-action-chips">';
-  html += '<span class="fe-action-chip" onclick="logVomitingEpisodeEntry(\'spit-up\', _epGetSelectedTime(\'voLog\'))">'+zi('warn')+' Spit-up</span>';
-  html += '<span class="fe-action-chip" onclick="logVomitingEpisodeEntry(\'vomit\', _epGetSelectedTime(\'voLog\'))">'+zi('siren')+' Vomit</span>';
-  html += '<span class="fe-action-chip" onclick="logVomitingEpisodeEntry(\'projectile\', _epGetSelectedTime(\'voLog\'))">'+zi('siren')+' Projectile</span>';
-  html += '<span class="fe-action-chip" onclick="logVomitingEpisodeEntry(\'bile\', _epGetSelectedTime(\'voLog\'))">'+zi('warn')+' Bile/green</span>';
+  html += '<span class="fe-action-chip" data-action="logVomitingEpisodeEntry" data-arg="voLog" data-arg2="spit-up">'+zi('warn')+' Spit-up</span>';
+  html += '<span class="fe-action-chip" data-action="logVomitingEpisodeEntry" data-arg="voLog" data-arg2="vomit">'+zi('siren')+' Vomit</span>';
+  html += '<span class="fe-action-chip" data-action="logVomitingEpisodeEntry" data-arg="voLog" data-arg2="projectile">'+zi('siren')+' Projectile</span>';
+  html += '<span class="fe-action-chip" data-action="logVomitingEpisodeEntry" data-arg="voLog" data-arg2="bile">'+zi('warn')+' Bile/green</span>';
   html += '</div>';
 
   if (ep.episodes.length > 0) {
@@ -51440,7 +51454,7 @@ function renderVomitingEpisodeCard() {
   html += _epTimePickerHTML('voAction');
   html += '<div class="fe-action-chips">';
   ['Kept upright 30min', 'Small feed given', 'Breastfed', 'Doctor called'].forEach(a => {
-    html += '<span class="fe-action-chip" onclick="logVomitingAction(\'' + a.replace(/'/g, "\\'") + '\', _epGetSelectedTime(\'voAction\'))">' + a + '</span>';
+    html += '<span class="fe-action-chip" data-action="logVomitingAction" data-arg="voAction" data-arg2="' + escAttr(a) + '">' + escHtml(a) + '</span>';
   });
   html += '</div>';
   if (ep.actions.length > 0) {
@@ -51691,7 +51705,7 @@ function renderColdEpisodeCard() {
   html += '<div class="fe-action-chips">';
   COLD_SYMPTOMS.forEach(s => {
     const active = todaySymptoms.has(s);
-    html += '<span class="fe-action-chip" style="' + (active ? 'background:var(--sage);color:white;' : '') + '" onclick="ceToggleSymptom(\'' + s.replace(/'/g, "\\'") + '\')">' + (active ? '✓ ' : '') + s + '</span>';
+    html += '<span class="fe-action-chip" style="' + (active ? 'background:var(--sage);color:white;' : '') + '" data-action="ceToggleSymptom" data-arg="' + escAttr(s) + '">' + (active ? '✓ ' : '') + escHtml(s) + '</span>';
   });
   html += '</div>';
 
@@ -51701,7 +51715,7 @@ function renderColdEpisodeCard() {
   for (let i = 1; i <= 5; i++) {
     const isActive = latestSeverity === i;
     const color = i <= 2 ? 'var(--tc-sage)' : i <= 3 ? 'var(--tc-amber)' : 'var(--tc-caution)';
-    html += '<span class="fe-action-chip" style="' + (isActive ? 'background:' + color + ';color:white;border-color:' + color + ';' : '') + 'min-width:32px;justify-content:center;" onclick="ceSetSeverity(' + i + ')">' + i + '</span>';
+    html += '<span class="fe-action-chip" style="' + (isActive ? 'background:' + color + ';color:white;border-color:' + color + ';' : '') + 'min-width:32px;justify-content:center;" data-action="ceSetSeverity" data-arg="' + i + '">' + i + '</span>';
   }
   html += '</div></div>';
 
@@ -51721,7 +51735,7 @@ function renderColdEpisodeCard() {
   html += _epTimePickerHTML('ceAction');
   html += '<div class="fe-action-chips">';
   ['Saline drops', 'Steam inhalation', 'Humidifier on', 'Elevated mattress', 'Breastfed', 'Doctor called'].forEach(a => {
-    html += '<span class="fe-action-chip" onclick="logColdAction(\'' + a.replace(/'/g, "\\'") + '\', _epGetSelectedTime(\'ceAction\'))">' + a + '</span>';
+    html += '<span class="fe-action-chip" data-action="logColdAction" data-arg="ceAction" data-arg2="' + escAttr(a) + '">' + escHtml(a) + '</span>';
   });
   html += '</div>';
   if (ep.actions.length > 0) {
@@ -57986,11 +58000,11 @@ function renderInfoNutrientHeatmap() {
         gridHtml += `<div class="nh-cell nh-nodata" title="No meals logged">–</div>`;
       } else if (count === 0) {
         // Meals logged but nutrient absent — real gap
-        gridHtml += `<div class="nh-cell nh-0 ${n.cssClass}" title="Gap" onclick="showHeatmapDetail('${n.key}',${dayIdx},'${data.days[dayIdx]}')">·</div>`;
+        gridHtml += `<div class="nh-cell nh-0 ${n.cssClass}" title="Gap" data-action="showHeatmapDetail" data-arg="${escAttr(n.key)}" data-arg2="${dayIdx}" data-arg3="${escAttr(data.days[dayIdx])}">·</div>`;
       } else {
         // Nutrient present — colored fill, tap to see sources
         const level = count <= 2 ? 1 : count <= 4 ? 2 : 3;
-        gridHtml += `<div class="nh-cell nh-${level} ${n.cssClass}" title="${escAttr(foods.join(', '))}" onclick="showHeatmapDetail('${n.key}',${dayIdx},'${data.days[dayIdx]}')"></div>`;
+        gridHtml += `<div class="nh-cell nh-${level} ${n.cssClass}" title="${escAttr(foods.join(', '))}" data-action="showHeatmapDetail" data-arg="${escAttr(n.key)}" data-arg2="${dayIdx}" data-arg3="${escAttr(data.days[dayIdx])}"></div>`;
       }
     });
   });

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -3128,3 +3128,68 @@ test.describe('Polish-10b — HR-3 onclick batch (Care + Home; ~24 sites)', () =
       .toEqual([]);
   });
 });
+
+test.describe('Polish-10c — HR-3 onclick batch (Intelligence + Diet; ~15 sites)', () => {
+  // Polish-10c absorbs the inline-onclick HR-3 violations across the
+  // Intelligence jurisdiction (intelligence.js fever/diarrhoea/vomiting/
+  // cold episode action chips, severity selectors, nutrient-heatmap cells)
+  // plus 1 diet.js site (toggleCorrEvidence). Single fix-shape per atomic-
+  // canon discipline: function-call delegation via data-action + data-arg.
+  //
+  // Compound onclicks (set-value + call, this.closest, template-string
+  // injection) deferred to R-10 carry-forward — different fix-shape needs
+  // separate atomic-canon treatment.
+
+  test('positive — 11 named function dispatchers wired in core.js for Intelligence + Diet domains', async ({ request }) => {
+    const res = await request.get('/split/core.js');
+    expect(res.ok(), '/split/core.js fetchable').toBeTruthy();
+    const js = await res.text();
+
+    const NAMED_HANDLERS = [
+      'logFeverAction',
+      'logDiarrhoeaWetDiaper', 'logDiarrhoeaAction',
+      'logVomitingWetDiaper', 'logVomitingEpisodeEntry', 'logVomitingAction',
+      'ceToggleSymptom', 'ceSetSeverity',
+      'logColdAction',
+      'showHeatmapDetail',
+      'toggleCorrEvidence',
+    ];
+    for (const handler of NAMED_HANDLERS) {
+      expect(js.includes(`action === '${handler}'`),
+        `core.js dispatcher includes ${handler}`).toBeTruthy();
+    }
+  });
+
+  test('regression-guard — zero onclick=" attrs at converted Polish-10c ranges (intelligence.js + diet.js)', async ({ request }) => {
+    const intelRes = await request.get('/split/intelligence.js');
+    const intel = await intelRes.text();
+    const dietRes = await request.get('/split/diet.js');
+    const diet = await dietRes.text();
+
+    const buggyIntelPatterns = [
+      `onclick="logFeverAction(`,
+      `onclick="logDiarrhoeaWetDiaper(`,
+      `onclick="logDiarrhoeaAction(`,
+      `onclick="logVomitingWetDiaper(`,
+      `onclick="logVomitingEpisodeEntry(`,
+      `onclick="logVomitingAction(`,
+      `onclick="ceToggleSymptom(`,
+      `onclick="ceSetSeverity(`,
+      `onclick="logColdAction(`,
+      `onclick="showHeatmapDetail(`,
+    ];
+    for (const pattern of buggyIntelPatterns) {
+      expect(intel.includes(pattern),
+        `intelligence.js: zero residual inlined onclick of pattern: ${pattern}`).toBeFalsy();
+    }
+
+    expect(diet.includes(`onclick="toggleCorrEvidence(`),
+      'diet.js: zero residual inlined onclick of toggleCorrEvidence').toBeFalsy();
+
+    // Verify the new data-action attribute presence as positive complement.
+    expect(intel.includes(`data-action="logFeverAction"`),
+      'intelligence.js: logFeverAction converted to data-action').toBeTruthy();
+    expect(diet.includes(`data-action="toggleCorrEvidence"`),
+      'diet.js: toggleCorrEvidence converted to data-action').toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Polish-10c completes the HR-3 onclick sweep across Phase 4 Polish by absorbing the Intelligence jurisdiction sites (intelligence.js fever/diarrhoea/vomiting/cold episode action chips, severity selectors, nutrient-heatmap cells) plus 1 diet.js site (toggleCorrEvidence). Same fix-shape as Polish-10b: function-call delegation via `data-action` + `data-arg` with optional `data-stop="1"`.

**Sequencing note:** This PR is branched off PR-35 (Polish-10b) per charter §7 sequencing — both touch `core.js` dispatcher; sequential merge avoids conflict on dispatcher entries. PR-35 needs to land first.

## Sites converted (15)

### intelligence.js (14)
- `:7196` `logFeverAction` (2 args; eliminates `a.replace(/'/g, "\\'")` double-escape via straight `escAttr`)
- `:7886` `logDiarrhoeaWetDiaper` (1 arg — `deHydra` time selector)
- `:7944` `logDiarrhoeaAction` (2 args; same escape simplification)
- `:8387` `logVomitingWetDiaper` (1 arg; companion to existing `voLogFluidPrompt` data-action on same line)
- `:8393, :8394, :8395, :8396` `logVomitingEpisodeEntry` × 4 (2 args: arg=time-selector `voLog`, arg2=entry-type `spit-up` / `vomit` / `projectile` / `bile`)
- `:8412` `logVomitingAction` (2 args)
- `:8663` `ceToggleSymptom` (1 arg, escAttr-bearing; preserves dynamic inline-style — HR-2 carve-out routes to Polish-6+ first-instance)
- `:8673` `ceSetSeverity` (1 arg numeric)
- `:8693` `logColdAction` (2 args)
- `:14958, :14962` `showHeatmapDetail` × 2 (3 args via `data-arg/arg2/arg3`)

### diet.js (1)
- `:3419` `toggleCorrEvidence` (1 arg numeric)

## core.js dispatcher additions (~14 LOC)

- 11 named function dispatchers with `typeof function` guard
- All log* episode entries normalize the 2-arg shape (`arg`=time-selector string, `arg2`=action-or-entry-type string) and call `_epGetSelectedTime(arg)` internally before invoking the underlying logger function

## Tests (R-7 binary-mode duo)

1. **positive** — 11 named function dispatchers wired in core.js for Intelligence + Diet domains
2. **regression-guard** — zero residual inlined onclick patterns at converted ranges in intelligence.js + diet.js; data-action attrs present at representative converted sites

## Verification

```bash
# onclick deltas
intelligence.js: 20 → 6  (−14)
diet.js:         10 → 9  (−1)
```

## Carry-forwards (deferred per narrow-scope discipline; route to R-10 at Polish-10 close)

- **intelligence.js**: `:6793` (compound: setValue with function-call result), `:8793` (compound chained: stopPropagation + switchTab + setTimeout + switchTrackSub), `:11761` (compound: var assign + openQuickModal), `:11779` (json-array-literal arg via Array.join), `:11883` (compound: set value + call), `:12270` (compound with `this.closest`)
- **diet.js**: `:428, :853, :897` (compound: set value + activateBtn + checkFoodCombo / renderComboResult), `:3052` (compound: closeScorePopup + setTimeout + switchTab), `:3316, :3338` (template-string injection via `getAlertNavAction` — needs caller refactor), `:3926, :3949` (selectQLBackfillDate with `this` reference), `:3995` (compound: set value + focus chain)

## Test plan

- [ ] Build verifies clean: `cd split && bash build.sh > sproutlab.html`
- [ ] Hermetic floor: load index.html in browser
- [ ] Tap fever-action chip → logs action with selected time
- [ ] Tap diarrhoea wet-diaper chip → logs hydration entry
- [ ] Tap vomiting type chips (spit-up/vomit/projectile/bile) → each logs correctly
- [ ] Tap cold-symptom chip → toggles symptom in active set
- [ ] Tap cold-severity chip → sets severity 1-5
- [ ] Tap nutrient-heatmap cell → opens detail modal with correct n.key/dayIdx/date args
- [ ] Tap "View evidence" on poop-correlation → toggles evidence trail
- [ ] Smoke spec duo passes: 2 new tests in `tests/e2e/smoke.spec.ts` Polish-10c describe block

→ **Cipher:** advisory review on dispatcher pattern (typeof guard, log* normalization)
→ **Kael:** Intelligence-jurisdiction audit (14 intelligence.js conversions; 11 new dispatcher entries)
→ **Maren:** diet.js review (1 site — toggleCorrEvidence)
→ **Aurelius / Sovereign:** merge gate (sequenced after PR-35)

— Lyra (The Weaver)

https://claude.ai/code/session_01CM2dJFnSvrR7FDkGXcn8ZA

---
_Generated by [Claude Code](https://claude.ai/code/session_01CM2dJFnSvrR7FDkGXcn8ZA)_