### PR TITLE
fix: remove [bump-version] artifact from HTML output (build stderr leak)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-[bump-version] 2026.05.03-5 → 2026.05.06-1
+[bump-version] 2026.05.06-1 → 2026.05.06-2
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -401,7 +401,7 @@ svg.zi { width:16px; height:16px; vertical-align:-2px; flex-shrink:0; }
 }
 .gh-gauge-val { font-family:'Fraunces',serif; font-size:var(--fs-xl); font-weight:600; line-height:var(--lh-none); }
 .gh-gauge-unit { font-size:var(--fs-2xs); font-weight:600; color:var(--mid); text-transform:uppercase; letter-spacing:var(--ls-tight); margin-top:1px; }
-.gh-gauge-pct { font-size:var(--fs-xs); font-weight:600; margin-top:var(--sp-2); padding:1px var(--sp-6); border-radius:var(--r-full); }
+.gh-gauge-pct { font-size:var(--fs-sm); font-weight:600; margin-top:var(--sp-2); padding:var(--sp-2) var(--sp-8); border-radius:var(--r-full); }
 .gh-gauge-label { font-size:var(--fs-xs); font-weight:600; color:var(--text); text-transform:uppercase; letter-spacing:var(--ls-tight); margin-top:var(--sp-6); }
 .gh-gauge-sub { font-size:var(--fs-xs); color:var(--mid); margin-top:1px; }
 .gh-meta-row { display:flex; gap:var(--sp-8); min-width:0; flex-wrap:wrap;}
@@ -35528,21 +35528,24 @@ function renderGrowthHero() {
   const ageStr = `${months}m ${days}d`;
 
   // Compute percentiles
-  let wtPct = null, htPct = null, wtVal = '—', htVal = '—';
+  let wtPct = null, htPct = null, wtVal = '—', htVal = '—', wtUnit = 'kg', htUnit = '';
   let wtPctNum = 50, htPctNum = 50;
   if (lastWtE) {
     const who = getGrowthRef(ageMonthsAt(lastWtE.date));
     const p = calcPercentile(lastWtE.wt, who.w3, who.w50, who.w97, who.w15, who.w85);
     wtPct = p;
     wtPctNum = parseInt(p.text) || 50;
-    wtVal = lastWtE.wt + ' kg';
+    wtVal = String(lastWtE.wt);
   }
   if (lastHtE) {
     const who = getGrowthRef(ageMonthsAt(lastHtE.date));
     const p = calcPercentile(lastHtE.ht, who.h3, who.h50, who.h97, who.h15, who.h85);
     htPct = p;
     htPctNum = parseInt(p.text) || 50;
-    htVal = formatHeight(lastHtE.ht);
+    const htUnitPref = localStorage.getItem('ziva_height_unit') || 'ft';
+    if (htUnitPref === 'cm') { htVal = String(lastHtE.ht); htUnit = 'cm'; }
+    else if (htUnitPref === 'in') { htVal = (lastHtE.ht / 2.54).toFixed(1); htUnit = 'in'; }
+    else { const _ft = Math.floor(lastHtE.ht / 2.54 / 12); const _in = (lastHtE.ht / 2.54 % 12).toFixed(1); htVal = `${_ft}′${_in}″`; }
   }
 
   // Gain rate
@@ -35580,7 +35583,7 @@ function renderGrowthHero() {
         <div class="gh-gauge-inner">
           <div class="gh-gauge-val" style="color:${color};">${val}</div>
           <div class="gh-gauge-unit">${unit}</div>
-          ${pctText ? `<div class="gh-gauge-pct" style="background:${pctBg};color:${pctColor};">${pctText}</div>` : ''}
+          ${pctText ? `<div class="gh-gauge-pct" style="background:${pctBg};color:${pctColor};">${escHtml(pctText)}</div>` : ''}
         </div>
       </div>
       <div class="gh-gauge-label">${label}</div>
@@ -35599,8 +35602,8 @@ function renderGrowthHero() {
 
   // Gauge rings
   html += '<div class="gh-gauges">';
-  html += gaugeRing(wtPctNum, wtVal, 'weight', wtPct ? wtPct.text : null, 'Weight', wtColor);
-  html += gaugeRing(htPctNum, htVal, 'height', htPct ? htPct.text : null, 'Height', htColor);
+  html += gaugeRing(wtPctNum, wtVal, wtUnit, wtPct ? wtPct.text : null, 'Weight', wtColor);
+  html += gaugeRing(htPctNum, htVal, htUnit, htPct ? htPct.text : null, 'Height', htColor);
   html += '</div>';
 
   // Meta pills row

--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+[bump-version] 2026.05.03-5 → 2026.05.06-1
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -20476,9 +20477,10 @@ function updateHeader() {
     const avg = getAvgDailySleepScore7d();
     const pill = document.getElementById('homeAvgSleepScorePill');
     if (avg > 0) {
-      const emoji = avg >= 70 ? zi('moon') : avg >= 40 ? zi('target') : zi('warn');
-      sleepScorePill.textContent = `${emoji} ${avg}`;
+      sleepScorePill.textContent = String(avg);
       if (pill) {
+        const iconEl = pill.querySelector('.hsp-icon');
+        if (iconEl) iconEl.innerHTML = avg >= 70 ? zi('moon') : avg >= 40 ? zi('target') : zi('warn');
         pill.classList.remove('hsp-sage','hsp-peach','hsp-rose','hsp-indigo');
         pill.classList.add(avg >= 70 ? 'hsp-sage' : avg >= 40 ? 'hsp-peach' : 'hsp-rose');
       }

--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-[bump-version] 2026.05.06-1 → 2026.05.06-2
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.03-5",
+  "version": "2026.05.06-3",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "sproutlab-tests",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sproutlab-tests",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "1.48.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.2.tgz",
+      "integrity": "sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.48.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.2.tgz",
+      "integrity": "sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.48.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.48.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.2.tgz",
+      "integrity": "sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/split/home.js
+++ b/split/home.js
@@ -94,9 +94,10 @@ function updateHeader() {
     const avg = getAvgDailySleepScore7d();
     const pill = document.getElementById('homeAvgSleepScorePill');
     if (avg > 0) {
-      const emoji = avg >= 70 ? zi('moon') : avg >= 40 ? zi('target') : zi('warn');
-      sleepScorePill.textContent = `${emoji} ${avg}`;
+      sleepScorePill.textContent = String(avg);
       if (pill) {
+        const iconEl = pill.querySelector('.hsp-icon');
+        if (iconEl) iconEl.innerHTML = avg >= 70 ? zi('moon') : avg >= 40 ? zi('target') : zi('warn');
         pill.classList.remove('hsp-sage','hsp-peach','hsp-rose','hsp-indigo');
         pill.classList.add(avg >= 70 ? 'hsp-sage' : avg >= 40 ? 'hsp-peach' : 'hsp-rose');
       }

--- a/split/medical.js
+++ b/split/medical.js
@@ -1872,21 +1872,24 @@ function renderGrowthHero() {
   const ageStr = `${months}m ${days}d`;
 
   // Compute percentiles
-  let wtPct = null, htPct = null, wtVal = '—', htVal = '—';
+  let wtPct = null, htPct = null, wtVal = '—', htVal = '—', wtUnit = 'kg', htUnit = '';
   let wtPctNum = 50, htPctNum = 50;
   if (lastWtE) {
     const who = getGrowthRef(ageMonthsAt(lastWtE.date));
     const p = calcPercentile(lastWtE.wt, who.w3, who.w50, who.w97, who.w15, who.w85);
     wtPct = p;
     wtPctNum = parseInt(p.text) || 50;
-    wtVal = lastWtE.wt + ' kg';
+    wtVal = String(lastWtE.wt);
   }
   if (lastHtE) {
     const who = getGrowthRef(ageMonthsAt(lastHtE.date));
     const p = calcPercentile(lastHtE.ht, who.h3, who.h50, who.h97, who.h15, who.h85);
     htPct = p;
     htPctNum = parseInt(p.text) || 50;
-    htVal = formatHeight(lastHtE.ht);
+    const htUnitPref = localStorage.getItem('ziva_height_unit') || 'ft';
+    if (htUnitPref === 'cm') { htVal = String(lastHtE.ht); htUnit = 'cm'; }
+    else if (htUnitPref === 'in') { htVal = (lastHtE.ht / 2.54).toFixed(1); htUnit = 'in'; }
+    else { const _ft = Math.floor(lastHtE.ht / 2.54 / 12); const _in = (lastHtE.ht / 2.54 % 12).toFixed(1); htVal = `${_ft}′${_in}″`; }
   }
 
   // Gain rate
@@ -1924,7 +1927,7 @@ function renderGrowthHero() {
         <div class="gh-gauge-inner">
           <div class="gh-gauge-val" style="color:${color};">${val}</div>
           <div class="gh-gauge-unit">${unit}</div>
-          ${pctText ? `<div class="gh-gauge-pct" style="background:${pctBg};color:${pctColor};">${pctText}</div>` : ''}
+          ${pctText ? `<div class="gh-gauge-pct" style="background:${pctBg};color:${pctColor};">${escHtml(pctText)}</div>` : ''}
         </div>
       </div>
       <div class="gh-gauge-label">${label}</div>
@@ -1943,8 +1946,8 @@ function renderGrowthHero() {
 
   // Gauge rings
   html += '<div class="gh-gauges">';
-  html += gaugeRing(wtPctNum, wtVal, 'weight', wtPct ? wtPct.text : null, 'Weight', wtColor);
-  html += gaugeRing(htPctNum, htVal, 'height', htPct ? htPct.text : null, 'Height', htColor);
+  html += gaugeRing(wtPctNum, wtVal, wtUnit, wtPct ? wtPct.text : null, 'Weight', wtColor);
+  html += gaugeRing(htPctNum, htVal, htUnit, htPct ? htPct.text : null, 'Height', htColor);
   html += '</div>';
 
   // Meta pills row

--- a/split/styles.css
+++ b/split/styles.css
@@ -393,7 +393,7 @@ svg.zi { width:16px; height:16px; vertical-align:-2px; flex-shrink:0; }
 }
 .gh-gauge-val { font-family:'Fraunces',serif; font-size:var(--fs-xl); font-weight:600; line-height:var(--lh-none); }
 .gh-gauge-unit { font-size:var(--fs-2xs); font-weight:600; color:var(--mid); text-transform:uppercase; letter-spacing:var(--ls-tight); margin-top:1px; }
-.gh-gauge-pct { font-size:var(--fs-xs); font-weight:600; margin-top:var(--sp-2); padding:1px var(--sp-6); border-radius:var(--r-full); }
+.gh-gauge-pct { font-size:var(--fs-sm); font-weight:600; margin-top:var(--sp-2); padding:var(--sp-2) var(--sp-8); border-radius:var(--r-full); }
 .gh-gauge-label { font-size:var(--fs-xs); font-weight:600; color:var(--text); text-transform:uppercase; letter-spacing:var(--ls-tight); margin-top:var(--sp-6); }
 .gh-gauge-sub { font-size:var(--fs-xs); color:var(--mid); margin-top:1px; }
 .gh-meta-row { display:flex; gap:var(--sp-8); min-width:0; flex-wrap:wrap;}

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -1,4 +1,4 @@
-[bump-version] 2026.05.03-5 → 2026.05.06-1
+[bump-version] 2026.05.06-1 → 2026.05.06-2
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -401,7 +401,7 @@ svg.zi { width:16px; height:16px; vertical-align:-2px; flex-shrink:0; }
 }
 .gh-gauge-val { font-family:'Fraunces',serif; font-size:var(--fs-xl); font-weight:600; line-height:var(--lh-none); }
 .gh-gauge-unit { font-size:var(--fs-2xs); font-weight:600; color:var(--mid); text-transform:uppercase; letter-spacing:var(--ls-tight); margin-top:1px; }
-.gh-gauge-pct { font-size:var(--fs-xs); font-weight:600; margin-top:var(--sp-2); padding:1px var(--sp-6); border-radius:var(--r-full); }
+.gh-gauge-pct { font-size:var(--fs-sm); font-weight:600; margin-top:var(--sp-2); padding:var(--sp-2) var(--sp-8); border-radius:var(--r-full); }
 .gh-gauge-label { font-size:var(--fs-xs); font-weight:600; color:var(--text); text-transform:uppercase; letter-spacing:var(--ls-tight); margin-top:var(--sp-6); }
 .gh-gauge-sub { font-size:var(--fs-xs); color:var(--mid); margin-top:1px; }
 .gh-meta-row { display:flex; gap:var(--sp-8); min-width:0; flex-wrap:wrap;}
@@ -35528,21 +35528,24 @@ function renderGrowthHero() {
   const ageStr = `${months}m ${days}d`;
 
   // Compute percentiles
-  let wtPct = null, htPct = null, wtVal = '—', htVal = '—';
+  let wtPct = null, htPct = null, wtVal = '—', htVal = '—', wtUnit = 'kg', htUnit = '';
   let wtPctNum = 50, htPctNum = 50;
   if (lastWtE) {
     const who = getGrowthRef(ageMonthsAt(lastWtE.date));
     const p = calcPercentile(lastWtE.wt, who.w3, who.w50, who.w97, who.w15, who.w85);
     wtPct = p;
     wtPctNum = parseInt(p.text) || 50;
-    wtVal = lastWtE.wt + ' kg';
+    wtVal = String(lastWtE.wt);
   }
   if (lastHtE) {
     const who = getGrowthRef(ageMonthsAt(lastHtE.date));
     const p = calcPercentile(lastHtE.ht, who.h3, who.h50, who.h97, who.h15, who.h85);
     htPct = p;
     htPctNum = parseInt(p.text) || 50;
-    htVal = formatHeight(lastHtE.ht);
+    const htUnitPref = localStorage.getItem('ziva_height_unit') || 'ft';
+    if (htUnitPref === 'cm') { htVal = String(lastHtE.ht); htUnit = 'cm'; }
+    else if (htUnitPref === 'in') { htVal = (lastHtE.ht / 2.54).toFixed(1); htUnit = 'in'; }
+    else { const _ft = Math.floor(lastHtE.ht / 2.54 / 12); const _in = (lastHtE.ht / 2.54 % 12).toFixed(1); htVal = `${_ft}′${_in}″`; }
   }
 
   // Gain rate
@@ -35580,7 +35583,7 @@ function renderGrowthHero() {
         <div class="gh-gauge-inner">
           <div class="gh-gauge-val" style="color:${color};">${val}</div>
           <div class="gh-gauge-unit">${unit}</div>
-          ${pctText ? `<div class="gh-gauge-pct" style="background:${pctBg};color:${pctColor};">${pctText}</div>` : ''}
+          ${pctText ? `<div class="gh-gauge-pct" style="background:${pctBg};color:${pctColor};">${escHtml(pctText)}</div>` : ''}
         </div>
       </div>
       <div class="gh-gauge-label">${label}</div>
@@ -35599,8 +35602,8 @@ function renderGrowthHero() {
 
   // Gauge rings
   html += '<div class="gh-gauges">';
-  html += gaugeRing(wtPctNum, wtVal, 'weight', wtPct ? wtPct.text : null, 'Weight', wtColor);
-  html += gaugeRing(htPctNum, htVal, 'height', htPct ? htPct.text : null, 'Height', htColor);
+  html += gaugeRing(wtPctNum, wtVal, wtUnit, wtPct ? wtPct.text : null, 'Weight', wtColor);
+  html += gaugeRing(htPctNum, htVal, htUnit, htPct ? htPct.text : null, 'Height', htColor);
   html += '</div>';
 
   // Meta pills row

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -1,3 +1,4 @@
+[bump-version] 2026.05.03-5 → 2026.05.06-1
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -20476,9 +20477,10 @@ function updateHeader() {
     const avg = getAvgDailySleepScore7d();
     const pill = document.getElementById('homeAvgSleepScorePill');
     if (avg > 0) {
-      const emoji = avg >= 70 ? zi('moon') : avg >= 40 ? zi('target') : zi('warn');
-      sleepScorePill.textContent = `${emoji} ${avg}`;
+      sleepScorePill.textContent = String(avg);
       if (pill) {
+        const iconEl = pill.querySelector('.hsp-icon');
+        if (iconEl) iconEl.innerHTML = avg >= 70 ? zi('moon') : avg >= 40 ? zi('target') : zi('warn');
         pill.classList.remove('hsp-sage','hsp-peach','hsp-rose','hsp-indigo');
         pill.classList.add(avg >= 70 ? 'hsp-sage' : avg >= 40 ? 'hsp-peach' : 'hsp-rose');
       }

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -1,4 +1,3 @@
-[bump-version] 2026.05.06-1 → 2026.05.06-2
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -3298,3 +3298,74 @@ test.describe('Polish-11a — Sleep Score pill HR-7 fix (SVG-via-textContent)', 
       "Polish-11a: sleep score icon update uses iconEl.innerHTML = zi(...) (HR-7)").toBeTruthy();
   });
 });
+
+test.describe('Polish-11b — Growth gauge overflow + percentile pill legibility + HR-4', () => {
+  // Bug 2: gauge val "70 cm" / "7.5 kg" combined strings overflow the 78px inner
+  // ring clear diameter at --fs-xl on large zoom. Fix: split number from unit;
+  // val = number-only, unit param = measurement abbreviation.
+  // Bug 3a (CSS): --fs-xs ≈ 9px sub-legibility for Nunito digit rendering on
+  // mobile. Fix: --fs-sm (≈10.5px) + increased padding.
+  // Bug 3b (HR-4): pctText from calcPercentile can return "<3rd" / ">97th";
+  // must escape before innerHTML injection.
+
+  test('regression-guard — gauge wtVal is number-only, no combined "X kg" string', async ({ request }) => {
+    const res = await request.get('/split/medical.js');
+    expect(res.ok(), '/split/medical.js fetchable').toBeTruthy();
+    const js = await res.text();
+
+    // Negative: combined weight+unit string must not be assigned to wtVal.
+    const buggyWt = /wtVal\s*=\s*lastWtE\.wt\s*\+\s*' kg'/g;
+    expect(js.match(buggyWt) || [],
+      "Polish-11b: wtVal must not concatenate ' kg' (combined string overflows gauge ring)").toEqual([]);
+
+    // Positive: wtVal receives String(lastWtE.wt) — number-only.
+    expect(js.includes('wtVal = String(lastWtE.wt)'),
+      'Polish-11b: wtVal = String(lastWtE.wt) (number-only in gauge val)').toBeTruthy();
+  });
+
+  test('regression-guard — gauge htVal splits number from unit (no formatHeight combined string)', async ({ request }) => {
+    const res = await request.get('/split/medical.js');
+    expect(res.ok(), '/split/medical.js fetchable').toBeTruthy();
+    const js = await res.text();
+
+    // Negative: htVal must not be directly assigned from formatHeight() (returns "70 cm" etc.).
+    const buggyHt = /htVal\s*=\s*formatHeight\s*\(/g;
+    expect(js.match(buggyHt) || [],
+      'Polish-11b: htVal must not be assigned directly from formatHeight() (combined string)').toEqual([]);
+
+    // Positive: separate unit tracking variables present.
+    expect(js.includes('wtUnit') && js.includes('htUnit'),
+      'Polish-11b: wtUnit + htUnit variables track measurement units separately').toBeTruthy();
+  });
+
+  test('regression-guard — pctText escaped via escHtml before innerHTML injection (HR-4)', async ({ request }) => {
+    const res = await request.get('/split/medical.js');
+    expect(res.ok(), '/split/medical.js fetchable').toBeTruthy();
+    const js = await res.text();
+
+    // Negative: bare ${pctText} inside gh-gauge-pct template literal is the HR-4 violation.
+    const buggyPct = /gh-gauge-pct[^`]*>\$\{pctText\}</g;
+    expect(js.match(buggyPct) || [],
+      'Polish-11b: pctText must be wrapped in escHtml() in gh-gauge-pct template (HR-4)').toEqual([]);
+
+    // Positive: escHtml(pctText) in the template.
+    expect(js.includes('>${escHtml(pctText)}</div>'),
+      'Polish-11b: gh-gauge-pct renders escHtml(pctText) (HR-4 compliant)').toBeTruthy();
+  });
+
+  test('regression-guard — .gh-gauge-pct uses --fs-sm (not --fs-xs) for legible pill rendering', async ({ request }) => {
+    const res = await request.get('/split/styles.css');
+    expect(res.ok(), '/split/styles.css fetchable').toBeTruthy();
+    const css = await res.text();
+
+    // Negative: --fs-xs at 9px is sub-legible for Nunito digits on mobile.
+    const buggyFontSize = /\.gh-gauge-pct\s*\{[^}]*font-size\s*:\s*var\(--fs-xs\)/;
+    expect(buggyFontSize.test(css),
+      'Polish-11b: .gh-gauge-pct must not use --fs-xs (sub-legible at mobile scale)').toBeFalsy();
+
+    // Positive: --fs-sm (≈10.5px base) provides legible digit rendering.
+    const fixedFontSize = /\.gh-gauge-pct\s*\{[^}]*font-size\s*:\s*var\(--fs-sm\)/;
+    expect(fixedFontSize.test(css),
+      'Polish-11b: .gh-gauge-pct uses --fs-sm for legible percentile pill').toBeTruthy();
+  });
+});

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -3265,3 +3265,36 @@ test.describe('Polish-10d hotfix — sections.* iconKey architectural sweep (Sov
       `Polish-10d: zero 'emoji: bowl' string-literal residue (visible-bug source)`).toEqual([]);
   });
 });
+
+test.describe('Polish-11a — Sleep Score pill HR-7 fix (SVG-via-textContent)', () => {
+  // Visible-bug root cause: home.js renderHomeSleep assigned zi() SVG output
+  // via sleepScorePill.textContent — the SVG markup rendered as literal text in
+  // the pill value slot. Fix: set numeric score via textContent; set icon via
+  // pill.querySelector('.hsp-icon').innerHTML (HR-7 compliant).
+  // Doctrine: architectural-sweep-PR-misses-sibling-sites 3/3 RATIFIED (this
+  // catch is the 3rd independent instance after Polish-10a + Polish-10d r1).
+
+  test('regression-guard — sleepScorePill never assigned via textContent with zi() output', async ({ request }) => {
+    const res = await request.get('/split/home.js');
+    expect(res.ok(), '/split/home.js fetchable').toBeTruthy();
+    const js = await res.text();
+
+    // Negative-absence assertion: the buggy pattern concatenates zi() SVG HTML
+    // into a template literal assigned to .textContent. Match any variation.
+    const buggyPattern = /sleepScorePill\.textContent\s*=\s*`[^`]*zi\s*\(/g;
+    const violations = js.match(buggyPattern) || [];
+    expect(violations,
+      `Polish-11a: sleepScorePill.textContent must not receive zi() SVG output. Found: ${violations.join(' | ')}`)
+      .toEqual([]);
+  });
+
+  test('regression-guard — sleep icon set via .hsp-icon innerHTML (HR-7 compliant)', async ({ request }) => {
+    const res = await request.get('/split/home.js');
+    expect(res.ok(), '/split/home.js fetchable').toBeTruthy();
+    const js = await res.text();
+
+    // Positive assertion: icon update must go through innerHTML on .hsp-icon.
+    expect(js.includes("iconEl.innerHTML = avg >= 70 ? zi('moon') : avg >= 40 ? zi('target') : zi('warn')"),
+      "Polish-11a: sleep score icon update uses iconEl.innerHTML = zi(...) (HR-7)").toBeTruthy();
+  });
+});


### PR DESCRIPTION
**Root cause:** Polish-11 build used `bash build.sh > sproutlab.html 2>&1` — the `2>&1` merged stderr into stdout. `bump-version.mjs` intentionally uses `console.error()` (stderr) to keep HTML stdout clean, but the merge caused `[bump-version] 2026.05.06-1 → 2026.05.06-2` to appear as line 1 of the HTML document, rendering as visible text in the app.

**Fix:** Correct build (`bash build.sh > sproutlab.html` — stderr separate). Line 1 is now `<!DOCTYPE html>`.

**Note for future builds:** Never use `2>&1` with `build.sh`. `bump-version.mjs`'s stderr log is intentionally kept off stdout — mixing them corrupts the HTML.

https://claude.ai/code/session_01J2uWaYd5yLfXWsdTkeg1N7

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2uWaYd5yLfXWsdTkeg1N7)_