### PR TITLE
fix(sync): cache-bust syncReload to bypass browser HTTP cache on update

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-[bump-version] 2026.05.06-1 → 2026.05.06-2
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -63117,8 +63116,9 @@ function _syncUpdateStatusIndicator(snap) {
 // (sl-1-3). Reloading re-bootstraps sync and clears the circuit breaker's
 // in-memory crash count.
 function syncReload() {
-  if (typeof window !== 'undefined' && window.location && window.location.reload) {
-    window.location.reload();
+  if (typeof window !== 'undefined' && window.location) {
+    // Cache-bust: append timestamp so browser HTTP cache can't serve stale HTML.
+    window.location.replace(window.location.pathname + '?_cb=' + Date.now());
   }
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.06-3",
+  "version": "2026.05.06-4",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/sync.js
+++ b/split/sync.js
@@ -1928,8 +1928,9 @@ function _syncUpdateStatusIndicator(snap) {
 // (sl-1-3). Reloading re-bootstraps sync and clears the circuit breaker's
 // in-memory crash count.
 function syncReload() {
-  if (typeof window !== 'undefined' && window.location && window.location.reload) {
-    window.location.reload();
+  if (typeof window !== 'undefined' && window.location) {
+    // Cache-bust: append timestamp so browser HTTP cache can't serve stale HTML.
+    window.location.replace(window.location.pathname + '?_cb=' + Date.now());
   }
 }
 

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -1,4 +1,3 @@
-[bump-version] 2026.05.06-1 → 2026.05.06-2
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -63117,8 +63116,9 @@ function _syncUpdateStatusIndicator(snap) {
 // (sl-1-3). Reloading re-bootstraps sync and clears the circuit breaker's
 // in-memory crash count.
 function syncReload() {
-  if (typeof window !== 'undefined' && window.location && window.location.reload) {
-    window.location.reload();
+  if (typeof window !== 'undefined' && window.location) {
+    // Cache-bust: append timestamp so browser HTTP cache can't serve stale HTML.
+    window.location.replace(window.location.pathname + '?_cb=' + Date.now());
   }
 }
 


### PR DESCRIPTION
Root cause of persistent stale HTML after update toast: `syncReload()` used `location.reload()` which respects the browser's HTTP cache. Even with the SW bypassing navigation requests (PR#42), `reload()` can serve from the browser's own cache. Fix: `location.replace(pathname + '?_cb=' + Date.now())` — the timestamp query param makes it a new URL that can't be in the HTTP cache, forcing a fresh network fetch.

**Immediate workaround for the current stuck banner:** open Safari (not the PWA icon), navigate to the site URL — this bypasses all caches.

https://claude.ai/code/session_01J2uWaYd5yLfXWsdTkeg1N7

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2uWaYd5yLfXWsdTkeg1N7)_