### PR TITLE
PR-α: renderMilestones split + Recent Evidence attribution wiring

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -33,19 +33,17 @@
 - **Symptom:** Activities tab shows "Social Smiling" (a milestone display name) repeatedly, making the tab feel haphazard. Root cause: UI conflates "what to do" (Recommended Activities) with "what was done" (Recent Evidence Feed); Recent Evidence Feed lacks rollup aggregation so high-frequency milestone observations flood the view.
 - **Fix shape:** Rollup aggregation (PR-β scope) — e.g. "Social Smiling — 12 observations this week, last: 3pm today"; tappable expand reveals individual entries.
 - **Sequencing:** Blocked on PR-α merge (Stability sub-phase). PR-β opens post-PR-α + Sovereign real-device verification.
-- **File:** `split/medical.js` — `renderRecentEvidence()` (~line 22271)
+- **File:** `split/home.js` — `renderRecentEvidence()` (PR-α scout-deep correction; was incorrectly logged as `medical.js`)
 
-#### P1 — `_renderAttribution` not wired into Recent Evidence Feed (Phase 3 deferred PR-19.6)
+#### P1 — `_renderAttribution` not wired into Recent Evidence Feed (Phase 3 deferred PR-19.6) — **FIXED in PR-α**
 - **Symptom:** Attribution chips (who logged the entry) don't appear on Recent Evidence Feed entries, only on Visit entries.
-- **Fix shape:** Wire `_renderAttribution(entry)` per entry in `renderRecentEvidence()`, modeled on `renderVisits()` (~line 22353).
-- **Sequencing:** PR-α scope (Stability sub-phase first feature PR).
-- **File:** `split/medical.js`
+- **Fix:** Wired `_renderAttribution(e)` per entry inside `renderRecentEvidence()`, modeled on `renderVisits()` and `renderActiveMilestones()` precedents.
+- **File:** `split/home.js` — `renderRecentEvidence()` (PR-α correction; was logged as `medical.js`)
 
-#### P1 — `renderMilestones()` is a monolith (~300 LOC)
-- **Symptom:** Single function bundles stats, wheels, feed, highlights, and regression alerts. Prevents independent re-renders and makes per-renderer SYNC_RENDER_DEPS wiring impossible.
-- **Fix shape:** Split into `renderMilestoneStats()`, `renderCategoryWheels()`, `renderRecentEvidence()`, `renderMilestoneHighlights()`, `renderRegressionAlerts()`; update `SYNC_RENDER_DEPS` at ~line 61194.
-- **Sequencing:** PR-α scope (Stability sub-phase).
-- **File:** `split/medical.js` — `renderMilestones()` (~line 21640+)
+#### P1 — `renderMilestones()` is a monolith (~165 LOC body + 5 tail-calls) — **FIXED in PR-α**
+- **Symptom:** Single function bundled milestoneList HTML build with implicit tail-calls to 5 sibling renderers. Prevented independent per-surface re-renders and per-renderer `SYNC_RENDER_DEPS` wiring.
+- **Fix:** Split into `renderMilestoneList()` (extracted from body), kept `renderMilestones()` as facade calling all 6 sub-renderers; also extracted `renderMilestoneHighlights()` from `renderMilestoneStats()` (was double-duty rendering both pills + cards). `SYNC_RENDER_DEPS[KEYS.activityLog]` and `SYNC_RENDER_DEPS[KEYS.milestones]` `'track:milestones'` extended to dispatch all 8 milestone-tab renderers.
+- **File:** `split/home.js` — `renderMilestones()` (PR-α correction; was logged as `medical.js`)
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -18140,7 +18140,7 @@ function switchTrackSub(sub) {
   // Trigger sub-tab renders
   if (sub === 'medical') { renderMedicalStats(); orderMedicalCards(); renderVaccPastList(); renderDoctorPrep(); initSymptomChips(); renderFeverEpisodeCard(); renderFeverHistory(); renderDiarrhoeaEpisodeCard(); renderDiarrhoeaHistory(); renderVomitingEpisodeCard(); renderVomitingHistory(); renderColdEpisodeCard(); renderColdHistory(); }
   if (sub === 'diet') renderDietStats();
-  if (sub === 'milestones') renderMilestoneStats();
+  if (sub === 'milestones') { renderMilestoneStats(); renderMilestoneHighlights(); }
   if (sub === 'sleep') { renderSleep(); setTimeout(drawSleepChart, 60); }
   if (sub === 'poop') { renderPoop(); setTimeout(drawPoopChart, 60); }
 
@@ -21823,9 +21823,30 @@ function getMilestoneTidbits(milestoneText) {
   return MILESTONE_TIDBITS.find(t => t.match.some(m => lower.includes(m))) || null;
 }
 
+// renderMilestones — facade for the milestones-tab data-mutation-hook entry
+// point (8 external callsites in home / core / intel / medical). PR-α split
+// (Stability sub-phase 2): orchestrator-only — body extracted to per-surface
+// renderers so SYNC_RENDER_DEPS can dispatch each independently. Persistence
+// write-through retained at facade level: setMilestoneStatus / deleteMilestone
+// / addMilestone (this file) all rely on this save() as the de-facto save
+// floor and don't independently persist before invoking renderMilestones.
+// (Care/Maren E1' carve-out at PR-α charter; render-functions-must-be-pure
+// candidate landing deferred until those 3 callsites save explicitly.)
 function renderMilestones() {
   save(KEYS.milestones, milestones);
+  renderMilestoneList();
+  renderCategoryWheels();
+  renderRegressionAlerts();
+  renderMilestoneTimeline();
+  renderRecentEvidence();
+  renderActiveMilestones();
+}
+
+// renderMilestoneList — extracted from renderMilestones (PR-α). Owns the
+// #milestoneList element only: category-grouped 5-stage milestone display.
+function renderMilestoneList() {
   const list = document.getElementById('milestoneList');
+  if (!list) return;
   list.innerHTML = '';
 
   if (milestones.length === 0) {
@@ -21988,13 +22009,6 @@ function renderMilestones() {
 
   html += '</div>';
   list.innerHTML = html;
-
-  // Render category wheels + regression alerts + timeline + evidence feed + active milestones
-  renderCategoryWheels();
-  renderRegressionAlerts();
-  renderMilestoneTimeline();
-  renderRecentEvidence();
-  renderActiveMilestones();
 }
 
 // Generic category card toggle — used by milestones, foods, tips, activities, upcoming
@@ -22521,6 +22535,7 @@ function renderRecentEvidence() {
         '<div class="al-feed-body">' +
           '<div class="al-feed-text">' + escHtml(e.text) + '</div>' +
           '<div class="al-feed-chips">' + domainChips + '</div>' +
+          _renderAttribution(e) +
         '</div>' +
         '<div class="al-feed-meta">' + durStr + ' · ' + evidCount + ' ev</div>' +
       '</div>';
@@ -23513,9 +23528,12 @@ function updateMealInsight(meal) {
 
 // MILESTONES TAB QUICK STATS
 // ─────────────────────────────────────────
+// renderMilestoneStats — owns #milestoneStats pill grid + the milestones
+// domain-hero card. PR-α split: #milestoneHighlights extracted to its own
+// renderer (renderMilestoneHighlights) so SYNC_RENDER_DEPS dispatches each
+// surface independently and the function becomes single-target.
 function renderMilestoneStats() {
   const el = document.getElementById('milestoneStats');
-  const hlEl = document.getElementById('milestoneHighlights');
   if (!el) return;
 
   const doneMs = milestones.filter(m => isMsDone(m));
@@ -23524,39 +23542,11 @@ function renderMilestoneStats() {
   const advanced = milestones.filter(m => m.advanced && isMsDone(m)).length;
   const acts = typeof getFilteredActivities === 'function' ? getFilteredActivities() : [];
 
-  // Latest achievement
-  const latestDone = doneMs.filter(m => m.doneAt).sort((a, b) => new Date(b.doneAt) - new Date(a.doneAt));
-  const latestMs = latestDone[0] || doneMs[doneMs.length - 1];
-  const catIcons = { motor:zi('run'), language:zi('chat'), social:zi('handshake'), cognitive:zi('brain') };
-
-  // Next expected milestone from getUpcomingMilestones()
-  const mo = getAgeInMonths();
-  const brackets = Object.keys(getUpcomingMilestones()).map(Number).sort((a, b) => a - b);
-  let nextMilestone = null;
-  let nextMonth = null;
-  const doneTexts = milestones.filter(m => isMsDone(m)).map(m => m.text.toLowerCase().trim());
-  for (const br of brackets) {
-    if (br < mo) continue;
-    const items = getUpcomingMilestones()[br] || [];
-    const notDone = items.filter(item => {
-      return !doneTexts.includes(item.text.toLowerCase().trim());
-    });
-    const nonAdvanced = notDone.filter(i => !i.advanced);
-    if (nonAdvanced.length) { nextMilestone = nonAdvanced[0]; nextMonth = br; break; }
-    if (notDone.length) { nextMilestone = notDone[0]; nextMonth = br; break; }
-  }
-
-  // Random activity
-  const doy = Math.floor((new Date() - new Date(new Date().getFullYear(), 0, 0)) / 86400000);
-  const randomAct = acts.length ? acts[(doy + 7) % acts.length] : null;
-
-  // Total evidence entries
   let totalEvidence = 0;
   Object.values(activityLog).forEach(entries => {
     if (Array.isArray(entries)) totalEvidence += entries.length;
   });
 
-  // ── Card 1: Pills only ──
   el.innerHTML = `
       <div class="diet-stat ds-sage" data-action="expandMilestones" data-arg="done">
         <div class="diet-stat-icon"><svg class="zi"><use href="#zi-check"/></svg></div>
@@ -23589,8 +23579,41 @@ function renderMilestoneStats() {
       </div>`}
   `;
 
-  // ── Card 2: Highlights ──
+  renderDomainHero('milestones');
+}
+
+// renderMilestoneHighlights — extracted from renderMilestoneStats (PR-α).
+// Owns the #milestoneHighlights card: Latest-achieved + Coming-up-next +
+// Try-this-activity strips.
+function renderMilestoneHighlights() {
+  const hlEl = document.getElementById('milestoneHighlights');
   if (!hlEl) return;
+
+  const doneMs = milestones.filter(m => isMsDone(m));
+  const acts = typeof getFilteredActivities === 'function' ? getFilteredActivities() : [];
+  const latestDone = doneMs.filter(m => m.doneAt).sort((a, b) => new Date(b.doneAt) - new Date(a.doneAt));
+  const latestMs = latestDone[0] || doneMs[doneMs.length - 1];
+  const catIcons = { motor:zi('run'), language:zi('chat'), social:zi('handshake'), cognitive:zi('brain') };
+
+  const mo = getAgeInMonths();
+  const brackets = Object.keys(getUpcomingMilestones()).map(Number).sort((a, b) => a - b);
+  let nextMilestone = null;
+  let nextMonth = null;
+  const doneTexts = milestones.filter(m => isMsDone(m)).map(m => m.text.toLowerCase().trim());
+  for (const br of brackets) {
+    if (br < mo) continue;
+    const items = getUpcomingMilestones()[br] || [];
+    const notDone = items.filter(item => {
+      return !doneTexts.includes(item.text.toLowerCase().trim());
+    });
+    const nonAdvanced = notDone.filter(i => !i.advanced);
+    if (nonAdvanced.length) { nextMilestone = nonAdvanced[0]; nextMonth = br; break; }
+    if (notDone.length) { nextMilestone = notDone[0]; nextMonth = br; break; }
+  }
+
+  const doy = Math.floor((new Date() - new Date(new Date().getFullYear(), 0, 0)) / 86400000);
+  const randomAct = acts.length ? acts[(doy + 7) % acts.length] : null;
+
   let hlHtml = '';
 
   if (latestMs) {
@@ -23634,7 +23657,6 @@ function renderMilestoneStats() {
 
   hlEl.innerHTML = hlHtml || '<div class="t-sub-light">No highlights yet.</div>';
   hlEl.style.display = hlHtml ? '' : 'none';
-  renderDomainHero('milestones');
 }
 
 function renderFoodChips() {
@@ -34768,6 +34790,7 @@ function setReferenceStandard(std) {
   renderSizeComparison();
   renderGrowthHero();
   renderMilestoneStats();
+  renderMilestoneHighlights();
   renderUpcomingMilestones();
   renderActivities();
   // Re-render sleep stats if on sleep tab
@@ -61391,8 +61414,13 @@ const SYNC_RENDER_DEPS = {
   [KEYS.sleep]:             { global: 'sleepData',   renderers: { home: ['renderHome'], 'track:sleep': ['renderSleep'] } },
   [KEYS.poop]:              { global: 'poopData',    renderers: { home: ['renderHome'], 'track:poop':  ['renderPoop'] } },
   [KEYS.notes]:             { global: 'notes',       renderers: { history: ['renderNotes'] } },
-  [KEYS.activityLog]:       { global: 'activityLog', renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats'] } },
-  [KEYS.milestones]:        { global: 'milestones',  renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats'] } },
+  // PR-α (Stability sub-phase 2 first feature): renderMilestones split into
+  // 8 per-surface renderers so cross-device sync re-renders every milestones-
+  // tab surface (previously only renderMilestoneStats fired — list / wheels /
+  // regression / timeline / recentEvidence / active / highlights stayed
+  // stale on sync receive).
+  [KEYS.activityLog]:       { global: 'activityLog', renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats', 'renderMilestoneHighlights', 'renderMilestoneList', 'renderCategoryWheels', 'renderRegressionAlerts', 'renderRecentEvidence', 'renderMilestoneTimeline', 'renderActiveMilestones'] } },
+  [KEYS.milestones]:        { global: 'milestones',  renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats', 'renderMilestoneHighlights', 'renderMilestoneList', 'renderCategoryWheels', 'renderRegressionAlerts', 'renderRecentEvidence', 'renderMilestoneTimeline', 'renderActiveMilestones'] } },
   [KEYS.growth]:            { global: 'growthData',  renderers: { home: ['renderHome'], 'track:medical': ['renderGrowth'], growth: ['renderGrowthStats'] } },
   [KEYS.vacc]:              { global: 'vaccData',    renderers: { home: ['renderHome'], 'track:medical': ['renderVaccPastList'] } },
   [KEYS.vaccBooked]:        { global: null,          renderers: { home: ['renderHome'], 'track:medical': ['renderVaccPastList'] } },

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.06-4",
+  "version": "2026.05.06-5",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -2715,7 +2715,7 @@ function switchTrackSub(sub) {
   // Trigger sub-tab renders
   if (sub === 'medical') { renderMedicalStats(); orderMedicalCards(); renderVaccPastList(); renderDoctorPrep(); initSymptomChips(); renderFeverEpisodeCard(); renderFeverHistory(); renderDiarrhoeaEpisodeCard(); renderDiarrhoeaHistory(); renderVomitingEpisodeCard(); renderVomitingHistory(); renderColdEpisodeCard(); renderColdHistory(); }
   if (sub === 'diet') renderDietStats();
-  if (sub === 'milestones') renderMilestoneStats();
+  if (sub === 'milestones') { renderMilestoneStats(); renderMilestoneHighlights(); }
   if (sub === 'sleep') { renderSleep(); setTimeout(drawSleepChart, 60); }
   if (sub === 'poop') { renderPoop(); setTimeout(drawPoopChart, 60); }
 

--- a/split/home.js
+++ b/split/home.js
@@ -1441,9 +1441,30 @@ function getMilestoneTidbits(milestoneText) {
   return MILESTONE_TIDBITS.find(t => t.match.some(m => lower.includes(m))) || null;
 }
 
+// renderMilestones — facade for the milestones-tab data-mutation-hook entry
+// point (8 external callsites in home / core / intel / medical). PR-α split
+// (Stability sub-phase 2): orchestrator-only — body extracted to per-surface
+// renderers so SYNC_RENDER_DEPS can dispatch each independently. Persistence
+// write-through retained at facade level: setMilestoneStatus / deleteMilestone
+// / addMilestone (this file) all rely on this save() as the de-facto save
+// floor and don't independently persist before invoking renderMilestones.
+// (Care/Maren E1' carve-out at PR-α charter; render-functions-must-be-pure
+// candidate landing deferred until those 3 callsites save explicitly.)
 function renderMilestones() {
   save(KEYS.milestones, milestones);
+  renderMilestoneList();
+  renderCategoryWheels();
+  renderRegressionAlerts();
+  renderMilestoneTimeline();
+  renderRecentEvidence();
+  renderActiveMilestones();
+}
+
+// renderMilestoneList — extracted from renderMilestones (PR-α). Owns the
+// #milestoneList element only: category-grouped 5-stage milestone display.
+function renderMilestoneList() {
   const list = document.getElementById('milestoneList');
+  if (!list) return;
   list.innerHTML = '';
 
   if (milestones.length === 0) {
@@ -1606,13 +1627,6 @@ function renderMilestones() {
 
   html += '</div>';
   list.innerHTML = html;
-
-  // Render category wheels + regression alerts + timeline + evidence feed + active milestones
-  renderCategoryWheels();
-  renderRegressionAlerts();
-  renderMilestoneTimeline();
-  renderRecentEvidence();
-  renderActiveMilestones();
 }
 
 // Generic category card toggle — used by milestones, foods, tips, activities, upcoming
@@ -2139,6 +2153,7 @@ function renderRecentEvidence() {
         '<div class="al-feed-body">' +
           '<div class="al-feed-text">' + escHtml(e.text) + '</div>' +
           '<div class="al-feed-chips">' + domainChips + '</div>' +
+          _renderAttribution(e) +
         '</div>' +
         '<div class="al-feed-meta">' + durStr + ' · ' + evidCount + ' ev</div>' +
       '</div>';
@@ -3131,9 +3146,12 @@ function updateMealInsight(meal) {
 
 // MILESTONES TAB QUICK STATS
 // ─────────────────────────────────────────
+// renderMilestoneStats — owns #milestoneStats pill grid + the milestones
+// domain-hero card. PR-α split: #milestoneHighlights extracted to its own
+// renderer (renderMilestoneHighlights) so SYNC_RENDER_DEPS dispatches each
+// surface independently and the function becomes single-target.
 function renderMilestoneStats() {
   const el = document.getElementById('milestoneStats');
-  const hlEl = document.getElementById('milestoneHighlights');
   if (!el) return;
 
   const doneMs = milestones.filter(m => isMsDone(m));
@@ -3142,39 +3160,11 @@ function renderMilestoneStats() {
   const advanced = milestones.filter(m => m.advanced && isMsDone(m)).length;
   const acts = typeof getFilteredActivities === 'function' ? getFilteredActivities() : [];
 
-  // Latest achievement
-  const latestDone = doneMs.filter(m => m.doneAt).sort((a, b) => new Date(b.doneAt) - new Date(a.doneAt));
-  const latestMs = latestDone[0] || doneMs[doneMs.length - 1];
-  const catIcons = { motor:zi('run'), language:zi('chat'), social:zi('handshake'), cognitive:zi('brain') };
-
-  // Next expected milestone from getUpcomingMilestones()
-  const mo = getAgeInMonths();
-  const brackets = Object.keys(getUpcomingMilestones()).map(Number).sort((a, b) => a - b);
-  let nextMilestone = null;
-  let nextMonth = null;
-  const doneTexts = milestones.filter(m => isMsDone(m)).map(m => m.text.toLowerCase().trim());
-  for (const br of brackets) {
-    if (br < mo) continue;
-    const items = getUpcomingMilestones()[br] || [];
-    const notDone = items.filter(item => {
-      return !doneTexts.includes(item.text.toLowerCase().trim());
-    });
-    const nonAdvanced = notDone.filter(i => !i.advanced);
-    if (nonAdvanced.length) { nextMilestone = nonAdvanced[0]; nextMonth = br; break; }
-    if (notDone.length) { nextMilestone = notDone[0]; nextMonth = br; break; }
-  }
-
-  // Random activity
-  const doy = Math.floor((new Date() - new Date(new Date().getFullYear(), 0, 0)) / 86400000);
-  const randomAct = acts.length ? acts[(doy + 7) % acts.length] : null;
-
-  // Total evidence entries
   let totalEvidence = 0;
   Object.values(activityLog).forEach(entries => {
     if (Array.isArray(entries)) totalEvidence += entries.length;
   });
 
-  // ── Card 1: Pills only ──
   el.innerHTML = `
       <div class="diet-stat ds-sage" data-action="expandMilestones" data-arg="done">
         <div class="diet-stat-icon"><svg class="zi"><use href="#zi-check"/></svg></div>
@@ -3207,8 +3197,41 @@ function renderMilestoneStats() {
       </div>`}
   `;
 
-  // ── Card 2: Highlights ──
+  renderDomainHero('milestones');
+}
+
+// renderMilestoneHighlights — extracted from renderMilestoneStats (PR-α).
+// Owns the #milestoneHighlights card: Latest-achieved + Coming-up-next +
+// Try-this-activity strips.
+function renderMilestoneHighlights() {
+  const hlEl = document.getElementById('milestoneHighlights');
   if (!hlEl) return;
+
+  const doneMs = milestones.filter(m => isMsDone(m));
+  const acts = typeof getFilteredActivities === 'function' ? getFilteredActivities() : [];
+  const latestDone = doneMs.filter(m => m.doneAt).sort((a, b) => new Date(b.doneAt) - new Date(a.doneAt));
+  const latestMs = latestDone[0] || doneMs[doneMs.length - 1];
+  const catIcons = { motor:zi('run'), language:zi('chat'), social:zi('handshake'), cognitive:zi('brain') };
+
+  const mo = getAgeInMonths();
+  const brackets = Object.keys(getUpcomingMilestones()).map(Number).sort((a, b) => a - b);
+  let nextMilestone = null;
+  let nextMonth = null;
+  const doneTexts = milestones.filter(m => isMsDone(m)).map(m => m.text.toLowerCase().trim());
+  for (const br of brackets) {
+    if (br < mo) continue;
+    const items = getUpcomingMilestones()[br] || [];
+    const notDone = items.filter(item => {
+      return !doneTexts.includes(item.text.toLowerCase().trim());
+    });
+    const nonAdvanced = notDone.filter(i => !i.advanced);
+    if (nonAdvanced.length) { nextMilestone = nonAdvanced[0]; nextMonth = br; break; }
+    if (notDone.length) { nextMilestone = notDone[0]; nextMonth = br; break; }
+  }
+
+  const doy = Math.floor((new Date() - new Date(new Date().getFullYear(), 0, 0)) / 86400000);
+  const randomAct = acts.length ? acts[(doy + 7) % acts.length] : null;
+
   let hlHtml = '';
 
   if (latestMs) {
@@ -3252,7 +3275,6 @@ function renderMilestoneStats() {
 
   hlEl.innerHTML = hlHtml || '<div class="t-sub-light">No highlights yet.</div>';
   hlEl.style.display = hlHtml ? '' : 'none';
-  renderDomainHero('milestones');
 }
 
 function renderFoodChips() {

--- a/split/medical.js
+++ b/split/medical.js
@@ -1113,6 +1113,7 @@ function setReferenceStandard(std) {
   renderSizeComparison();
   renderGrowthHero();
   renderMilestoneStats();
+  renderMilestoneHighlights();
   renderUpcomingMilestones();
   renderActivities();
   // Re-render sleep stats if on sleep tab

--- a/split/sync.js
+++ b/split/sync.js
@@ -203,8 +203,13 @@ const SYNC_RENDER_DEPS = {
   [KEYS.sleep]:             { global: 'sleepData',   renderers: { home: ['renderHome'], 'track:sleep': ['renderSleep'] } },
   [KEYS.poop]:              { global: 'poopData',    renderers: { home: ['renderHome'], 'track:poop':  ['renderPoop'] } },
   [KEYS.notes]:             { global: 'notes',       renderers: { history: ['renderNotes'] } },
-  [KEYS.activityLog]:       { global: 'activityLog', renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats'] } },
-  [KEYS.milestones]:        { global: 'milestones',  renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats'] } },
+  // PR-α (Stability sub-phase 2 first feature): renderMilestones split into
+  // 8 per-surface renderers so cross-device sync re-renders every milestones-
+  // tab surface (previously only renderMilestoneStats fired — list / wheels /
+  // regression / timeline / recentEvidence / active / highlights stayed
+  // stale on sync receive).
+  [KEYS.activityLog]:       { global: 'activityLog', renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats', 'renderMilestoneHighlights', 'renderMilestoneList', 'renderCategoryWheels', 'renderRegressionAlerts', 'renderRecentEvidence', 'renderMilestoneTimeline', 'renderActiveMilestones'] } },
+  [KEYS.milestones]:        { global: 'milestones',  renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats', 'renderMilestoneHighlights', 'renderMilestoneList', 'renderCategoryWheels', 'renderRegressionAlerts', 'renderRecentEvidence', 'renderMilestoneTimeline', 'renderActiveMilestones'] } },
   [KEYS.growth]:            { global: 'growthData',  renderers: { home: ['renderHome'], 'track:medical': ['renderGrowth'], growth: ['renderGrowthStats'] } },
   [KEYS.vacc]:              { global: 'vaccData',    renderers: { home: ['renderHome'], 'track:medical': ['renderVaccPastList'] } },
   [KEYS.vaccBooked]:        { global: null,          renderers: { home: ['renderHome'], 'track:medical': ['renderVaccPastList'] } },

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -18140,7 +18140,7 @@ function switchTrackSub(sub) {
   // Trigger sub-tab renders
   if (sub === 'medical') { renderMedicalStats(); orderMedicalCards(); renderVaccPastList(); renderDoctorPrep(); initSymptomChips(); renderFeverEpisodeCard(); renderFeverHistory(); renderDiarrhoeaEpisodeCard(); renderDiarrhoeaHistory(); renderVomitingEpisodeCard(); renderVomitingHistory(); renderColdEpisodeCard(); renderColdHistory(); }
   if (sub === 'diet') renderDietStats();
-  if (sub === 'milestones') renderMilestoneStats();
+  if (sub === 'milestones') { renderMilestoneStats(); renderMilestoneHighlights(); }
   if (sub === 'sleep') { renderSleep(); setTimeout(drawSleepChart, 60); }
   if (sub === 'poop') { renderPoop(); setTimeout(drawPoopChart, 60); }
 
@@ -21823,9 +21823,30 @@ function getMilestoneTidbits(milestoneText) {
   return MILESTONE_TIDBITS.find(t => t.match.some(m => lower.includes(m))) || null;
 }
 
+// renderMilestones — facade for the milestones-tab data-mutation-hook entry
+// point (8 external callsites in home / core / intel / medical). PR-α split
+// (Stability sub-phase 2): orchestrator-only — body extracted to per-surface
+// renderers so SYNC_RENDER_DEPS can dispatch each independently. Persistence
+// write-through retained at facade level: setMilestoneStatus / deleteMilestone
+// / addMilestone (this file) all rely on this save() as the de-facto save
+// floor and don't independently persist before invoking renderMilestones.
+// (Care/Maren E1' carve-out at PR-α charter; render-functions-must-be-pure
+// candidate landing deferred until those 3 callsites save explicitly.)
 function renderMilestones() {
   save(KEYS.milestones, milestones);
+  renderMilestoneList();
+  renderCategoryWheels();
+  renderRegressionAlerts();
+  renderMilestoneTimeline();
+  renderRecentEvidence();
+  renderActiveMilestones();
+}
+
+// renderMilestoneList — extracted from renderMilestones (PR-α). Owns the
+// #milestoneList element only: category-grouped 5-stage milestone display.
+function renderMilestoneList() {
   const list = document.getElementById('milestoneList');
+  if (!list) return;
   list.innerHTML = '';
 
   if (milestones.length === 0) {
@@ -21988,13 +22009,6 @@ function renderMilestones() {
 
   html += '</div>';
   list.innerHTML = html;
-
-  // Render category wheels + regression alerts + timeline + evidence feed + active milestones
-  renderCategoryWheels();
-  renderRegressionAlerts();
-  renderMilestoneTimeline();
-  renderRecentEvidence();
-  renderActiveMilestones();
 }
 
 // Generic category card toggle — used by milestones, foods, tips, activities, upcoming
@@ -22521,6 +22535,7 @@ function renderRecentEvidence() {
         '<div class="al-feed-body">' +
           '<div class="al-feed-text">' + escHtml(e.text) + '</div>' +
           '<div class="al-feed-chips">' + domainChips + '</div>' +
+          _renderAttribution(e) +
         '</div>' +
         '<div class="al-feed-meta">' + durStr + ' · ' + evidCount + ' ev</div>' +
       '</div>';
@@ -23513,9 +23528,12 @@ function updateMealInsight(meal) {
 
 // MILESTONES TAB QUICK STATS
 // ─────────────────────────────────────────
+// renderMilestoneStats — owns #milestoneStats pill grid + the milestones
+// domain-hero card. PR-α split: #milestoneHighlights extracted to its own
+// renderer (renderMilestoneHighlights) so SYNC_RENDER_DEPS dispatches each
+// surface independently and the function becomes single-target.
 function renderMilestoneStats() {
   const el = document.getElementById('milestoneStats');
-  const hlEl = document.getElementById('milestoneHighlights');
   if (!el) return;
 
   const doneMs = milestones.filter(m => isMsDone(m));
@@ -23524,39 +23542,11 @@ function renderMilestoneStats() {
   const advanced = milestones.filter(m => m.advanced && isMsDone(m)).length;
   const acts = typeof getFilteredActivities === 'function' ? getFilteredActivities() : [];
 
-  // Latest achievement
-  const latestDone = doneMs.filter(m => m.doneAt).sort((a, b) => new Date(b.doneAt) - new Date(a.doneAt));
-  const latestMs = latestDone[0] || doneMs[doneMs.length - 1];
-  const catIcons = { motor:zi('run'), language:zi('chat'), social:zi('handshake'), cognitive:zi('brain') };
-
-  // Next expected milestone from getUpcomingMilestones()
-  const mo = getAgeInMonths();
-  const brackets = Object.keys(getUpcomingMilestones()).map(Number).sort((a, b) => a - b);
-  let nextMilestone = null;
-  let nextMonth = null;
-  const doneTexts = milestones.filter(m => isMsDone(m)).map(m => m.text.toLowerCase().trim());
-  for (const br of brackets) {
-    if (br < mo) continue;
-    const items = getUpcomingMilestones()[br] || [];
-    const notDone = items.filter(item => {
-      return !doneTexts.includes(item.text.toLowerCase().trim());
-    });
-    const nonAdvanced = notDone.filter(i => !i.advanced);
-    if (nonAdvanced.length) { nextMilestone = nonAdvanced[0]; nextMonth = br; break; }
-    if (notDone.length) { nextMilestone = notDone[0]; nextMonth = br; break; }
-  }
-
-  // Random activity
-  const doy = Math.floor((new Date() - new Date(new Date().getFullYear(), 0, 0)) / 86400000);
-  const randomAct = acts.length ? acts[(doy + 7) % acts.length] : null;
-
-  // Total evidence entries
   let totalEvidence = 0;
   Object.values(activityLog).forEach(entries => {
     if (Array.isArray(entries)) totalEvidence += entries.length;
   });
 
-  // ── Card 1: Pills only ──
   el.innerHTML = `
       <div class="diet-stat ds-sage" data-action="expandMilestones" data-arg="done">
         <div class="diet-stat-icon"><svg class="zi"><use href="#zi-check"/></svg></div>
@@ -23589,8 +23579,41 @@ function renderMilestoneStats() {
       </div>`}
   `;
 
-  // ── Card 2: Highlights ──
+  renderDomainHero('milestones');
+}
+
+// renderMilestoneHighlights — extracted from renderMilestoneStats (PR-α).
+// Owns the #milestoneHighlights card: Latest-achieved + Coming-up-next +
+// Try-this-activity strips.
+function renderMilestoneHighlights() {
+  const hlEl = document.getElementById('milestoneHighlights');
   if (!hlEl) return;
+
+  const doneMs = milestones.filter(m => isMsDone(m));
+  const acts = typeof getFilteredActivities === 'function' ? getFilteredActivities() : [];
+  const latestDone = doneMs.filter(m => m.doneAt).sort((a, b) => new Date(b.doneAt) - new Date(a.doneAt));
+  const latestMs = latestDone[0] || doneMs[doneMs.length - 1];
+  const catIcons = { motor:zi('run'), language:zi('chat'), social:zi('handshake'), cognitive:zi('brain') };
+
+  const mo = getAgeInMonths();
+  const brackets = Object.keys(getUpcomingMilestones()).map(Number).sort((a, b) => a - b);
+  let nextMilestone = null;
+  let nextMonth = null;
+  const doneTexts = milestones.filter(m => isMsDone(m)).map(m => m.text.toLowerCase().trim());
+  for (const br of brackets) {
+    if (br < mo) continue;
+    const items = getUpcomingMilestones()[br] || [];
+    const notDone = items.filter(item => {
+      return !doneTexts.includes(item.text.toLowerCase().trim());
+    });
+    const nonAdvanced = notDone.filter(i => !i.advanced);
+    if (nonAdvanced.length) { nextMilestone = nonAdvanced[0]; nextMonth = br; break; }
+    if (notDone.length) { nextMilestone = notDone[0]; nextMonth = br; break; }
+  }
+
+  const doy = Math.floor((new Date() - new Date(new Date().getFullYear(), 0, 0)) / 86400000);
+  const randomAct = acts.length ? acts[(doy + 7) % acts.length] : null;
+
   let hlHtml = '';
 
   if (latestMs) {
@@ -23634,7 +23657,6 @@ function renderMilestoneStats() {
 
   hlEl.innerHTML = hlHtml || '<div class="t-sub-light">No highlights yet.</div>';
   hlEl.style.display = hlHtml ? '' : 'none';
-  renderDomainHero('milestones');
 }
 
 function renderFoodChips() {
@@ -34768,6 +34790,7 @@ function setReferenceStandard(std) {
   renderSizeComparison();
   renderGrowthHero();
   renderMilestoneStats();
+  renderMilestoneHighlights();
   renderUpcomingMilestones();
   renderActivities();
   // Re-render sleep stats if on sleep tab
@@ -61391,8 +61414,13 @@ const SYNC_RENDER_DEPS = {
   [KEYS.sleep]:             { global: 'sleepData',   renderers: { home: ['renderHome'], 'track:sleep': ['renderSleep'] } },
   [KEYS.poop]:              { global: 'poopData',    renderers: { home: ['renderHome'], 'track:poop':  ['renderPoop'] } },
   [KEYS.notes]:             { global: 'notes',       renderers: { history: ['renderNotes'] } },
-  [KEYS.activityLog]:       { global: 'activityLog', renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats'] } },
-  [KEYS.milestones]:        { global: 'milestones',  renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats'] } },
+  // PR-α (Stability sub-phase 2 first feature): renderMilestones split into
+  // 8 per-surface renderers so cross-device sync re-renders every milestones-
+  // tab surface (previously only renderMilestoneStats fired — list / wheels /
+  // regression / timeline / recentEvidence / active / highlights stayed
+  // stale on sync receive).
+  [KEYS.activityLog]:       { global: 'activityLog', renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats', 'renderMilestoneHighlights', 'renderMilestoneList', 'renderCategoryWheels', 'renderRegressionAlerts', 'renderRecentEvidence', 'renderMilestoneTimeline', 'renderActiveMilestones'] } },
+  [KEYS.milestones]:        { global: 'milestones',  renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats', 'renderMilestoneHighlights', 'renderMilestoneList', 'renderCategoryWheels', 'renderRegressionAlerts', 'renderRecentEvidence', 'renderMilestoneTimeline', 'renderActiveMilestones'] } },
   [KEYS.growth]:            { global: 'growthData',  renderers: { home: ['renderHome'], 'track:medical': ['renderGrowth'], growth: ['renderGrowthStats'] } },
   [KEYS.vacc]:              { global: 'vaccData',    renderers: { home: ['renderHome'], 'track:medical': ['renderVaccPastList'] } },
   [KEYS.vaccBooked]:        { global: null,          renderers: { home: ['renderHome'], 'track:medical': ['renderVaccPastList'] } },


### PR DESCRIPTION
## Summary

Stability sub-phase 2 first feature PR. Closes Phase 3 PR-19.6 deferred attribution wiring + monolithic `renderMilestones()` refactor.

**Charter:** `Codex/docs/charters/PR_ALPHA_STABILITY_CHARTER_2026-05-06.md` (sister PR on Codex branch `claude/pr-alpha-renderer-split-L1kVh`).

## Source changes

- **`split/home.js`** — Extract `renderMilestoneList()` from `renderMilestones()` body (~165 LOC). Facade retains `save()` + orchestration only. Extract `renderMilestoneHighlights()` from `renderMilestoneStats()` (was double-duty rendering both `#milestoneStats` pills and `#milestoneHighlights` cards). Wire `_renderAttribution(e)` per entry in `renderRecentEvidence()` (modeled on `renderVisits` line 2172 and `renderActiveMilestones` medical.js:315 precedents).
- **`split/sync.js`** — Extend `SYNC_RENDER_DEPS[KEYS.activityLog]` and `SYNC_RENDER_DEPS[KEYS.milestones]` `'track:milestones'` from `['renderMilestoneStats']` to full 8-renderer name array. Closes cross-device dispatch coverage gap (previously only Stats pills re-rendered on sync; list / wheels / regression / timeline / recentEvidence / active / highlights stayed stale on sync receive).
- **`split/core.js`** + **`split/medical.js`** — Parity callsites pair `renderMilestoneStats()` with `renderMilestoneHighlights()` at sub-tab activation + reference-standard toggle.
- **`docs/BUGS.md`** — Scout-deep correction: `renderMilestones` / `renderRecentEvidence` live in `home.js`, not `medical.js`. Mark P1 attribution wiring + P1 monolith split as FIXED.

## Charter axes-of-resolution (verdicts)

| Axis | Subject | Verdict |
|------|---------|---------|
| A | Naming for extracted `#milestoneList` renderer | **A1** `renderMilestoneList()` (DOM-element-name parity; avoids collision with existing `#milestoneHighlights` element) |
| B | Split granularity | **B2** Extract list + extract Highlights from Stats (single-purpose discipline; reachable-through-surface) |
| C | `SYNC_RENDER_DEPS` shape | **C1** Name-string array of all 8 split renderers |
| D | `renderMilestones()` retention | **D1** Retain as facade tail-calling all sub-renderers (zero-regression on 9 callsites) |
| E | Purity audit | **E1' (Maren-revised)** Keep `save(KEYS.milestones)` in facade body — 3 home.js callsites rely on it as de-facto persistence floor; `render-functions-must-be-pure` candidate landing deferred to follow-up PR |

## Doctrine prophylactics applied

- **`architectural-shift-PRs-bias-toward-r1-catch-cycle`** (1/3) — Cipher byte-precision regression-guard regex sweep + sibling-site grep + dispatch-name resolution audit at byte-precision phase. **PASS — no catches.**
- **`pattern-shape-guards-over-hardcoded-enumerations`** — name-string dispatch (Phase 3 declarative pattern) preserved.
- **`source-grep-verification-should-mirror-regression-guard-regex`** — All 8 dispatch-array names verified resolvable via top-level function declarations.

## Persona auto-invocations (hat-switch experimental mode)

- **Maren** (Care): re-read source files independently; veto-partial on Axis E (3 home.js mutating callsites lack independent `save()`); **E1' revision** keeps save in facade body. `_renderAttribution` confirmed null-safe for legacy entries.
- **Kael** (Intelligence): re-read source files independently; endorses 8-renderer broad-dispatch (closes coverage gap); pattern homogeneity preserved (`home: ['renderHome']` shape unchanged across all entries).
- **Cipher** (Codewright): byte-precision audit (12 checks); architectural-shift r1-prophylactic discipline applied; PASS.

## Hold-pending-Sovereign-real-device-verification

**Applies** per RATIFIED `hermetic-floor-doesnt-substitute-for-production-floor` doctrine (behavior-shape change at attribution display + renderer dispatch).

Sovereign-floor real-device checks post-merge:
- [ ] Open Activities tab → Recent Evidence Feed shows attribution chips ("by …") on every entry
- [ ] Log activity from Quick Log → all milestone surfaces update (list, stats, highlights, wheels, regression, recentEvidence, active)
- [ ] Cross-device: log on device A → device B re-renders all 8 milestone surfaces via `_syncDispatchRender`
- [ ] No regression on existing milestone display, override, evidence expansion, tidbit toggles
- [ ] Sub-tab activation (track → milestones) renders both Stats and Highlights (parity preserved)

## Test plan

- [ ] `bash build.sh > sproutlab.html` produces clean 3 MB output (no `2>&1` contamination)
- [ ] All 8 dispatch-array renderer names resolve at runtime (top-level function declarations)
- [ ] `renderMilestones()` facade preserves all 9 historical callsites (home/core/intel/medical)
- [ ] `_renderAttribution(e)` null-safe path verified at core.js:2282-2287
- [ ] Manual: Quick Log activity → Recent Evidence Feed shows attribution chip
- [ ] Manual: Edit milestone status → all milestone-tab surfaces refresh

## Sequencing

PR-α (this) → Sovereign real-device verification → PR-β (Polish-A1: rollup aggregation, deferred per PR-23 Ruling 2).

— Lyra (lyra-stability-1)

---
_Generated by [Claude Code](https://claude.ai/code/session_011JhmDyFtAuQQyj1dtjyJCh)_