### PR TITLE
PR-α r1: stamp __sync_updatedBy on activityLog entries (Sovereign-floor catch)

### DIFF
--- a/index.html
+++ b/index.html
@@ -62164,25 +62164,66 @@ function _syncDebounceSingleDoc(hRef, collection, key, oldVal, newVal) {
 // change (vs. PR-19's per-key sidecar) the Sovereign-side production
 // verification surfaced as missing on the history-tab surface.
 //
-// Scope (PR-19.5): array-shape values only (growth, sleep, poop, vacc,
-// meds, visits, milestones, notes, doctors, episodes, careTickets). Object-
-// keyed shapes (feeding, activityLog, medChecks) are Phase 4 carry-forward;
-// stamping a date-keyed sub-object requires a wrapper-shape decision that
-// affects every renderer reading those fields.
+// Scope (PR-19.5 baseline): array-shape values (growth, sleep, poop, vacc,
+// meds, visits, milestones, notes, doctors, episodes, careTickets).
+//
+// PR-α r1 hotfix (Stability sub-phase 2 post-merge Sovereign-floor catch):
+// extended to also walk object-keyed shapes whose VALUES are entry-arrays —
+// activityLog (`{ dateStr: [entry, entry, ...] }`). This closes the gap
+// where PR-α wired _renderAttribution(e) into renderRecentEvidence but
+// entries never carried the __sync_updatedBy stamp. feeding (`{ dateStr:
+// { meal: '...' } }`) and medChecks (`{ dateStr: { medname: 'status' } }`)
+// have non-array values and remain Phase 4 carry-forward — the wrapper-
+// shape decision for those affects every renderer reading those fields.
 function _syncStampUnattributed(value, writer) {
-  if (!Array.isArray(value)) return value;
   if (!writer || (!writer.uid && !writer.name)) return value;
-  var changed = false;
-  var stamped = value.map(function(entry) {
-    if (entry && typeof entry === 'object' && !Array.isArray(entry) && !entry.__sync_updatedBy) {
-      changed = true;
-      return Object.assign({}, entry, {
-        __sync_updatedBy: { uid: writer.uid || null, name: writer.name || null },
-      });
-    }
-    return entry;
-  });
-  return changed ? stamped : value;
+
+  // Array-shape: stamp each entry directly (PR-19.5 baseline)
+  if (Array.isArray(value)) {
+    var changed = false;
+    var stamped = value.map(function(entry) {
+      if (entry && typeof entry === 'object' && !Array.isArray(entry) && !entry.__sync_updatedBy) {
+        changed = true;
+        return Object.assign({}, entry, {
+          __sync_updatedBy: { uid: writer.uid || null, name: writer.name || null },
+        });
+      }
+      return entry;
+    });
+    return changed ? stamped : value;
+  }
+
+  // Object-keyed shape with entry-array values (PR-α r1 hotfix; activityLog).
+  // Walks each top-level key whose value is an array; stamps each entry
+  // lacking __sync_updatedBy. Non-array values (feeding/medChecks shape)
+  // are passed through untouched — those shapes need a wrapper-level
+  // attribution decision and remain deferred.
+  if (value && typeof value === 'object') {
+    var anyChanged = false;
+    var out = {};
+    Object.keys(value).forEach(function(k) {
+      var v = value[k];
+      if (Array.isArray(v)) {
+        var subChanged = false;
+        var subStamped = v.map(function(entry) {
+          if (entry && typeof entry === 'object' && !Array.isArray(entry) && !entry.__sync_updatedBy) {
+            subChanged = true;
+            return Object.assign({}, entry, {
+              __sync_updatedBy: { uid: writer.uid || null, name: writer.name || null },
+            });
+          }
+          return entry;
+        });
+        if (subChanged) anyChanged = true;
+        out[k] = subChanged ? subStamped : v;
+      } else {
+        out[k] = v;
+      }
+    });
+    return anyChanged ? out : value;
+  }
+
+  return value;
 }
 
 function _syncFlushSingleDoc(hRef, collection) {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.06-5",
+  "version": "2026.05.06-6",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/sync.js
+++ b/split/sync.js
@@ -953,25 +953,66 @@ function _syncDebounceSingleDoc(hRef, collection, key, oldVal, newVal) {
 // change (vs. PR-19's per-key sidecar) the Sovereign-side production
 // verification surfaced as missing on the history-tab surface.
 //
-// Scope (PR-19.5): array-shape values only (growth, sleep, poop, vacc,
-// meds, visits, milestones, notes, doctors, episodes, careTickets). Object-
-// keyed shapes (feeding, activityLog, medChecks) are Phase 4 carry-forward;
-// stamping a date-keyed sub-object requires a wrapper-shape decision that
-// affects every renderer reading those fields.
+// Scope (PR-19.5 baseline): array-shape values (growth, sleep, poop, vacc,
+// meds, visits, milestones, notes, doctors, episodes, careTickets).
+//
+// PR-α r1 hotfix (Stability sub-phase 2 post-merge Sovereign-floor catch):
+// extended to also walk object-keyed shapes whose VALUES are entry-arrays —
+// activityLog (`{ dateStr: [entry, entry, ...] }`). This closes the gap
+// where PR-α wired _renderAttribution(e) into renderRecentEvidence but
+// entries never carried the __sync_updatedBy stamp. feeding (`{ dateStr:
+// { meal: '...' } }`) and medChecks (`{ dateStr: { medname: 'status' } }`)
+// have non-array values and remain Phase 4 carry-forward — the wrapper-
+// shape decision for those affects every renderer reading those fields.
 function _syncStampUnattributed(value, writer) {
-  if (!Array.isArray(value)) return value;
   if (!writer || (!writer.uid && !writer.name)) return value;
-  var changed = false;
-  var stamped = value.map(function(entry) {
-    if (entry && typeof entry === 'object' && !Array.isArray(entry) && !entry.__sync_updatedBy) {
-      changed = true;
-      return Object.assign({}, entry, {
-        __sync_updatedBy: { uid: writer.uid || null, name: writer.name || null },
-      });
-    }
-    return entry;
-  });
-  return changed ? stamped : value;
+
+  // Array-shape: stamp each entry directly (PR-19.5 baseline)
+  if (Array.isArray(value)) {
+    var changed = false;
+    var stamped = value.map(function(entry) {
+      if (entry && typeof entry === 'object' && !Array.isArray(entry) && !entry.__sync_updatedBy) {
+        changed = true;
+        return Object.assign({}, entry, {
+          __sync_updatedBy: { uid: writer.uid || null, name: writer.name || null },
+        });
+      }
+      return entry;
+    });
+    return changed ? stamped : value;
+  }
+
+  // Object-keyed shape with entry-array values (PR-α r1 hotfix; activityLog).
+  // Walks each top-level key whose value is an array; stamps each entry
+  // lacking __sync_updatedBy. Non-array values (feeding/medChecks shape)
+  // are passed through untouched — those shapes need a wrapper-level
+  // attribution decision and remain deferred.
+  if (value && typeof value === 'object') {
+    var anyChanged = false;
+    var out = {};
+    Object.keys(value).forEach(function(k) {
+      var v = value[k];
+      if (Array.isArray(v)) {
+        var subChanged = false;
+        var subStamped = v.map(function(entry) {
+          if (entry && typeof entry === 'object' && !Array.isArray(entry) && !entry.__sync_updatedBy) {
+            subChanged = true;
+            return Object.assign({}, entry, {
+              __sync_updatedBy: { uid: writer.uid || null, name: writer.name || null },
+            });
+          }
+          return entry;
+        });
+        if (subChanged) anyChanged = true;
+        out[k] = subChanged ? subStamped : v;
+      } else {
+        out[k] = v;
+      }
+    });
+    return anyChanged ? out : value;
+  }
+
+  return value;
 }
 
 function _syncFlushSingleDoc(hRef, collection) {

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -62164,25 +62164,66 @@ function _syncDebounceSingleDoc(hRef, collection, key, oldVal, newVal) {
 // change (vs. PR-19's per-key sidecar) the Sovereign-side production
 // verification surfaced as missing on the history-tab surface.
 //
-// Scope (PR-19.5): array-shape values only (growth, sleep, poop, vacc,
-// meds, visits, milestones, notes, doctors, episodes, careTickets). Object-
-// keyed shapes (feeding, activityLog, medChecks) are Phase 4 carry-forward;
-// stamping a date-keyed sub-object requires a wrapper-shape decision that
-// affects every renderer reading those fields.
+// Scope (PR-19.5 baseline): array-shape values (growth, sleep, poop, vacc,
+// meds, visits, milestones, notes, doctors, episodes, careTickets).
+//
+// PR-α r1 hotfix (Stability sub-phase 2 post-merge Sovereign-floor catch):
+// extended to also walk object-keyed shapes whose VALUES are entry-arrays —
+// activityLog (`{ dateStr: [entry, entry, ...] }`). This closes the gap
+// where PR-α wired _renderAttribution(e) into renderRecentEvidence but
+// entries never carried the __sync_updatedBy stamp. feeding (`{ dateStr:
+// { meal: '...' } }`) and medChecks (`{ dateStr: { medname: 'status' } }`)
+// have non-array values and remain Phase 4 carry-forward — the wrapper-
+// shape decision for those affects every renderer reading those fields.
 function _syncStampUnattributed(value, writer) {
-  if (!Array.isArray(value)) return value;
   if (!writer || (!writer.uid && !writer.name)) return value;
-  var changed = false;
-  var stamped = value.map(function(entry) {
-    if (entry && typeof entry === 'object' && !Array.isArray(entry) && !entry.__sync_updatedBy) {
-      changed = true;
-      return Object.assign({}, entry, {
-        __sync_updatedBy: { uid: writer.uid || null, name: writer.name || null },
-      });
-    }
-    return entry;
-  });
-  return changed ? stamped : value;
+
+  // Array-shape: stamp each entry directly (PR-19.5 baseline)
+  if (Array.isArray(value)) {
+    var changed = false;
+    var stamped = value.map(function(entry) {
+      if (entry && typeof entry === 'object' && !Array.isArray(entry) && !entry.__sync_updatedBy) {
+        changed = true;
+        return Object.assign({}, entry, {
+          __sync_updatedBy: { uid: writer.uid || null, name: writer.name || null },
+        });
+      }
+      return entry;
+    });
+    return changed ? stamped : value;
+  }
+
+  // Object-keyed shape with entry-array values (PR-α r1 hotfix; activityLog).
+  // Walks each top-level key whose value is an array; stamps each entry
+  // lacking __sync_updatedBy. Non-array values (feeding/medChecks shape)
+  // are passed through untouched — those shapes need a wrapper-level
+  // attribution decision and remain deferred.
+  if (value && typeof value === 'object') {
+    var anyChanged = false;
+    var out = {};
+    Object.keys(value).forEach(function(k) {
+      var v = value[k];
+      if (Array.isArray(v)) {
+        var subChanged = false;
+        var subStamped = v.map(function(entry) {
+          if (entry && typeof entry === 'object' && !Array.isArray(entry) && !entry.__sync_updatedBy) {
+            subChanged = true;
+            return Object.assign({}, entry, {
+              __sync_updatedBy: { uid: writer.uid || null, name: writer.name || null },
+            });
+          }
+          return entry;
+        });
+        if (subChanged) anyChanged = true;
+        out[k] = subChanged ? subStamped : v;
+      } else {
+        out[k] = v;
+      }
+    });
+    return anyChanged ? out : value;
+  }
+
+  return value;
 }
 
 function _syncFlushSingleDoc(hRef, collection) {


### PR DESCRIPTION
## Summary

Sovereign-floor catch on PR-α (sl-main `84cfab37`): Recent Activity Evidence entries did not show attribution chips on real-device verification. `_renderAttribution(e)` was correctly wired into `renderRecentEvidence` but entries never carried the `__sync_updatedBy` stamp, so the helper returned empty string per its null-safe contract.

## Root cause

`_syncStampUnattributed` scope was **Array-only** per PR-19.5 comment:

> Scope (PR-19.5): array-shape values only … Object-keyed shapes (feeding, activityLog, medChecks) are Phase 4 carry-forward; stamping a date-keyed sub-object requires a wrapper-shape decision that affects every renderer reading those fields.

PR-α wired the **consumer** (`_renderAttribution(e)` in `renderRecentEvidence`) without addressing the **producer** side of the data-shape gap. Active Milestones worked because `milestones` is array-shape (PR-19.5 baseline scope).

## Fix

Extend `_syncStampUnattributed` to walk object-keyed shapes whose top-level **values are entry-arrays**:

- `activityLog`: `{ dateStr: [entry, entry, ...] }` → stamps each entry lacking `__sync_updatedBy` ✓
- `feeding`: `{ dateStr: { meal: '...' } }` → values are objects, not arrays → **passes through untouched** (Phase 4 carry-forward, wrapper-shape decision deferred)
- `medChecks`: `{ dateStr: { medname: 'status' } }` → same — passes through untouched

On flush, stamps echo through Firestore + listener and land in localStorage on receive — picked up by `_syncDispatchRender`'s rehydrate. `_renderAttribution(e)` now resolves to "by Rishabh Jain" for newly-stamped entries.

## Doctrine surfacing — 3rd instance

`architectural-shift-PRs-bias-toward-r1-catch-cycle` candidate (currently 1/3 per Cipher session-close harvest 2026-05-03):
- Polish-10a r1 (PR-34) — sections.* sibling-site catch → 1st
- Polish-10d r1 (PR-38) — defensive-fallback shape-homogeneity → 2nd
- **PR-α r1 (this) — data-shape producer-vs-consumer gap → 3rd → RATIFICATION-ELIGIBLE**

Cipher's framing: data-shape-changing PRs catch real bugs at r1; sweep/vocabulary/class-extraction PRs land clean.

## Hold-pending-Sovereign-real-device-verification

Per RATIFIED `hermetic-floor-doesnt-substitute-for-production-floor`:
- [ ] Log a fresh activity from Quick Log
- [ ] Wait one autosave debounce (~2-3s)
- [ ] Reload the activities tab
- [ ] Attribution chip "by Rishabh Jain" appears on the freshly-logged entry
- [ ] Existing legacy entries get stamped on next flush they participate in (e.g. when next entry pushed for same activityLog)

## Test plan

- [x] Build clean (`bash build.sh > sproutlab.html`, no `2>&1`)
- [x] feeding/medChecks unchanged: non-array values pass through (`Object.keys(value).forEach` → `Array.isArray(v) === false` branch returns value untouched)
- [x] activityLog walked: each `dateStr`'s array stamped per-entry
- [ ] Real-device: fresh activity logged → attribution echoed back through sync → chip appears

— Lyra (lyra-stability-1)

---
_Generated by [Claude Code](https://claude.ai/code/session_011JhmDyFtAuQQyj1dtjyJCh)_