### PR TITLE
PR-β: Recent Evidence Feed rollup aggregation (Social Smiling × N fix)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5472,6 +5472,21 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 .al-feed-summary { display:flex; gap:var(--sp-8); flex-wrap:wrap; margin:var(--sp-4) 0; }
 .al-feed-summary-chip { font-size:var(--fs-2xs); padding:var(--sp-2) var(--sp-4); border-radius:var(--r-sm); font-weight:600; }
 
+/* ── PR-β: Recent Evidence Feed rollups ── */
+.al-feed-rollups-label { font-size:var(--fs-2xs); font-weight:700; text-transform:uppercase; letter-spacing:var(--ls-wide); color:var(--light); padding:var(--sp-4) 0; margin-bottom:var(--sp-4); }
+.al-feed-rollup { margin-bottom:var(--sp-6); }
+.al-feed-rollup-pill { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-8) var(--sp-12); border-radius:var(--r-md); font-size:var(--fs-sm); cursor:pointer; }
+.al-feed-rollup-icon { flex-shrink:0; }
+.al-feed-rollup-label-text { flex:1; min-width:0; }
+.al-feed-rollup-label-text strong { font-weight:700; }
+.al-feed-rollup-meta { font-size:var(--fs-2xs); opacity:0.8; white-space:nowrap; }
+.al-feed-rollup-chevron { flex-shrink:0; opacity:0.7; }
+.al-feed-rollup-body { padding:var(--sp-4) var(--sp-12); display:flex; flex-direction:column; gap:var(--sp-6); }
+.al-feed-rollup-entry { padding:var(--sp-6) 0; border-bottom:1px solid var(--border-subtle); }
+.al-feed-rollup-entry:last-child { border-bottom:none; }
+.al-feed-rollup-when { font-size:var(--fs-2xs); color:var(--light); font-weight:600; }
+.al-feed-rollup-text { font-size:var(--fs-sm); color:var(--text); margin-top:var(--sp-2); }
+
 /* ── Activity Intelligence Cards ── */
 .ai-dot-cal { display:grid; grid-template-columns:repeat(7, 1fr); gap:var(--sp-2); margin:var(--sp-8) 0; }
 .ai-dot { width:100%; aspect-ratio:1; border-radius:var(--r-sm); background:var(--warm); transition:background var(--ease-fast); }
@@ -22472,10 +22487,19 @@ function renderRecentEvidence() {
   const feedEl = document.getElementById('recentEvidenceFeed');
   if (!feedEl) return;
 
+  // PR-β rollup config — across the 7-day window, observations whose
+  // primary milestone keyword recurs ≥ ROLLUP_THRESHOLD times collapse
+  // into a "Frequent observations" rollup section above the per-day groups.
+  // Activities (durational; type='activity' or has duration) always stay
+  // flat. Render-time client-side aggregation only — no data-shape change
+  // to activityLog (preserves PR-α per-entry attribution stamps).
+  const ROLLUP_THRESHOLD = 3;
+  const ROLLUP_WINDOW_DAYS = 7;
+
   // Gather last 7 days of activity entries
   const now = new Date();
   const dayGroups = {};
-  for (let d = 0; d < 7; d++) {
+  for (let d = 0; d < ROLLUP_WINDOW_DAYS; d++) {
     const dt = new Date(now);
     dt.setDate(dt.getDate() - d);
     const dateStr = toDateStr(dt);
@@ -22496,13 +22520,103 @@ function renderRecentEvidence() {
   const todayStr = today();
   const yesterdayStr = toDateStr(new Date(Date.now() - 86400000));
 
-  let html = '<div class="micro-label text-center mb-4 fw-600" >Recent Activity Evidence</div>';
+  // ── PR-β rollup pre-pass ──
+  // Pick the primary milestone keyword for an observation entry: highest-
+  // confidence wins, ties resolved by first occurrence (stable for cross-
+  // device determinism). Activities (type='activity' OR has duration) and
+  // entries with no milestone-bearing evidence don't roll up.
+  const confRank = { high: 3, medium: 2, low: 1 };
+  function _primaryMilestone(e) {
+    if (e.type === 'activity' || e.duration) return null;
+    const evid = (e.evidence || []).filter(ev => ev && ev.milestone);
+    if (evid.length === 0) return null;
+    let best = evid[0], bestRank = confRank[best.confidence] || 0;
+    for (let i = 1; i < evid.length; i++) {
+      const r = confRank[evid[i].confidence] || 0;
+      if (r > bestRank) { best = evid[i]; bestRank = r; }
+    }
+    return best.milestone;
+  }
 
+  // Group observations by primary milestone across the full 7d window.
+  const obsByMilestone = {};
+  Object.entries(dayGroups).forEach(([dateStr, entries]) => {
+    entries.forEach(e => {
+      const ms = _primaryMilestone(e);
+      if (!ms) return;
+      if (!obsByMilestone[ms]) obsByMilestone[ms] = [];
+      obsByMilestone[ms].push({ entry: e, dateStr });
+    });
+  });
+
+  // Promote milestones at or above threshold into rollups; track rolled-up
+  // entry IDs so per-day sections can subtract them from counts + display.
+  const rolledIds = new Set();
+  const rollups = [];
+  Object.entries(obsByMilestone).forEach(([ms, occs]) => {
+    if (occs.length < ROLLUP_THRESHOLD) return;
+    const sorted = occs.slice().sort((a, b) => {
+      const aTs = a.entry.ts || a.dateStr;
+      const bTs = b.entry.ts || b.dateStr;
+      return bTs.localeCompare(aTs);
+    });
+    rollups.push({
+      milestone: ms,
+      count: occs.length,
+      latest: sorted[0],
+      entries: sorted,
+    });
+    sorted.forEach(o => { if (o.entry.id) rolledIds.add(o.entry.id); });
+  });
+
+  rollups.sort((a, b) => b.count - a.count || a.milestone.localeCompare(b.milestone));
+
+  let html = '<div class="micro-label text-center mb-4 fw-600">Recent Activity Evidence</div>';
+
+  // ── Render rollups section (if any) ──
+  if (rollups.length > 0) {
+    html += '<div class="al-feed-rollups-label">Frequent observations · last ' + ROLLUP_WINDOW_DAYS + ' days</div>';
+    rollups.forEach((r, ri) => {
+      const label = (typeof createMilestoneLabel === 'function') ? createMilestoneLabel(r.milestone) : r.milestone.replace(/_/g, ' ');
+      const latestEntry = r.latest.entry;
+      const latestDate = r.latest.dateStr;
+      const latestLabel = latestDate === todayStr ? 'today' : latestDate === yesterdayStr ? 'yesterday' : formatDate(latestDate);
+      const latestTimeStr = latestEntry.ts ? new Date(latestEntry.ts).toLocaleTimeString('en-IN', { hour: '2-digit', minute: '2-digit' }) : '';
+      const rollupBodyId = 'al-feed-rollup-' + ri;
+      const primaryDomain = (latestEntry.domains && latestEntry.domains[0]) || 'cognitive';
+
+      html += '<div class="al-feed-rollup">';
+      html += '<div class="al-feed-rollup-pill al-chip-' + primaryDomain + ' ptr" data-action="toggleDisplayBlock" data-arg="' + rollupBodyId + '">' +
+        '<span class="al-feed-rollup-icon">' + (domainIcons[primaryDomain] || '') + '</span>' +
+        '<span class="al-feed-rollup-label-text"><strong>' + escHtml(label) + '</strong> × ' + r.count + '</span>' +
+        '<span class="al-feed-rollup-meta">last ' + latestLabel + (latestTimeStr ? ' ' + latestTimeStr : '') + '</span>' +
+        '<span class="al-feed-rollup-chevron">▾</span>' +
+        '</div>';
+      html += '<div id="' + rollupBodyId + '" class="al-feed-rollup-body" style="display:none;">';
+      r.entries.forEach(o => {
+        const e = o.entry;
+        const dStr = o.dateStr;
+        const dLabel = dStr === todayStr ? 'Today' : dStr === yesterdayStr ? 'Yesterday' : formatDate(dStr);
+        const tStr = e.ts ? new Date(e.ts).toLocaleTimeString('en-IN', { hour: '2-digit', minute: '2-digit' }) : '';
+        html += '<div class="al-feed-rollup-entry">' +
+          '<div class="al-feed-rollup-when">' + dLabel + (tStr ? ' · ' + tStr : '') + '</div>' +
+          '<div class="al-feed-rollup-text">' + escHtml(e.text) + '</div>' +
+          _renderAttribution(e) +
+          '</div>';
+      });
+      html += '</div>';
+      html += '</div>';
+    });
+  }
+
+  // ── Render per-day groups (excluding rolled-up entries) ──
   dayKeys.forEach((dateStr, dayIdx) => {
-    const entries = dayGroups[dateStr].sort((a, b) => (b.ts || b._date).localeCompare(a.ts || a._date));
+    const allEntries = dayGroups[dateStr].slice().sort((a, b) => (b.ts || b._date).localeCompare(a.ts || a._date));
+    const entries = allEntries.filter(e => !(e.id && rolledIds.has(e.id)));
+    if (entries.length === 0) return;
+
     const dayLabel = dateStr === todayStr ? 'Today' : dateStr === yesterdayStr ? 'Yesterday' : formatDate(dateStr);
 
-    // Day summary: count by domain
     const domainCounts = {};
     let totalEvidence = 0;
     entries.forEach(e => {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.06-6",
+  "version": "2026.05.06-7",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/home.js
+++ b/split/home.js
@@ -2090,10 +2090,19 @@ function renderRecentEvidence() {
   const feedEl = document.getElementById('recentEvidenceFeed');
   if (!feedEl) return;
 
+  // PR-β rollup config — across the 7-day window, observations whose
+  // primary milestone keyword recurs ≥ ROLLUP_THRESHOLD times collapse
+  // into a "Frequent observations" rollup section above the per-day groups.
+  // Activities (durational; type='activity' or has duration) always stay
+  // flat. Render-time client-side aggregation only — no data-shape change
+  // to activityLog (preserves PR-α per-entry attribution stamps).
+  const ROLLUP_THRESHOLD = 3;
+  const ROLLUP_WINDOW_DAYS = 7;
+
   // Gather last 7 days of activity entries
   const now = new Date();
   const dayGroups = {};
-  for (let d = 0; d < 7; d++) {
+  for (let d = 0; d < ROLLUP_WINDOW_DAYS; d++) {
     const dt = new Date(now);
     dt.setDate(dt.getDate() - d);
     const dateStr = toDateStr(dt);
@@ -2114,13 +2123,103 @@ function renderRecentEvidence() {
   const todayStr = today();
   const yesterdayStr = toDateStr(new Date(Date.now() - 86400000));
 
-  let html = '<div class="micro-label text-center mb-4 fw-600" >Recent Activity Evidence</div>';
+  // ── PR-β rollup pre-pass ──
+  // Pick the primary milestone keyword for an observation entry: highest-
+  // confidence wins, ties resolved by first occurrence (stable for cross-
+  // device determinism). Activities (type='activity' OR has duration) and
+  // entries with no milestone-bearing evidence don't roll up.
+  const confRank = { high: 3, medium: 2, low: 1 };
+  function _primaryMilestone(e) {
+    if (e.type === 'activity' || e.duration) return null;
+    const evid = (e.evidence || []).filter(ev => ev && ev.milestone);
+    if (evid.length === 0) return null;
+    let best = evid[0], bestRank = confRank[best.confidence] || 0;
+    for (let i = 1; i < evid.length; i++) {
+      const r = confRank[evid[i].confidence] || 0;
+      if (r > bestRank) { best = evid[i]; bestRank = r; }
+    }
+    return best.milestone;
+  }
 
+  // Group observations by primary milestone across the full 7d window.
+  const obsByMilestone = {};
+  Object.entries(dayGroups).forEach(([dateStr, entries]) => {
+    entries.forEach(e => {
+      const ms = _primaryMilestone(e);
+      if (!ms) return;
+      if (!obsByMilestone[ms]) obsByMilestone[ms] = [];
+      obsByMilestone[ms].push({ entry: e, dateStr });
+    });
+  });
+
+  // Promote milestones at or above threshold into rollups; track rolled-up
+  // entry IDs so per-day sections can subtract them from counts + display.
+  const rolledIds = new Set();
+  const rollups = [];
+  Object.entries(obsByMilestone).forEach(([ms, occs]) => {
+    if (occs.length < ROLLUP_THRESHOLD) return;
+    const sorted = occs.slice().sort((a, b) => {
+      const aTs = a.entry.ts || a.dateStr;
+      const bTs = b.entry.ts || b.dateStr;
+      return bTs.localeCompare(aTs);
+    });
+    rollups.push({
+      milestone: ms,
+      count: occs.length,
+      latest: sorted[0],
+      entries: sorted,
+    });
+    sorted.forEach(o => { if (o.entry.id) rolledIds.add(o.entry.id); });
+  });
+
+  rollups.sort((a, b) => b.count - a.count || a.milestone.localeCompare(b.milestone));
+
+  let html = '<div class="micro-label text-center mb-4 fw-600">Recent Activity Evidence</div>';
+
+  // ── Render rollups section (if any) ──
+  if (rollups.length > 0) {
+    html += '<div class="al-feed-rollups-label">Frequent observations · last ' + ROLLUP_WINDOW_DAYS + ' days</div>';
+    rollups.forEach((r, ri) => {
+      const label = (typeof createMilestoneLabel === 'function') ? createMilestoneLabel(r.milestone) : r.milestone.replace(/_/g, ' ');
+      const latestEntry = r.latest.entry;
+      const latestDate = r.latest.dateStr;
+      const latestLabel = latestDate === todayStr ? 'today' : latestDate === yesterdayStr ? 'yesterday' : formatDate(latestDate);
+      const latestTimeStr = latestEntry.ts ? new Date(latestEntry.ts).toLocaleTimeString('en-IN', { hour: '2-digit', minute: '2-digit' }) : '';
+      const rollupBodyId = 'al-feed-rollup-' + ri;
+      const primaryDomain = (latestEntry.domains && latestEntry.domains[0]) || 'cognitive';
+
+      html += '<div class="al-feed-rollup">';
+      html += '<div class="al-feed-rollup-pill al-chip-' + primaryDomain + ' ptr" data-action="toggleDisplayBlock" data-arg="' + rollupBodyId + '">' +
+        '<span class="al-feed-rollup-icon">' + (domainIcons[primaryDomain] || '') + '</span>' +
+        '<span class="al-feed-rollup-label-text"><strong>' + escHtml(label) + '</strong> × ' + r.count + '</span>' +
+        '<span class="al-feed-rollup-meta">last ' + latestLabel + (latestTimeStr ? ' ' + latestTimeStr : '') + '</span>' +
+        '<span class="al-feed-rollup-chevron">▾</span>' +
+        '</div>';
+      html += '<div id="' + rollupBodyId + '" class="al-feed-rollup-body" style="display:none;">';
+      r.entries.forEach(o => {
+        const e = o.entry;
+        const dStr = o.dateStr;
+        const dLabel = dStr === todayStr ? 'Today' : dStr === yesterdayStr ? 'Yesterday' : formatDate(dStr);
+        const tStr = e.ts ? new Date(e.ts).toLocaleTimeString('en-IN', { hour: '2-digit', minute: '2-digit' }) : '';
+        html += '<div class="al-feed-rollup-entry">' +
+          '<div class="al-feed-rollup-when">' + dLabel + (tStr ? ' · ' + tStr : '') + '</div>' +
+          '<div class="al-feed-rollup-text">' + escHtml(e.text) + '</div>' +
+          _renderAttribution(e) +
+          '</div>';
+      });
+      html += '</div>';
+      html += '</div>';
+    });
+  }
+
+  // ── Render per-day groups (excluding rolled-up entries) ──
   dayKeys.forEach((dateStr, dayIdx) => {
-    const entries = dayGroups[dateStr].sort((a, b) => (b.ts || b._date).localeCompare(a.ts || a._date));
+    const allEntries = dayGroups[dateStr].slice().sort((a, b) => (b.ts || b._date).localeCompare(a.ts || a._date));
+    const entries = allEntries.filter(e => !(e.id && rolledIds.has(e.id)));
+    if (entries.length === 0) return;
+
     const dayLabel = dateStr === todayStr ? 'Today' : dateStr === yesterdayStr ? 'Yesterday' : formatDate(dateStr);
 
-    // Day summary: count by domain
     const domainCounts = {};
     let totalEvidence = 0;
     entries.forEach(e => {

--- a/split/styles.css
+++ b/split/styles.css
@@ -5465,6 +5465,21 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 .al-feed-summary { display:flex; gap:var(--sp-8); flex-wrap:wrap; margin:var(--sp-4) 0; }
 .al-feed-summary-chip { font-size:var(--fs-2xs); padding:var(--sp-2) var(--sp-4); border-radius:var(--r-sm); font-weight:600; }
 
+/* ── PR-β: Recent Evidence Feed rollups ── */
+.al-feed-rollups-label { font-size:var(--fs-2xs); font-weight:700; text-transform:uppercase; letter-spacing:var(--ls-wide); color:var(--light); padding:var(--sp-4) 0; margin-bottom:var(--sp-4); }
+.al-feed-rollup { margin-bottom:var(--sp-6); }
+.al-feed-rollup-pill { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-8) var(--sp-12); border-radius:var(--r-md); font-size:var(--fs-sm); cursor:pointer; }
+.al-feed-rollup-icon { flex-shrink:0; }
+.al-feed-rollup-label-text { flex:1; min-width:0; }
+.al-feed-rollup-label-text strong { font-weight:700; }
+.al-feed-rollup-meta { font-size:var(--fs-2xs); opacity:0.8; white-space:nowrap; }
+.al-feed-rollup-chevron { flex-shrink:0; opacity:0.7; }
+.al-feed-rollup-body { padding:var(--sp-4) var(--sp-12); display:flex; flex-direction:column; gap:var(--sp-6); }
+.al-feed-rollup-entry { padding:var(--sp-6) 0; border-bottom:1px solid var(--border-subtle); }
+.al-feed-rollup-entry:last-child { border-bottom:none; }
+.al-feed-rollup-when { font-size:var(--fs-2xs); color:var(--light); font-weight:600; }
+.al-feed-rollup-text { font-size:var(--fs-sm); color:var(--text); margin-top:var(--sp-2); }
+
 /* ── Activity Intelligence Cards ── */
 .ai-dot-cal { display:grid; grid-template-columns:repeat(7, 1fr); gap:var(--sp-2); margin:var(--sp-8) 0; }
 .ai-dot { width:100%; aspect-ratio:1; border-radius:var(--r-sm); background:var(--warm); transition:background var(--ease-fast); }

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -5472,6 +5472,21 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 .al-feed-summary { display:flex; gap:var(--sp-8); flex-wrap:wrap; margin:var(--sp-4) 0; }
 .al-feed-summary-chip { font-size:var(--fs-2xs); padding:var(--sp-2) var(--sp-4); border-radius:var(--r-sm); font-weight:600; }
 
+/* ── PR-β: Recent Evidence Feed rollups ── */
+.al-feed-rollups-label { font-size:var(--fs-2xs); font-weight:700; text-transform:uppercase; letter-spacing:var(--ls-wide); color:var(--light); padding:var(--sp-4) 0; margin-bottom:var(--sp-4); }
+.al-feed-rollup { margin-bottom:var(--sp-6); }
+.al-feed-rollup-pill { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-8) var(--sp-12); border-radius:var(--r-md); font-size:var(--fs-sm); cursor:pointer; }
+.al-feed-rollup-icon { flex-shrink:0; }
+.al-feed-rollup-label-text { flex:1; min-width:0; }
+.al-feed-rollup-label-text strong { font-weight:700; }
+.al-feed-rollup-meta { font-size:var(--fs-2xs); opacity:0.8; white-space:nowrap; }
+.al-feed-rollup-chevron { flex-shrink:0; opacity:0.7; }
+.al-feed-rollup-body { padding:var(--sp-4) var(--sp-12); display:flex; flex-direction:column; gap:var(--sp-6); }
+.al-feed-rollup-entry { padding:var(--sp-6) 0; border-bottom:1px solid var(--border-subtle); }
+.al-feed-rollup-entry:last-child { border-bottom:none; }
+.al-feed-rollup-when { font-size:var(--fs-2xs); color:var(--light); font-weight:600; }
+.al-feed-rollup-text { font-size:var(--fs-sm); color:var(--text); margin-top:var(--sp-2); }
+
 /* ── Activity Intelligence Cards ── */
 .ai-dot-cal { display:grid; grid-template-columns:repeat(7, 1fr); gap:var(--sp-2); margin:var(--sp-8) 0; }
 .ai-dot { width:100%; aspect-ratio:1; border-radius:var(--r-sm); background:var(--warm); transition:background var(--ease-fast); }
@@ -22472,10 +22487,19 @@ function renderRecentEvidence() {
   const feedEl = document.getElementById('recentEvidenceFeed');
   if (!feedEl) return;
 
+  // PR-β rollup config — across the 7-day window, observations whose
+  // primary milestone keyword recurs ≥ ROLLUP_THRESHOLD times collapse
+  // into a "Frequent observations" rollup section above the per-day groups.
+  // Activities (durational; type='activity' or has duration) always stay
+  // flat. Render-time client-side aggregation only — no data-shape change
+  // to activityLog (preserves PR-α per-entry attribution stamps).
+  const ROLLUP_THRESHOLD = 3;
+  const ROLLUP_WINDOW_DAYS = 7;
+
   // Gather last 7 days of activity entries
   const now = new Date();
   const dayGroups = {};
-  for (let d = 0; d < 7; d++) {
+  for (let d = 0; d < ROLLUP_WINDOW_DAYS; d++) {
     const dt = new Date(now);
     dt.setDate(dt.getDate() - d);
     const dateStr = toDateStr(dt);
@@ -22496,13 +22520,103 @@ function renderRecentEvidence() {
   const todayStr = today();
   const yesterdayStr = toDateStr(new Date(Date.now() - 86400000));
 
-  let html = '<div class="micro-label text-center mb-4 fw-600" >Recent Activity Evidence</div>';
+  // ── PR-β rollup pre-pass ──
+  // Pick the primary milestone keyword for an observation entry: highest-
+  // confidence wins, ties resolved by first occurrence (stable for cross-
+  // device determinism). Activities (type='activity' OR has duration) and
+  // entries with no milestone-bearing evidence don't roll up.
+  const confRank = { high: 3, medium: 2, low: 1 };
+  function _primaryMilestone(e) {
+    if (e.type === 'activity' || e.duration) return null;
+    const evid = (e.evidence || []).filter(ev => ev && ev.milestone);
+    if (evid.length === 0) return null;
+    let best = evid[0], bestRank = confRank[best.confidence] || 0;
+    for (let i = 1; i < evid.length; i++) {
+      const r = confRank[evid[i].confidence] || 0;
+      if (r > bestRank) { best = evid[i]; bestRank = r; }
+    }
+    return best.milestone;
+  }
 
+  // Group observations by primary milestone across the full 7d window.
+  const obsByMilestone = {};
+  Object.entries(dayGroups).forEach(([dateStr, entries]) => {
+    entries.forEach(e => {
+      const ms = _primaryMilestone(e);
+      if (!ms) return;
+      if (!obsByMilestone[ms]) obsByMilestone[ms] = [];
+      obsByMilestone[ms].push({ entry: e, dateStr });
+    });
+  });
+
+  // Promote milestones at or above threshold into rollups; track rolled-up
+  // entry IDs so per-day sections can subtract them from counts + display.
+  const rolledIds = new Set();
+  const rollups = [];
+  Object.entries(obsByMilestone).forEach(([ms, occs]) => {
+    if (occs.length < ROLLUP_THRESHOLD) return;
+    const sorted = occs.slice().sort((a, b) => {
+      const aTs = a.entry.ts || a.dateStr;
+      const bTs = b.entry.ts || b.dateStr;
+      return bTs.localeCompare(aTs);
+    });
+    rollups.push({
+      milestone: ms,
+      count: occs.length,
+      latest: sorted[0],
+      entries: sorted,
+    });
+    sorted.forEach(o => { if (o.entry.id) rolledIds.add(o.entry.id); });
+  });
+
+  rollups.sort((a, b) => b.count - a.count || a.milestone.localeCompare(b.milestone));
+
+  let html = '<div class="micro-label text-center mb-4 fw-600">Recent Activity Evidence</div>';
+
+  // ── Render rollups section (if any) ──
+  if (rollups.length > 0) {
+    html += '<div class="al-feed-rollups-label">Frequent observations · last ' + ROLLUP_WINDOW_DAYS + ' days</div>';
+    rollups.forEach((r, ri) => {
+      const label = (typeof createMilestoneLabel === 'function') ? createMilestoneLabel(r.milestone) : r.milestone.replace(/_/g, ' ');
+      const latestEntry = r.latest.entry;
+      const latestDate = r.latest.dateStr;
+      const latestLabel = latestDate === todayStr ? 'today' : latestDate === yesterdayStr ? 'yesterday' : formatDate(latestDate);
+      const latestTimeStr = latestEntry.ts ? new Date(latestEntry.ts).toLocaleTimeString('en-IN', { hour: '2-digit', minute: '2-digit' }) : '';
+      const rollupBodyId = 'al-feed-rollup-' + ri;
+      const primaryDomain = (latestEntry.domains && latestEntry.domains[0]) || 'cognitive';
+
+      html += '<div class="al-feed-rollup">';
+      html += '<div class="al-feed-rollup-pill al-chip-' + primaryDomain + ' ptr" data-action="toggleDisplayBlock" data-arg="' + rollupBodyId + '">' +
+        '<span class="al-feed-rollup-icon">' + (domainIcons[primaryDomain] || '') + '</span>' +
+        '<span class="al-feed-rollup-label-text"><strong>' + escHtml(label) + '</strong> × ' + r.count + '</span>' +
+        '<span class="al-feed-rollup-meta">last ' + latestLabel + (latestTimeStr ? ' ' + latestTimeStr : '') + '</span>' +
+        '<span class="al-feed-rollup-chevron">▾</span>' +
+        '</div>';
+      html += '<div id="' + rollupBodyId + '" class="al-feed-rollup-body" style="display:none;">';
+      r.entries.forEach(o => {
+        const e = o.entry;
+        const dStr = o.dateStr;
+        const dLabel = dStr === todayStr ? 'Today' : dStr === yesterdayStr ? 'Yesterday' : formatDate(dStr);
+        const tStr = e.ts ? new Date(e.ts).toLocaleTimeString('en-IN', { hour: '2-digit', minute: '2-digit' }) : '';
+        html += '<div class="al-feed-rollup-entry">' +
+          '<div class="al-feed-rollup-when">' + dLabel + (tStr ? ' · ' + tStr : '') + '</div>' +
+          '<div class="al-feed-rollup-text">' + escHtml(e.text) + '</div>' +
+          _renderAttribution(e) +
+          '</div>';
+      });
+      html += '</div>';
+      html += '</div>';
+    });
+  }
+
+  // ── Render per-day groups (excluding rolled-up entries) ──
   dayKeys.forEach((dateStr, dayIdx) => {
-    const entries = dayGroups[dateStr].sort((a, b) => (b.ts || b._date).localeCompare(a.ts || a._date));
+    const allEntries = dayGroups[dateStr].slice().sort((a, b) => (b.ts || b._date).localeCompare(a.ts || a._date));
+    const entries = allEntries.filter(e => !(e.id && rolledIds.has(e.id)));
+    if (entries.length === 0) return;
+
     const dayLabel = dateStr === todayStr ? 'Today' : dateStr === yesterdayStr ? 'Yesterday' : formatDate(dateStr);
 
-    // Day summary: count by domain
     const domainCounts = {};
     let totalEvidence = 0;
     entries.forEach(e => {


### PR DESCRIPTION
## Summary

Closes the **"Social Smiling × N flooding"** screen-real-estate complaint that originated this whole activities-tab arc. Render-time client-side aggregation in `renderRecentEvidence` across the existing 7-day window — **no data-shape change** to `activityLog` (preserves PR-α per-entry attribution stamps).

**Charter:** `Codex/docs/charters/PR_BETA_ROLLUP_CHARTER_2026-05-06.md` (sister PR on Codex `claude/pr-beta-rollup-charter`).

## Behavior

**Before:** Recent Activity Evidence showed every observation as its own row, so 12 social-smile observations consumed 12 rows.

**After:**
- **Pre-pass:** group observations by primary milestone keyword (highest-confidence pick from `evidence[]`, ties→first occurrence for cross-device determinism)
- Milestones with **≥3 occurrences in the 7-day window** collapse into a new "Frequent observations" rollup section above the per-day groups
- **Rollup pill:** domain-tinted full-width row with milestone label + count + last-seen meta + tap-to-expand caret
- **Expanded body:** lists each individual entry with date/time/text/attribution chip (PR-α attribution carries through)
- **Activities** (`type='activity'` OR has `duration`) ALWAYS render flat (durational items stay flat per Sovereign Q2 ratification)
- **Per-day sections** subtract rolled-up entries from counts + display
- **Empty-day post-filter:** hidden (no render)

## Charter axes (verdicts)

| Axis | Subject | Verdict |
|------|---------|---------|
| A | Rollup grouping key | **A1** Per-milestone (highest-confidence) — directly addresses user-reported pattern |
| B | Rollup threshold | **B1** ≥ 3 (catches floods; conservative) |
| C | Rollup window | **C1** 7 days (matches existing loop; no data-shape change) |
| D | Cross-device behavior | **D1** Render-time client-side aggregation — both devices independently compute same rollup from same dispatch fire |
| E | Day-count semantics | **E1** Day count subtracts rolled-up entries (matches what's rendered) |

## Doctrine surfacing

**1st-instance landing candidate for `render-functions-must-be-pure`** (currently 0/3): `renderRecentEvidence` is now a pure read-side projection — no `save()` side effects, deterministic given input. This is the first instance where a render-only PR could land the candidate. Aurelius can ratify-track on next chronicle update.

## Hold-pending-Sovereign-real-device-verification

Per RATIFIED `hermetic-floor-doesnt-substitute-for-production-floor` (visual-shape change):

- [ ] Open Activities tab → "Frequent observations · last 7 days" section appears at top if any milestone has ≥3 occurrences
- [ ] Rollup pill shows: `<domain icon> <Milestone Label> × <count>  last <when>  ▾`
- [ ] Tap rollup pill → individual entries expand with attribution chips per entry
- [ ] Activities (durational) still render flat in per-day sections
- [ ] Day-header counts match number of entries actually shown on each day (not pre-rollup totals)
- [ ] Cross-device: device A logs → device B re-renders feed; rollup recomputes consistently
- [ ] Empty state: no entries → feed hidden (existing behavior preserved)
- [ ] No regression on attribution chips (PR-α + r1 fix)

## Test plan

- [x] Build clean (`bash build.sh > sproutlab.html`, no `2>&1`)
- [x] HR-4 escHtml at boundaries (`escHtml(label)`, `escHtml(e.text)`)
- [x] HR-3 data-action delegation (`toggleDisplayBlock` for both rollup-pill and day-header)
- [x] HR-7 zi() via innerHTML
- [x] `_primaryMilestone` returns null for activities, missing-evidence entries, missing-keyword entries
- [x] Rollup ordering deterministic (count desc, milestone label asc tie-break) for cross-device parity
- [ ] Real-device: verify rollup with actual user data (Sovereign verification)

— Lyra (lyra-stability-1)

---
_Generated by [Claude Code](https://claude.ai/code/session_011JhmDyFtAuQQyj1dtjyJCh)_