### PR TITLE
PR-β r1: dedupe duplicate milestones array entries (Sovereign-floor catch)

### DIFF
--- a/index.html
+++ b/index.html
@@ -16277,6 +16277,14 @@ function init() {
       m.confidenceHigh = 0;
     }
   });
+  // PR-β r1 hotfix: dedupe duplicate milestones array entries (case-insensitive
+  // trimmed-text grouping; conservative merge). Runs unconditionally on boot —
+  // legacy data may have duplicates from prior cross-device sync races that
+  // syncMilestoneStatuses' find()-and-update loop never repaired.
+  if (typeof dedupeMilestonesByText === 'function') {
+    dedupeMilestonesByText();
+  }
+
   // Sync evidence-based statuses on boot (if any activity log entries exist)
   if (Object.keys(activityLog).length > 0) {
     syncMilestoneStatuses();
@@ -33921,8 +33929,80 @@ function checkEvidenceRegression(milestoneKeyword, currentAutoStatus) {
   return daysSince > 21;
 }
 
+// dedupeMilestonesByText — PR-β r1 hotfix (Sovereign-floor catch on PR-α/β):
+// the milestones array can accumulate duplicates with same text but different
+// status/evidence-count snapshots (legacy data + cross-device sync rounds
+// where syncMilestoneStatuses' find() saw an empty array mid-flight and
+// pushed a fresh entry). syncMilestoneStatuses' find() always returns the
+// FIRST match thereafter — so duplicates persist as ghosts that all render.
+// This function consolidates by case-insensitive trimmed text, merging
+// stage/evidence/dates conservatively (max stage, max evidence, earliest
+// firstSeen, latest lastSeen, latest manualAt, any-advanced-true wins).
+// Mutates milestones in-place via reassignment + saves. Returns true if
+// any merge happened.
+function dedupeMilestonesByText() {
+  if (!Array.isArray(milestones) || milestones.length === 0) return false;
+  const stageRank = { not_started: 0, emerging: 1, practicing: 2, consistent: 3, mastered: 4 };
+  const groups = {};
+  const order = [];
+
+  milestones.forEach(m => {
+    if (!m || typeof m !== 'object') return;
+    const k = (m.text || '').toLowerCase().trim();
+    if (!k) return;
+    if (!groups[k]) { groups[k] = []; order.push(k); }
+    groups[k].push(m);
+  });
+
+  const hasDups = Object.values(groups).some(arr => arr.length > 1);
+  if (!hasDups) return false;
+
+  const deduped = order.map(k => {
+    const grp = groups[k];
+    if (grp.length === 1) return grp[0];
+
+    const merged = Object.assign({}, grp[0]);
+
+    grp.slice(1).forEach(m => {
+      if ((stageRank[m.status] || 0) > (stageRank[merged.status] || 0)) merged.status = m.status;
+      if ((stageRank[m.autoStatus] || 0) > (stageRank[merged.autoStatus] || 0)) merged.autoStatus = m.autoStatus;
+      if ((m.evidenceCount || 0) > (merged.evidenceCount || 0)) merged.evidenceCount = m.evidenceCount;
+      if ((m.confidenceHigh || 0) > (merged.confidenceHigh || 0)) merged.confidenceHigh = m.confidenceHigh;
+      if (m.firstSeen && (!merged.firstSeen || m.firstSeen < merged.firstSeen)) merged.firstSeen = m.firstSeen;
+      if (m.lastSeen && (!merged.lastSeen || m.lastSeen > merged.lastSeen)) merged.lastSeen = m.lastSeen;
+      ['emergingAt','practicingAt','consistentAt','masteredAt','doneAt','inProgressAt'].forEach(f => {
+        if (m[f] && (!merged[f] || m[f] < merged[f])) merged[f] = m[f];
+      });
+      if (m.manualStatus && m.manualAt) {
+        if (!merged.manualStatus || !merged.manualAt || m.manualAt > merged.manualAt) {
+          merged.manualStatus = m.manualStatus;
+          merged.manualAt = m.manualAt;
+        }
+      }
+      if (m.advanced) merged.advanced = true;
+      if (!merged.cat && m.cat) merged.cat = m.cat;
+      if (m.__sync_updatedBy) {
+        const mAt = m.__sync_updatedBy.at || 0;
+        const curAt = (merged.__sync_updatedBy && merged.__sync_updatedBy.at) || 0;
+        if (!merged.__sync_updatedBy || mAt > curAt) merged.__sync_updatedBy = m.__sync_updatedBy;
+      }
+    });
+
+    return merged;
+  });
+
+  milestones = deduped;
+  save(KEYS.milestones, milestones);
+  return true;
+}
+
 // ─── Sync All Milestone Statuses (runs after every log entry) ───
 function syncMilestoneStatuses() {
+  // PR-β r1 hotfix: clean up duplicate text entries before find()-and-update
+  // loop. Without this, a stale 2nd "Social smiling" entry never gets touched
+  // and renders as a ghost in renderMilestoneList + renderActiveMilestones.
+  dedupeMilestonesByText();
+
   const allKeywords = [...new Set(EVIDENCE_PATTERNS.map(p => p.milestone))];
 
   allKeywords.forEach(keyword => {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.06-7",
+  "version": "2026.05.06-8",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -837,6 +837,14 @@ function init() {
       m.confidenceHigh = 0;
     }
   });
+  // PR-β r1 hotfix: dedupe duplicate milestones array entries (case-insensitive
+  // trimmed-text grouping; conservative merge). Runs unconditionally on boot —
+  // legacy data may have duplicates from prior cross-device sync races that
+  // syncMilestoneStatuses' find()-and-update loop never repaired.
+  if (typeof dedupeMilestonesByText === 'function') {
+    dedupeMilestonesByText();
+  }
+
   // Sync evidence-based statuses on boot (if any activity log entries exist)
   if (Object.keys(activityLog).length > 0) {
     syncMilestoneStatuses();

--- a/split/medical.js
+++ b/split/medical.js
@@ -130,8 +130,80 @@ function checkEvidenceRegression(milestoneKeyword, currentAutoStatus) {
   return daysSince > 21;
 }
 
+// dedupeMilestonesByText — PR-β r1 hotfix (Sovereign-floor catch on PR-α/β):
+// the milestones array can accumulate duplicates with same text but different
+// status/evidence-count snapshots (legacy data + cross-device sync rounds
+// where syncMilestoneStatuses' find() saw an empty array mid-flight and
+// pushed a fresh entry). syncMilestoneStatuses' find() always returns the
+// FIRST match thereafter — so duplicates persist as ghosts that all render.
+// This function consolidates by case-insensitive trimmed text, merging
+// stage/evidence/dates conservatively (max stage, max evidence, earliest
+// firstSeen, latest lastSeen, latest manualAt, any-advanced-true wins).
+// Mutates milestones in-place via reassignment + saves. Returns true if
+// any merge happened.
+function dedupeMilestonesByText() {
+  if (!Array.isArray(milestones) || milestones.length === 0) return false;
+  const stageRank = { not_started: 0, emerging: 1, practicing: 2, consistent: 3, mastered: 4 };
+  const groups = {};
+  const order = [];
+
+  milestones.forEach(m => {
+    if (!m || typeof m !== 'object') return;
+    const k = (m.text || '').toLowerCase().trim();
+    if (!k) return;
+    if (!groups[k]) { groups[k] = []; order.push(k); }
+    groups[k].push(m);
+  });
+
+  const hasDups = Object.values(groups).some(arr => arr.length > 1);
+  if (!hasDups) return false;
+
+  const deduped = order.map(k => {
+    const grp = groups[k];
+    if (grp.length === 1) return grp[0];
+
+    const merged = Object.assign({}, grp[0]);
+
+    grp.slice(1).forEach(m => {
+      if ((stageRank[m.status] || 0) > (stageRank[merged.status] || 0)) merged.status = m.status;
+      if ((stageRank[m.autoStatus] || 0) > (stageRank[merged.autoStatus] || 0)) merged.autoStatus = m.autoStatus;
+      if ((m.evidenceCount || 0) > (merged.evidenceCount || 0)) merged.evidenceCount = m.evidenceCount;
+      if ((m.confidenceHigh || 0) > (merged.confidenceHigh || 0)) merged.confidenceHigh = m.confidenceHigh;
+      if (m.firstSeen && (!merged.firstSeen || m.firstSeen < merged.firstSeen)) merged.firstSeen = m.firstSeen;
+      if (m.lastSeen && (!merged.lastSeen || m.lastSeen > merged.lastSeen)) merged.lastSeen = m.lastSeen;
+      ['emergingAt','practicingAt','consistentAt','masteredAt','doneAt','inProgressAt'].forEach(f => {
+        if (m[f] && (!merged[f] || m[f] < merged[f])) merged[f] = m[f];
+      });
+      if (m.manualStatus && m.manualAt) {
+        if (!merged.manualStatus || !merged.manualAt || m.manualAt > merged.manualAt) {
+          merged.manualStatus = m.manualStatus;
+          merged.manualAt = m.manualAt;
+        }
+      }
+      if (m.advanced) merged.advanced = true;
+      if (!merged.cat && m.cat) merged.cat = m.cat;
+      if (m.__sync_updatedBy) {
+        const mAt = m.__sync_updatedBy.at || 0;
+        const curAt = (merged.__sync_updatedBy && merged.__sync_updatedBy.at) || 0;
+        if (!merged.__sync_updatedBy || mAt > curAt) merged.__sync_updatedBy = m.__sync_updatedBy;
+      }
+    });
+
+    return merged;
+  });
+
+  milestones = deduped;
+  save(KEYS.milestones, milestones);
+  return true;
+}
+
 // ─── Sync All Milestone Statuses (runs after every log entry) ───
 function syncMilestoneStatuses() {
+  // PR-β r1 hotfix: clean up duplicate text entries before find()-and-update
+  // loop. Without this, a stale 2nd "Social smiling" entry never gets touched
+  // and renders as a ghost in renderMilestoneList + renderActiveMilestones.
+  dedupeMilestonesByText();
+
   const allKeywords = [...new Set(EVIDENCE_PATTERNS.map(p => p.milestone))];
 
   allKeywords.forEach(keyword => {

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -16277,6 +16277,14 @@ function init() {
       m.confidenceHigh = 0;
     }
   });
+  // PR-β r1 hotfix: dedupe duplicate milestones array entries (case-insensitive
+  // trimmed-text grouping; conservative merge). Runs unconditionally on boot —
+  // legacy data may have duplicates from prior cross-device sync races that
+  // syncMilestoneStatuses' find()-and-update loop never repaired.
+  if (typeof dedupeMilestonesByText === 'function') {
+    dedupeMilestonesByText();
+  }
+
   // Sync evidence-based statuses on boot (if any activity log entries exist)
   if (Object.keys(activityLog).length > 0) {
     syncMilestoneStatuses();
@@ -33921,8 +33929,80 @@ function checkEvidenceRegression(milestoneKeyword, currentAutoStatus) {
   return daysSince > 21;
 }
 
+// dedupeMilestonesByText — PR-β r1 hotfix (Sovereign-floor catch on PR-α/β):
+// the milestones array can accumulate duplicates with same text but different
+// status/evidence-count snapshots (legacy data + cross-device sync rounds
+// where syncMilestoneStatuses' find() saw an empty array mid-flight and
+// pushed a fresh entry). syncMilestoneStatuses' find() always returns the
+// FIRST match thereafter — so duplicates persist as ghosts that all render.
+// This function consolidates by case-insensitive trimmed text, merging
+// stage/evidence/dates conservatively (max stage, max evidence, earliest
+// firstSeen, latest lastSeen, latest manualAt, any-advanced-true wins).
+// Mutates milestones in-place via reassignment + saves. Returns true if
+// any merge happened.
+function dedupeMilestonesByText() {
+  if (!Array.isArray(milestones) || milestones.length === 0) return false;
+  const stageRank = { not_started: 0, emerging: 1, practicing: 2, consistent: 3, mastered: 4 };
+  const groups = {};
+  const order = [];
+
+  milestones.forEach(m => {
+    if (!m || typeof m !== 'object') return;
+    const k = (m.text || '').toLowerCase().trim();
+    if (!k) return;
+    if (!groups[k]) { groups[k] = []; order.push(k); }
+    groups[k].push(m);
+  });
+
+  const hasDups = Object.values(groups).some(arr => arr.length > 1);
+  if (!hasDups) return false;
+
+  const deduped = order.map(k => {
+    const grp = groups[k];
+    if (grp.length === 1) return grp[0];
+
+    const merged = Object.assign({}, grp[0]);
+
+    grp.slice(1).forEach(m => {
+      if ((stageRank[m.status] || 0) > (stageRank[merged.status] || 0)) merged.status = m.status;
+      if ((stageRank[m.autoStatus] || 0) > (stageRank[merged.autoStatus] || 0)) merged.autoStatus = m.autoStatus;
+      if ((m.evidenceCount || 0) > (merged.evidenceCount || 0)) merged.evidenceCount = m.evidenceCount;
+      if ((m.confidenceHigh || 0) > (merged.confidenceHigh || 0)) merged.confidenceHigh = m.confidenceHigh;
+      if (m.firstSeen && (!merged.firstSeen || m.firstSeen < merged.firstSeen)) merged.firstSeen = m.firstSeen;
+      if (m.lastSeen && (!merged.lastSeen || m.lastSeen > merged.lastSeen)) merged.lastSeen = m.lastSeen;
+      ['emergingAt','practicingAt','consistentAt','masteredAt','doneAt','inProgressAt'].forEach(f => {
+        if (m[f] && (!merged[f] || m[f] < merged[f])) merged[f] = m[f];
+      });
+      if (m.manualStatus && m.manualAt) {
+        if (!merged.manualStatus || !merged.manualAt || m.manualAt > merged.manualAt) {
+          merged.manualStatus = m.manualStatus;
+          merged.manualAt = m.manualAt;
+        }
+      }
+      if (m.advanced) merged.advanced = true;
+      if (!merged.cat && m.cat) merged.cat = m.cat;
+      if (m.__sync_updatedBy) {
+        const mAt = m.__sync_updatedBy.at || 0;
+        const curAt = (merged.__sync_updatedBy && merged.__sync_updatedBy.at) || 0;
+        if (!merged.__sync_updatedBy || mAt > curAt) merged.__sync_updatedBy = m.__sync_updatedBy;
+      }
+    });
+
+    return merged;
+  });
+
+  milestones = deduped;
+  save(KEYS.milestones, milestones);
+  return true;
+}
+
 // ─── Sync All Milestone Statuses (runs after every log entry) ───
 function syncMilestoneStatuses() {
+  // PR-β r1 hotfix: clean up duplicate text entries before find()-and-update
+  // loop. Without this, a stale 2nd "Social smiling" entry never gets touched
+  // and renders as a ghost in renderMilestoneList + renderActiveMilestones.
+  dedupeMilestonesByText();
+
   const allKeywords = [...new Set(EVIDENCE_PATTERNS.map(p => p.milestone))];
 
   allKeywords.forEach(keyword => {


### PR DESCRIPTION
## Summary

**Sovereign-floor catch on PR-α/β surface.** Production `milestones[]` array contains **7+ duplicate "Social smiling" entries** (and similar duplicates for other milestones), each with its own status/evidence-count snapshot. PR-β rolled up the Recent Evidence Feed surface, but the **Active Milestones + 5-stage milestoneList sections** still render every duplicate row, continuing to flood screen real estate.

## Root cause

Legacy data + cross-device sync races where `syncMilestoneStatuses` find() saw an empty/mid-flight array and pushed a fresh entry. find() always returns the FIRST match thereafter — duplicates persist as ghosts that never get touched by the auto-update loop, but every renderer iterates the full array.

## Fix

`dedupeMilestonesByText()` consolidates entries by case-insensitive trimmed text, conservatively merging:

| Field | Merge rule |
|-------|-----------|
| `status` / `autoStatus` | max stage rank (mastered > consistent > practicing > emerging > not_started) |
| `evidenceCount` / `confidenceHigh` | max |
| `firstSeen` | earliest non-null |
| `lastSeen` | latest non-null |
| `emergingAt`/`practicingAt`/`consistentAt`/`masteredAt`/`doneAt`/`inProgressAt` | earliest non-null per field |
| `manualStatus` + `manualAt` | latest `manualAt` wins (preserves user override semantically) |
| `advanced` | any-true wins |
| `cat` | first non-null |
| `__sync_updatedBy` | latest `at` timestamp wins |

## Hooks

- **`core.js` boot:** runs unconditionally after the existing evidence-based migration block. Cleans legacy duplicates from prior sync races on first load with new code.
- **`medical.js` `syncMilestoneStatuses`:** runs at top of the function. Defense-in-depth — catches future duplicates from cross-device sync rounds.

## Doctrine surfacing

**4th independent instance for `architectural-shift-PRs-bias-toward-r1-catch-cycle`** — counter sits at 3/3 RATIFICATION-ELIGIBLE post PR-α r1. This is sustainment evidence in a different shape:
- PR-α r1 = **data-shape gap** (consumer wired, producer not stamping)
- PR-β r1 = **data-integrity gap** (legacy duplicate state surfacing through correct-shape consumer)

Both are "the visible PR-α/β surface didn't fully address the data-side root cause" — Aurelius can fold this into the candidate ratification rationale on next chronicle.

## Hold-pending-Sovereign-real-device-verification

- [ ] Reload SproutLab (cache-bust via PR-43 syncReload)
- [ ] Milestones tab → "Social smiling" rows collapse to a single entry
- [ ] Single entry preserves: highest stage observed, max evidence count, earliest first-seen, latest last-seen, any manual override (most recent), all stage date stamps
- [ ] Active Milestones section: single "Social smiling" row instead of 5-7
- [ ] 5-stage milestoneList: single "Social smiling" milestone-item with progress bar at correct stage
- [ ] Cross-device: reload device B → deduped array propagates clean

## Test plan

- [x] Build clean (`bash build.sh > sproutlab.html`)
- [x] `dedupeMilestonesByText` returns false (no-op) when no duplicates exist — preserves existing array reference
- [x] Boot-time call only runs if `dedupeMilestonesByText` is defined (typeof guard handles concat-order edge cases)
- [ ] Real-device verification with current production duplicates
- [ ] Real-device verification: log a NEW activity → trigger syncMilestoneStatuses → no new duplicates spawn

— Lyra (lyra-stability-1)

---
_Generated by [Claude Code](https://claude.ai/code/session_011JhmDyFtAuQQyj1dtjyJCh)_