### PR TITLE
PR-β r2: post-receive migrate + dedupe hook for milestones (Bugs A+B)

### DIFF
--- a/index.html
+++ b/index.html
@@ -33929,6 +33929,32 @@ function checkEvidenceRegression(milestoneKeyword, currentAutoStatus) {
   return daysSince > 21;
 }
 
+// _postReceiveMilestones — PR-β r2 (cross-device receive hook). Called from
+// _syncDispatchRender after the listener has set milestones = remoteValue,
+// before renderer dispatch fires. Runs both:
+//   1. migrateMilestoneStatus per entry — repairs pre-Phase-3 enum values
+//      (status='done'/'in_progress'/'pending' → mastered/practicing/not_started)
+//      that arrive from devices running older code or stuck in legacy state.
+//   2. dedupeMilestonesByText — collapses duplicate text entries that arrive
+//      from cross-device sync races (one device pushes a fresh entry while
+//      another device's canonical entry is mid-flight).
+// Both functions save() locally if they made changes, which triggers autosave
+// to Firestore so the cleaned state propagates back. Convergent: once both
+// devices run this code, Firestore lands at deduped+migrated state.
+function _postReceiveMilestones() {
+  if (!Array.isArray(milestones)) return;
+  try {
+    if (typeof migrateMilestoneStatus === 'function') {
+      milestones.forEach(m => migrateMilestoneStatus(m));
+    }
+  } catch(e) { console.warn('[post-receive milestones] migrate:', e); }
+  try {
+    if (typeof dedupeMilestonesByText === 'function') {
+      dedupeMilestonesByText();
+    }
+  } catch(e) { console.warn('[post-receive milestones] dedupe:', e); }
+}
+
 // dedupeMilestonesByText — PR-β r1 hotfix (Sovereign-floor catch on PR-α/β):
 // the milestones array can accumulate duplicates with same text but different
 // status/evidence-count snapshots (legacy data + cross-device sync rounds
@@ -61614,7 +61640,7 @@ const SYNC_RENDER_DEPS = {
   // regression / timeline / recentEvidence / active / highlights stayed
   // stale on sync receive).
   [KEYS.activityLog]:       { global: 'activityLog', renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats', 'renderMilestoneHighlights', 'renderMilestoneList', 'renderCategoryWheels', 'renderRegressionAlerts', 'renderRecentEvidence', 'renderMilestoneTimeline', 'renderActiveMilestones'] } },
-  [KEYS.milestones]:        { global: 'milestones',  renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats', 'renderMilestoneHighlights', 'renderMilestoneList', 'renderCategoryWheels', 'renderRegressionAlerts', 'renderRecentEvidence', 'renderMilestoneTimeline', 'renderActiveMilestones'] } },
+  [KEYS.milestones]:        { global: 'milestones',  postReceive: '_postReceiveMilestones', renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats', 'renderMilestoneHighlights', 'renderMilestoneList', 'renderCategoryWheels', 'renderRegressionAlerts', 'renderRecentEvidence', 'renderMilestoneTimeline', 'renderActiveMilestones'] } },
   [KEYS.growth]:            { global: 'growthData',  renderers: { home: ['renderHome'], 'track:medical': ['renderGrowth'], growth: ['renderGrowthStats'] } },
   [KEYS.vacc]:              { global: 'vaccData',    renderers: { home: ['renderHome'], 'track:medical': ['renderVaccPastList'] } },
   [KEYS.vaccBooked]:        { global: null,          renderers: { home: ['renderHome'], 'track:medical': ['renderVaccPastList'] } },
@@ -61738,6 +61764,20 @@ function _syncDispatchRender(lsKey, value, attribution) {
   if (dep.global) {
     try { _syncSetGlobal(dep.global, value); }
     catch(e) { console.warn('[sync-dispatch] set-global ' + lsKey + ':', e); }
+  }
+  // (1.5) Post-receive hook (PR-β r2). Optional name-string in dep.postReceive
+  //       resolved via window[name] (same pattern as renderers — spy/stub
+  //       friendly, graceful runtime fallback). Use case: data migrations
+  //       (legacy enum repair) + integrity passes (dedupe by text) that need
+  //       to run AFTER the listener saved the raw remote value but BEFORE
+  //       renderers see it. The hook may save() the cleaned value, which
+  //       triggers autosave back to Firestore so cross-device sync converges
+  //       on the cleaned state.
+  if (dep.postReceive) {
+    try {
+      var hook = (typeof window !== 'undefined') ? window[dep.postReceive] : undefined;
+      if (typeof hook === 'function') hook();
+    } catch(e) { console.warn('[sync-dispatch] post-receive ' + lsKey + '/' + dep.postReceive + ':', e); }
   }
   // (2) Active-tab renderer dispatch (Finding C idiom). Renderers are name
   //     strings resolved via window[name] so spy-based tests work and a

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.06-8",
+  "version": "2026.05.06-9",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/medical.js
+++ b/split/medical.js
@@ -130,6 +130,32 @@ function checkEvidenceRegression(milestoneKeyword, currentAutoStatus) {
   return daysSince > 21;
 }
 
+// _postReceiveMilestones — PR-β r2 (cross-device receive hook). Called from
+// _syncDispatchRender after the listener has set milestones = remoteValue,
+// before renderer dispatch fires. Runs both:
+//   1. migrateMilestoneStatus per entry — repairs pre-Phase-3 enum values
+//      (status='done'/'in_progress'/'pending' → mastered/practicing/not_started)
+//      that arrive from devices running older code or stuck in legacy state.
+//   2. dedupeMilestonesByText — collapses duplicate text entries that arrive
+//      from cross-device sync races (one device pushes a fresh entry while
+//      another device's canonical entry is mid-flight).
+// Both functions save() locally if they made changes, which triggers autosave
+// to Firestore so the cleaned state propagates back. Convergent: once both
+// devices run this code, Firestore lands at deduped+migrated state.
+function _postReceiveMilestones() {
+  if (!Array.isArray(milestones)) return;
+  try {
+    if (typeof migrateMilestoneStatus === 'function') {
+      milestones.forEach(m => migrateMilestoneStatus(m));
+    }
+  } catch(e) { console.warn('[post-receive milestones] migrate:', e); }
+  try {
+    if (typeof dedupeMilestonesByText === 'function') {
+      dedupeMilestonesByText();
+    }
+  } catch(e) { console.warn('[post-receive milestones] dedupe:', e); }
+}
+
 // dedupeMilestonesByText — PR-β r1 hotfix (Sovereign-floor catch on PR-α/β):
 // the milestones array can accumulate duplicates with same text but different
 // status/evidence-count snapshots (legacy data + cross-device sync rounds

--- a/split/sync.js
+++ b/split/sync.js
@@ -209,7 +209,7 @@ const SYNC_RENDER_DEPS = {
   // regression / timeline / recentEvidence / active / highlights stayed
   // stale on sync receive).
   [KEYS.activityLog]:       { global: 'activityLog', renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats', 'renderMilestoneHighlights', 'renderMilestoneList', 'renderCategoryWheels', 'renderRegressionAlerts', 'renderRecentEvidence', 'renderMilestoneTimeline', 'renderActiveMilestones'] } },
-  [KEYS.milestones]:        { global: 'milestones',  renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats', 'renderMilestoneHighlights', 'renderMilestoneList', 'renderCategoryWheels', 'renderRegressionAlerts', 'renderRecentEvidence', 'renderMilestoneTimeline', 'renderActiveMilestones'] } },
+  [KEYS.milestones]:        { global: 'milestones',  postReceive: '_postReceiveMilestones', renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats', 'renderMilestoneHighlights', 'renderMilestoneList', 'renderCategoryWheels', 'renderRegressionAlerts', 'renderRecentEvidence', 'renderMilestoneTimeline', 'renderActiveMilestones'] } },
   [KEYS.growth]:            { global: 'growthData',  renderers: { home: ['renderHome'], 'track:medical': ['renderGrowth'], growth: ['renderGrowthStats'] } },
   [KEYS.vacc]:              { global: 'vaccData',    renderers: { home: ['renderHome'], 'track:medical': ['renderVaccPastList'] } },
   [KEYS.vaccBooked]:        { global: null,          renderers: { home: ['renderHome'], 'track:medical': ['renderVaccPastList'] } },
@@ -333,6 +333,20 @@ function _syncDispatchRender(lsKey, value, attribution) {
   if (dep.global) {
     try { _syncSetGlobal(dep.global, value); }
     catch(e) { console.warn('[sync-dispatch] set-global ' + lsKey + ':', e); }
+  }
+  // (1.5) Post-receive hook (PR-β r2). Optional name-string in dep.postReceive
+  //       resolved via window[name] (same pattern as renderers — spy/stub
+  //       friendly, graceful runtime fallback). Use case: data migrations
+  //       (legacy enum repair) + integrity passes (dedupe by text) that need
+  //       to run AFTER the listener saved the raw remote value but BEFORE
+  //       renderers see it. The hook may save() the cleaned value, which
+  //       triggers autosave back to Firestore so cross-device sync converges
+  //       on the cleaned state.
+  if (dep.postReceive) {
+    try {
+      var hook = (typeof window !== 'undefined') ? window[dep.postReceive] : undefined;
+      if (typeof hook === 'function') hook();
+    } catch(e) { console.warn('[sync-dispatch] post-receive ' + lsKey + '/' + dep.postReceive + ':', e); }
   }
   // (2) Active-tab renderer dispatch (Finding C idiom). Renderers are name
   //     strings resolved via window[name] so spy-based tests work and a

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -33929,6 +33929,32 @@ function checkEvidenceRegression(milestoneKeyword, currentAutoStatus) {
   return daysSince > 21;
 }
 
+// _postReceiveMilestones — PR-β r2 (cross-device receive hook). Called from
+// _syncDispatchRender after the listener has set milestones = remoteValue,
+// before renderer dispatch fires. Runs both:
+//   1. migrateMilestoneStatus per entry — repairs pre-Phase-3 enum values
+//      (status='done'/'in_progress'/'pending' → mastered/practicing/not_started)
+//      that arrive from devices running older code or stuck in legacy state.
+//   2. dedupeMilestonesByText — collapses duplicate text entries that arrive
+//      from cross-device sync races (one device pushes a fresh entry while
+//      another device's canonical entry is mid-flight).
+// Both functions save() locally if they made changes, which triggers autosave
+// to Firestore so the cleaned state propagates back. Convergent: once both
+// devices run this code, Firestore lands at deduped+migrated state.
+function _postReceiveMilestones() {
+  if (!Array.isArray(milestones)) return;
+  try {
+    if (typeof migrateMilestoneStatus === 'function') {
+      milestones.forEach(m => migrateMilestoneStatus(m));
+    }
+  } catch(e) { console.warn('[post-receive milestones] migrate:', e); }
+  try {
+    if (typeof dedupeMilestonesByText === 'function') {
+      dedupeMilestonesByText();
+    }
+  } catch(e) { console.warn('[post-receive milestones] dedupe:', e); }
+}
+
 // dedupeMilestonesByText — PR-β r1 hotfix (Sovereign-floor catch on PR-α/β):
 // the milestones array can accumulate duplicates with same text but different
 // status/evidence-count snapshots (legacy data + cross-device sync rounds
@@ -61614,7 +61640,7 @@ const SYNC_RENDER_DEPS = {
   // regression / timeline / recentEvidence / active / highlights stayed
   // stale on sync receive).
   [KEYS.activityLog]:       { global: 'activityLog', renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats', 'renderMilestoneHighlights', 'renderMilestoneList', 'renderCategoryWheels', 'renderRegressionAlerts', 'renderRecentEvidence', 'renderMilestoneTimeline', 'renderActiveMilestones'] } },
-  [KEYS.milestones]:        { global: 'milestones',  renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats', 'renderMilestoneHighlights', 'renderMilestoneList', 'renderCategoryWheels', 'renderRegressionAlerts', 'renderRecentEvidence', 'renderMilestoneTimeline', 'renderActiveMilestones'] } },
+  [KEYS.milestones]:        { global: 'milestones',  postReceive: '_postReceiveMilestones', renderers: { home: ['renderHome'], 'track:milestones': ['renderMilestoneStats', 'renderMilestoneHighlights', 'renderMilestoneList', 'renderCategoryWheels', 'renderRegressionAlerts', 'renderRecentEvidence', 'renderMilestoneTimeline', 'renderActiveMilestones'] } },
   [KEYS.growth]:            { global: 'growthData',  renderers: { home: ['renderHome'], 'track:medical': ['renderGrowth'], growth: ['renderGrowthStats'] } },
   [KEYS.vacc]:              { global: 'vaccData',    renderers: { home: ['renderHome'], 'track:medical': ['renderVaccPastList'] } },
   [KEYS.vaccBooked]:        { global: null,          renderers: { home: ['renderHome'], 'track:medical': ['renderVaccPastList'] } },
@@ -61738,6 +61764,20 @@ function _syncDispatchRender(lsKey, value, attribution) {
   if (dep.global) {
     try { _syncSetGlobal(dep.global, value); }
     catch(e) { console.warn('[sync-dispatch] set-global ' + lsKey + ':', e); }
+  }
+  // (1.5) Post-receive hook (PR-β r2). Optional name-string in dep.postReceive
+  //       resolved via window[name] (same pattern as renderers — spy/stub
+  //       friendly, graceful runtime fallback). Use case: data migrations
+  //       (legacy enum repair) + integrity passes (dedupe by text) that need
+  //       to run AFTER the listener saved the raw remote value but BEFORE
+  //       renderers see it. The hook may save() the cleaned value, which
+  //       triggers autosave back to Firestore so cross-device sync converges
+  //       on the cleaned state.
+  if (dep.postReceive) {
+    try {
+      var hook = (typeof window !== 'undefined') ? window[dep.postReceive] : undefined;
+      if (typeof hook === 'function') hook();
+    } catch(e) { console.warn('[sync-dispatch] post-receive ' + lsKey + '/' + dep.postReceive + ':', e); }
   }
   // (2) Active-tab renderer dispatch (Finding C idiom). Renderers are name
   //     strings resolved via window[name] so spy-based tests work and a


### PR DESCRIPTION
## Summary

Sovereign-floor catches on PR-β r1 (#48). Database audit (governors Maren + Kael with ziva backup 2026-05-06) revealed:

**Bug A** — 1 "Social smiling" duplicate survived dedup. Entry [0] = user-edited canonical (`manualStatus: mastered` + full April date stamps). Entry [39] = bare auto-detect created TODAY (`masteredAt: 2026-05-06`, no other stamps). Means a fresh duplicate spawned post PR-48 merge.

**Bug B** — 2 entries persist with pre-Phase-3 status enum:
- `[32] "Responds to own name" status='done'`
- `[33] 'Says "mama" or "dada" (non-specific)' status='in_progress'`

Phase 3 enum is `mastered/consistent/practicing/emerging/not_started`. `migrateMilestoneStatus` exists (medical.js:406) and runs at boot (core.js:781), but legacy entries keep arriving in stale shape.

## Unified root cause

**Cross-device sync receive doesn't re-run data-shape repairs that boot-time migrations apply locally.** When the listener fires:
1. Saves raw remote value to localStorage
2. Calls `_syncDispatchRender` → `_syncSetGlobal` → `milestones = remoteValue`
3. Renderers fire on the raw remote value

Step 2.5 was missing: there's no hook to run migrations / integrity passes between rebind and render. Boot-time migrations only fire once on initial load — subsequent cross-device receives bypass them entirely.

## Fix

**Add a generic `postReceive: '<fn-name-string>'` field to `SYNC_RENDER_DEPS` entries.** Mirrors the existing `renderers: ['name1', 'name2']` pattern — name-string resolution via `window[name]` (Cipher surfacing #2: spy/stub-friendly, graceful runtime fallback for renamed handlers).

`_syncDispatchRender` invokes the post-receive hook AFTER `_syncSetGlobal` rebinds the module global but BEFORE renderers fire. Renderers always see migrated + deduped state.

**`_postReceiveMilestones()` (new in medical.js)** orchestrates:
1. `migrateMilestoneStatus` per entry — repairs legacy enum values
2. `dedupeMilestonesByText` — collapses duplicates by trimmed lowercase text

Both helpers save() locally if they made changes, which triggers autosave back to Firestore. **Convergent:** once both devices run new code, Firestore lands at deduped + migrated state within 1-2 sync cycles.

**`SYNC_RENDER_DEPS[KEYS.milestones]`** gets `postReceive: '_postReceiveMilestones'`.

## Why declarative not inline

Path C narrow-scope tension considered: an inline `if (lsKey === KEYS.milestones)` check in `_syncDispatchRender` would be 5 lines smaller. Chose the declarative approach because:
- Pattern consistency with existing `renderers` field (Cipher surfacing #2)
- Future migrations (medChecks/feedingData object-keyed shape) can declare their own `postReceive` hooks without further dispatch-function edits
- Optional field — non-milestones entries pass through unchanged (verified: no behavioral change for any other key)

## Doctrine surfacing

**5th independent r1 instance for `architectural-shift-PRs-bias-toward-r1-catch-cycle`** — sustained beyond the 3/3 ratification threshold. PR-β r2 closes the same root-cause class as PR-α r1: **cross-device sync receive doesn't re-run data-shape repairs that boot-time migrations apply locally.** The `postReceive` hook is the architectural addition that closes this gap generally.

| r1 instance | Root cause shape |
|---|---|
| PR-α r1 (#46) | Producer-side stamp gap (consumer wired, _syncStampUnattributed didn't walk object-keyed) |
| PR-β r1 (#48) | Data-integrity gap (legacy duplicates surfacing through correct-shape consumer) |
| **PR-β r2 (this)** | **Receive-side migration gap (boot-time repairs don't re-run on cross-device receive)** |

## Audit findings beyond Bugs A+B (deferred to future PRs)

| Bug | Description | Defer reason |
|---|---|---|
| C | vacc array 0/27 stamped despite array-shape | Investigation needed; lower urgency (no UI surface for vacc attribution today) |
| D | scrapbook + episode arrays 0% stamped | Same as C; never-touched-since-stamp-was-added |
| E | medChecks + feeding object-keyed unstamped | Phase 4 carry-forward (next planned Stability piece) |
| F | `ziva_power_outage: true` stuck flag? | Need to trace setter/clearer |
| G | `alerts_history: 200` (at cap) | Verify rolling cap enforcement |
| H | `ql_predictions: 126` no obvious cap | Unbounded-growth risk |

## Hold-pending-Sovereign-real-device-verification

Per RATIFIED `hermetic-floor-doesnt-substitute-for-production-floor`:
- [ ] Reload SproutLab → milestones tab → "Social smiling" duplicates collapse to single entry on receive
- [ ] "Responds to own name" migrates from `done` → `mastered` (date stamps preserved via migrateMilestoneStatus mapping)
- [ ] 'Says "mama" or "dada"' migrates from `in_progress` → `practicing`
- [ ] Cross-device: device B receives device A's clean state; renderer displays clean
- [ ] Autosave loop: dedupe save → flush → Firestore receives → no infinite loop (verified by hasDups guard in dedupeMilestonesByText returning false on no-op iterations)

— Lyra (lyra-stability-1)

---
_Generated by [Claude Code](https://claude.ai/code/session_011JhmDyFtAuQQyj1dtjyJCh)_