### PR TITLE
PR-γ: Edit/Delete on activity entries + deleteMilestone fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -5487,6 +5487,13 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 .al-feed-rollup-when { font-size:var(--fs-2xs); color:var(--light); font-weight:600; }
 .al-feed-rollup-text { font-size:var(--fs-sm); color:var(--text); margin-top:var(--sp-2); }
 
+/* PR-γ: Edit / Delete affordances on activity-log entries */
+.al-feed-actions { display:flex; gap:var(--sp-4); margin-top:var(--sp-4); align-items:center; }
+.al-feed-action-btn { font-size:var(--fs-2xs); padding:var(--sp-2) var(--sp-6); border-radius:var(--r-sm); background:transparent; color:var(--light); border:1px solid var(--border-subtle); cursor:pointer; line-height:1; }
+.al-feed-action-btn:hover { background:var(--warm); color:var(--text); }
+.al-feed-action-btn.al-feed-del { color:var(--tc-rose); }
+.al-feed-action-btn.al-feed-del:hover { background:var(--surface-rose); }
+
 /* ── Activity Intelligence Cards ── */
 .ai-dot-cal { display:grid; grid-template-columns:repeat(7, 1fr); gap:var(--sp-2); margin:var(--sp-8) 0; }
 .ai-dot { width:100%; aspect-ratio:1; border-radius:var(--r-sm); background:var(--warm); transition:background var(--ease-fast); }
@@ -15882,6 +15889,10 @@ function init() {
     else if (action === 'editDoctor') editDoctor(parseInt(arg));
     else if (action === 'openVaccEditModal') openVaccEditModal(arg);
     else if (action === 'deleteMilestone') deleteMilestone(arg);
+    else if (action === 'deleteActivityEntry') { const args = arg.split(',').map(s => s.trim()); deleteActivityEntry(args[0], args[1]); }
+    else if (action === 'editActivityEntry') { const args = arg.split(',').map(s => s.trim()); editActivityEntry(args[0], args[1]); }
+    else if (action === 'closeActivityEdit') closeActivityEdit();
+    else if (action === 'saveActivityEdit') { const args = arg.split(',').map(s => s.trim()); saveActivityEdit(args[0], args[1]); }
     else if (action === 'deleteNote') deleteNote(parseInt(arg));
     else if (action === 'toggleNote') toggleNote(parseInt(arg));
     else if (action === 'clearNotePhoto') clearNotePhoto(parseInt(arg));
@@ -22013,7 +22024,7 @@ function renderMilestoneList() {
               <div class="milestone-actions">
                 ${nextStage ? `<button class="ms-action-btn" data-action="overrideMilestoneStatus" data-stop="1" data-arg="${m._i},'${nextStage}'" aria-label="Override to ${escAttr(nextMeta.label)}" title="Override: ${escAttr(nextMeta.label)}">Edit ${escHtml(nextMeta.label)}</button>` : ''}
                 ${prevStage ? `<button class="ms-action-btn" data-action="overrideMilestoneStatus" data-stop="1" data-arg="${m._i},'${prevStage}'" aria-label="Move back">↩</button>` : ''}
-                <button class="ms-action-btn del-ms" data-action="deleteMilestone" data-stop="1" data-arg="${m._i})" aria-label="Delete milestone">×</button>
+                <button class="ms-action-btn del-ms" data-action="deleteMilestone" data-stop="1" data-arg="${m._i}" aria-label="Delete milestone">×</button>
               </div>
             </div>
             ${progressHtml}
@@ -22273,9 +22284,16 @@ function logMilestoneEvent(text, stage, date) {
 
 // ageAtDate, daysBetween → migrated to core.js
 function deleteMilestone(i) {
+  // PR-γ: data-action dispatcher passes arg as string; coerce to integer.
+  // Pre-fix data-arg had a stray trailing ')' that made parseInt yield NaN
+  // → splice(NaN, 1) treated start=0 → ALWAYS deleted milestones[0] regardless
+  // of which × button was clicked. Now data-arg is the bare index string.
+  const idx = typeof i === 'number' ? i : parseInt(i, 10);
+  if (!Number.isInteger(idx) || idx < 0 || idx >= milestones.length) return;
   const expandedMsCats = [];
   document.querySelectorAll('.ms-cat-items.open').forEach(el => expandedMsCats.push(el.id));
-  milestones.splice(i,1);
+  milestones.splice(idx, 1);
+  save(KEYS.milestones, milestones);
   renderMilestones();
   renderUpcomingMilestones();
   expandedMsCats.forEach(id => {
@@ -22606,10 +22624,15 @@ function renderRecentEvidence() {
         const dStr = o.dateStr;
         const dLabel = dStr === todayStr ? 'Today' : dStr === yesterdayStr ? 'Yesterday' : formatDate(dStr);
         const tStr = e.ts ? new Date(e.ts).toLocaleTimeString('en-IN', { hour: '2-digit', minute: '2-digit' }) : '';
+        const actBtns = e.id ? '<div class="al-feed-actions">' +
+          '<button class="al-feed-action-btn" data-action="editActivityEntry" data-arg="' + dStr + ',' + e.id + '" data-stop="1" aria-label="Edit entry">Edit</button>' +
+          '<button class="al-feed-action-btn al-feed-del" data-action="deleteActivityEntry" data-arg="' + dStr + ',' + e.id + '" data-stop="1" aria-label="Delete entry">×</button>' +
+          '</div>' : '';
         html += '<div class="al-feed-rollup-entry">' +
           '<div class="al-feed-rollup-when">' + dLabel + (tStr ? ' · ' + tStr : '') + '</div>' +
           '<div class="al-feed-rollup-text">' + escHtml(e.text) + '</div>' +
           _renderAttribution(e) +
+          actBtns +
           '</div>';
       });
       html += '</div>';
@@ -22652,12 +22675,17 @@ function renderRecentEvidence() {
       const evidCount = (e.evidence || []).length;
       const timeStr = e.ts ? new Date(e.ts).toLocaleTimeString('en-IN', { hour: '2-digit', minute: '2-digit' }) : '';
       const durStr = e.duration ? e.duration + ' min' : 'obs';
+      const actBtns = e.id ? '<div class="al-feed-actions">' +
+        '<button class="al-feed-action-btn" data-action="editActivityEntry" data-arg="' + dateStr + ',' + e.id + '" data-stop="1" aria-label="Edit entry">Edit</button>' +
+        '<button class="al-feed-action-btn al-feed-del" data-action="deleteActivityEntry" data-arg="' + dateStr + ',' + e.id + '" data-stop="1" aria-label="Delete entry">×</button>' +
+        '</div>' : '';
       html += '<div class="al-feed-entry">' +
         '<div class="al-feed-time">' + timeStr + '</div>' +
         '<div class="al-feed-body">' +
           '<div class="al-feed-text">' + escHtml(e.text) + '</div>' +
           '<div class="al-feed-chips">' + domainChips + '</div>' +
           _renderAttribution(e) +
+          actBtns +
         '</div>' +
         '<div class="al-feed-meta">' + durStr + ' · ' + evidCount + ' ev</div>' +
       '</div>';
@@ -22667,6 +22695,97 @@ function renderRecentEvidence() {
   });
 
   feedEl.innerHTML = html;
+}
+
+// ── PR-γ: Edit / Delete affordances on activity-log entries ──
+// User can fix typos / wrong durations on logged activities + observations,
+// or remove erroneous entries. Re-runs classifyActivity on edited text so
+// detected domains / evidence keywords stay aligned with the current text.
+
+function deleteActivityEntry(dateStr, entryId) {
+  if (!dateStr || !entryId) return;
+  if (!activityLog[dateStr]) return;
+  confirmAction('Delete this entry? Milestone evidence will be recomputed.', () => {
+    const idx = activityLog[dateStr].findIndex(e => e && e.id === entryId);
+    if (idx < 0) return;
+    activityLog[dateStr].splice(idx, 1);
+    if (activityLog[dateStr].length === 0) delete activityLog[dateStr];
+    save(KEYS.activityLog, activityLog);
+    if (typeof syncMilestoneStatuses === 'function') syncMilestoneStatuses();
+    if (typeof renderMilestones === 'function') renderMilestones();
+    if (typeof renderHomeActivity === 'function') renderHomeActivity();
+  });
+}
+
+function editActivityEntry(dateStr, entryId) {
+  if (!dateStr || !entryId) return;
+  if (!activityLog[dateStr]) return;
+  const entry = activityLog[dateStr].find(e => e && e.id === entryId);
+  if (!entry) return;
+
+  const isActivity = entry.type === 'activity' || !!entry.duration;
+  const overlay = document.createElement('div');
+  overlay.className = 'confirm-overlay';
+  overlay.id = 'activityEditOverlay';
+  overlay.innerHTML =
+    '<div class="modal" style="max-width:420px;">' +
+      '<h3>Edit ' + (isActivity ? 'Activity' : 'Observation') + '</h3>' +
+      '<label class="micro-label">Description</label>' +
+      '<textarea id="actEditText" class="form-input" rows="3" style="width:100%;margin-bottom:var(--sp-8);">' + escHtml(entry.text || '') + '</textarea>' +
+      (isActivity
+        ? '<label class="micro-label">Duration (minutes)</label>' +
+          '<input id="actEditDuration" type="number" class="form-input" min="0" value="' + (entry.duration || '') + '" style="width:100%;margin-bottom:var(--sp-8);">'
+        : '') +
+      '<div class="modal-btns" style="display:flex;gap:var(--sp-8);justify-content:flex-end;">' +
+        '<button class="btn btn-ghost" data-action="closeActivityEdit">Cancel</button>' +
+        '<button class="btn btn-primary" data-action="saveActivityEdit" data-arg="' + dateStr + ',' + entryId + '">Save</button>' +
+      '</div>' +
+    '</div>';
+  overlay.addEventListener('click', e => { if (e.target === overlay) overlay.remove(); });
+  document.body.appendChild(overlay);
+  setTimeout(() => { const ta = document.getElementById('actEditText'); if (ta) ta.focus(); }, 50);
+}
+
+function closeActivityEdit() {
+  const overlay = document.getElementById('activityEditOverlay');
+  if (overlay) overlay.remove();
+}
+
+function saveActivityEdit(dateStr, entryId) {
+  if (!dateStr || !entryId) { closeActivityEdit(); return; }
+  if (!activityLog[dateStr]) { closeActivityEdit(); return; }
+  const entry = activityLog[dateStr].find(e => e && e.id === entryId);
+  if (!entry) { closeActivityEdit(); return; }
+
+  const ta = document.getElementById('actEditText');
+  const newText = ta ? (ta.value || '').trim() : '';
+  if (!newText) { closeActivityEdit(); return; }
+  entry.text = newText;
+
+  const durEl = document.getElementById('actEditDuration');
+  if (durEl) {
+    const dur = parseInt(durEl.value, 10);
+    entry.duration = (Number.isFinite(dur) && dur > 0) ? dur : null;
+    entry.type = entry.duration ? 'activity' : 'observation';
+  }
+
+  // Re-run evidence classifier on the new text so detected domains/evidence
+  // keywords stay aligned. Falls back gracefully if classifier missing.
+  if (typeof classifyActivity === 'function') {
+    try {
+      const c = classifyActivity(entry.text);
+      if (c) {
+        entry.domains = c.domains || [];
+        entry.evidence = c.evidence || [];
+      }
+    } catch(e) { console.warn('[edit-activity] classify:', e); }
+  }
+
+  save(KEYS.activityLog, activityLog);
+  if (typeof syncMilestoneStatuses === 'function') syncMilestoneStatuses();
+  closeActivityEdit();
+  if (typeof renderMilestones === 'function') renderMilestones();
+  if (typeof renderHomeActivity === 'function') renderHomeActivity();
 }
 
 // ─────────────────────────────────────────

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.06-9",
+  "version": "2026.05.06-10",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -442,6 +442,10 @@ function init() {
     else if (action === 'editDoctor') editDoctor(parseInt(arg));
     else if (action === 'openVaccEditModal') openVaccEditModal(arg);
     else if (action === 'deleteMilestone') deleteMilestone(arg);
+    else if (action === 'deleteActivityEntry') { const args = arg.split(',').map(s => s.trim()); deleteActivityEntry(args[0], args[1]); }
+    else if (action === 'editActivityEntry') { const args = arg.split(',').map(s => s.trim()); editActivityEntry(args[0], args[1]); }
+    else if (action === 'closeActivityEdit') closeActivityEdit();
+    else if (action === 'saveActivityEdit') { const args = arg.split(',').map(s => s.trim()); saveActivityEdit(args[0], args[1]); }
     else if (action === 'deleteNote') deleteNote(parseInt(arg));
     else if (action === 'toggleNote') toggleNote(parseInt(arg));
     else if (action === 'clearNotePhoto') clearNotePhoto(parseInt(arg));

--- a/split/home.js
+++ b/split/home.js
@@ -1608,7 +1608,7 @@ function renderMilestoneList() {
               <div class="milestone-actions">
                 ${nextStage ? `<button class="ms-action-btn" data-action="overrideMilestoneStatus" data-stop="1" data-arg="${m._i},'${nextStage}'" aria-label="Override to ${escAttr(nextMeta.label)}" title="Override: ${escAttr(nextMeta.label)}">Edit ${escHtml(nextMeta.label)}</button>` : ''}
                 ${prevStage ? `<button class="ms-action-btn" data-action="overrideMilestoneStatus" data-stop="1" data-arg="${m._i},'${prevStage}'" aria-label="Move back">↩</button>` : ''}
-                <button class="ms-action-btn del-ms" data-action="deleteMilestone" data-stop="1" data-arg="${m._i})" aria-label="Delete milestone">×</button>
+                <button class="ms-action-btn del-ms" data-action="deleteMilestone" data-stop="1" data-arg="${m._i}" aria-label="Delete milestone">×</button>
               </div>
             </div>
             ${progressHtml}
@@ -1868,9 +1868,16 @@ function logMilestoneEvent(text, stage, date) {
 
 // ageAtDate, daysBetween → migrated to core.js
 function deleteMilestone(i) {
+  // PR-γ: data-action dispatcher passes arg as string; coerce to integer.
+  // Pre-fix data-arg had a stray trailing ')' that made parseInt yield NaN
+  // → splice(NaN, 1) treated start=0 → ALWAYS deleted milestones[0] regardless
+  // of which × button was clicked. Now data-arg is the bare index string.
+  const idx = typeof i === 'number' ? i : parseInt(i, 10);
+  if (!Number.isInteger(idx) || idx < 0 || idx >= milestones.length) return;
   const expandedMsCats = [];
   document.querySelectorAll('.ms-cat-items.open').forEach(el => expandedMsCats.push(el.id));
-  milestones.splice(i,1);
+  milestones.splice(idx, 1);
+  save(KEYS.milestones, milestones);
   renderMilestones();
   renderUpcomingMilestones();
   expandedMsCats.forEach(id => {
@@ -2201,10 +2208,15 @@ function renderRecentEvidence() {
         const dStr = o.dateStr;
         const dLabel = dStr === todayStr ? 'Today' : dStr === yesterdayStr ? 'Yesterday' : formatDate(dStr);
         const tStr = e.ts ? new Date(e.ts).toLocaleTimeString('en-IN', { hour: '2-digit', minute: '2-digit' }) : '';
+        const actBtns = e.id ? '<div class="al-feed-actions">' +
+          '<button class="al-feed-action-btn" data-action="editActivityEntry" data-arg="' + dStr + ',' + e.id + '" data-stop="1" aria-label="Edit entry">Edit</button>' +
+          '<button class="al-feed-action-btn al-feed-del" data-action="deleteActivityEntry" data-arg="' + dStr + ',' + e.id + '" data-stop="1" aria-label="Delete entry">×</button>' +
+          '</div>' : '';
         html += '<div class="al-feed-rollup-entry">' +
           '<div class="al-feed-rollup-when">' + dLabel + (tStr ? ' · ' + tStr : '') + '</div>' +
           '<div class="al-feed-rollup-text">' + escHtml(e.text) + '</div>' +
           _renderAttribution(e) +
+          actBtns +
           '</div>';
       });
       html += '</div>';
@@ -2247,12 +2259,17 @@ function renderRecentEvidence() {
       const evidCount = (e.evidence || []).length;
       const timeStr = e.ts ? new Date(e.ts).toLocaleTimeString('en-IN', { hour: '2-digit', minute: '2-digit' }) : '';
       const durStr = e.duration ? e.duration + ' min' : 'obs';
+      const actBtns = e.id ? '<div class="al-feed-actions">' +
+        '<button class="al-feed-action-btn" data-action="editActivityEntry" data-arg="' + dateStr + ',' + e.id + '" data-stop="1" aria-label="Edit entry">Edit</button>' +
+        '<button class="al-feed-action-btn al-feed-del" data-action="deleteActivityEntry" data-arg="' + dateStr + ',' + e.id + '" data-stop="1" aria-label="Delete entry">×</button>' +
+        '</div>' : '';
       html += '<div class="al-feed-entry">' +
         '<div class="al-feed-time">' + timeStr + '</div>' +
         '<div class="al-feed-body">' +
           '<div class="al-feed-text">' + escHtml(e.text) + '</div>' +
           '<div class="al-feed-chips">' + domainChips + '</div>' +
           _renderAttribution(e) +
+          actBtns +
         '</div>' +
         '<div class="al-feed-meta">' + durStr + ' · ' + evidCount + ' ev</div>' +
       '</div>';
@@ -2262,6 +2279,97 @@ function renderRecentEvidence() {
   });
 
   feedEl.innerHTML = html;
+}
+
+// ── PR-γ: Edit / Delete affordances on activity-log entries ──
+// User can fix typos / wrong durations on logged activities + observations,
+// or remove erroneous entries. Re-runs classifyActivity on edited text so
+// detected domains / evidence keywords stay aligned with the current text.
+
+function deleteActivityEntry(dateStr, entryId) {
+  if (!dateStr || !entryId) return;
+  if (!activityLog[dateStr]) return;
+  confirmAction('Delete this entry? Milestone evidence will be recomputed.', () => {
+    const idx = activityLog[dateStr].findIndex(e => e && e.id === entryId);
+    if (idx < 0) return;
+    activityLog[dateStr].splice(idx, 1);
+    if (activityLog[dateStr].length === 0) delete activityLog[dateStr];
+    save(KEYS.activityLog, activityLog);
+    if (typeof syncMilestoneStatuses === 'function') syncMilestoneStatuses();
+    if (typeof renderMilestones === 'function') renderMilestones();
+    if (typeof renderHomeActivity === 'function') renderHomeActivity();
+  });
+}
+
+function editActivityEntry(dateStr, entryId) {
+  if (!dateStr || !entryId) return;
+  if (!activityLog[dateStr]) return;
+  const entry = activityLog[dateStr].find(e => e && e.id === entryId);
+  if (!entry) return;
+
+  const isActivity = entry.type === 'activity' || !!entry.duration;
+  const overlay = document.createElement('div');
+  overlay.className = 'confirm-overlay';
+  overlay.id = 'activityEditOverlay';
+  overlay.innerHTML =
+    '<div class="modal" style="max-width:420px;">' +
+      '<h3>Edit ' + (isActivity ? 'Activity' : 'Observation') + '</h3>' +
+      '<label class="micro-label">Description</label>' +
+      '<textarea id="actEditText" class="form-input" rows="3" style="width:100%;margin-bottom:var(--sp-8);">' + escHtml(entry.text || '') + '</textarea>' +
+      (isActivity
+        ? '<label class="micro-label">Duration (minutes)</label>' +
+          '<input id="actEditDuration" type="number" class="form-input" min="0" value="' + (entry.duration || '') + '" style="width:100%;margin-bottom:var(--sp-8);">'
+        : '') +
+      '<div class="modal-btns" style="display:flex;gap:var(--sp-8);justify-content:flex-end;">' +
+        '<button class="btn btn-ghost" data-action="closeActivityEdit">Cancel</button>' +
+        '<button class="btn btn-primary" data-action="saveActivityEdit" data-arg="' + dateStr + ',' + entryId + '">Save</button>' +
+      '</div>' +
+    '</div>';
+  overlay.addEventListener('click', e => { if (e.target === overlay) overlay.remove(); });
+  document.body.appendChild(overlay);
+  setTimeout(() => { const ta = document.getElementById('actEditText'); if (ta) ta.focus(); }, 50);
+}
+
+function closeActivityEdit() {
+  const overlay = document.getElementById('activityEditOverlay');
+  if (overlay) overlay.remove();
+}
+
+function saveActivityEdit(dateStr, entryId) {
+  if (!dateStr || !entryId) { closeActivityEdit(); return; }
+  if (!activityLog[dateStr]) { closeActivityEdit(); return; }
+  const entry = activityLog[dateStr].find(e => e && e.id === entryId);
+  if (!entry) { closeActivityEdit(); return; }
+
+  const ta = document.getElementById('actEditText');
+  const newText = ta ? (ta.value || '').trim() : '';
+  if (!newText) { closeActivityEdit(); return; }
+  entry.text = newText;
+
+  const durEl = document.getElementById('actEditDuration');
+  if (durEl) {
+    const dur = parseInt(durEl.value, 10);
+    entry.duration = (Number.isFinite(dur) && dur > 0) ? dur : null;
+    entry.type = entry.duration ? 'activity' : 'observation';
+  }
+
+  // Re-run evidence classifier on the new text so detected domains/evidence
+  // keywords stay aligned. Falls back gracefully if classifier missing.
+  if (typeof classifyActivity === 'function') {
+    try {
+      const c = classifyActivity(entry.text);
+      if (c) {
+        entry.domains = c.domains || [];
+        entry.evidence = c.evidence || [];
+      }
+    } catch(e) { console.warn('[edit-activity] classify:', e); }
+  }
+
+  save(KEYS.activityLog, activityLog);
+  if (typeof syncMilestoneStatuses === 'function') syncMilestoneStatuses();
+  closeActivityEdit();
+  if (typeof renderMilestones === 'function') renderMilestones();
+  if (typeof renderHomeActivity === 'function') renderHomeActivity();
 }
 
 // ─────────────────────────────────────────

--- a/split/styles.css
+++ b/split/styles.css
@@ -5480,6 +5480,13 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 .al-feed-rollup-when { font-size:var(--fs-2xs); color:var(--light); font-weight:600; }
 .al-feed-rollup-text { font-size:var(--fs-sm); color:var(--text); margin-top:var(--sp-2); }
 
+/* PR-γ: Edit / Delete affordances on activity-log entries */
+.al-feed-actions { display:flex; gap:var(--sp-4); margin-top:var(--sp-4); align-items:center; }
+.al-feed-action-btn { font-size:var(--fs-2xs); padding:var(--sp-2) var(--sp-6); border-radius:var(--r-sm); background:transparent; color:var(--light); border:1px solid var(--border-subtle); cursor:pointer; line-height:1; }
+.al-feed-action-btn:hover { background:var(--warm); color:var(--text); }
+.al-feed-action-btn.al-feed-del { color:var(--tc-rose); }
+.al-feed-action-btn.al-feed-del:hover { background:var(--surface-rose); }
+
 /* ── Activity Intelligence Cards ── */
 .ai-dot-cal { display:grid; grid-template-columns:repeat(7, 1fr); gap:var(--sp-2); margin:var(--sp-8) 0; }
 .ai-dot { width:100%; aspect-ratio:1; border-radius:var(--r-sm); background:var(--warm); transition:background var(--ease-fast); }

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -5487,6 +5487,13 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 .al-feed-rollup-when { font-size:var(--fs-2xs); color:var(--light); font-weight:600; }
 .al-feed-rollup-text { font-size:var(--fs-sm); color:var(--text); margin-top:var(--sp-2); }
 
+/* PR-γ: Edit / Delete affordances on activity-log entries */
+.al-feed-actions { display:flex; gap:var(--sp-4); margin-top:var(--sp-4); align-items:center; }
+.al-feed-action-btn { font-size:var(--fs-2xs); padding:var(--sp-2) var(--sp-6); border-radius:var(--r-sm); background:transparent; color:var(--light); border:1px solid var(--border-subtle); cursor:pointer; line-height:1; }
+.al-feed-action-btn:hover { background:var(--warm); color:var(--text); }
+.al-feed-action-btn.al-feed-del { color:var(--tc-rose); }
+.al-feed-action-btn.al-feed-del:hover { background:var(--surface-rose); }
+
 /* ── Activity Intelligence Cards ── */
 .ai-dot-cal { display:grid; grid-template-columns:repeat(7, 1fr); gap:var(--sp-2); margin:var(--sp-8) 0; }
 .ai-dot { width:100%; aspect-ratio:1; border-radius:var(--r-sm); background:var(--warm); transition:background var(--ease-fast); }
@@ -15882,6 +15889,10 @@ function init() {
     else if (action === 'editDoctor') editDoctor(parseInt(arg));
     else if (action === 'openVaccEditModal') openVaccEditModal(arg);
     else if (action === 'deleteMilestone') deleteMilestone(arg);
+    else if (action === 'deleteActivityEntry') { const args = arg.split(',').map(s => s.trim()); deleteActivityEntry(args[0], args[1]); }
+    else if (action === 'editActivityEntry') { const args = arg.split(',').map(s => s.trim()); editActivityEntry(args[0], args[1]); }
+    else if (action === 'closeActivityEdit') closeActivityEdit();
+    else if (action === 'saveActivityEdit') { const args = arg.split(',').map(s => s.trim()); saveActivityEdit(args[0], args[1]); }
     else if (action === 'deleteNote') deleteNote(parseInt(arg));
     else if (action === 'toggleNote') toggleNote(parseInt(arg));
     else if (action === 'clearNotePhoto') clearNotePhoto(parseInt(arg));
@@ -22013,7 +22024,7 @@ function renderMilestoneList() {
               <div class="milestone-actions">
                 ${nextStage ? `<button class="ms-action-btn" data-action="overrideMilestoneStatus" data-stop="1" data-arg="${m._i},'${nextStage}'" aria-label="Override to ${escAttr(nextMeta.label)}" title="Override: ${escAttr(nextMeta.label)}">Edit ${escHtml(nextMeta.label)}</button>` : ''}
                 ${prevStage ? `<button class="ms-action-btn" data-action="overrideMilestoneStatus" data-stop="1" data-arg="${m._i},'${prevStage}'" aria-label="Move back">↩</button>` : ''}
-                <button class="ms-action-btn del-ms" data-action="deleteMilestone" data-stop="1" data-arg="${m._i})" aria-label="Delete milestone">×</button>
+                <button class="ms-action-btn del-ms" data-action="deleteMilestone" data-stop="1" data-arg="${m._i}" aria-label="Delete milestone">×</button>
               </div>
             </div>
             ${progressHtml}
@@ -22273,9 +22284,16 @@ function logMilestoneEvent(text, stage, date) {
 
 // ageAtDate, daysBetween → migrated to core.js
 function deleteMilestone(i) {
+  // PR-γ: data-action dispatcher passes arg as string; coerce to integer.
+  // Pre-fix data-arg had a stray trailing ')' that made parseInt yield NaN
+  // → splice(NaN, 1) treated start=0 → ALWAYS deleted milestones[0] regardless
+  // of which × button was clicked. Now data-arg is the bare index string.
+  const idx = typeof i === 'number' ? i : parseInt(i, 10);
+  if (!Number.isInteger(idx) || idx < 0 || idx >= milestones.length) return;
   const expandedMsCats = [];
   document.querySelectorAll('.ms-cat-items.open').forEach(el => expandedMsCats.push(el.id));
-  milestones.splice(i,1);
+  milestones.splice(idx, 1);
+  save(KEYS.milestones, milestones);
   renderMilestones();
   renderUpcomingMilestones();
   expandedMsCats.forEach(id => {
@@ -22606,10 +22624,15 @@ function renderRecentEvidence() {
         const dStr = o.dateStr;
         const dLabel = dStr === todayStr ? 'Today' : dStr === yesterdayStr ? 'Yesterday' : formatDate(dStr);
         const tStr = e.ts ? new Date(e.ts).toLocaleTimeString('en-IN', { hour: '2-digit', minute: '2-digit' }) : '';
+        const actBtns = e.id ? '<div class="al-feed-actions">' +
+          '<button class="al-feed-action-btn" data-action="editActivityEntry" data-arg="' + dStr + ',' + e.id + '" data-stop="1" aria-label="Edit entry">Edit</button>' +
+          '<button class="al-feed-action-btn al-feed-del" data-action="deleteActivityEntry" data-arg="' + dStr + ',' + e.id + '" data-stop="1" aria-label="Delete entry">×</button>' +
+          '</div>' : '';
         html += '<div class="al-feed-rollup-entry">' +
           '<div class="al-feed-rollup-when">' + dLabel + (tStr ? ' · ' + tStr : '') + '</div>' +
           '<div class="al-feed-rollup-text">' + escHtml(e.text) + '</div>' +
           _renderAttribution(e) +
+          actBtns +
           '</div>';
       });
       html += '</div>';
@@ -22652,12 +22675,17 @@ function renderRecentEvidence() {
       const evidCount = (e.evidence || []).length;
       const timeStr = e.ts ? new Date(e.ts).toLocaleTimeString('en-IN', { hour: '2-digit', minute: '2-digit' }) : '';
       const durStr = e.duration ? e.duration + ' min' : 'obs';
+      const actBtns = e.id ? '<div class="al-feed-actions">' +
+        '<button class="al-feed-action-btn" data-action="editActivityEntry" data-arg="' + dateStr + ',' + e.id + '" data-stop="1" aria-label="Edit entry">Edit</button>' +
+        '<button class="al-feed-action-btn al-feed-del" data-action="deleteActivityEntry" data-arg="' + dateStr + ',' + e.id + '" data-stop="1" aria-label="Delete entry">×</button>' +
+        '</div>' : '';
       html += '<div class="al-feed-entry">' +
         '<div class="al-feed-time">' + timeStr + '</div>' +
         '<div class="al-feed-body">' +
           '<div class="al-feed-text">' + escHtml(e.text) + '</div>' +
           '<div class="al-feed-chips">' + domainChips + '</div>' +
           _renderAttribution(e) +
+          actBtns +
         '</div>' +
         '<div class="al-feed-meta">' + durStr + ' · ' + evidCount + ' ev</div>' +
       '</div>';
@@ -22667,6 +22695,97 @@ function renderRecentEvidence() {
   });
 
   feedEl.innerHTML = html;
+}
+
+// ── PR-γ: Edit / Delete affordances on activity-log entries ──
+// User can fix typos / wrong durations on logged activities + observations,
+// or remove erroneous entries. Re-runs classifyActivity on edited text so
+// detected domains / evidence keywords stay aligned with the current text.
+
+function deleteActivityEntry(dateStr, entryId) {
+  if (!dateStr || !entryId) return;
+  if (!activityLog[dateStr]) return;
+  confirmAction('Delete this entry? Milestone evidence will be recomputed.', () => {
+    const idx = activityLog[dateStr].findIndex(e => e && e.id === entryId);
+    if (idx < 0) return;
+    activityLog[dateStr].splice(idx, 1);
+    if (activityLog[dateStr].length === 0) delete activityLog[dateStr];
+    save(KEYS.activityLog, activityLog);
+    if (typeof syncMilestoneStatuses === 'function') syncMilestoneStatuses();
+    if (typeof renderMilestones === 'function') renderMilestones();
+    if (typeof renderHomeActivity === 'function') renderHomeActivity();
+  });
+}
+
+function editActivityEntry(dateStr, entryId) {
+  if (!dateStr || !entryId) return;
+  if (!activityLog[dateStr]) return;
+  const entry = activityLog[dateStr].find(e => e && e.id === entryId);
+  if (!entry) return;
+
+  const isActivity = entry.type === 'activity' || !!entry.duration;
+  const overlay = document.createElement('div');
+  overlay.className = 'confirm-overlay';
+  overlay.id = 'activityEditOverlay';
+  overlay.innerHTML =
+    '<div class="modal" style="max-width:420px;">' +
+      '<h3>Edit ' + (isActivity ? 'Activity' : 'Observation') + '</h3>' +
+      '<label class="micro-label">Description</label>' +
+      '<textarea id="actEditText" class="form-input" rows="3" style="width:100%;margin-bottom:var(--sp-8);">' + escHtml(entry.text || '') + '</textarea>' +
+      (isActivity
+        ? '<label class="micro-label">Duration (minutes)</label>' +
+          '<input id="actEditDuration" type="number" class="form-input" min="0" value="' + (entry.duration || '') + '" style="width:100%;margin-bottom:var(--sp-8);">'
+        : '') +
+      '<div class="modal-btns" style="display:flex;gap:var(--sp-8);justify-content:flex-end;">' +
+        '<button class="btn btn-ghost" data-action="closeActivityEdit">Cancel</button>' +
+        '<button class="btn btn-primary" data-action="saveActivityEdit" data-arg="' + dateStr + ',' + entryId + '">Save</button>' +
+      '</div>' +
+    '</div>';
+  overlay.addEventListener('click', e => { if (e.target === overlay) overlay.remove(); });
+  document.body.appendChild(overlay);
+  setTimeout(() => { const ta = document.getElementById('actEditText'); if (ta) ta.focus(); }, 50);
+}
+
+function closeActivityEdit() {
+  const overlay = document.getElementById('activityEditOverlay');
+  if (overlay) overlay.remove();
+}
+
+function saveActivityEdit(dateStr, entryId) {
+  if (!dateStr || !entryId) { closeActivityEdit(); return; }
+  if (!activityLog[dateStr]) { closeActivityEdit(); return; }
+  const entry = activityLog[dateStr].find(e => e && e.id === entryId);
+  if (!entry) { closeActivityEdit(); return; }
+
+  const ta = document.getElementById('actEditText');
+  const newText = ta ? (ta.value || '').trim() : '';
+  if (!newText) { closeActivityEdit(); return; }
+  entry.text = newText;
+
+  const durEl = document.getElementById('actEditDuration');
+  if (durEl) {
+    const dur = parseInt(durEl.value, 10);
+    entry.duration = (Number.isFinite(dur) && dur > 0) ? dur : null;
+    entry.type = entry.duration ? 'activity' : 'observation';
+  }
+
+  // Re-run evidence classifier on the new text so detected domains/evidence
+  // keywords stay aligned. Falls back gracefully if classifier missing.
+  if (typeof classifyActivity === 'function') {
+    try {
+      const c = classifyActivity(entry.text);
+      if (c) {
+        entry.domains = c.domains || [];
+        entry.evidence = c.evidence || [];
+      }
+    } catch(e) { console.warn('[edit-activity] classify:', e); }
+  }
+
+  save(KEYS.activityLog, activityLog);
+  if (typeof syncMilestoneStatuses === 'function') syncMilestoneStatuses();
+  closeActivityEdit();
+  if (typeof renderMilestones === 'function') renderMilestones();
+  if (typeof renderHomeActivity === 'function') renderHomeActivity();
 }
 
 // ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two changes addressing Sovereign feedback after PR-β r2 verification:

### 1. Edit + Delete on activity-log entries (the requested feature)

Per Sovereign: "introduce an option to edit or delete an activity or observation, right now it's one way."

- **Delete** button (×) on every activity / observation entry in Recent Activity Evidence (per-day section AND inside expanded rollup pills). Confirm-prompt → removes entry from `activityLog[dateStr]` → drops date key if array empties → triggers `syncMilestoneStatuses` to recompute milestone evidence counts.
- **Edit** button on every entry. Opens a small modal with text + duration (for activities) inputs. Save updates entry in-place. Re-runs `classifyActivity` on the new text so detected domains/evidence keywords stay aligned with the corrected wording.
- Both preserve PR-α attribution stamps + PR-β rollup logic — edited entries flow through the same dispatch path.

### 2. `deleteMilestone` broken since pre-Phase-3 (incidental catch)

While auditing the database for the cruise/mama duplicate complaint, found that the milestone × button **always deletes index 0** regardless of which entry the user tapped:

- `data-arg="${m._i})"` had a stray trailing `)` (home.js:1611)
- Dispatcher passed `"3)"` to `deleteMilestone(arg)`
- `milestones.splice("3)", 1)` → `Number("3)")` is NaN → splice treats NaN as 0 → wrong entry deleted

Likely explains why earlier manual cleanup attempts didn't reduce the visible duplicate count: deleting "the third Social smiling" actually removed something else, and the duplicates remained.

Fix:
- Removed stray `)`
- Added `parseInt` + `Number.isInteger` + range guard
- Added explicit `save(KEYS.milestones)` post-splice (paranoid; facade save still runs but defense-in-depth)

## Wires

- `core.js` dispatcher: 4 new actions (`deleteActivityEntry` / `editActivityEntry` / `closeActivityEdit` / `saveActivityEdit`)
- `styles.css`: `.al-feed-actions` + `.al-feed-action-btn` (+ `.al-feed-del` rose tint for delete)

## Note on cruise/mama duplicates

Database audit confirmed 3+ pairs of variant-text milestones (e.g. "Cruising along furniture" auto-detect + "Cruises along furniture" user-added). These have **same milestone keyword but different text**, so the existing text-equality dedup correctly leaves them alone. Auto-merging by keyword would over-collapse genuine stage variants like "Pincer grasp" / "Pincer grasp emerging" / "Refined pincer grasp" — risky.

With the deleteMilestone fix in this PR, you can now manually × the duplicates in 30 seconds. If you'd prefer an automated "Find duplicates" wizard, that's a separate PR-δ scope.

## Hold-pending-Sovereign-real-device-verification

Per RATIFIED `hermetic-floor-doesnt-substitute-for-production-floor`:

- [ ] Tap × on a milestone duplicate → only THAT index gets deleted (was: always index 0)
- [ ] Tap **Edit** on any activity entry → modal opens, text pre-filled, duration pre-filled if applicable
- [ ] Save edit → entry text/duration update in place; rollup re-aggregates if milestone keyword changed
- [ ] Tap **×** on an activity entry → confirm prompt → entry removed → milestone evidence recomputes (counts update on next render)
- [ ] Empty activityLog day → date key removed (no orphan empty arrays)
- [ ] No regression on Quick Log new-entry flow

— Lyra (lyra-stability-1)

---
_Generated by [Claude Code](https://claude.ai/code/session_011JhmDyFtAuQQyj1dtjyJCh)_