### PR TITLE
docs(spec): PR-ε.0 v6 — folds Kael+Maren v5 audit + Cipher cross-cut

### DIFF
--- a/docs/specs/lyra-pr-epsilon-0-foundation.md
+++ b/docs/specs/lyra-pr-epsilon-0-foundation.md
@@ -1,6 +1,87 @@
-# PR-ε.0 v5 — Foundation: stable IDs + scrapbook sync + milestone linkage
+# PR-ε.0 v6 — Foundation: stable IDs + scrapbook sync + milestone linkage
 
-> **v5 changelog (this revision):** addresses Kael + Maren v4 dual-audit.
+> **v6 changelog (this revision):** addresses Kael + Maren v5 dual-Governor
+> audit + Cipher Edict V cross-cutting pass.
+> 1 BLOCKER, 9 MAJORs, 1 MINOR folded; 2 MAJORs deferred with forward-pointer.
+> - **BLOCKER (Cipher cross-cutting):** v5 §0a relocated `slugify` to
+>   `config.js` but three index-level artifacts still said it lived in
+>   `core.js` — line 183 (Build-system prose), line 191 (Critical-files
+>   table: `Add genId(), slugify()` in core.js), and Phase A step 1
+>   ("`genId()` and `slugify()` in `core.js`"). An implementer following
+>   the Implementation Order verbatim would have re-introduced the v4
+>   BLOCKER. **Fix:** updated all three sites; split Phase A step 1
+>   into 1a (`slugify` in config.js per §0a) + 1b (`genId` in core.js
+>   per §0b).
+> - **MAJOR (Kael):** §1 — slug-uniqueness assert in `migrateMilestoneIds`
+>   checks Set-size only; two empty-text DEFAULTs would produce distinct
+>   `ms-fallback-*` ids and pass. **Fix:** added a parallel assert that
+>   no DEFAULT id matches `/^ms-fallback-/`.
+> - **MAJOR (Kael):** §6.3 — lex-smaller-id survivor selection could
+>   favor UUIDs over DEFAULT slugs (UUID leading-digit < kebab-letter).
+>   Custom-text-collision with a DEFAULT would have orphaned the
+>   deterministic slug. **Fix:** prefer `defaultSlugIds.has(m.id)` short-
+>   circuit before lex compare so DEFAULT slugs always win same-text
+>   collisions.
+> - **MAJOR (Kael):** §6.3 — `typeof migrateMilestoneIds === 'function'`
+>   guard masked future renames. **Fix:** converted to `console.assert`
+>   matching the §1 assertion idiom.
+> - **MAJOR (Kael):** §6.1 — `_syncSetGlobal('scrapbook', value)`
+>   reassigns; §6.3 mandates in-place mutation for `milestones` for the
+>   same closure-pin hazard. Asymmetry is benign today (Maren+Kael both
+>   confirm no closure-pinning reader) but undocumented. **Fix:** added
+>   a comment stating the asymmetry is acceptable absent in-place mutator
+>   + closure-pinning reader; flag for re-verification.
+> - **MAJOR (Kael):** §6.2(c) — synchronous throw inside the orphan
+>   `forEach` (e.g. firebase uninitialized) would skip subsequent orphans
+>   this fire. Data still survives via concat + reattach retry, but the
+>   partial-attempt path was undocumented. **Fix:** wrapped each forEach
+>   body in inner `try/catch` that logs and continues, matching the
+>   `.catch()` handling for async rejections.
+> - **MAJOR (Maren):** §4 — `escAttr` (`core.js:2304`) only escapes `'`
+>   and `"`, not `&`. Milestone text containing `&` (e.g. `Tom & Jerry`)
+>   produced malformed-but-tolerated attribute markup; `&mama;` could
+>   parse as a numeric/named entity reference → SR mis-announcement.
+>   **Fix:** double-wrap aria-label as `${escAttr(escHtml(m.text))}`
+>   for the chip × only. (Extending escAttr globally has wider blast
+>   radius — deferred to a separate PR.)
+> - **MAJOR (Maren):** §4 — orphan-toast fired only on `editScrapEntry`
+>   open. If a remote sync dropped a milestone WHILE the form was open,
+>   `confirmScrapMilestonePicker` (line ~550) silently filtered orphans
+>   at confirm with no feedback — two-stage misleading UX. **Fix:** added
+>   a parallel toast in `confirmScrapMilestonePicker` when the orphan-
+>   filter drops anything.
+> - **MAJOR (Maren):** §7.3 — `.picker-row { align-items: center; }`
+>   paired with `word-break: break-word` and a 22×22 sibling check
+>   vertically centers the check against multi-line wrapped labels;
+>   appears mis-aligned with the first line on phone. **Fix:** changed
+>   `.picker-row` to `align-items: flex-start` and added small
+>   `margin-top` to `.picker-row-check` for first-line cap-height
+>   alignment.
+> - **MAJOR (Maren):** §7.7 — visual checklist omitted a
+>   `prefers-reduced-motion` verification. `styles.css:3902` global
+>   block already zeros transitions, but the spec didn't claim it.
+>   **Fix:** added one §7.7 checklist line.
+> - **MINOR (Maren):** §4 — chip render of a milestone with empty/
+>   whitespace `text` produced an empty `.chip-label` and aria-label
+>   `"Remove  tag"` (double space). `addMilestone` guards new entries
+>   but legacy data could contain them. **Fix:** `(m.text || '').trim()
+>   || '(unnamed milestone)'` fallback before escHtml. Doc-only:
+>   `removeScrapMilestone` wait-for-save semantics noted (chip × drops
+>   from pending; persists on form save; `cancelScrapEdit` discards).
+> - **Deferred MAJORs (2, with forward-pointer):**
+>   §4 picker modal lacks `role="dialog"` / `aria-modal="true"` /
+>   `aria-labelledby` — pre-existing pattern gap across all SproutLab
+>   modals; PR-ε.0 adopting it unilaterally would create per-modal
+>   inconsistency. Filed to "Out of scope" register; separate repo-wide
+>   a11y uplift ticket.
+>   §6.2(d) in-flight Firestore snapshot stragglers can run
+>   `save(lsKey, entries)` after detach, overwriting local with stale
+>   remote. Reconcile-gate placement protects reconcile re-fire but
+>   not the underlying snapshot-apply. Pre-existing pipeline limitation
+>   outside §6.2's scope; forward-pointer note added in §6.2(d); defer
+>   generation-counter / `_syncDisabled`-flip to a separate hardening PR.
+
+> **v5 changelog (previous revision):** addressed Kael + Maren v4 dual-audit.
 > 1 BLOCKER, 5 MAJORs, 4 MINORs folded.
 > - **BLOCKER (Kael):** `slugify()` cannot run at `data.js` parse time
 >   (concat order: `data → core`). **Fix:** relocate `slugify` to
@@ -178,9 +259,13 @@ PR-ε.1.**
 - **Build system:** `bash build.sh` concatenates split files in order
   (`config → data → core → home → diet → medical → intelligence →
   sync → start`). Never edit the concatenated `sproutlab.html`
-  directly; always edit `split/*` and rebuild. New helpers added to
-  `core.js` are visible to all later files in concat order — fine for
-  `genId`/`slugify` (called from `home.js`, `data.js`, `sync.js`).
+  directly; always edit `split/*` and rebuild. **Helper placement
+  follows concat-order constraint:** `slugify` lives in `config.js`
+  (first concatenated, in scope when `data.js` parses
+  `DEFAULT_MILESTONES` slug-baking — see §0a); `genId` lives in
+  `core.js` (only ever called at runtime, after `data.js` has parsed
+  — see §0b). Both are visible to all later files in concat order
+  (`home.js`, `medical.js`, `sync.js`).
 
 ## Critical files (v2 — added sync.js + medical.js + styles.css)
 
@@ -188,7 +273,8 @@ PR-ε.1.**
 |---|---|
 | `split/data.js:1468–1476` | Bake `id` slug into each DEFAULT_MILESTONES entry |
 | `split/core.js:9–54` (KEYS) | Confirm `KEYS.scrapbook` exists; no edit |
-| `split/core.js` near utilities | Add `genId()`, `slugify()` |
+| `split/config.js` (top, after constants) | Add `slugify()` (see §0a — must parse before `data.js` for DEFAULT_MILESTONES slug bake) |
+| `split/core.js` near utilities (next to `escHtml`/`escAttr`) | Add `genId()` (see §0b — runtime-only, safe in core.js) |
 | `split/core.js:752–800` (init) | Insert `migrateMilestoneIds()` after sanitize, before first render |
 | `split/core.js` (scrapbook init) | Insert `migrateScrapbookIds()` between scrapbook sanitize and first render |
 | `split/core.js:2113` (`renderScrapbook`) | **Remove the `save()` call** AND add a 1-line header comment to the function: `// DOES NOT SAVE — mutators must call save(KEYS.scrapbook, scrapbook) explicitly. (PR-ε.0 §6.1 + Maren v4 audit.)` Documents the contract for future maintainers. |
@@ -298,6 +384,17 @@ function migrateMilestoneIds() {
   console.assert(
     new Set(DEFAULT_MILESTONES.map(m => m.id)).size === DEFAULT_MILESTONES.length,
     'PR-ε.0: duplicate milestone slug in DEFAULT_MILESTONES'
+  );
+  // PR-ε.0 v6 — Kael v5 audit MAJOR §0a fallback assert.
+  // The §0a `slugify` empty-text fallback yields `ms-fallback-<random>`,
+  // which is non-deterministic across page loads. Two empty-text DEFAULTs
+  // would each get a unique fallback id, pass the Set-uniqueness assert
+  // above, but break cross-device sync (every device's `milestoneIds`
+  // references would point at a different fallback). This second assert
+  // catches the developer error at init.
+  console.assert(
+    DEFAULT_MILESTONES.every(m => !/^ms-fallback-/.test(m.id || '')),
+    'PR-ε.0: DEFAULT_MILESTONES contains an empty-text entry — fallback id is non-deterministic across loads'
   );
   let dirty = false;
   const slugByText = Object.fromEntries(
@@ -449,19 +546,27 @@ text):
 `renderScrapMilestoneChips()` reads `_scrapMilestoneIdsPending`,
 resolves each id via `milestones.find(...)` (silent skip on orphan),
 renders into `#scrapMilestonePicker`:
+```js
+// PR-ε.0 v6 — Maren v5 audit MINOR: empty-text legacy guard.
+// addMilestone (home.js:1907) trims+rejects empty text for new entries,
+// but legacy data could contain whitespace-only text. Fall back to
+// '(unnamed milestone)' so the chip and aria-label stay readable
+// instead of rendering as `Remove  tag` (double space).
+const labelText = (m.text || '').trim() || '(unnamed milestone)';
+```
 ```html
 <span class="chip chip-milestone" role="listitem">
-  <span class="chip-label">${escHtml(m.text)}</span>
+  <span class="chip-label">${escHtml(labelText)}</span>
   <button type="button" class="chip-x"
           data-action="removeScrapMilestone" data-arg="${m.id}"
-          aria-label="Remove ${escAttr(m.text)} tag">
+          aria-label="Remove ${escAttr(escHtml(labelText))} tag">
     <svg class="zi" aria-hidden="true"><use href="#zi-close"/></svg>
   </button>
 </span>
 ```
 **Escape contracts:**
-- `${escHtml(m.text)}` for the visible text node (`.chip-label` body) — HTML context.
-- `${escAttr(m.text)}` for the `aria-label` — attribute context. `escHtml` does NOT escape `"`; using it here would break attribute parsing on milestone text containing quotes (e.g. `Said "mama"`). `escAttr` (`core.js:2304`) is the codebase's attribute-safe helper. (Audit v2 finding §7.3.)
+- `${escHtml(labelText)}` for the visible text node (`.chip-label` body) — HTML context.
+- `${escAttr(escHtml(labelText))}` for the `aria-label` — attribute context, **double-wrapped**. `escAttr` (`core.js:2304`) only escapes `'` and `"`, NOT `&` or `<`. Milestone text containing `&` (e.g. `Tom & Jerry`) would otherwise produce malformed-but-tolerated attribute markup; `&mama;` could parse as a numeric/named entity reference, causing screen-reader mis-announcement. `escHtml` (`core.js:2282`) escapes `&`, `<`, `>` first; `escAttr` then handles quotes. The result is safe in both HTML5 attribute parsing and SR pronunciation. (Maren v5 audit MAJOR; v6 fix.) Extending `escAttr` to also escape `&` globally has wider blast radius (call sites in home.js et al.) — deferred to a separate PR.
 - `${m.id}` in `data-arg` is safe without escape: ids are either deterministic slugs (`[a-z0-9-]+`) or UUIDs / `'id-' + base36` — all attribute-safe by construction.
 **Composition rationale:** the chip body is a label (informational,
 `cursor: default` via CSS), not a click target — only the inner ×
@@ -547,9 +652,9 @@ HR-4: every `m.text` interpolation in this renderer goes through
 |---|---|
 | `openScrapMilestonePicker` | **Always reseed:** `_scrapPickerWorkingSet = new Set(_scrapMilestoneIdsPending)`. Render list. `openModal('scrapMilestonePickerModal')`. (Audit major #8 — back-button leak mitigated by always-reseed.) |
 | `toggleScrapPickerMilestone` | Toggle id in working set; re-render list |
-| `confirmScrapMilestonePicker` | **Filter against current ids:** `_scrapMilestoneIdsPending = [..._scrapPickerWorkingSet].filter(id => milestones.some(m => m.id === id))`. (Audit major #13 — drops orphans before persist.) Close modal. Render chips. |
+| `confirmScrapMilestonePicker` | **Filter against current ids:** `const pre = [..._scrapPickerWorkingSet]; _scrapMilestoneIdsPending = pre.filter(id => milestones.some(m => m.id === id)); const droppedAtConfirm = pre.length - _scrapMilestoneIdsPending.length;` Then if `droppedAtConfirm > 0`, fire `showQLToast` with the same copy used at edit-load (`"${droppedAtConfirm} ${noun} removed — milestone no longer exists"`). (Audit major #13 — drops orphans before persist; **v6 Maren MAJOR fix:** now also surfaces a toast when a remote sync deletes a milestone WHILE the picker is open — closes the two-stage misleading-UX gap.) Close modal. Render chips. |
 | `cancelScrapMilestonePicker` | Discard working set. Close modal. |
-| `removeScrapMilestone` | Drop id from `_scrapMilestoneIdsPending`. Re-render chips. |
+| `removeScrapMilestone` | Drop id from `_scrapMilestoneIdsPending`. Re-render chips. **Note (v6 Maren MINOR):** does NOT persist until the parent saves the form (chip × is a pending-state edit, parallel to typing in the title field). `cancelScrapEdit` discards pending changes. Do NOT "fix" this to immediate-persist — it would change form-edit semantics. |
 
 **Wiring into create/edit lifecycle:**
 - `addScrapEntry()` (`core.js:2192`):
@@ -626,6 +731,24 @@ case 'scrapbook': return scrapbook;
 ```
 Pattern matches existing entries (`feeding`, `sleep`, etc.). Read the
 existing cases for exact form before editing.
+
+**v6 — reassignment vs in-place mutation asymmetry (Kael v5 audit MAJOR):**
+the `_syncSetGlobal('scrapbook', value) → scrapbook = value` line above
+is a **reassignment** of the global. §6.3 explicitly forbids
+reassignment for `milestones` (mandates
+`milestones.length = 0; milestones.push.apply(milestones, survivors)`)
+because `dedupeMilestonesByText` runs in-place and any closure that
+captured `milestones` pre-dedup would point at the orphaned old array.
+The `scrapbook` reassignment here is **acceptable today** because:
+(i) no in-place mutator exists for the `scrapbook` global (no
+`dedupeScrapbookByText` analog); (ii) Maren v5 audit confirmed no
+closure-pinning reader in `home.js`/`renderScrapbook`/
+`renderScrapbookHistory`; (iii) Kael v5 audit confirmed no
+closure-pinning reader in core/sync/intelligence. **If a future PR
+adds either an in-place scrapbook mutator OR a closure that captures
+the `scrapbook` global by reference, this case must be re-verified
+and likely converted to in-place mutation** matching §6.3's pattern.
+Document carried at the case-statement source comment.
 
 #### 6.2 Per-entry listener reconcile (audit blocker #4)
 
@@ -708,16 +831,29 @@ if (!_reconcileDone.has(collection)) {
       _syncIsReconciling = true;
       try {
         orphanLocals.forEach(e => {
-          _syncWriteCount++;  // count toward circuit breaker
-          colRef.doc(e.id).set(Object.assign({}, e, stampBase), { merge: false })
-            .catch(err => {
-              console.error('[sync] reconcile push failed', collection, e.id, err);
-              // Local entry is already merged into `entries` above (it survives
-              // this session's snapshot-apply). Retry happens on next sync
-              // re-attach (offline→online, auth state change, or page reload),
-              // NOT on the next snapshot fire in this same session — because
-              // _reconcileDone gates within the session.
-            });
+          // PR-ε.0 v6 — Kael v5 audit MAJOR §6.2(c) inner try/catch.
+          // A synchronous throw inside .set() (e.g. firebase not yet
+          // initialized, malformed entry) would otherwise propagate out of
+          // forEach and skip every subsequent orphan this fire. Data still
+          // survives via `entries.concat(orphanLocals)` above + reattach retry
+          // (gate stays open per §6.2(c) bail rule), but partial-attempt is
+          // worth logging so the operator sees a breadcrumb. Convert sync
+          // throws to the same logged-and-continue path as async rejections.
+          try {
+            _syncWriteCount++;  // count toward circuit breaker
+            colRef.doc(e.id).set(Object.assign({}, e, stampBase), { merge: false })
+              .catch(err => {
+                console.error('[sync] reconcile push failed', collection, e.id, err);
+                // Local entry is already merged into `entries` above (it survives
+                // this session's snapshot-apply). Retry happens on next sync
+                // re-attach (offline→online, auth state change, or page reload),
+                // NOT on the next snapshot fire in this same session — because
+                // _reconcileDone gates within the session.
+              });
+          } catch (syncErr) {
+            console.error('[sync] reconcile push threw synchronously', collection, e.id, syncErr);
+            // Local entry already in `entries` above; survives. Continue forEach.
+          }
         });
       } finally {
         _syncIsReconciling = wasReconciling;
@@ -795,6 +931,22 @@ offline → online or auth state change. Locals created during the
 offline window — and orphans deferred during a prior circuit-breaker
 bail — get pushed up on the first fire after re-attach.
 
+**v6 — in-flight straggler limitation (Kael v5 audit MAJOR, deferred).**
+Firestore `onSnapshot` callbacks that were already on the microtask
+queue when `_syncDetachListeners()` ran will still fire after detach
+returns. The reconcile gate placement above protects **reconcile re-fire**
+(straggler runs against the OLD gate, finds it consumed, no-ops the
+reconcile push), but the straggler's wholesale `save(lsKey, entries)`
+at sync.js:1291 still runs and could overwrite local with stale remote
+state captured at the prior listener's last snapshot. The existing
+`_syncDisabled` guard at sync.js:1152 is the only flag protecting the
+snapshot-apply path; it is not flipped during detach. **This is a
+pre-existing snapshot-pipeline limitation outside §6.2's scope.** A
+proper fix needs either (a) a generation counter on the listener so
+stragglers detect they're stale, or (b) `_syncDisabled` flip during
+detach windows. Defer to a separate sync-pipeline hardening PR; not
+introduced by PR-ε.0 and not made worse by it.
+
 ##### Verification (manual)
 
 - Member device with 3 local entries + admin with 5 different. Both
@@ -859,15 +1011,37 @@ function dedupeMilestonesByText() {
   const byKey = new Map();          // normalized text -> survivor entry
   const idRewrite = new Map();      // discarded id -> survivor id
   const dropped = [];               // entries to remove from milestones
+  // PR-ε.0 v6 — Kael v5 audit MAJOR: DEFAULT-slug ids win same-text
+  // collisions over UUIDs/genId fallbacks. Lex-only compare can put a
+  // UUID ('0abc...' or 'id-...') BEFORE a kebab slug ('babbling') in
+  // ASCII order, which would orphan the deterministic DEFAULT slug
+  // when a parent creates a custom milestone with the same text.
+  // Build the set once before the loop.
+  const defaultSlugIds = new Set(
+    (typeof DEFAULT_MILESTONES !== 'undefined' ? DEFAULT_MILESTONES : [])
+      .map(d => d.id).filter(Boolean)
+  );
 
   for (let i = 0; i < milestones.length; i++) {
     const m = milestones[i];
     const key = (m.text || '').trim().toLowerCase();
     const prev = byKey.get(key);
     if (!prev) { byKey.set(key, m); continue; }
-    // Pick lexicographically smaller id as survivor (deterministic across devices).
-    const winner = (m.id || '￿') < (prev.id || '￿') ? m : prev;
-    const loser  = winner === m ? prev : m;
+    // PR-ε.0 v6 — Kael v5 audit MAJOR survivor selection.
+    // Priority: (1) DEFAULT-slug id wins over non-DEFAULT — preserves the
+    // deterministic id every device computes from DEFAULT_MILESTONES at
+    // boot. (2) If both or neither are DEFAULT slugs, fall back to
+    // lex-smaller-id (deterministic across devices for UUID/UUID and
+    // slug/slug ties).
+    const mIsDefault    = defaultSlugIds.has(m.id);
+    const prevIsDefault = defaultSlugIds.has(prev.id);
+    let winner, loser;
+    if (mIsDefault && !prevIsDefault)        { winner = m;    loser = prev; }
+    else if (prevIsDefault && !mIsDefault)   { winner = prev; loser = m;    }
+    else {
+      winner = (m.id || '￿') < (prev.id || '￿') ? m : prev;
+      loser  = winner === m ? prev : m;
+    }
     if (loser.id && winner.id && loser.id !== winner.id) {
       idRewrite.set(loser.id, winner.id);
     }
@@ -939,17 +1113,27 @@ forEach AND BEFORE the existing dedup call:
 function _postReceiveMilestones() {
   // existing: per-entry status migration forEach (unchanged)
   // existing: any other pre-dedup logic (unchanged)
-  if (typeof migrateMilestoneIds === 'function') migrateMilestoneIds();  // PR-ε.0 §6.3
+  // PR-ε.0 v6 — Kael v5 audit MAJOR: convert silent-skip guard to assert.
+  // Concat order (config → data → core → home → diet → medical) GUARANTEES
+  // migrateMilestoneIds is in scope by medical.js parse time. The original
+  // v5 `typeof === 'function'` guard would silently skip migration if a
+  // future PR renamed the function — assert instead so the failure is loud
+  // at dev time, matching the §1 assertion idiom.
+  console.assert(
+    typeof migrateMilestoneIds === 'function',
+    'PR-ε.0 §6.3: _postReceiveMilestones expects migrateMilestoneIds in scope (concat order: core.js loads before medical.js)'
+  );
+  migrateMilestoneIds();  // PR-ε.0 §6.3
   dedupeMilestonesByText();  // existing call, unchanged
   // existing: any post-dedup logic (unchanged)
 }
 ```
 
-The `typeof === 'function'` guard handles the case where `medical.js`
-loads before `core.js` migration helpers are defined (concat order
-per CLAUDE.md is config → data → core → home → diet → **medical** →
-... so `migrateMilestoneIds` IS in scope by `medical.js` parse time;
-the guard is belt-and-suspenders).
+Concat order per CLAUDE.md is config → data → core → home → diet →
+**medical** → ... so `migrateMilestoneIds` IS in scope by `medical.js`
+parse time. The `console.assert` is dev-time-only — production runs
+won't pay any cost — and surfaces a loud failure at init if a rename
+ever breaks the contract.
 
 `migrateMilestoneIds` is idempotent: if all entries already have ids,
 it short-circuits without calling `save`. **No write loop:** when a
@@ -1116,7 +1300,15 @@ All values use existing tokens (HR-2, HR-5). Append to the existing
   padding: 0 var(--sp-4);
 }
 .picker-row {
-  display: flex; align-items: center; gap: var(--sp-10);
+  display: flex;
+  /* PR-ε.0 v6 — Maren v5 audit MAJOR: flex-start (was: center).
+     With center + word-break: break-word on the label, the 22×22 check
+     vertically centers against multi-line wrapped text, appearing
+     mis-aligned with the first line on phone-narrow widths. flex-start
+     keeps the check optically aligned with the first line; the
+     margin-top below nudges it to first-line cap-height. */
+  align-items: flex-start;
+  gap: var(--sp-10);
   padding: var(--sp-8) var(--sp-10);
   border-radius: var(--r-lg);
   cursor: pointer;
@@ -1132,6 +1324,11 @@ All values use existing tokens (HR-2, HR-5). Append to the existing
   flex-shrink: 0;
   background: var(--card-bg);
   transition: background var(--ease-fast);
+  /* PR-ε.0 v6 — Maren v5 audit MAJOR: optical-align with first-line
+     cap height of the picker-row-label (--fs-base, --lh-snug). 2px
+     covers the typical baseline offset between a small filled square
+     and the cap height of body text in Nunito at 16px. */
+  margin-top: 2px;
 }
 .picker-row-check[data-checked="1"] { background: var(--lavender); }
 .picker-row-check[data-checked="0"] .zi { display: none; }
@@ -1250,6 +1447,8 @@ The pre-build visual checklist Lyra runs before opening the PR:
 - [ ] **Attribute escape audit:** every interpolation in an attribute context (`aria-label`, `data-arg` with arbitrary text) uses `escAttr`, not `escHtml`. Test: rename a custom milestone to `Said "mama"`, tag a memory, inspect chip × `aria-label` attribute — must read `Remove Said &quot;mama&quot; tag` (not `Remove Said "mama" tag`).
 - [ ] **No keyboard trap when picker has 0 milestones:** picker-empty state still allows Tab to reach Cancel/Done.
 - [ ] **Disabled state (Tag-a-milestone with no milestones existing):** button stays active so the user can still open the picker and see the empty-state guidance — no premature disable.
+- [ ] **Reduced motion (v6 Maren MAJOR):** confirmed `styles.css:3902` `@media (prefers-reduced-motion: reduce)` global block zeroes all `--ease-fast` transitions on the new `.chip-x`, `.picker-row-check`, and `.picker-row` rules. Test: Settings → Accessibility → Reduce Motion ON → no transition flash on chip × hover, picker-row hover, or check toggle.
+- [ ] **Confirm-time orphan toast (v6 Maren MAJOR):** open the picker, while the picker is open delete the milestone via another window/device, hit Done — a toast fires reading "1 milestone tag removed — milestone no longer exists". Closes the two-stage misleading-UX gap where v5 only fired on edit-load.
 
 ## Out of scope (explicitly)
 
@@ -1263,6 +1462,18 @@ The pre-build visual checklist Lyra runs before opening the PR:
   at `core.js:752`.
 - Pre-existing inline-style debt in `template.html` scrapbook form
   (HR-2 violation predates this PR; not ours to repay).
+- **Modal a11y uplift (v6 Maren v5 audit MAJOR — deferred):** the picker
+  modal lacks `role="dialog"` / `aria-modal="true"` /
+  `aria-labelledby` pointing at the `<h3>Tag milestones</h3>` title.
+  This is a **pre-existing pattern gap** across all SproutLab modals
+  (`growthModal`, `vaccModal`, `milestoneModal` in `template.html`
+  lines 2704–2857 — none use `role="dialog"`). PR-ε.0 inherits the
+  pattern intentionally to avoid creating a per-modal a11y
+  inconsistency. **Followup register entry:** open a separate ticket
+  for a repo-wide modal a11y uplift that adds `role="dialog"`,
+  `aria-modal="true"`, and `aria-labelledby` to every existing modal
+  in one pass. Until then, screen-reader users get focus context but
+  no explicit dialog announcement on open — degraded but not broken.
 - **`addMilestone()` missing-save bug** at `home.js:1905–1914` — the
   function pushes to global `milestones` but does NOT call
   `save(KEYS.milestones, milestones)`. Relies on subsequent render
@@ -1355,7 +1566,7 @@ The pre-build visual checklist Lyra runs before opening the PR:
     a clean concat with no errors; `index.html` and `sproutlab.html`
     sync; smoke test the built artifact.
 
-## Implementation order (v5 — 25 steps in 6 phases)
+## Implementation order (v6 — 26 steps in 6 phases)
 
 > **Line-number drift reminder (Kael v4 audit MINOR):** every phase
 > below cites specific line numbers from the codebase as it stood
@@ -1377,7 +1588,16 @@ The pre-build visual checklist Lyra runs before opening the PR:
 
 ### Phase A — Primitives & helpers (no behavior change)
 
-1. **§0 helpers:** `genId()` and `slugify()` in `core.js`.
+1a. **§0a slugify in `config.js`** (Cipher v6 BLOCKER fix; was
+    incorrectly listed under core.js in v5). `config.js` is the FIRST
+    concatenated file, so `slugify` is in scope when `data.js` parses
+    `DEFAULT_MILESTONES` and bakes slug ids inline. Use the empty-text
+    `Math.random` fallback per §0a — `genId` does NOT exist at
+    `config.js` scope.
+1b. **§0b genId in `core.js`** next to `escHtml`/`escAttr`. Runtime-only
+    (called from `home.js:addMilestone` and `core.js:addScrapEntry`),
+    safe in core.js. Do NOT call `genId` from `data.js` parse-time
+    contexts.
 2. **§7.1 sprite:** add `<symbol id="zi-close">` to `template.html`
    sprite block (X path, currentColor, 2px stroke, matches existing
    icon weight).

--- a/docs/specs/lyra-pr-epsilon-0-foundation.md
+++ b/docs/specs/lyra-pr-epsilon-0-foundation.md
@@ -1,8 +1,9 @@
-# PR-ε.0 v6 — Foundation: stable IDs + scrapbook sync + milestone linkage
+# PR-ε.0 v6.1 — Foundation: stable IDs + scrapbook sync + milestone linkage
 
 > **v6 changelog (this revision):** addresses Kael + Maren v5 dual-Governor
 > audit + Cipher Edict V cross-cutting pass.
-> 1 BLOCKER, 9 MAJORs, 1 MINOR folded; 2 MAJORs deferred with forward-pointer.
+> 1 BLOCKER + 7 MAJORs folded + 1 MINOR; 2 MAJORs deferred with
+> forward-pointer (filed as issues #53 + #54). 9 total MAJORs touched.
 > - **BLOCKER (Cipher cross-cutting):** v5 §0a relocated `slugify` to
 >   `config.js` but three index-level artifacts still said it lived in
 >   `core.js` — line 183 (Build-system prose), line 191 (Critical-files
@@ -68,18 +69,40 @@
 >   || '(unnamed milestone)'` fallback before escHtml. Doc-only:
 >   `removeScrapMilestone` wait-for-save semantics noted (chip × drops
 >   from pending; persists on form save; `cancelScrapEdit` discards).
-> - **Deferred MAJORs (2, with forward-pointer):**
+> - **Deferred MAJORs (2, with forward-pointer + tracked issues):**
 >   §4 picker modal lacks `role="dialog"` / `aria-modal="true"` /
 >   `aria-labelledby` — pre-existing pattern gap across all SproutLab
 >   modals; PR-ε.0 adopting it unilaterally would create per-modal
->   inconsistency. Filed to "Out of scope" register; separate repo-wide
->   a11y uplift ticket.
+>   inconsistency. Filed to "Out of scope" register; **tracked as
+>   issue #54** (repo-wide modal a11y uplift).
 >   §6.2(d) in-flight Firestore snapshot stragglers can run
 >   `save(lsKey, entries)` after detach, overwriting local with stale
 >   remote. Reconcile-gate placement protects reconcile re-fire but
 >   not the underlying snapshot-apply. Pre-existing pipeline limitation
 >   outside §6.2's scope; forward-pointer note added in §6.2(d); defer
->   generation-counter / `_syncDisabled`-flip to a separate hardening PR.
+>   generation-counter / `_syncDisabled`-flip to a separate hardening
+>   PR. **Tracked as issue #53.**
+>
+> **v6.1 (this push):** addresses Aurelius polish-pass review on PR #52.
+> - **Item 1** (§6.3 `defaultSlugIds` invariant comment): skipped —
+>   Kael + Cipher confirmed `const` declaration on `DEFAULT_MILESTONES`
+>   IS the invariant; Set is rebuilt fresh per call inside the function.
+> - **Item 2** (§6.2(c) write-counter one-liner): landed verbatim above
+>   the new `_syncWriteCount++` in the orphan forEach. Documents
+>   "overcount is fail-safe" so a future reader doesn't invert the
+>   safety direction.
+> - **Item 3** (§7.7 entity-reference positive verification): landed —
+>   fixture string is `&mama;` (not `Tom & Jerry`); Maren caught that
+>   bare `&` is HTML5-tolerated and would pass on v5 too. The canonical
+>   hazard is entity-reference parsing.
+> - **Item 4** (forward-pointer durability): filed issues #53 (snapshot
+>   stragglers) + #54 (modal a11y) and cross-linked both into the
+>   deferred bullets above + their respective spec sections.
+> - **Cipher additional finding** (changelog arithmetic): clarified
+>   header from "9 MAJORs" → "1 BLOCKER + 7 MAJORs folded + 1 MINOR;
+>   2 MAJORs deferred (issues #53 + #54). 9 total MAJORs touched."
+> - **Cipher additional finding** (CLAUDE.md line-count drift): tracked
+>   as issue #55 (non-blocking; doc hygiene only).
 
 > **v5 changelog (previous revision):** addressed Kael + Maren v4 dual-audit.
 > 1 BLOCKER, 5 MAJORs, 4 MINORs folded.
@@ -840,6 +863,11 @@ if (!_reconcileDone.has(collection)) {
           // worth logging so the operator sees a breadcrumb. Convert sync
           // throws to the same logged-and-continue path as async rejections.
           try {
+            // PR-ε.0 v6.1 — Aurelius polish item 2.
+            // Increment before .set() — overcount is fail-safe (breaker bails earlier);
+            // do NOT move post-resolve, async settlement would let bursts under-count
+            // and overshoot the limit. Matches existing _syncWritePerEntry pattern at
+            // sync.js:884.
             _syncWriteCount++;  // count toward circuit breaker
             colRef.doc(e.id).set(Object.assign({}, e, stampBase), { merge: false })
               .catch(err => {
@@ -946,6 +974,8 @@ proper fix needs either (a) a generation counter on the listener so
 stragglers detect they're stale, or (b) `_syncDisabled` flip during
 detach windows. Defer to a separate sync-pipeline hardening PR; not
 introduced by PR-ε.0 and not made worse by it.
+**Tracked as issue #53** (filed v6.1 per Aurelius polish item 4 —
+forward-pointer durability).
 
 ##### Verification (manual)
 
@@ -1445,6 +1475,7 @@ The pre-build visual checklist Lyra runs before opening the PR:
 - [ ] **iOS VoiceOver real-device test:** the `role="checkbox"` on `<button>` pattern is the codebase's first use; iOS sometimes appends "double-tap to activate" mid-announcement. Test on a real iPhone before ship — not just simulator. (Maren v4 audit MAJOR.)
 - [ ] **Orphan-tag toast surfaces on edit-load:** create a memory tagged with a custom milestone, delete the milestone on the same device, edit the memory → toast reads "1 milestone tag removed — milestone no longer exists". Toast text is informational, not alarming. (Maren v4 audit MAJOR §4 wiring.)
 - [ ] **Attribute escape audit:** every interpolation in an attribute context (`aria-label`, `data-arg` with arbitrary text) uses `escAttr`, not `escHtml`. Test: rename a custom milestone to `Said "mama"`, tag a memory, inspect chip × `aria-label` attribute — must read `Remove Said &quot;mama&quot; tag` (not `Remove Said "mama" tag`).
+- [ ] **Entity-reference escape (v6 MAJOR positive verification, Aurelius polish item 3):** rename a custom milestone to `&mama;`, tag a memory, inspect the chip. Visible `.chip-label` body must render the literal string `&mama;` (DOM text node, not an entity). Chip × `aria-label` attribute must read `Remove &amp;mama; tag` in the inspector and announce as "Remove and mama semicolon tag" (or equivalent literal) in VoiceOver — never as "Remove mama tag". Confirms `escHtml` runs before `escAttr` on both surfaces; positively verifies the v6 §4 double-wrap fix (not just the regression boundary).
 - [ ] **No keyboard trap when picker has 0 milestones:** picker-empty state still allows Tab to reach Cancel/Done.
 - [ ] **Disabled state (Tag-a-milestone with no milestones existing):** button stays active so the user can still open the picker and see the empty-state guidance — no premature disable.
 - [ ] **Reduced motion (v6 Maren MAJOR):** confirmed `styles.css:3902` `@media (prefers-reduced-motion: reduce)` global block zeroes all `--ease-fast` transitions on the new `.chip-x`, `.picker-row-check`, and `.picker-row` rules. Test: Settings → Accessibility → Reduce Motion ON → no transition flash on chip × hover, picker-row hover, or check toggle.
@@ -1469,11 +1500,11 @@ The pre-build visual checklist Lyra runs before opening the PR:
   (`growthModal`, `vaccModal`, `milestoneModal` in `template.html`
   lines 2704–2857 — none use `role="dialog"`). PR-ε.0 inherits the
   pattern intentionally to avoid creating a per-modal a11y
-  inconsistency. **Followup register entry:** open a separate ticket
-  for a repo-wide modal a11y uplift that adds `role="dialog"`,
-  `aria-modal="true"`, and `aria-labelledby` to every existing modal
-  in one pass. Until then, screen-reader users get focus context but
-  no explicit dialog announcement on open — degraded but not broken.
+  inconsistency. **Tracked as issue #54** (filed v6.1 per Aurelius
+  polish item 4 — forward-pointer durability) — repo-wide modal a11y
+  uplift in one pass. Until then, screen-reader users get focus
+  context but no explicit dialog announcement on open — degraded but
+  not broken.
 - **`addMilestone()` missing-save bug** at `home.js:1905–1914` — the
   function pushes to global `milestones` but does NOT call
   `save(KEYS.milestones, milestones)`. Relies on subsequent render

--- a/docs/specs/lyra-pr-epsilon-0-foundation.md
+++ b/docs/specs/lyra-pr-epsilon-0-foundation.md
@@ -1,6 +1,18 @@
-# PR-ε.0 v6.1 — Foundation: stable IDs + scrapbook sync + milestone linkage
+# PR-ε.0 v6.2 — Foundation: stable IDs + scrapbook sync + milestone linkage
 
-> **v6 changelog (this revision):** addresses Kael + Maren v5 dual-Governor
+> **v6.2 changelog (this revision):** atomic spec package — pseudocode doc
+> folded in.
+> - **Paper-cut (Aurelius v6.1 review):** v6 header label was "(this
+>   revision)"; now "(prior revision)" — the v6.1 sub-block is current.
+> - **New artifact:** `docs/specs/lyra-pr-epsilon-0-pseudocode.md` —
+>   implementation pseudocode + reference JS for the 26-step order.
+>   Sub-50 LOC sections drafted by Maren + Kael in build-mode flex
+>   (Sovereign-authorized scope expansion); Lyra drafts ≥50 LOC
+>   sections (§6.2(c) reconcile pipeline, §6.3 dedupeMilestonesByText)
+>   + assembly + cross-section synthesis. Same audit chain as v6.1
+>   to follow on the assembled doc.
+
+> **v6 changelog (prior revision):** addresses Kael + Maren v5 dual-Governor
 > audit + Cipher Edict V cross-cutting pass.
 > 1 BLOCKER + 7 MAJORs folded + 1 MINOR; 2 MAJORs deferred with
 > forward-pointer (filed as issues #53 + #54). 9 total MAJORs touched.

--- a/docs/specs/lyra-pr-epsilon-0-pseudocode.md
+++ b/docs/specs/lyra-pr-epsilon-0-pseudocode.md
@@ -1,0 +1,934 @@
+# PR-ε.0 v6.2 — Implementation pseudocode + reference JS
+
+> **Companion to:** [`lyra-pr-epsilon-0-foundation.md`](./lyra-pr-epsilon-0-foundation.md) (v6.2)
+> **PR:** [#52](https://github.com/Rishabh1804/sproutlab/pull/52) (draft, atomic spec package; un-drafts after this doc passes the audit chain)
+> **Audit base SHA:** `a64b80d41f900e70cc36bde7b60169802a1f5c0c` (v5 spec line refs; some drift since — see footer)
+> **Drafters:** Maren (Care/UX sections, build-mode flex), Kael (Intelligence/data-layer sections, build-mode flex), Lyra (≥50 LOC sections + assembly + cross-section synthesis).
+
+This doc translates the v6.2 foundation spec's 26-step Implementation Order into closer-to-code form. It does **not** re-derive any audit decisions — every block carries forward the spec's anchoring (§-section + file:line + MAJORs folded). When a section in this doc and the foundation spec disagree, the foundation spec wins; this doc is a translation aid, not the source of truth.
+
+## Format and conventions
+
+- **Real JS** for sections ≤15 LOC — copy-paste-ready modulo line-drift verification.
+- **Pseudocode** for sections >15 LOC — control-flow scaffold the implementer concretizes. Each pseudocode block carries a 2–3-bullet **concretization checklist** of constraints to verify when translating to real JS.
+- **Anchoring discipline** (every block): (1) §-section in v6.2 foundation spec, (2) `split/<file>:<lines>` codebase anchor, (3) audit MAJORs folded.
+- **Build-mode flex** (Sovereign-authorized): Maren and Kael drafted sub-50 LOC sections in their jurisdictions; Lyra reviewed/synthesized and drafted the two ≥50 LOC orchestration sections (§6.2(c), §6.3 dedupe). Same downstream audit chain (Maren+Kael audit → Cipher Edict V → Aurelius final → un-draft) follows on the assembled doc.
+- **Out of scope here:** deferred MAJORs (issues [#53](https://github.com/Rishabh1804/sproutlab/issues/53), [#54](https://github.com/Rishabh1804/sproutlab/issues/54)); CLAUDE.md line-count drift ([#55](https://github.com/Rishabh1804/sproutlab/issues/55)); re-litigation of any spec audit decision.
+
+## Table of contents (mapped to spec Implementation Order)
+
+- **Phase A — Primitives & helpers**
+  - [§0a slugify in `config.js`](#0a-slugify-in-configjs) (Kael)
+  - [§0b genId in `core.js`](#0b-genid-in-corejs) (Kael)
+  - [§7.1 `zi-close` sprite](#71-zi-close-sprite-symbol) (Maren)
+  - [§7.3 CSS additions](#73-css-additions) (Maren)
+- **Phase B — Schema & migrations**
+  - [§1 `migrateMilestoneIds`](#1-migratemilestoneids-pseudocode) (Kael, pseudocode)
+  - [§1 `migrateScrapbookIds`](#1-migratescrapbookids) (Kael)
+  - [§1 `addMilestone` id assignment](#1-addmilestone-id-assignment) (cross-cut, brief)
+- **Phase C — Identity refactor**
+  - [§2 Dispatcher migration patterns](#2-dispatcher-migration-patterns) (Kael)
+- **Phase D — Sync layer integration**
+  - [§6.1 `_syncSetGlobal` scrapbook arm](#61-syncsetglobal-scrapbook-arm) (Kael)
+  - [§6.2(a) `_reconcileDone` state declaration](#62a-reconciledone-state-declaration) (Kael)
+  - [§6.2(c) Reconcile pipeline ★](#62c-reconcile-pipeline-pseudocode) (Lyra, pseudocode, ≥50 LOC)
+  - [§6.2(d) Reconnect-clear](#62d-reconnect-clear-in-syncattachlisteners) (Kael)
+  - [§6.3 `dedupeMilestonesByText` ★](#63-dedupemilestonesbytext-pseudocode) (Lyra, pseudocode, ≥50 LOC)
+  - [§6.3 `_postReceiveMilestones`](#63-postreceivemilestones) (Kael)
+  - [§6.3 `rewriteScrapbookMilestoneIds`](#63-rewritescrapbookmilestoneids) (Kael)
+  - [§3 SYNC_KEYS + SYNC_RENDER_DEPS](#3-synckeys--syncrenderdeps-registration-atomic) (Kael, atomic)
+- **Phase E — UI surface (chips + picker)**
+  - [§4.A `renderScrapMilestoneChips`](#4a-renderscrapmilestonechips) (Maren)
+  - [§4.B Picker action handlers](#4b-picker-action-handlers-five-small-handlers) (Maren)
+  - [§4.C Wiring into create/edit lifecycle](#4c-wiring-into-createedit-lifecycle-cross-cut) (cross-cut, Lyra)
+- **Phase F — Verification & ship**
+  - [§7.7 Visual sanity checklist](#77-visual-sanity-checklist) (Maren)
+- [Line-drift verification footer](#line-drift-verification-footer)
+- [Cross-section invariants summary](#cross-section-invariants-summary)
+
+---
+
+## Phase A — Primitives & helpers
+
+### §0a — `slugify` in `config.js`
+
+**Implements:** v6.2 spec §0a
+**Touches:** `split/config.js` (append after the existing constant block — file is 13 lines today; new code lands at top of file body, BEFORE any later concat consumer parses)
+**MAJORs folded:** Cipher v5 BLOCKER (slugify location consistency — must parse before `data.js` for DEFAULT_MILESTONES slug bake); Kael v4 §0a empty-text fallback (`genId` not in scope at config.js parse time, so inline `Math.random` fallback).
+
+```js
+// Stable-id slug for default milestones. Pure / deterministic.
+// Lives in config.js (not core.js) because data.js calls it at parse
+// time when baking DEFAULT_MILESTONES — and concat order puts data.js
+// BEFORE core.js. (PR-ε.0 §0a — Kael v4 audit.)
+function slugify(text) {
+  const out = String(text || '').toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return out || ('ms-fallback-' + Math.random().toString(36).slice(2, 10));
+}
+```
+
+**Concat-order rationale:** `config → data → core → home → diet → medical → intelligence → sync → start`. `data.js` calls `slugify(text)` inline inside `DEFAULT_MILESTONES` literals (`data.js:1468–1476`) at parse time; `genId` from `core.js` is NOT yet in scope. The empty-text `Math.random` fallback is non-deterministic across loads — caught by the §1 second assert (cross-section invariant — see [Cross-section invariants summary](#cross-section-invariants-summary)).
+
+---
+
+### §0b — `genId` in `core.js`
+
+**Implements:** v6.2 spec §0b
+**Touches:** `split/core.js` near other utilities (next to `escHtml` ~line 2282 / `escAttr` ~line 2304 — verify against drift)
+**MAJORs folded:** none new; complements §0a split.
+
+```js
+function genId() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return 'id-' + Date.now().toString(36) + '-'
+    + Math.random().toString(36).slice(2, 10);
+}
+```
+
+Runtime-only. `id-` prefix keeps fallback IDs visually distinct from DEFAULT kebab slugs and from crypto UUIDs.
+
+---
+
+### §7.1 — `zi-close` sprite symbol
+
+**Implements:** v6.2 spec §7.1
+**Touches:** `split/template.html` sprite block; insert near sibling `<symbol id="zi-check">` at `template.html:43` (alphabetical proximity within the existing 62-symbol sprite — verified absent via grep).
+**MAJORs folded:** HR-1 (no literal `×`), HR-7 (zi() SVG via `<use href>`); §7.1 sprite-gap closure.
+
+```html
+<symbol id="zi-close" viewBox="0 0 24 24">
+  <path d="M6 6 L18 18 M18 6 L6 18"
+        stroke="currentColor" stroke-width="2" stroke-linecap="round"
+        fill="none"/>
+</symbol>
+```
+
+Stroke-only, currentColor — inherits chip color. Matches existing icons' 2px stroke weight (verified vs `zi-check` at `template.html:43`).
+
+---
+
+### §7.3 — CSS additions
+
+**Implements:** v6.2 spec §7.3
+**Touches:** `split/styles.css` — append all three blocks contiguously at the end of the existing Chips section starting at `styles.css:3401` (immediately after `.chip-avoid:hover` at ~`styles.css:3413`).
+**MAJORs folded:** Maren v5 §7.3 picker-row alignment MAJOR (`align-items: flex-start` + 2px `margin-top` on `.picker-row-check` — corrects multi-line wrap mis-alignment on phone widths); HR-2 / HR-5 token discipline; HR-10 no ellipsis (`word-break: break-word`); WCAG 2.5.5 44×44 touch targets.
+
+**Block 1 — chip-milestone:**
+
+```css
+/* ── Milestone tag chips (PR-ε.0) ── */
+.chip-milestone {
+  background: var(--lav-light);
+  color: var(--text);
+  border-color: rgba(201, 184, 232, 0.6);
+  cursor: default;
+  padding-right: var(--sp-4);
+  gap: var(--sp-6);
+}
+.chip-milestone:hover { filter: none; transform: none; }
+.chip-label {
+  font-size: var(--fs-sm);
+  white-space: normal;
+  word-break: break-word;
+  max-width: 200px;
+  line-height: var(--lh-snug);
+}
+.chip-x {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 28px; height: 28px;
+  min-width: 44px; min-height: 44px;
+  padding: var(--sp-8);
+  margin-left: calc(-1 * var(--sp-4));
+  margin-right: calc(-1 * var(--sp-4));
+  border: none; background: transparent;
+  color: var(--mid);
+  cursor: pointer;
+  border-radius: var(--r-full);
+  transition: background var(--ease-fast), color var(--ease-fast);
+}
+.chip-x:hover { background: var(--surface-lav); color: var(--text); }
+.chip-x .zi { width: var(--icon-xs); height: var(--icon-xs); }
+```
+
+**Block 2 — scrap-form-row + milestone-chips + scrap-tag-btn:**
+
+```css
+/* ── Scrapbook form: milestone link row (PR-ε.0) ── */
+.scrap-form-row {
+  display: flex; flex-direction: column;
+  gap: var(--sp-6);
+  margin-top: var(--sp-8);
+}
+.scrap-form-label {
+  font-size: var(--fs-sm); color: var(--mid);
+  font-family: 'Nunito', sans-serif;
+}
+.milestone-chips {
+  display: flex; flex-wrap: wrap;
+  gap: var(--sp-6);
+  min-height: 32px;
+}
+.milestone-chips[data-empty="true"] { min-height: 0; }
+.scrap-tag-btn {
+  align-self: flex-start;
+  display: inline-flex; align-items: center; gap: var(--sp-6);
+}
+.scrap-tag-btn .zi { width: var(--icon-sm); height: var(--icon-sm); }
+```
+
+**Block 3 — picker modal (with v6 alignment fix):**
+
+```css
+/* ── Picker modal (PR-ε.0) ── */
+.scrap-picker-modal {
+  max-width: 480px;
+  max-height: 80vh;
+  display: flex; flex-direction: column;
+  padding: var(--sp-20) var(--sp-24);
+}
+.scrap-picker-modal h3 { margin-bottom: var(--sp-12); }
+.picker-list {
+  flex: 1; overflow-y: auto;
+  display: flex; flex-direction: column; gap: var(--sp-16);
+  padding: var(--sp-4) 0;
+  margin-bottom: var(--sp-16);
+}
+.picker-cat-group { display: flex; flex-direction: column; gap: var(--sp-4); }
+.picker-cat-header {
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-xs); font-weight: 700;
+  text-transform: uppercase; letter-spacing: var(--ls-wide);
+  color: var(--mid);
+  padding: 0 var(--sp-4);
+}
+.picker-row {
+  display: flex;
+  align-items: flex-start; /* v6 fix: was center; broke multi-line wrap alignment */
+  gap: var(--sp-10);
+  padding: var(--sp-8) var(--sp-10);
+  border-radius: var(--r-lg);
+  cursor: pointer;
+  transition: background var(--ease-fast);
+  min-height: 44px;
+}
+.picker-row:hover { background: var(--surface-lav); }
+.picker-row-check {
+  width: 22px; height: 22px;
+  border: 1.5px solid var(--lavender);
+  border-radius: var(--r-sm);
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+  background: var(--card-bg);
+  transition: background var(--ease-fast);
+  margin-top: 2px; /* v6 fix: optical-align with first-line cap height */
+}
+.picker-row-check[data-checked="1"] { background: var(--lavender); }
+.picker-row-check[data-checked="0"] .zi { display: none; }
+.picker-row-check .zi { width: 14px; height: 14px; color: white; }
+.picker-row-label {
+  font-size: var(--fs-base);
+  color: var(--text);
+  word-break: break-word;
+  line-height: var(--lh-snug);
+}
+.picker-empty {
+  display: flex; flex-direction: column; align-items: center;
+  gap: var(--sp-8);
+  padding: var(--sp-32) var(--sp-16);
+  color: var(--mid);
+  text-align: center;
+}
+.picker-empty .zi { width: var(--icon-lg); height: var(--icon-lg); color: var(--lavender); }
+.picker-empty p { margin: 0; font-size: var(--fs-base); }
+.picker-empty-sub { color: var(--light); font-size: var(--fs-sm); }
+```
+
+---
+
+## Phase B — Schema & migrations
+
+### §1 — `migrateMilestoneIds` (pseudocode)
+
+**Implements:** v6.2 spec §1
+**Touches:** `split/core.js` — new helper near other migration utilities. Call site between milestones sanitize block (`core.js` ~778) and `save(KEYS.milestones, milestones)` (~`core.js:826`). Spec range "752–790" understates the actual sanitize+migrate footprint by ~36 lines — verify the precise line at edit time.
+**MAJORs folded:** Kael v5 §1 fallback-id assert (Set-size is necessary but not sufficient — two empty-text DEFAULTs each slug to a unique `ms-fallback-<random>` and pass). **Cross-section invariant:** this assert protects §6.3 DEFAULT-wins survivor selection — a non-deterministic fallback id in `defaultSlugIds` would let same-text collisions orphan the slug at dedup. Loud assert here means §6.3 never sees that input.
+
+**Pseudocode:**
+
+```text
+function migrateMilestoneIds() {
+    if not array(milestones): return
+    // Assert 1: DEFAULT slug uniqueness (Set-size check on DEFAULT_MILESTONES.id).
+    // Assert 2 (v6 Kael MAJOR): NO DEFAULT id matches /^ms-fallback-/ —
+    //          empty-text developer error. Protects §6.3 defaultSlugIds composition.
+    build slugByText: text -> id  from DEFAULT_MILESTONES
+    for each m in milestones:
+        if m.id: skip
+        m.id = slugByText[m.text]  OR  genId()   // DEFAULT-text match wins, else fresh UUID
+        mark dirty
+    if dirty: save(KEYS.milestones, milestones)
+}
+```
+
+**Concretization checklist:**
+- [ ] Both `console.assert` calls land verbatim from spec (Set-size + `/^ms-fallback-/` parallel assertions).
+- [ ] Call inserted between cat-migration loop end (~`core.js:825`) and `save(KEYS.milestones, milestones)` at ~`core.js:826` — verify exact line at edit time.
+- [ ] Idempotency confirmed: second invocation in same session is a no-op (every entry has `m.id`, loop early-returns, `dirty` stays false).
+
+---
+
+### §1 — `migrateScrapbookIds`
+
+**Implements:** v6.2 spec §1 (scrapbook migration)
+**Touches:** `split/core.js` — new helper sibling to `migrateMilestoneIds`. Call site between scrapbook sanitize at ~`core.js:792` (`if (!Array.isArray(scrapbook)) scrapbook = []`) and the first `renderScrapbook()` call at ~`core.js:960`.
+**MAJORs folded:** none new; complements §1 idempotent-init pattern.
+
+```js
+function migrateScrapbookIds() {
+  if (!Array.isArray(scrapbook)) return;
+  let dirty = false;
+  scrapbook.forEach(e => {
+    if (e.id) return;
+    e.id = genId();
+    dirty = true;
+  });
+  if (dirty) save(KEYS.scrapbook, scrapbook);
+}
+```
+
+Mirrors §1 milestones minus the slug-table — scrapbook has no deterministic id source. Idempotent on re-run.
+
+---
+
+### §1 — `addMilestone` id assignment
+
+**Implements:** v6.2 spec §1 (custom milestone path)
+**Touches:** `split/home.js:1905–1914` (`addMilestone` body)
+**MAJORs folded:** none new.
+
+```js
+// At the existing milestones.push site in addMilestone, prepend:
+milestones.push({
+  id: genId(),                 // PR-ε.0 §1 — custom milestones use genId
+  text: t,
+  // ...existing fields preserved
+});
+```
+
+**Out-of-scope reminder (Maren v5 audit MINOR, deferred):** `addMilestone` does not call `save(KEYS.milestones, milestones)` today. PR-ε.0 inherits the bug; orphan-tolerance in §4 (silent filter on read + edit-load toast) handles the consequence gracefully. Followup register only.
+
+---
+
+## Phase C — Identity refactor
+
+### §2 — Dispatcher migration patterns
+
+**Implements:** v6.2 spec §2 (identity refactor)
+**Touches:** `split/core.js:454–456` (dispatcher arm — verified exact); render-side at `core.js:2128` (`origIdx = scrapbook.indexOf(entry)`), `core.js:2135` (`openScrapPhoto` data-arg), `core.js:2144–2145` (edit/delete data-arg). Function bodies at `core.js:2192–2256` (`addScrapEntry` / `editScrapEntry` / `deleteScrapEntry` / `openScrapPhoto`).
+**MAJORs folded:** Kael v4 audit MAJOR — line 2135 was missed in v3; all three buttons need id-based `data-arg`, not just edit/delete.
+
+**Dispatcher arm — three one-liners, BEFORE/AFTER:**
+
+```js
+// BEFORE (core.js:454-456):
+else if (action === 'editScrapEntry')   editScrapEntry(parseInt(arg));
+else if (action === 'deleteScrapEntry') deleteScrapEntry(parseInt(arg));
+else if (action === 'openScrapPhoto')   openScrapPhoto(parseInt(arg));
+
+// AFTER:
+else if (action === 'editScrapEntry')   editScrapEntry(arg);
+else if (action === 'deleteScrapEntry') deleteScrapEntry(arg);
+else if (action === 'openScrapPhoto')   openScrapPhoto(arg);
+```
+
+**Function-body lookup pattern:**
+
+```js
+// BEFORE (e.g. editScrapEntry at core.js:2220+):
+function editScrapEntry(i) {
+  const entry = scrapbook[i];
+  _scrapEditIdx = i;
+  // ...
+}
+
+// AFTER:
+function editScrapEntry(id) {
+  const entry = scrapbook.find(e => e.id === id);
+  if (!entry) return;
+  _scrapEditId = id;            // global rename: _scrapEditIdx → _scrapEditId
+  // ...rest of v6.2 §4 edit-load orphan-toast logic (see §4.B / §4.C)
+}
+
+// deleteScrapEntry — splice via findIndex, NOT array index:
+const i = scrapbook.findIndex(e => e.id === id);
+if (i < 0) return;
+scrapbook.splice(i, 1);
+save(KEYS.scrapbook, scrapbook);   // explicit — render-side save removed
+// DELETE the `else if (_scrapEditIdx > i) _scrapEditIdx--` index-fixup branch entirely.
+```
+
+**Render-side `data-arg` swap — three buttons (`core.js:2135, 2144, 2145`):**
+
+```js
+// BEFORE: data-arg="${origIdx}"
+// AFTER:  data-arg="${e.id}"   // also drop `const origIdx = scrapbook.indexOf(entry)` at 2128
+```
+
+Also harmonize `home.js:6532+` `renderScrapbookHistory` (currently uses `origIdx = scrapbook.indexOf(entry)`) — rewrite to `entry.id`.
+
+**Verification grep guards (run in `split/` before merge):**
+
+```bash
+grep -n 'scrapbook\['        split/   # expect 0 hits in mutation paths
+grep -n '_scrapEditIdx'      split/   # expect 0 hits — full rename
+grep -n 'parseInt.*scrap'    split/   # expect 0 hits — no leftover coercions
+grep -n 'origIdx'            split/   # expect 0 hits in scrapbook render
+```
+
+**[Drift correction — Kael build-time finding]** Spec §2 lists "estimated lines 2197, 2199, 2223, 2243, 2252, 2253" for `_scrapEditIdx` references — actual hits are **2190, 2197, 2199, 2223, 2243, 2252, 2253** (the `let`-declaration at 2190 is the additional one). Verify all 7 sites get renamed.
+
+**Atomicity constraint:** the dispatcher edits, function-body lookups, and `_scrapEditIdx → _scrapEditId` rename MUST land in one commit. Intermediate state (string id flowing into `scrapbook[i]` or numeric index into `scrapbook.find(e => e.id === ...)`) yields runtime `undefined`. See [Cross-section invariants summary](#cross-section-invariants-summary).
+
+---
+
+## Phase D — Sync layer integration
+
+### §6.1 — `_syncSetGlobal` scrapbook arm
+
+**Implements:** v6.2 spec §6.1
+**Touches:** `split/sync.js:238–255` (set switch ends at 255) + `split/sync.js:257–275` (get switch).
+**MAJORs folded:** Cipher audit BLOCKER #1 (without scrapbook case, listener writes localStorage but in-memory `scrapbook` global stays stale → next mutation re-emits as delete+re-add). Kael v5 MAJOR (reassignment-vs-in-place asymmetry comment vs §6.3 milestones in-place mandate).
+
+```js
+// sync.js _syncSetGlobal switch (insert near case 'visits' or end of switch, before default):
+// PR-ε.0 §6.1 — scrapbook reassignment is acceptable here ONLY because no
+// in-place mutator (no dedupeScrapbookByText analog) and no closure-pinning
+// reader exists today (Maren+Kael v5 audit). §6.3 mandates in-place mutation
+// for `milestones` for the symmetric closure-pin hazard. Re-verify if either
+// constraint changes (closure-pinning reader added, OR in-place scrapbook
+// mutator like a future dedupeScrapbookByText).
+case 'scrapbook':    scrapbook    = value; return true;
+
+// sync.js _syncGetGlobal switch:
+case 'scrapbook':    return scrapbook;
+```
+
+The asymmetry comment is the v6 fold — without it, a future reader sees `milestones` use `length=0; push.apply` and `scrapbook` use direct assignment with no rationale and could "harmonize" the wrong direction.
+
+---
+
+### §6.2(a) — `_reconcileDone` state declaration
+
+**Implements:** v6.2 spec §6.2(a)
+**Touches:** `split/sync.js:14–20` (module-scope var block). Verified: lines 14–20 are `var _syncShadow`, `var _syncDebounceTimers`, `var _syncWriteCount`, `var _syncWriteCountReset`, `var _syncToastQueue`, `var _syncIsMigrating`, `var _syncIsReconciling`. Line 21 flips to `const CIRCUIT_BREAKER_LIMIT`.
+**MAJORs folded:** none new (foundational state for §6.2(c) + (d)).
+
+```js
+// PR-ε.0 §6.2 — per-entry reconcile gate.
+// Keyed by collection name; entry exists once the first successful snapshot
+// apply has happened for that collection in this session. Cleared on
+// reconnect / household-rejoin (§6.2(d)).
+var _reconcileDone = new Set();
+```
+
+`var` matches the surrounding seven-line idiom; `const` would not work (reassigned in §6.2(d)). Insert immediately after `var _syncIsReconciling = false;` at line 20, before the `const` boundary at 21.
+
+---
+
+### §6.2(c) — Reconcile pipeline (pseudocode)
+
+**Implements:** v6.2 spec §6.2(c)
+**Touches:** `split/sync.js` `_syncHandlePerEntrySnapshot` body (~lines 1188–1320 per spec). The reconcile block sits **AFTER** the empty-snapshot guard at ~`sync.js:1275–1279` and **BEFORE** the wholesale `save(lsKey, entries)` at ~`sync.js:1291`. Cross-reference: `_syncWritePerEntry` at ~`sync.js:907+` for the canonical stamp-trio + counter idiom.
+**MAJORs folded (Kael v5):** circuit-breaker bail must not silently drop local data (orphans concat into `entries` regardless of push outcome); reconcile push must stamp full sync metadata trio (`__sync_createdBy/updatedBy/syncedAt`); `_reconcileDone.add` only on success path (bail leaves gate open for retry on next attach). **MAJORs folded (v6.1 Aurelius polish):** inner try/catch around each `forEach` body (sync throw inside `.set()` no longer skips subsequent orphans); counter-comment one-liner above `_syncWriteCount++` (overcount-fail-safe rationale, prevents future "fix" that would invert safety direction).
+
+**Pseudocode (the orchestration; embeds real-JS sub-blocks where they're already concrete in the spec):**
+
+```text
+function _syncHandlePerEntrySnapshot(collection, snapshot) {
+    // [existing: parse snapshot to `entries`; existing: empty-snapshot guard]
+
+    // ── PR-ε.0 §6.2 reconcile gate (fires once per collection per session) ──
+    if NOT _reconcileDone.has(collection):
+        remoteIds = new Set(entries.map(e => e && e.id).filter(Boolean))
+        orphanLocals = (current || []).filter(e => e && e.id AND NOT remoteIds.has(e.id))
+
+        if orphanLocals.length > 0:
+            // INVARIANT 1 (Kael v5 §6.2 MAJOR): orphans concat into `entries` IMMEDIATELY,
+            // BEFORE any breaker/push branching. Survives the wholesale
+            // `save(lsKey, entries)` below regardless of push outcome.
+            entries = entries.concat(orphanLocals)
+
+            if (_syncWriteCount + orphanLocals.length) > CIRCUIT_BREAKER_LIMIT:
+                // INVARIANT 2 (Kael v5 §6.2(c) MAJOR): bail path.
+                //   - Skip remote `set()` calls.
+                //   - Local entries already concat'd into `entries` above (survive).
+                //   - Do NOT add to _reconcileDone — gate stays OPEN for retry.
+                //   - Next sync re-attach (§6.2(d)) clears the gate; next snapshot retries.
+                console.warn('[sync] reconcile would exceed circuit breaker; deferring push',
+                             collection, orphanLocals.length)
+                // fall through to existing save(lsKey, entries) below
+            else:
+                // Push path
+                hRef        = firebase.firestore().collection('households').doc(_syncHouseholdId)
+                colRef      = hRef.collection(collection)
+                writerIdent = { uid: _syncUser.uid, name: _syncUser.displayName || 'Parent' }
+                stampBase   = {
+                    __sync_createdBy: writerIdent,    // matches _syncWritePerEntry sync.js:917-918
+                    __sync_updatedBy: writerIdent,
+                    __sync_syncedAt:  firebase.firestore.FieldValue.serverTimestamp()
+                }
+
+                // INVARIANT 3 (v6.1 Aurelius polish item 2):
+                //   - Suppress "X added N memories" toasts during reconcile.
+                //   - try/finally restores _syncIsReconciling on any throw.
+                wasReconciling = _syncIsReconciling
+                _syncIsReconciling = true
+                try:
+                    for each e in orphanLocals:
+                        // INVARIANT 4 (v6.1 Aurelius polish item 2):
+                        //   - INNER try/catch wraps EACH forEach body (not the forEach itself).
+                        //   - Sync throw on `.set()` (e.g., firebase uninit) doesn't skip
+                        //     subsequent orphans this fire — log and continue.
+                        try:
+                            // INVARIANT 5 (v6.1 Aurelius polish item 2 counter comment):
+                            //   - Increment BEFORE .set() — overcount is fail-safe (breaker
+                            //     bails earlier); do NOT move post-resolve, async settlement
+                            //     would let bursts under-count and overshoot the limit.
+                            //   - Matches existing _syncWritePerEntry pattern at sync.js:884.
+                            _syncWriteCount++
+                            colRef.doc(e.id).set(Object.assign({}, e, stampBase), {merge: false})
+                                  .catch(err => {
+                                      console.error('[sync] reconcile push failed',
+                                                    collection, e.id, err)
+                                      // Local entry already in `entries`; survives this session.
+                                      // Retry on next sync re-attach (§6.2(d) clears gate).
+                                  })
+                        catch syncErr:
+                            console.error('[sync] reconcile push threw synchronously',
+                                          collection, e.id, syncErr)
+                            // Local entry already in `entries` above; survives. Continue forEach.
+                finally:
+                    _syncIsReconciling = wasReconciling
+
+                // INVARIANT 6 (Kael v5 §6.2 MAJOR):
+                //   - _reconcileDone.add ONLY on success path. Bail (above) leaves it open.
+                _reconcileDone.add(collection)
+        else:
+            // No orphans this fire — close gate immediately. Future fires this session skip the diff.
+            _reconcileDone.add(collection)
+
+    // [existing: save(lsKey, entries)]
+    // [existing: dispatch render via SYNC_RENDER_DEPS]
+}
+```
+
+**Concretization checklist:**
+- [ ] **Placement:** reconcile block sits AFTER the empty-snapshot guard (`sync.js:1275–1279`) and BEFORE the wholesale `save(lsKey, entries)` (`sync.js:1291`). Spec accepts this trade-off (an empty-remote + non-empty-local first fire will NOT push orphans via reconcile; next local-mutation diff push handles it).
+- [ ] **Concat survival:** `entries = entries.concat(orphanLocals)` runs on EVERY orphan-detected branch (success, bail, exception). Local data must never be dropped. Single statement, before the branch split.
+- [ ] **Gate-add scope:** `_reconcileDone.add(collection)` lives in TWO places — (a) end of success push path, (b) the no-orphans else-branch. NEVER inside the bail branch (gate must stay open for retry).
+- [ ] **Inner try/catch (v6.1):** wraps each `forEach` body, NOT the `forEach` itself. The outer `_syncIsReconciling` try/finally remains around the whole `forEach`.
+- [ ] **Counter comment (v6.1):** the multi-line comment block lands above `_syncWriteCount++` verbatim (overcount fail-safe rationale + `sync.js:884` cross-reference).
+- [ ] **Stamp parity:** `stampBase` includes all three of `__sync_createdBy`, `__sync_updatedBy`, `__sync_syncedAt` — matches `_syncWritePerEntry` at `sync.js:917–918`. Without `__sync_createdBy`, the per-entry attribution composition at `sync.js:1238–1259` silently loses creation provenance for reconciled entries.
+
+---
+
+### §6.2(d) — Reconnect-clear in `_syncAttachListeners`
+
+**Implements:** v6.2 spec §6.2(d)
+**Touches:** `split/sync.js:1123–1124` (`_syncAttachListeners` body — verified exact: function declaration at 1123, `_syncDetachListeners()` first call at 1124).
+**MAJORs folded:** Kael v4 audit MAJOR — reset MUST run AFTER `_syncDetachListeners()` so any in-flight microtask-queued snapshot callback (already armed before detach, runs after detach returns) fires against the OLD consumed gate and is a no-op for reconcile. Pre-detach reset would let stragglers re-attempt reconcile against stale state.
+
+```js
+function _syncAttachListeners(hId) {
+  _syncDetachListeners();           // existing line 1124 — DO NOT reorder
+  _reconcileDone = new Set();       // PR-ε.0 §6.2(d) — AFTER detach, BEFORE re-arm
+  var db = firebase.firestore();    // existing line 1125
+  // ...rest of existing arm logic unchanged
+}
+```
+
+**Placement constraint:** the inline comment MUST stay. Moving the reset to line 1 of the function (intuitive "reset at top") re-introduces the v4 straggler-vs-fresh-gate bug. **Issue [#53](https://github.com/Rishabh1804/sproutlab/issues/53)** tracks the broader snapshot-pipeline straggler limitation; this reset only protects reconcile re-fire, not snapshot-apply.
+
+---
+
+### §6.3 — `dedupeMilestonesByText` (pseudocode)
+
+**Implements:** v6.2 spec §6.3
+**Touches:** `split/medical.js:170+` (`dedupeMilestonesByText` body) — body grows from existing ~50 lines to ~70 lines after v6 additions. Three call sites unchanged: `core.js:849`, `medical.js:154` (via `_postReceiveMilestones`), `medical.js:231` (via `syncMilestoneStatuses`).
+**MAJORs folded:** v6 BLOCKER (in-place mutation via `length=0; push.apply` — NOT reassignment, which would orphan any closure that captured the pre-dedup reference, e.g. §6.1 `_syncSetGlobal('milestones', ...)` rehydrate path). v6 Kael MAJOR (DEFAULT-slug-wins survivor selection — lex-only could put UUID `0abc...` BEFORE kebab `babbling`, orphaning the deterministic slug on same-text custom-vs-DEFAULT collisions). v4 Kael MAJOR (survivor-mutation behavioral delta — `_mergeMilestoneFieldsInline` mutates `winner` in place; benign today since no closure pins; flagged for re-verification). Audit BLOCKER #3 fold (id-orphan on cross-device dedup — scrapbook `milestoneIds` rewritten via `rewriteScrapbookMilestoneIds` side-effect call).
+
+**Cross-section invariant (Cipher v6.1 finding):** §1's `/^ms-fallback-/` assert is the precondition for `defaultSlugIds` determinism here. If §1 assert is ever softened, this dedup loses determinism on empty-text DEFAULT collisions. See [Cross-section invariants summary](#cross-section-invariants-summary).
+
+**Pseudocode:**
+
+```text
+function dedupeMilestonesByText() {
+    byKey      = new Map()    // normalized text → survivor entry
+    idRewrite  = new Map()    // discarded id → survivor id
+    dropped    = []           // entries to remove from milestones
+
+    // INVARIANT 1 (v6 Kael MAJOR): build defaultSlugIds INSIDE the function.
+    //   - Rebuilt fresh per call (not module-scope cached).
+    //   - DEFAULT_MILESTONES is `const` at data.js:1468 — Kael+Cipher v6.1 confirm
+    //     no mutation sites; the `const` declaration IS the load-bearing invariant.
+    //   - Cross-section: §1 fallback-assert ensures `defaultSlugIds` membership
+    //     is itself deterministic (no `ms-fallback-*` ids enter this Set).
+    defaultSlugIds = new Set(
+        (typeof DEFAULT_MILESTONES !== 'undefined' ? DEFAULT_MILESTONES : [])
+            .map(d => d.id).filter(Boolean)
+    )
+
+    for i = 0 to milestones.length - 1:
+        m   = milestones[i]
+        key = (m.text || '').trim().toLowerCase()
+        prev = byKey.get(key)
+
+        if NOT prev:
+            byKey.set(key, m); continue
+
+        // INVARIANT 2 (v6 Kael MAJOR): DEFAULT-slug wins over UUID/genId fallback.
+        //   - Priority 1: if exactly one of (m, prev) is a DEFAULT-slug id, that one wins.
+        //   - Priority 2 (both DEFAULT or both custom): lex-smaller-id wins
+        //     (deterministic across devices for UUID/UUID and slug/slug ties).
+        mIsDefault    = defaultSlugIds.has(m.id)
+        prevIsDefault = defaultSlugIds.has(prev.id)
+        if mIsDefault AND NOT prevIsDefault:
+            winner = m;    loser = prev
+        else if prevIsDefault AND NOT mIsDefault:
+            winner = prev; loser = m
+        else:
+            winner = (m.id || '￿') < (prev.id || '￿') ? m : prev
+            loser  = winner === m ? prev : m
+
+        if loser.id AND winner.id AND loser.id !== winner.id:
+            idRewrite.set(loser.id, winner.id)
+
+        // INVARIANT 3 (v4 Kael MAJOR — survivor-mutation behavioral delta):
+        //   - _mergeMilestoneFieldsInline mutates winner IN PLACE (latest *At dates,
+        //     most-advanced status, etc. — existing rules at medical.js:191-217).
+        //   - Differs from prior `Object.assign({}, grp[0])` clone idiom.
+        //   - Benign today (no closure pinning confirmed in jurisdiction-Kael
+        //     and jurisdiction-Maren); flag for re-verification if any later PR
+        //     pins a milestone object reference.
+        _mergeMilestoneFieldsInline(winner, loser)
+        byKey.set(key, winner)
+        dropped.push(loser)
+
+    if dropped.length === 0: return false
+
+    // INVARIANT 4 (v6 BLOCKER): in-place mutation.
+    //   - `milestones = survivors` would orphan any closure that captured the
+    //     pre-dedup array reference. §6.1 _syncSetGlobal rehydrate would write
+    //     to a fresh array while readers read the orphaned old one.
+    //   - `length = 0; push.apply(target, source)` mutates the same array object.
+    survivors = Array.from(byKey.values())
+    milestones.length = 0
+    milestones.push.apply(milestones, survivors)
+
+    // INVARIANT 5 (audit BLOCKER #3 fold):
+    //   - Side-effect call to rewriteScrapbookMilestoneIds when any id was rewritten.
+    //   - Without this, scrapbook entries that referenced discarded ids become
+    //     orphans across cross-device dedup merges.
+    if idRewrite.size > 0:
+        rewriteScrapbookMilestoneIds(idRewrite)
+
+    return true   // existing contract: returns whether milestones changed
+}
+```
+
+**Concretization checklist:**
+- [ ] **In-place mutation:** `milestones.length = 0; milestones.push.apply(milestones, survivors)` — NOT `milestones = survivors` reassignment. The v6 BLOCKER reverts the existing `medical.js:221` reassignment idiom; verify the diff drops that line.
+- [ ] **DEFAULT-wins short-circuit precedes lex compare:** the two `if mIsDefault ...` branches must run before the `winner = (m.id||...) < (prev.id||...) ? m : prev` fallback. Order matters.
+- [ ] **`defaultSlugIds` Set is built INSIDE the function:** rebuilt fresh per call (not hoisted to module scope, not cached). Cipher+Kael v6.1 confirmed this satisfies the freshness invariant absent `const` mutation.
+- [ ] **`_mergeMilestoneFieldsInline` mutates `winner` in place:** existing `medical.js:191–217` field-merge rules preserved; survivor-mutation behavioral delta accepted per Kael v4 audit MAJOR.
+- [ ] **`rewriteScrapbookMilestoneIds(idRewrite)` called only when `idRewrite.size > 0`:** avoids needless write to scrapbook localStorage.
+- [ ] **Boolean return contract preserved:** three call sites (`core.js:849`, `medical.js:154`, `medical.js:231`) all still no-arg, all expect `true`/`false`. No signature change.
+- [ ] **Cross-section invariant:** §1 `/^ms-fallback-/` assert MUST hold for `defaultSlugIds` to be deterministic across loads. If §1 assert is ever softened, this dedup loses determinism on empty-text DEFAULT collisions.
+
+---
+
+### §6.3 — `_postReceiveMilestones`
+
+**Implements:** v6.2 spec §6.3 (migrate-before-dedup integration)
+**Touches:** `split/medical.js:145–157` — verified exact. Function signature at 145, dedupe call at 153–155, function close at 157.
+**MAJORs folded:** Kael v5 MAJOR (`typeof migrateMilestoneIds === 'function'` silent-skip → `console.assert`). Concat order GUARANTEES `migrateMilestoneIds` is in scope by `medical.js` parse time (config → data → core → home → diet → medical), so the typeof guard hides nothing today but masks future renames.
+
+```js
+function _postReceiveMilestones() {
+  if (!Array.isArray(milestones)) return;
+  try {
+    if (typeof migrateMilestoneStatus === 'function') {
+      milestones.forEach(m => migrateMilestoneStatus(m));
+    }
+  } catch(e) { console.warn('[post-receive milestones] migrate:', e); }
+  // PR-ε.0 §6.3 — Kael v5 MAJOR: assert (don't typeof-guard) migrateMilestoneIds.
+  // Concat order config → data → core → home → diet → medical guarantees
+  // in-scope at medical.js parse time. Assert fires loud at dev time if a
+  // rename ever breaks the contract. Matches §1 assertion idiom.
+  console.assert(
+    typeof migrateMilestoneIds === 'function',
+    'PR-ε.0 §6.3: _postReceiveMilestones expects migrateMilestoneIds in scope'
+  );
+  migrateMilestoneIds();   // PR-ε.0 §6.3 — runs BEFORE dedupe so all entries have ids
+  try {
+    if (typeof dedupeMilestonesByText === 'function') {
+      dedupeMilestonesByText();
+    }
+  } catch(e) { console.warn('[post-receive milestones] dedupe:', e); }
+}
+```
+
+Idempotent: post-PR-ε.0 receive is a no-op; pre-PR-ε.0 receive writes once, propagates via single-doc sync, other devices receive migrated entries and their own `_postReceiveMilestones` is then a no-op. Terminates in one round-trip per legacy entry.
+
+---
+
+### §6.3 — `rewriteScrapbookMilestoneIds`
+
+**Implements:** v6.2 spec §6.3(b)
+**Touches:** `split/medical.js` — new sibling helper to `dedupeMilestonesByText` (which lives at line 170+). Suggested placement: directly after `dedupeMilestonesByText`'s close (~line 225 today; verify against drift via the footer table).
+**MAJORs folded:** Cipher audit BLOCKER #3 fold (id-orphan on cross-device dedup). Used by §6.3 dedup as a side-effect call when `idRewrite.size > 0`.
+
+```js
+function rewriteScrapbookMilestoneIds(idRewrite) {
+  if (!Array.isArray(scrapbook) || !idRewrite.size) return;
+  let dirty = false;
+  scrapbook.forEach(e => {
+    if (!Array.isArray(e.milestoneIds)) return;
+    const remapped = e.milestoneIds.map(id => idRewrite.get(id) || id);
+    // Dedup after remap (in case both survivor + discarded were tagged on same entry).
+    const unique = Array.from(new Set(remapped));
+    if (unique.length !== e.milestoneIds.length ||
+        unique.some((id, i) => id !== e.milestoneIds[i])) {
+      e.milestoneIds = unique;
+      dirty = true;
+    }
+  });
+  if (dirty) save(KEYS.scrapbook, scrapbook);
+}
+```
+
+Called from inside `dedupeMilestonesByText` when `idRewrite.size > 0`. Side-effects on the `scrapbook` global; returns void (caller doesn't read return).
+
+---
+
+### §3 — SYNC_KEYS + SYNC_RENDER_DEPS registration (atomic)
+
+**Implements:** v6.2 spec §3
+**Touches:** `split/sync.js:120` (SYNC_KEYS object) + `split/sync.js:201` (SYNC_RENDER_DEPS object) — verified exact landmarks.
+**MAJORs folded:** Cipher v2 BLOCKER #9 (tab key is `'history'` not `'home'` — scrapbook lives in history tab post-v2.3 relocation per `template.html:1010`).
+
+```js
+// sync.js:120 — inside SYNC_KEYS object literal, alongside per-entry siblings (notes, careTickets):
+[KEYS.scrapbook]: { collection: 'scrapbook', model: 'per-entry' },
+
+// sync.js:201 — inside SYNC_RENDER_DEPS object literal:
+[KEYS.scrapbook]: {
+  global: 'scrapbook',
+  renderers: { 'history': ['renderScrapbook', 'renderScrapbookHistory'] }
+},
+```
+
+**Atomicity constraint (spec step 16):** both registrations MUST commit together. SYNC_KEYS alone arms a listener that dispatches against an undefined dep (silent render miss); SYNC_RENDER_DEPS alone is dead config. Land in one edit; verify `KEYS.scrapbook` appears in both literals via grep.
+
+---
+
+## Phase E — UI surface (chips + picker)
+
+### §4.A — `renderScrapMilestoneChips`
+
+**Implements:** v6.2 spec §4 (chip render block)
+**Touches:** `split/core.js` — new sibling function above `addScrapEntry` (~`core.js:2192`); insertion point near the existing scrapbook render block at ~`core.js:2130–2150` (verify-then-edit per Phase E).
+**MAJORs folded:** Maren v5 §4 entity-reference escape (escAttr+escHtml double-wrap on `aria-label`); Maren v5 §4 empty-text legacy guard (`labelText` fallback); HR-4 escape contracts at every interpolation boundary.
+
+```js
+function renderScrapMilestoneChips() {
+  const host = document.getElementById('scrapMilestonePicker');
+  if (!host) return;
+  const ids = _scrapMilestoneIdsPending || [];
+  host.setAttribute('role', 'list');
+  host.setAttribute('data-empty', ids.length === 0 ? 'true' : 'false');
+  host.innerHTML = ids.map(id => {
+    const m = milestones.find(x => x.id === id);
+    if (!m) return ''; // silent skip on orphan; confirm-time toast covers UX
+    const labelText = (m.text || '').trim() || '(unnamed milestone)';
+    return `<span class="chip chip-milestone" role="listitem">
+      <span class="chip-label">${escHtml(labelText)}</span>
+      <button type="button" class="chip-x"
+              data-action="removeScrapMilestone" data-arg="${m.id}"
+              aria-label="Remove ${escAttr(escHtml(labelText))} tag">
+        <svg class="zi" aria-hidden="true"><use href="#zi-close"/></svg>
+      </button>
+    </span>`;
+  }).join('');
+}
+```
+
+---
+
+### §4.B — Picker action handlers (five small handlers)
+
+**Implements:** v6.2 spec §4 action-handler table
+**Touches:** dispatcher arm at `split/core.js:259–469` (register five new `else if` branches alongside existing `addScrapEntry` / `editScrapEntry` cases at `core.js:377` and `core.js:454`); handler bodies live as module-scope functions colocated with `addScrapEntry` near `core.js:2192`.
+**MAJORs folded:** Maren v4 §4 silent-orphan-disappearance MAJOR (edit-load toast); Maren v6 §4 confirm-time orphan toast MAJOR (closes the two-stage gap where a remote-deleted milestone vanished mid-picker without explanation); audit major #8 always-reseed; audit major #13 filter-before-persist; v6.1 Maren MINOR `removeScrapMilestone` wait-for-save semantics doc.
+
+```js
+function openScrapMilestonePicker() {
+  // Always reseed working set from pending — back-button-leak safe.
+  _scrapPickerWorkingSet = new Set(_scrapMilestoneIdsPending || []);
+  renderScrapMilestonePickerList();
+  openModal('scrapMilestonePickerModal');
+}
+
+function toggleScrapPickerMilestone(id) {
+  if (_scrapPickerWorkingSet.has(id)) _scrapPickerWorkingSet.delete(id);
+  else _scrapPickerWorkingSet.add(id);
+  renderScrapMilestonePickerList();
+}
+
+function confirmScrapMilestonePicker() {
+  // v6 Maren MAJOR: surface confirm-time orphan toast for remote-deleted ids.
+  const pre = [..._scrapPickerWorkingSet];
+  _scrapMilestoneIdsPending = pre.filter(id => milestones.some(m => m.id === id));
+  const dropped = pre.length - _scrapMilestoneIdsPending.length;
+  if (dropped > 0) {
+    const noun = dropped === 1 ? 'milestone tag' : 'milestone tags';
+    showQLToast(`${dropped} ${noun} removed — milestone no longer exists`);
+  }
+  closeModal('scrapMilestonePickerModal');
+  renderScrapMilestoneChips();
+}
+
+function cancelScrapMilestonePicker() {
+  _scrapPickerWorkingSet = new Set(); // discard
+  closeModal('scrapMilestonePickerModal');
+}
+
+function removeScrapMilestone(id) {
+  // v6.1 Maren MINOR: pending-state edit; persists only on parent form save
+  // (parallels the title-field input semantic — see §4.C wiring).
+  // Do NOT "fix" to immediate-persist; cancelScrapEdit discards pending changes.
+  _scrapMilestoneIdsPending = (_scrapMilestoneIdsPending || []).filter(x => x !== id);
+  renderScrapMilestoneChips();
+}
+```
+
+**Dispatcher additions** (insert into the `core.js:259–469` `if/else if` chain — group near other scrapbook actions around `core.js:454`):
+
+```js
+else if (action === 'openScrapMilestonePicker')    openScrapMilestonePicker();
+else if (action === 'toggleScrapPickerMilestone')  toggleScrapPickerMilestone(arg);
+else if (action === 'confirmScrapMilestonePicker') confirmScrapMilestonePicker();
+else if (action === 'cancelScrapMilestonePicker')  cancelScrapMilestonePicker();
+else if (action === 'removeScrapMilestone')        removeScrapMilestone(arg);
+```
+
+---
+
+### §4.C — Wiring into create/edit lifecycle (cross-cut)
+
+**Implements:** v6.2 spec §4 wiring section
+**Touches:** `split/core.js:2192` (`addScrapEntry`), `~core.js:2220+` (`editScrapEntry`), `~core.js:2249+` (`deleteScrapEntry`), plus `clearScrapPhoto` / `cancelScrapEdit` for state-reset symmetry.
+**MAJORs folded:** Cipher BLOCKER #2 (render-side `save()` removed; mutators call `save` explicitly — also matches Maren v5 `// DOES NOT SAVE` header on `renderScrapbook`); Maren v5 §4 silent-orphan edit-load toast.
+
+This section is the cross-cut between Maren's UI surface and Kael's data-layer plumbing. The full real-JS lives in v6.2 spec §4 lines ~664–727; copy-forward verbatim — no behavioral changes since v6.2 spec landed.
+
+**Key invariants (concretization checklist):**
+- [ ] **`addScrapEntry` new-entry branch:** `id: genId()`, `milestoneIds: [..._scrapMilestoneIdsPending]` (always present, never omitted).
+- [ ] **`addScrapEntry` edit branch:** reuse `entry.id`; overwrite `entry.milestoneIds = [..._scrapMilestoneIdsPending]`.
+- [ ] **Both branches end with explicit `save(KEYS.scrapbook, scrapbook)`** before `renderScrapbook()` (compensates for the removed render-side save — Cipher BLOCKER #2 + Maren v5 audit major #10).
+- [ ] **`editScrapEntry(id)` seeds + filters:** `_scrapMilestoneIdsPending = (entry.milestoneIds || []).slice()`, then filter against current milestones AND surface the one-time `showQLToast` when orphans were dropped (Maren v5 audit MAJOR — silent disappearance violates parent-safety).
+- [ ] **`clearScrapPhoto()` resets** both `_scrapMilestoneIdsPending` and `_scrapPickerWorkingSet`.
+- [ ] **`cancelScrapEdit()` calls** `clearScrapPhoto()` (existing).
+- [ ] **`deleteScrapEntry(id)` looks up by id**, splices via `findIndex`, calls explicit `save(...)`. The index-fixup branch (`_scrapEditIdx > i` shift) is DELETED entirely.
+
+---
+
+## Phase F — Verification & ship
+
+### §7.7 — Visual sanity checklist
+
+**Implements:** v6.2 spec §7.7
+**Touches:** Pre-PR Lyra-runs-this checklist; not a code anchor — references `styles.css:152` (focus-visible global rose 2px outline) and `styles.css:3902` (reduced-motion global block, verified at HEAD).
+**MAJORs folded:** v6 reduced-motion verification line; v6.1 entity-reference (`&mama;`) positive-verification line; Maren v4 keyboard-nav correction (Tab not arrows); v6 confirm-time orphan toast verification.
+
+```markdown
+- [ ] Tag a milestone button is left-aligned to form, doesn't span full width
+- [ ] Chips wrap below the button, never overflow horizontally
+- [ ] Long milestone text wraps inside the chip, doesn't push the × off
+- [ ] × hit area extends past the visible × (hover reveals lavender circle)
+- [ ] Picker modal centers on screen, scrolls internally, never page-scrolls
+- [ ] Empty milestone state shows zi-sprout icon + warm copy, not a flat empty box
+- [ ] Category headers (uppercase, tracked) read as quiet labels, not loud
+- [ ] Checked check is filled lavender; unchecked is white with lavender border
+- [ ] Modal-btns row stays at bottom; Cancel/Done never scroll out of view
+- [ ] Done button uses `btn-lav` (lavender = milestones); Cancel uses `btn-ghost`
+- [ ] Color audit: only lavender domain tokens + neutrals appear in any new style rule
+- [ ] No emojis, no literal `×` or `+`, no inline `style=` attributes anywhere new
+- [ ] DevTools resolved sizes come from tokens (not raw px) on every new element
+- [ ] Focus-visible: Tab through every interactive element shows global rose 2px outline (`styles.css:152`); chip × hover lavender does NOT compete with focus ring
+- [ ] Keyboard: Space/Enter on focused picker-row toggles; Tab moves between rows (NOT arrows); Escape closes modal
+- [ ] Screen reader: picker rows announce "Rolling, checkbox, checked"; chip × announces "Remove Rolling tag, button"; modal title reads on open
+- [ ] iOS VoiceOver real-device test (not simulator) — first codebase use of `role="checkbox"` on `<button>`
+- [ ] Orphan-tag toast surfaces on edit-load: delete tagged milestone → edit memory → toast "1 milestone tag removed — milestone no longer exists"
+- [ ] Attribute escape audit: rename milestone to `Said "mama"` → chip × `aria-label` reads `Remove Said &quot;mama&quot; tag`
+- [ ] **Entity-reference escape (v6.1):** rename milestone to `&mama;`, tag a memory. Visible `.chip-label` renders literal `&mama;` (text node, not entity). Chip × `aria-label` reads `Remove &amp;mama; tag` in inspector and announces as "Remove and mama semicolon tag" in VoiceOver — never as "Remove mama tag". Positively verifies `escHtml`-then-`escAttr` double-wrap.
+- [ ] No keyboard trap when picker has 0 milestones — Tab still reaches Cancel/Done
+- [ ] Tag-a-milestone button stays active when no milestones exist (so user reaches empty-state guidance) — no premature disable
+- [ ] **Reduced motion (v6):** `styles.css:3902` `@media (prefers-reduced-motion: reduce)` global block zeroes all `--ease-fast` transitions on `.chip-x`, `.picker-row-check`, `.picker-row`. Settings → Accessibility → Reduce Motion ON → no transition flash on hover or check toggle.
+- [ ] **Confirm-time orphan toast (v6):** open picker → in another window/device delete a milestone whose id is in working set → hit Done → toast fires "1 milestone tag removed — milestone no longer exists". Closes the v5 two-stage misleading-UX gap.
+```
+
+---
+
+## Line-drift verification footer
+
+Verified against actual `split/*` at this session's HEAD:
+
+| File | Spec-stated length | Actual | Drift | Notes |
+|------|---|---|---|---|
+| `config.js` | 13 | 13 | 0 | exact |
+| `data.js` | 3,561 | 3,561 | 0 | DEFAULT_MILESTONES at 1468–1476 verified |
+| `core.js` | 4,842 | 4,969 | +127 | dispatcher 454–456 + scrapbook fns 2112–2256 + init 750–826 still hold; offsets at audit-base SHA |
+| `medical.js` | 9,359 | 9,493 | +134 | `_postReceiveMilestones` at 145, `dedupeMilestonesByText` at 170 — exact |
+| `sync.js` | 1,052 | 2,054 | **+1,002** | nearly 2x growth since spec authorship; landmark line numbers (120, 201, 238, 1123) still resolve to the named functions; verify each landmark **by name** before edit |
+| `template.html` | 2,853 | 2,853 | 0 | scrapTitle/scrapDate at 1030/1031, modal pattern 2704+, sprite at 1–80 — exact |
+| `styles.css` | 8,638 | 8,638 | 0 | tokens at 31–116, focus-visible at 152, chips at 3401, reduced-motion at 3902 — exact |
+
+**Drift discipline:** before each phase, re-grep the target files to find the current line for the cited symbol/function. Do NOT trust a phase-N step's line number after phase-N-1 has already inserted content into the same file. Specific high-risk shifts: §6.2(c) reconcile insertion in `sync.js` shifts everything below `sync.js:1290`; §6.3 dedup rewrite in `medical.js` shifts `_postReceiveMilestones` line numbers cited in step 5(b). Use grep, not memorized line numbers.
+
+CLAUDE.md line-count drift across `sync.js`/`medical.js`/`core.js` is tracked separately as issue [#55](https://github.com/Rishabh1804/sproutlab/issues/55) (non-blocking; doc hygiene only).
+
+---
+
+## Cross-section invariants summary
+
+The audit chain surfaced a handful of cross-section invariants that no single section captures alone. Implementer must hold these mentally during translation:
+
+1. **§1 fallback-assert ↔ §6.3 `defaultSlugIds` determinism** (Cipher v6.1).
+   §1 `migrateMilestoneIds` includes the v6 assert `DEFAULT_MILESTONES.every(m => !/^ms-fallback-/.test(m.id))`. This assert protects §6.3 `dedupeMilestonesByText`'s DEFAULT-wins survivor selection: a non-deterministic `ms-fallback-<random>` id in the `defaultSlugIds` Set would let same-text custom-vs-DEFAULT collisions orphan the deterministic slug across page loads. **If §1 assert is ever softened, §6.3 must add an alternative determinism guard.**
+
+2. **§2 dispatcher rename ↔ function-body atomicity** (Kael build-mode finding).
+   The `_scrapEditIdx → _scrapEditId` rename, dispatcher arm edits, and function-body `find`/`findIndex` lookups MUST land in one commit. Intermediate state (string id flowing into `scrapbook[i]` array index, OR numeric index flowing into `scrapbook.find(e => e.id === ...)`) yields runtime `undefined` and broken edit/delete buttons. Spec §2 lists 7 `_scrapEditIdx` reference sites (lines 2190, 2197, 2199, 2223, 2243, 2252, 2253); all 7 must rename in the same edit.
+
+3. **§3 SYNC_KEYS ↔ SYNC_RENDER_DEPS atomicity** (Cipher v2).
+   Both Firestore registrations MUST commit together. SYNC_KEYS alone arms a listener that dispatches against an `undefined` dep (silent render miss — same defect class as Cipher BLOCKER #1 in transient form). SYNC_RENDER_DEPS alone is dead config.
+
+4. **§6.1 reassignment ↔ §6.3 in-place mutation asymmetry** (Kael v5).
+   `_syncSetGlobal('scrapbook', value)` reassigns the global; §6.3 mandates in-place mutation (`length = 0; push.apply`) for `milestones` for the symmetric closure-pin hazard. The asymmetry is benign today (Maren+Kael+Cipher v5 confirm no closure-pinning reader exists for `scrapbook`) but must be re-verified if either (a) a closure pins `scrapbook` by reference, OR (b) a future PR adds an in-place mutator for `scrapbook` (e.g., a `dedupeScrapbookByText`).
+
+5. **§6.2(c) reconcile gate ↔ §6.2(d) reconnect-clear ordering** (Kael v4).
+   The gate reset (`_reconcileDone = new Set()`) MUST run AFTER `_syncDetachListeners()` inside `_syncAttachListeners`. Pre-detach reset would let in-flight microtask-queued snapshot stragglers re-attempt reconcile against stale state. Issue [#53](https://github.com/Rishabh1804/sproutlab/issues/53) tracks the broader snapshot-pipeline straggler limitation that this ordering only partially mitigates.
+
+6. **§6.2(c) circuit-breaker bail ↔ data preservation** (Kael v5).
+   On bail, local orphans must already be concat'd into `entries` BEFORE the bail decision branches — `entries.concat(orphanLocals)` is a single statement that runs unconditionally on the orphan-detected path. The `_reconcileDone.add(collection)` call is conditional on the success branch ONLY; bail leaves the gate open so the next sync re-attach (which clears the gate via §6.2(d)) retries the push.
+
+7. **§6.3 in-place mutation ↔ rehydrate path** (Kael+Maren v5).
+   The v6 BLOCKER fix mandates `milestones.length = 0; milestones.push.apply(milestones, survivors)` instead of `milestones = deduped` reassignment. The reassignment would orphan any closure that captured the pre-dedup array reference — including the §6.1 `_syncSetGlobal('milestones', ...)` rehydrate path. Verify no Object-pinning reader exists across both Governor jurisdictions when implementing (Maren v5 confirmed home.js readers all use transient `forEach`/`filter`; Kael v5 confirmed core/sync/intelligence have no closure pins).
+
+---
+
+*Drafters: Maren (Care/UX, build-mode flex) · Kael (Intelligence/data-layer, build-mode flex) · Lyra (≥50 LOC sections + assembly + cross-section synthesis). v6.2 atomic spec package — folds into PR [#52](https://github.com/Rishabh1804/sproutlab/pull/52) before un-drafting.*

--- a/docs/specs/lyra-pr-epsilon-0-pseudocode.md
+++ b/docs/specs/lyra-pr-epsilon-0-pseudocode.md
@@ -31,9 +31,9 @@ This doc translates the v6.2 foundation spec's 26-step Implementation Order into
 - **Phase D — Sync layer integration**
   - [§6.1 `_syncSetGlobal` scrapbook arm](#61-syncsetglobal-scrapbook-arm) (Kael)
   - [§6.2(a) `_reconcileDone` state declaration](#62a-reconciledone-state-declaration) (Kael)
-  - [§6.2(c) Reconcile pipeline ★](#62c-reconcile-pipeline-pseudocode) (Lyra, pseudocode, ≥50 LOC)
+  - [§6.2(c) Reconcile pipeline](#62c-reconcile-pipeline-pseudocode) (Lyra, pseudocode, ≥50 LOC)
   - [§6.2(d) Reconnect-clear](#62d-reconnect-clear-in-syncattachlisteners) (Kael)
-  - [§6.3 `dedupeMilestonesByText` ★](#63-dedupemilestonesbytext-pseudocode) (Lyra, pseudocode, ≥50 LOC)
+  - [§6.3 `dedupeMilestonesByText`](#63-dedupemilestonesbytext-pseudocode) (Lyra, pseudocode, ≥50 LOC)
   - [§6.3 `_postReceiveMilestones`](#63-postreceivemilestones) (Kael)
   - [§6.3 `rewriteScrapbookMilestoneIds`](#63-rewritescrapbookmilestoneids) (Kael)
   - [§3 SYNC_KEYS + SYNC_RENDER_DEPS](#3-synckeys--syncrenderdeps-registration-atomic) (Kael, atomic)
@@ -445,6 +445,8 @@ var _reconcileDone = new Set();
 **Touches:** `split/sync.js` `_syncHandlePerEntrySnapshot` body (~lines 1188–1320 per spec). The reconcile block sits **AFTER** the empty-snapshot guard at ~`sync.js:1275–1279` and **BEFORE** the wholesale `save(lsKey, entries)` at ~`sync.js:1291`. Cross-reference: `_syncWritePerEntry` at ~`sync.js:907+` for the canonical stamp-trio + counter idiom.
 **MAJORs folded (Kael v5):** circuit-breaker bail must not silently drop local data (orphans concat into `entries` regardless of push outcome); reconcile push must stamp full sync metadata trio (`__sync_createdBy/updatedBy/syncedAt`); `_reconcileDone.add` only on success path (bail leaves gate open for retry on next attach). **MAJORs folded (v6.1 Aurelius polish):** inner try/catch around each `forEach` body (sync throw inside `.set()` no longer skips subsequent orphans); counter-comment one-liner above `_syncWriteCount++` (overcount-fail-safe rationale, prevents future "fix" that would invert safety direction).
 
+> **Line-ref discipline (Kael v6.2 audit MINOR + Cipher v6.2 cross-cut):** all `sync.js:NNN` line references in this section (`917–918` for stamp parity, `884` for `_syncWritePerEntry` increment idiom, `1238–1259` for attribution composition) are audit-base SHA `a64b80d4…` values. With the documented `sync.js` +1,002-line drift (see [Line-drift verification footer](#line-drift-verification-footer)), the literal line numbers will NOT resolve at HEAD — **resolve by function name** (`_syncWritePerEntry`, the existing `_syncWriteCount` increment site, the per-entry attribution composition block) before edit.
+
 **Pseudocode (the orchestration; embeds real-JS sub-blocks where they're already concrete in the spec):**
 
 ```text
@@ -640,6 +642,8 @@ function dedupeMilestonesByText() {
 }
 ```
 
+**Parent-visible effect (DEFAULT-wins) — Maren v6.2 audit:** when a custom milestone collides on text with a DEFAULT (e.g. parent typed "Babbling" before DEFAULT slug `babbling` arrived via cross-device sync), the user sees no data loss. Fields merge via `_mergeMilestoneFieldsInline` (latest `*At` dates, most-advanced status, custom field carry-over); the surviving id flips silently to the DEFAULT slug; any scrapbook entry tagged with the discarded id is rewritten in-place by `rewriteScrapbookMilestoneIds`. **No toast fires; no parent-facing UX change.** This is the desired cross-device determinism behavior — text + dates + status + scrapbook tags all migrate; only the underlying id changes silently.
+
 **Concretization checklist:**
 - [ ] **In-place mutation:** `milestones.length = 0; milestones.push.apply(milestones, survivors)` — NOT `milestones = survivors` reassignment. The v6 BLOCKER reverts the existing `medical.js:221` reassignment idiom; verify the diff drops that line.
 - [ ] **DEFAULT-wins short-circuit precedes lex compare:** the two `if mIsDefault ...` branches must run before the `winner = (m.id||...) < (prev.id||...) ? m : prev` fallback. Order matters.
@@ -744,6 +748,8 @@ Called from inside `dedupeMilestonesByText` when `idRewrite.size > 0`. Side-effe
 **Touches:** `split/core.js` — new sibling function above `addScrapEntry` (~`core.js:2192`); insertion point near the existing scrapbook render block at ~`core.js:2130–2150` (verify-then-edit per Phase E).
 **MAJORs folded:** Maren v5 §4 entity-reference escape (escAttr+escHtml double-wrap on `aria-label`); Maren v5 §4 empty-text legacy guard (`labelText` fallback); HR-4 escape contracts at every interpolation boundary.
 
+> **Markup (foundation §4 / Implementation Order steps 17–18) — Cipher v6.2 cross-cut:** the picker's HTML markup additions land directly from foundation §4: (a) the chips region `<div class="scrap-form-row">…</div>` between `#scrapTitle` and `#scrapDate` in `template.html:1030–1031`, (b) the `<div class="modal-overlay" id="scrapMilestonePickerModal">…</div>` block at end of the existing modal section. Copy-forward from foundation verbatim — no pseudocode expansion needed; the markup is already real and the renderers below consume the IDs (`#scrapMilestonePicker`, `#scrapMilestonePickerList`) those nodes provide.
+
 ```js
 function renderScrapMilestoneChips() {
   const host = document.getElementById('scrapMilestonePicker');
@@ -834,7 +840,7 @@ else if (action === 'removeScrapMilestone')        removeScrapMilestone(arg);
 **Touches:** `split/core.js:2192` (`addScrapEntry`), `~core.js:2220+` (`editScrapEntry`), `~core.js:2249+` (`deleteScrapEntry`), plus `clearScrapPhoto` / `cancelScrapEdit` for state-reset symmetry.
 **MAJORs folded:** Cipher BLOCKER #2 (render-side `save()` removed; mutators call `save` explicitly — also matches Maren v5 `// DOES NOT SAVE` header on `renderScrapbook`); Maren v5 §4 silent-orphan edit-load toast.
 
-This section is the cross-cut between Maren's UI surface and Kael's data-layer plumbing. The full real-JS lives in v6.2 spec §4 lines ~664–727; copy-forward verbatim — no behavioral changes since v6.2 spec landed.
+This section is the cross-cut between Maren's UI surface and Kael's data-layer plumbing. The full real-JS lives in v6.2 spec §4 lines ~683–729 (Action handlers table starts ~683; wiring block ends ~729); copy-forward verbatim — no behavioral changes since v6.2 spec landed.
 
 **Key invariants (concretization checklist):**
 - [ ] **`addScrapEntry` new-entry branch:** `id: genId()`, `milestoneIds: [..._scrapMilestoneIdsPending]` (always present, never omitted).
@@ -928,6 +934,12 @@ The audit chain surfaced a handful of cross-section invariants that no single se
 
 7. **§6.3 in-place mutation ↔ rehydrate path** (Kael+Maren v5).
    The v6 BLOCKER fix mandates `milestones.length = 0; milestones.push.apply(milestones, survivors)` instead of `milestones = deduped` reassignment. The reassignment would orphan any closure that captured the pre-dedup array reference — including the §6.1 `_syncSetGlobal('milestones', ...)` rehydrate path. Verify no Object-pinning reader exists across both Governor jurisdictions when implementing (Maren v5 confirmed home.js readers all use transient `forEach`/`filter`; Kael v5 confirmed core/sync/intelligence have no closure pins).
+
+8. **§4 edit-load toast ↔ §4.B confirm-time toast** (Maren v4 + v6).
+   Two orphan-surfacing toasts cover disjoint windows and together provide complete coverage of the orphan-link parent-safety contract:
+   - **Edit-load toast** fires once when `editScrapEntry(id)` filters `entry.milestoneIds` against current `milestones` and finds drops — covers the case where a milestone was deleted between the parent's last memory edit and the current edit.
+   - **Confirm-time toast** fires once when `confirmScrapMilestonePicker` filters the picker's working-set against current `milestones` and finds drops — covers the case where a remote sync deleted a milestone WHILE the picker was open mid-session.
+   Same copy on both surfaces (`"${n} ${noun} removed — milestone no longer exists"`). **Mutually exclusive at fire-time** (different fire conditions: form load vs Done-click) **and jointly exhaustive** across the orphan-surfacing surface (every orphan path produces exactly one toast). **Removing either re-opens silent-disappearance regression.**
 
 ---
 


### PR DESCRIPTION
## Summary

PR-ε.0 v6 spec revision. HR-9 QA chain run on v5: Kael (Intelligence) + Maren (Care) Governor audits in parallel, Lyra synthesis, Cipher Edict V cross-cutting pass. **1 BLOCKER, 9 MAJORs, 1 MINOR** folded; 2 MAJORs deferred with forward-pointer notes.

This is a spec-only PR. No code changes. The implementation PR is downstream of v6 approval.

## What changed

### BLOCKER (Cipher cross-cutting catch — both Governors missed)
v5 §0a relocated `slugify` to `config.js` to fix the v4 concat-order BLOCKER, but three index-level artifacts still said it lived in `core.js`:
- Line 183 — Build-system prose
- Line 191 — Critical-files table (`Add genId(), slugify()` in core.js)
- Line 1380 — Phase A step 1

An implementer following the Implementation Order verbatim would have re-introduced the v4 BLOCKER (data.js parses before core.js → `slugify` undefined when DEFAULT_MILESTONES bakes ids). All three sites updated; Phase A step 1 split into 1a (`slugify` in config.js) + 1b (`genId` in core.js).

### Kael MAJORs (Intelligence — sync/concat lane)
- §1 — fallback-id uniqueness assert (Set-only assert would let two empty-text DEFAULTs ship non-deterministic `ms-fallback-*` ids)
- §6.3 — DEFAULT-slug-wins survivor selection (lex-only could let UUID lex before kebab, orphaning the deterministic slug on same-text collisions)
- §6.3 — `typeof migrateMilestoneIds === 'function'` guard → `console.assert` (loud failure on rename)
- §6.1 — reassignment-vs-in-place mutation asymmetry documented (benign today; flagged for re-verification if a closure-pinning reader or in-place mutator is added)
- §6.2(c) — inner try/catch around orphan `forEach` (sync throw inside `.set()` no longer skips subsequent orphans)

### Maren MAJORs (Care — UX/a11y lane)
- §4 — chip × aria-label `escAttr(escHtml(m.text))` double-wrap (escAttr only escapes `'`/`"`, not `&`; `Tom & Jerry` could break SR pronunciation)
- §4 — `confirmScrapMilestonePicker` now fires the orphan-removed toast when filter drops anything (closes two-stage misleading-UX where remote sync deletes a milestone WHILE the picker is open)
- §7.3 — `.picker-row { align-items: flex-start }` + 2px `margin-top` on `.picker-row-check` (center-alignment with wrapped multi-line labels was mis-aligned with first line)
- §7.7 — `prefers-reduced-motion` verification added to visual checklist

### MINOR (Maren)
- §4 — chip render fallback `(m.text || '').trim() || '(unnamed milestone)'` for legacy whitespace-only text; `removeScrapMilestone` wait-for-save semantics documented inline

### Deferred MAJORs (with forward-pointer)
- **§4 modal a11y uplift** — picker modal lacks `role="dialog"`/`aria-modal`/`aria-labelledby`. Pre-existing pattern gap across ALL SproutLab modals (`growthModal`, `vaccModal`, `milestoneModal`). PR-ε.0 inherits intentionally to avoid per-modal inconsistency. **Separate ticket:** repo-wide modal a11y uplift in one pass.
- **§6.2(d) in-flight Firestore snapshot stragglers** — `onSnapshot` callbacks already on the microtask queue can run `save(lsKey, entries)` after detach, overwriting local with stale remote. Pre-existing snapshot-pipeline limitation outside §6.2 scope. **Separate ticket:** generation-counter or `_syncDisabled`-flip during detach windows.

### Cleans confirmed both sides
§0a slug list, §0b genId, §2 dispatcher rename + index-fixup deletion, §3 step-16 atomicity, §6.2(a) `var` declaration, §6.2(b) `wasReconciling` save/restore, §6.3 in-place mutation + no-pinning + lex-smaller-id parent-visible effect (text preserved), §7.1 zi-close path, §7.3 token catalog, §7.7 focus-visible.

## Audit base

- **Audit base SHA:** `a64b80d41f900e70cc36bde7b60169802a1f5c0c` (v5 spec line refs)
- **v5 merged:** #51 (squash sha `eecc994`)
- Spec growth: +255 / −35 lines (1524 → 1744)

## Test plan

- [ ] Lyra reviews v6 changelog header bullet list for accuracy and tone
- [ ] Spot-check that §0a/§0b/Build-system prose/Critical-files table/Phase A 1a-1b all consistently put slugify in config.js and genId in core.js
- [ ] Verify the v6 §6.3 survivor-selection code reads correctly (DEFAULT-wins short-circuit + lex fallback)
- [ ] Verify the v6 §6.2(c) inner try/catch wrap doesn't double-handle the async `.catch()`
- [ ] Confirm the §7.7 reduced-motion line is testable on a real device (Settings → Accessibility → Reduce Motion)
- [ ] Confirm the §4 confirm-time toast fires only when the filter drops, not on every confirm
- [ ] Open implementation PR downstream once v6 lands

https://claude.ai/code/session_01NvgG9gouyjCQMZ6C2N1xaN

---
_Generated by [Claude Code](https://claude.ai/code/session_01NvgG9gouyjCQMZ6C2N1xaN)_