### PR TITLE
feat(symptom-checker): D1 Polish Mode-2 build — severity rail + sticky CTA + severity-aware doctor-card

### DIFF
--- a/split/intelligence.js
+++ b/split/intelligence.js
@@ -11903,6 +11903,9 @@ function openHomeSymptomChecker() {
   document.body.appendChild(overlay);
   document.body.style.overflow = 'hidden';
   overlay.onclick = e => { if (e.target === overlay) closeHomeSymptomChecker(); };
+  // D1 §2.2 — bind the sticky-CTA shadow-grow listener to the modal scroll container.
+  // Home-overlay path only; #symptomResult Medical-tab path has no modal scroll container.
+  _scInitStickyShadow(overlay.querySelector('.modal'));
   setTimeout(() => document.getElementById('homeSymptomInput')?.focus(), 200);
 }
 
@@ -11941,7 +11944,7 @@ function runHomeSymptomCheck() {
   });
 
   if (matches.length === 0) {
-    resultEl.innerHTML = '<div class="sc-result sc-mild"><div class="sc-title">No matching symptoms found</div><div class="sc-section-body">Try describing differently, or tap the chips above. If you\'re concerned, always call your paediatrician.</div>' + _scDoctorCardHTML(false) + '</div>';
+    resultEl.innerHTML = '<div class="sc-result sc-mild"><div class="sc-title">No matching symptoms found</div><div class="sc-section-body">Try describing differently, or tap the chips above. If you\'re concerned, always call your paediatrician.</div>' + _scDoctorCardHTML('mild') + '</div>';
     return;
   }
 
@@ -11952,6 +11955,8 @@ function runHomeSymptomCheck() {
   // Home-overlay variant uses closeAndPrompt* actions so the modal closes before the
   // episode-tracking prompt opens \u2014 per \u00A71.2 pre-merge diff gate behavioral drift.
   resultEl.innerHTML = _renderSymptomCheckerResults(matches, mo, {
+    // D1 §2.2 — Home overlay is a true modal scroll container; ship the sticky CTA here.
+    stickyFooter: true,
     actions: {
       fever:     'closeAndPromptFever',
       diarrhoea: 'closeAndPromptDiarrhoea',

--- a/split/medical.js
+++ b/split/medical.js
@@ -2448,9 +2448,19 @@ function _renderSymptomCheckerResults(matches, ageMo, opts) {
     cold:      'promptColdTrack'
   };
 
+  // D1 §2.4.1 V-K7 — empty-state guard; callers render their own no-match UI before invoking
+  if (!matches || matches.length === 0) { return ''; }
+
   var html = '';
   var shown = matches.slice(0, 2);
   var hasEmergency = shown.some(function(m) { return m.severity === 'emergency'; });
+  var hasWarning   = shown.some(function(m) { return m.severity === 'warning'; });
+  var needsDoctor  = hasEmergency || shown.some(function(m) { return m.entry.callDoctor; });
+
+  // D1 §2.4.1 — emergency: hoist doctor card to TOP of result-list (single-render discipline)
+  if (hasEmergency && needsDoctor) {
+    html += _scDoctorCardHTML('emergency');
+  }
 
   shown.forEach(function(m) {
     var e = m.entry;
@@ -2458,6 +2468,7 @@ function _renderSymptomCheckerResults(matches, ageMo, opts) {
     var sevLabel = m.severity === 'emergency' ? zi('siren') + ' Emergency' : m.severity === 'warning' ? zi('warn') + ' Monitor closely' : zi('check') + ' Usually manageable';
 
     html += '<div class="sc-result ' + sevClass + '">';
+    html += '<div class="sc-rail" aria-hidden="true"></div>';
     html += '<span class="sc-sev-badge">' + sevLabel + '</span>';
     html += '<div class="sc-title">' + escHtml(e.title) + '</div>';
 
@@ -2474,8 +2485,9 @@ function _renderSymptomCheckerResults(matches, ageMo, opts) {
     html += '</div>';
   });
 
-  if (hasEmergency || shown.some(function(m) { return m.entry.callDoctor; })) {
-    html += _scDoctorCardHTML(hasEmergency);
+  // D1 §2.4.1 — non-emergency: doctor card AFTER the result cards (single-render discipline)
+  if (!hasEmergency && needsDoctor) {
+    html += _scDoctorCardHTML(hasWarning ? 'warning' : 'mild');
   }
 
   var isFeverMatch = shown.some(function(m) { return m.entry.id === 'fever-high' || m.entry.id === 'fever-mild'; });
@@ -2504,6 +2516,20 @@ function _renderSymptomCheckerResults(matches, ageMo, opts) {
     html += '<div class="fe-center-action"><button class="btn btn-sage w-full" data-action="' + actions.cold + '" >'+zi('siren')+' Track this cold/cough</button></div>';
   } else if (isColdMatch && getActiveColdEpisode()) {
     html += '<div class="fe-center-status">'+zi('siren')+' Cold episode already being tracked</div>';
+  }
+
+  // D1 §2.4.1 — sticky CTA mirror (emergency tier only; opts.stickyFooter gates it to the
+  //   Home-overlay path per §2.2 surface asymmetry — Medical-tab #symptomResult has no scroll
+  //   container so a sticky footer there would just duplicate the hoisted-top card inline).
+  //   Build-time resolution of the §2.2 ↔ §2.4.1 spec contradiction: §2.2 (V-K8 fold) says
+  //   "sticky-footer does NOT ship on Medical tab"; §2.4.1's prose said "emit unconditionally".
+  //   Honor §2.2's reasoned intent via opts.stickyFooter (Home overlay caller passes true).
+  if (hasEmergency && opts.stickyFooter) {
+    var stickyDoc = getPrimaryDoctor();
+    if (stickyDoc && stickyDoc.phone) {
+      html += '<div class="sc-sticky-footer"><a class="sc-call-primary" href="tel:' + stickyDoc.phone + '">' +
+              zi('phone') + ' Call Now: ' + escHtml(stickyDoc.phoneDisplay || stickyDoc.phone) + '</a></div>';
+    }
   }
 
   html += '<div style="font-size:var(--fs-xs);color:var(--light);margin-top:10px;line-height:var(--lh-relaxed);font-style:italic;">This is guidance only, not medical advice. When in doubt, always call your paediatrician. Trust your instincts — you know Ziva best.</div>';
@@ -2542,7 +2568,7 @@ function checkSymptoms() {
   });
 
   if (matches.length === 0) {
-    resultEl.innerHTML = '<div class="sc-result sc-mild"><div class="sc-title">No matching symptoms found</div><div class="sc-section-body">Try describing what you\'re seeing differently, or check the quick chips above. If you\'re concerned about Ziva, always trust your instincts and call your paediatrician.</div>' + _scDoctorCardHTML(false) + '</div>';
+    resultEl.innerHTML = '<div class="sc-result sc-mild"><div class="sc-title">No matching symptoms found</div><div class="sc-section-body">Try describing what you\'re seeing differently, or check the quick chips above. If you\'re concerned about Ziva, always trust your instincts and call your paediatrician.</div>' + _scDoctorCardHTML('mild') + '</div>';
     return;
   }
 
@@ -2556,26 +2582,68 @@ function checkSymptoms() {
   resultEl.innerHTML = _renderSymptomCheckerResults(matches, mo);
 }
 
-function _scDoctorCardHTML(isEmergency) {
+function _scDoctorCardHTML(severity) {
+  // D1 \u00A72.3 \u2014 severity-aware doctor-card variants. severity: 'emergency' | 'warning' | 'mild'.
+  // (Legacy isEmergency boolean param dropped per Kael V-K9 \u2014 code-search confirmed zero
+  //  external callers as of bridge merge sha 7342d5d; signature is single-arg severity.)
   var doc = getPrimaryDoctor();
   if (!doc) {
-    return '<div class="sc-doctor-card"><span style="font-size:var(--fs-sm);color:var(--mid);">No doctor saved yet \u2014 </span><a href="#" onclick="event.preventDefault();openDoctorModal()" style="color:var(--tc-sage) !important;font-weight:600;">+ Add Doctor</a></div>';
+    // D1 \u00A72.3.2 \u2014 no-doctor severity-aware fallback. HR-3 retired: onclick \u2192 data-action.
+    var emptyHtml = '<div class="sc-doctor-card sc-doctor-card-' + severity + ' sc-doctor-card-empty">';
+    emptyHtml += '<span class="sc-doctor-empty">No doctor saved yet \u2014 </span>';
+    emptyHtml += '<a href="#" data-action="openDoctorModal" class="sc-doctor-add-link">+ Add Doctor</a>';
+    if (severity === 'emergency') {
+      // V-M2 P0 fold \u2014 hardcoded 112 (India unified emergency, live since 2019). D2 swaps to
+      // emergencyContacts.{region} lookup once that config table lands.
+      emptyHtml += '<div class="sc-emergency-fallback">If this is a true emergency, call your local emergency number now (in India: <strong>112</strong>).</div>';
+    } else if (severity === 'warning') {
+      // V-M1 P0 fold \u2014 warning-tier contextual nudge (not the emergency-services fallback).
+      emptyHtml += '<div class="sc-doctor-empty-nudge">Add a doctor so you can call if symptoms worsen.</div>';
+    }
+    emptyHtml += '</div>';
+    return emptyHtml;
   }
-  var html = '<div class="sc-doctor-card">';
-  html += '<div class="flex-1-min0">';
-  html += '<div style="font-weight:700;color:var(--text);font-size:var(--fs-sm);">' + (isEmergency ? zi('phone') + ' ' : '') + escHtml(doc.name) + (doc.title ? ' \u00B7 ' + escHtml(doc.title) : '') + '</div>';
-  if (doc.phone) {
-    html += '<a href="tel:' + doc.phone + '" style="font-size:var(--fs-md);display:inline-block;margin-top:4px;">' + zi('phone') + (isEmergency ? ' Call Now: ' : ' ') + escHtml(doc.phoneDisplay || doc.phone) + '</a>';
+  var html = '<div class="sc-doctor-card sc-doctor-card-' + severity + '">';
+  if (severity === 'emergency') {
+    if (doc.phone) {
+      html += '<a class="sc-call-primary" href="tel:' + doc.phone + '">' + zi('phone') + ' Call Now: ' + escHtml(doc.phoneDisplay || doc.phone) + '</a>';
+    }
+    html += '<div class="sc-doctor-name">' + escHtml(doc.name) + (doc.title ? ' \u00B7 ' + escHtml(doc.title) : '') + '</div>';
+  } else if (severity === 'warning') {
+    html += '<div class="sc-doctor-name">' + escHtml(doc.name) + (doc.title ? ' \u00B7 ' + escHtml(doc.title) : '') + '</div>';
+    if (doc.phone) {
+      html += '<a class="sc-call-secondary" href="tel:' + doc.phone + '">' + zi('phone') + ' Call if needed: ' + escHtml(doc.phoneDisplay || doc.phone) + '</a>';
+    }
+  } else {
+    html += '<div class="sc-doctor-name sc-doctor-name-mild">' + escHtml(doc.name) + (doc.title ? ' \u00B7 ' + escHtml(doc.title) : '') + '</div>';
+    if (doc.phone) {
+      html += '<a class="sc-call-tertiary" href="tel:' + doc.phone + '">' + zi('phone') + ' ' + escHtml(doc.phoneDisplay || doc.phone) + '</a>';
+    }
   }
   if (doc.address) {
-    html += '<div style="font-size:var(--fs-xs);color:var(--light);margin-top:2px;">' + escHtml(doc.address) + '</div>';
+    html += '<div class="sc-doctor-address">' + escHtml(doc.address) + '</div>';
   }
-  html += '</div>';
   if (doc.location) {
-    html += '<a href="' + doc.location + '" target="_blank" rel="noopener" style="font-size:var(--fs-xl);text-decoration:none;">'+zi('target')+'</a>';
+    // Build-time fidelity: preserve the directions link (D1 spec \u00A72.3 rewrite omitted it \u2014
+    // drafting oversight, not intent). Icon-only original got a text label too \u2014 icon-only
+    // links are an a11y miss, and D1 \u00A77.1 is an a11y phase.
+    html += '<a class="sc-call-tertiary" href="' + doc.location + '" target="_blank" rel="noopener">' + zi('target') + ' Directions</a>';
   }
   html += '</div>';
   return html;
+}
+
+function _scInitStickyShadow(container) {
+  // D1 \u00A72.2 \u2014 pin shadow-grow on the sticky CTA when the modal scrolls past 100px.
+  // Idempotent via dataset guard (Kael V-K11). Build-time fix of the spec sketch's
+  // early-return bug: bind the scroll listener once at modal-open, look the footer up
+  // lazily per scroll event so it works for results rendered AFTER this binds.
+  if (!container || container.dataset.scStickyInit === '1') return;
+  container.dataset.scStickyInit = '1';
+  container.addEventListener('scroll', function() {
+    var footer = container.querySelector('.sc-sticky-footer');
+    if (footer) footer.classList.toggle('is-pinned', container.scrollTop > 100);
+  }, { passive: true });
 }
 
 function renderDoctorContact() {

--- a/split/styles.css
+++ b/split/styles.css
@@ -5987,7 +5987,7 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 [data-theme="dark"] .dib-synergy-pill { background:rgba(181,213,197,0.1); }
 
 /* ── Symptom Checker ── */
-.sc-result { border-radius:var(--r-lg); padding:var(--sp-12); margin-bottom:var(--sp-10); }
+.sc-result { border-radius:var(--r-lg); padding:var(--sp-12); margin-bottom:var(--sp-10); position:relative; }
 .sc-emergency { background:rgba(220,60,60,0.08); border:1.5px solid rgba(220,60,60,0.3); }
 .sc-warning { background:rgba(240,180,80,0.08); border:1.5px solid rgba(240,180,80,0.25); }
 .sc-mild { background:rgba(58,112,96,0.06); border:1.5px solid rgba(58,112,96,0.2); }
@@ -6025,6 +6025,82 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 [data-theme="dark"] .sc-doctor-card { background:rgba(220,60,60,0.04); border-color:rgba(220,60,60,0.12); }
 [data-theme="dark"] .sc-doctor-card a { color:#e74c3c; }
 [data-theme="dark"] .sc-quick-chip { background:rgba(255,255,255,0.05); border-color:rgba(255,255,255,0.08); }
+
+/* ── Symptom Checker — D1 Polish (lyra-spec-2026-05-13-symptom-checker-d1-polish.md v3.1) ── */
+/* D1 §2.1 — severity rail. .sc-result gets position:relative above (line ~5990) to anchor. */
+.sc-rail {
+  position:absolute; top:var(--sp-8); bottom:var(--sp-8); left:var(--sp-4);
+  width:4px; border-radius:2px; pointer-events:none;
+}
+.sc-emergency .sc-rail { background:var(--tc-rose); }
+.sc-warning   .sc-rail { background:var(--amber-deep); }
+.sc-mild      .sc-rail { background:var(--accent-sage-deep); }
+.sc-emergency .sc-rail { animation:sc-rail-pulse 1.5s ease-out 1; }
+@keyframes sc-rail-pulse {
+  0%   { box-shadow:0 0 0 0 rgba(220,60,60,0); }
+  50%  { box-shadow:0 0 8px 2px rgba(220,60,60,0.5); }
+  100% { box-shadow:0 0 0 0 rgba(220,60,60,0); }
+}
+[data-theme="dark"] .sc-warning .sc-rail { background:var(--tc-warn); }
+[data-theme="dark"] .sc-mild    .sc-rail { background:var(--tc-sage-light); }
+
+/* D1 §2.2 — sticky doctor-CTA footer (Home overlay path only; #symptomResult Medical-tab
+   path has no scroll container so position:sticky no-ops there — surface asymmetry per V-K8). */
+.sc-sticky-footer {
+  position:sticky; bottom:0; z-index:2;
+  margin:var(--sp-8) calc(-1 * var(--sp-12)) calc(-1 * var(--sp-12));
+  padding:var(--sp-10) var(--sp-12);
+  background:var(--surface-danger);
+  border-top:1px solid rgba(220,60,60,0.2);
+  box-shadow:0 -2px 8px rgba(0,0,0,0);
+  transition:box-shadow 200ms ease-out;
+}
+.sc-sticky-footer.is-pinned { box-shadow:0 -2px 8px rgba(0,0,0,0.12); }
+#homeSymptomOverlay > .modal { padding-bottom:60px; } /* V-M1 #5 — sticky-CTA never covers content */
+
+/* D1 §2.3 — severity-aware doctor-card variants + call-CTA tiers */
+.sc-doctor-card-emergency { display:flex; flex-direction:column; gap:var(--sp-4); }
+.sc-doctor-card-warning   { display:flex; flex-direction:column; gap:var(--sp-4); }
+.sc-doctor-card-mild      { display:flex; flex-direction:column; gap:var(--sp-4); }
+.sc-call-primary {
+  display:flex; align-items:center; justify-content:center;
+  min-height:60px; min-width:60px; padding:var(--sp-10) var(--sp-12);
+  font-weight:700; font-size:var(--fs-md); border-radius:var(--r-lg);
+  background:rgba(220,60,60,0.12); color:var(--tc-danger); text-decoration:none;
+}
+.sc-call-secondary {
+  display:inline-flex; align-items:center; min-height:44px;
+  padding:var(--sp-6) var(--sp-10); font-weight:600; font-size:var(--fs-base);
+  color:var(--tc-rose); text-decoration:none;
+}
+.sc-call-tertiary {
+  display:inline-flex; align-items:center; min-height:44px; min-width:44px;
+  padding:var(--sp-6) var(--sp-8); font-size:var(--fs-sm); font-weight:500;
+  color:var(--mid); text-decoration:none;
+}
+.sc-doctor-name { font-weight:700; color:var(--text); font-size:var(--fs-sm); }
+.sc-doctor-name-mild { font-weight:500; }
+.sc-doctor-address { font-size:var(--fs-xs); color:var(--light); }
+/* D1 §2.3.2 — no-doctor severity-aware fallback */
+.sc-doctor-empty { font-size:var(--fs-sm); color:var(--mid); }
+.sc-doctor-add-link {
+  display:inline-flex; align-items:center; justify-content:center;
+  min-height:44px; min-width:44px; padding:var(--sp-4) var(--sp-8);
+  text-decoration:underline; font-weight:600; color:var(--tc-sage);
+}
+.sc-doctor-empty-nudge { margin-top:var(--sp-6); font-size:var(--fs-xs); color:var(--mid); font-style:italic; }
+.sc-emergency-fallback {
+  margin-top:var(--sp-6); padding:var(--sp-6) var(--sp-8);
+  background:rgba(220,60,60,0.12); border-radius:var(--r-md);
+  font-size:var(--fs-xs); font-weight:600; color:var(--tc-danger);
+}
+[data-theme="dark"] .sc-emergency-fallback { background:rgba(220,60,60,0.2); color:var(--tc-danger); }
+
+/* D1 §8 — prefers-reduced-motion override for every D1-introduced animation */
+@media (prefers-reduced-motion: reduce) {
+  .sc-emergency .sc-rail { animation:none; }
+  .sc-sticky-footer { transition:none; }
+}
 [data-theme="dark"] .ql-freq-pill { background:rgba(58,112,96,0.12); border-color:rgba(181,213,197,0.15); color:var(--tc-sage); }
 [data-theme="dark"] .ql-freq-pill:active { background:var(--accent-sage-deep); color:var(--body-bg); }
 [data-theme="dark"] .ql-bf-pill { background:rgba(201,184,232,0.1); border-color:rgba(201,184,232,0.15); }


### PR DESCRIPTION
## Summary

Mode-2 build of `docs/specs/lyra-spec-2026-05-13-symptom-checker-d1-polish.md` v3.1 (Sovereign-ratified 2026-05-13, PR #68). **Audit-chain step `[7]` Lyra Mode-2 build.**

D1 is the **Polish** phase — restructures the Symptom Checker result card without rewriting content.

**3 source files changed** (`split/styles.css`, `split/medical.js`, `split/intelligence.js`). No `data.js` / `template.html` change — `SG-D1-LT` defaulted Slip, so `lifeThreat` rendering is D2.

### What landed

**`split/styles.css`**
- `.sc-result { position:relative }` — anchors the rail (§1 contract row 8)
- `.sc-rail` 4px left-edge severity strip — 3 severity colours + dark variants + emergency pulse-glow keyframes (1.5s, runs once)
- `.sc-sticky-footer` + `.is-pinned` + `#homeSymptomOverlay > .modal` `padding-bottom:60px` (V-M1 #5)
- `.sc-doctor-card-{emergency,warning,mild}` + `.sc-call-{primary,secondary,tertiary}` (60/44/44 touch targets per §9) + `.sc-doctor-name`/`-mild`/`-address`/`-empty`/`-add-link`/`-empty-nudge` + `.sc-emergency-fallback` (+ dark)
- `@media (prefers-reduced-motion: reduce)` override for both D1 animated rules (§8)

**`split/medical.js`**
- `_renderSymptomCheckerResults` — empty-state guard (V-K7); `.sc-rail` emit; single-render doctor-card discipline (emergency hoists to top, non-emergency renders after cards); sticky-footer mirror gated on `opts.stickyFooter`
- `_scDoctorCardHTML` — single-arg `severity` signature (V-K9 dropped legacy `isEmergency`); severity-aware variants; no-doctor severity-aware fallback (§2.3.2 — emergency 112 hardcode V-M2, warning nudge V-M1, mild bare); HR-3 retired (`onclick` → `data-action`); inline styles → CSS classes
- `_scInitStickyShadow` — NEW; idempotent scroll-listener binding for the sticky-CTA shadow-grow
- `checkSymptoms` no-match branch: `_scDoctorCardHTML(false)` → `('mild')`

**`split/intelligence.js`**
- `openHomeSymptomChecker` — `_scInitStickyShadow(overlay.querySelector('.modal'))` bind after overlay append
- `runHomeSymptomCheck` — no-match `_scDoctorCardHTML(false)` → `('mild')`; helper call passes `stickyFooter: true` (Home overlay is a true modal scroll container per §2.2 surface asymmetry)

## 6 build-time discoveries — for `[8]` Cipher impl Edict V review

Mode-2 build surfaced 6 spec gaps/decisions. All resolved conservatively + documented; flagging for impl Edict V:

| # | Discovery | Resolution |
|---|---|---|
| 1 | `_scDoctorCardHTML` map-link — spec §2.3 rewrite **omitted** the `doc.location` directions link | **Preserved** (drafting oversight, not intent). Icon-only original got a text label too — icon-only links are an a11y miss; D1 §7.1 is an a11y phase |
| 2 | **§2.2 ↔ §2.4.1 spec contradiction** — §2.2 (V-K8 fold) says sticky footer does NOT ship on Medical tab; §2.4.1 prose said "emit unconditionally" | Resolved via `opts.stickyFooter` (Home overlay caller passes `true`; Medical tab doesn't). Honors §2.2's reasoned intent |
| 3 | `_scInitStickyShadow` early-return bug — spec §2.2 sketch's `if (!footer) return` fires at modal-open *before any result renders* → listener never binds | Fixed: bind listener at open, lazy-query footer per scroll event |
| 4 | No-match branch signature — `_scDoctorCardHTML(false)` invalid after V-K9 signature change | → `('mild')` in both callers |
| 5 | HR-3 retirement — no-doctor `onclick` | → `data-action="openDoctorModal"` per §5 |
| 6 | **Missing rail tokens** — spec §2.1 used `--rose-deep` / `--sage-deep` which **do not exist** in styles.css (only `--amber-deep` does) | Substituted existing theme-aware tokens: `--tc-rose` (emergency), `--amber-deep` + dark `--tc-warn` (warning), `--accent-sage-deep` + dark `--tc-sage-light` (mild). **No new tokens commissioned** — spec didn't direct it (unlike bridge's explicit `--tc-sage-light` directive) |

## §5 grep gates + HR checks — all PASS (local `/tmp/d1`)

| Check | Result |
|---|---|
| `node --check` medical.js + intelligence.js | SYNTAX OK |
| **G-D1-1** — `.sc-rail` emit has `aria-hidden="true"` | ✅ |
| **G-D1-2** — `#homeSymptomOverlay > .modal` `padding-bottom:60px` present | ✅ |
| **G-D1-3** — `prefers-reduced-motion: reduce` override for both D1 animated rules (`sc-rail-pulse`, `box-shadow` transition) | ✅ |
| HR-1 — 0 emoji escapes in D1-touched SC render path | ✅ |
| HR-2 — 0 new inline `style=` in rewritten `_scDoctorCardHTML` / `_scInitStickyShadow` | ✅ |
| HR-3 — 0 inline `onclick` in D1-touched medical.js SC region | ✅ |
| `build.sh` — exit 0; built artifact 3,079,568 bytes; closes `</html>`; bump-version `2026.05.13-1 → 2026.05.14-1` | ✅ |
| Call-site audit — `_scDoctorCardHTML` calls: `('emergency')`, `(hasWarning ? 'warning' : 'mild')`, `('mild')` ×2. Zero stale `(false)` / `(hasEmergency)` | ✅ |

## §8 motion budget

| Selector | Duration | Tier | Reduced-motion override |
|---|---|---|---|
| `.sc-emergency .sc-rail` `animation: sc-rail-pulse` | 1.5s, runs once | Emergency attention-draw (separate budget per vision §4.4) | `animation: none` ✅ |
| `.sc-sticky-footer` `transition: box-shadow` | 200ms | Within ≤200ms cap | `transition: none` ✅ |

Mild + warning tiers: zero animation introduced.

## Audit chain (spec §4)

- `[1] Lyra v1` → `[2] Maren ‖ [3] Kael` → `[4] Lyra synthesis` → `[5] Cipher Edict V` (RE-ROUND → RE-AUDIT PASS) → `[6] Sovereign ratification` — all DONE (PR #68)
- `[7] Lyra Mode-2 build` — **DONE (this PR, commit `9274041`)**
- `[8] Cipher Edict V on impl` — **NEXT** (cross-cut HR-1/HR-4/HR-7 + the 6 build-time discoveries above + motion-budget audit + helper-purity)
- `[9] Maren §7 contrast-verification fixture on real device` — both themes, 6 carry-forward + 8 D1-new combos (incl. composited no-doctor-fallback + pulse-glow mid-animation frame)
- `[10] Sovereign merges D1 Mode-2 PR`

## Test plan

- [x] `node --check` syntax sanity on modified JS
- [x] §5 G-D1-1/2/3 grep gates
- [x] HR-1/HR-2/HR-3 checks on D1-touched surfaces
- [x] `build.sh` clean build verification
- [ ] Cipher Edict V on impl (6 build-time discoveries + cross-cutting HR pass)
- [ ] Maren §7 contrast-verification fixture — real device, both themes:
  - `.sc-rail` × {rose, amber, sage} × {light, dark}
  - `.sc-doctor-card-{emergency,warning,mild}` bg + `.sc-call-{primary,secondary,tertiary}` text
  - `.sc-emergency-fallback` **composited** capture (real-device pixels, not stylesheet RGBA)
  - pulse-glow **mid-animation frame** (~750ms post-entrance) for emergency × {light, dark}
- [ ] Visual regression: 3 Sovereign screenshots (Constipation / Crying / Fall) — light + dark; verify rail renders, doctor-card severity hierarchy, sticky CTA on Home overlay emergency
- [ ] Sovereign merge
- [ ] Post-merge: artifact regen commit (`sproutlab.html` / `index.html` / `manifest.json`) per bridge-build precedent

After merge: D2 structural spec drafts (per phase sequencing).

https://claude.ai/code/session_01QMfUnsmFWwFPg97RHa8GPQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMfUnsmFWwFPg97RHa8GPQ)_