### PR TITLE
PR-C: sync-discipline cycle — V-K-23 ratify + V-K-24 widening + last-member copy refinement

### DIFF
--- a/index.html
+++ b/index.html
@@ -20071,7 +20071,13 @@ function confirmAction(msg, callback, btnText) {
   // missed forms like "Are you sure you want to delete this entry?" where the
   // destructive token isn't the leading word. Word-boundary match catches the
   // token anywhere in the message; explicit btnText still wins.
-  const label = btnText || (/\bdelete\b/i.test(msg) ? 'Delete' : 'Confirm');
+  // V-K-24 (PR-C, sync-discipline cycle) — widened to `delete|remove|clear`
+  // word-set. Catches the two live destructive callers at medical.js:2987
+  // (`Remove ${doctors[i].name}?`) and intelligence.js:17540 (`Remove this
+  // tracking? This cannot be undone.`) that the delete-only regex missed.
+  // Word-boundary preserves the "cleared" mid-word safety (the two `cleared`
+  // callers at core.js:690 + intelligence.js:8754 carry explicit btnText anyway).
+  const label = btnText || (/\b(delete|remove|clear)\b/i.test(msg) ? 'Delete' : 'Confirm');
   const btnCls = label === 'Delete' ? 'btn btn-rose' : label === 'Reset' ? 'btn btn-rose' : 'btn btn-sky';
   const overlay = document.createElement('div');
   overlay.className = 'confirm-overlay';
@@ -64250,8 +64256,16 @@ function syncLeaveHousehold() {
 
   // Check if last member (§4.5 #32)
   var memberCount = _syncHousehold ? Object.keys(_syncHousehold.members || {}).length : 0;
+  // V-K-23 disposition (PR-C sync-discipline cycle) — V-K-8's defensive-parse
+  // regex catches `\bdelete\b` in the last-member message and flips the
+  // confirm button from sky Confirm → rose Delete, which correctly matches
+  // the destructive verb on disk (_syncDeleteHouseholdDoc below). The
+  // closing "Continue?" question was sky-Confirm-era softener; under rose
+  // Delete the button itself is the answer prompt, so the close-line is
+  // dropped for tonal consistency. Multi-member message stays Confirm-toned
+  // and unchanged.
   var msg = memberCount <= 1
-    ? 'You are the last member. Leaving will delete all synced data permanently. Continue?'
+    ? 'You are the last member. Leaving will delete all synced data permanently.'
     : 'Leave this household? You can keep a local copy of your data.';
 
   confirmAction(msg, function() {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.18-7",
+  "version": "2026.05.18-8",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -3422,7 +3422,13 @@ function confirmAction(msg, callback, btnText) {
   // missed forms like "Are you sure you want to delete this entry?" where the
   // destructive token isn't the leading word. Word-boundary match catches the
   // token anywhere in the message; explicit btnText still wins.
-  const label = btnText || (/\bdelete\b/i.test(msg) ? 'Delete' : 'Confirm');
+  // V-K-24 (PR-C, sync-discipline cycle) — widened to `delete|remove|clear`
+  // word-set. Catches the two live destructive callers at medical.js:2987
+  // (`Remove ${doctors[i].name}?`) and intelligence.js:17540 (`Remove this
+  // tracking? This cannot be undone.`) that the delete-only regex missed.
+  // Word-boundary preserves the "cleared" mid-word safety (the two `cleared`
+  // callers at core.js:690 + intelligence.js:8754 carry explicit btnText anyway).
+  const label = btnText || (/\b(delete|remove|clear)\b/i.test(msg) ? 'Delete' : 'Confirm');
   const btnCls = label === 'Delete' ? 'btn btn-rose' : label === 'Reset' ? 'btn btn-rose' : 'btn btn-sky';
   const overlay = document.createElement('div');
   overlay.className = 'confirm-overlay';

--- a/split/sync.js
+++ b/split/sync.js
@@ -669,8 +669,16 @@ function syncLeaveHousehold() {
 
   // Check if last member (§4.5 #32)
   var memberCount = _syncHousehold ? Object.keys(_syncHousehold.members || {}).length : 0;
+  // V-K-23 disposition (PR-C sync-discipline cycle) — V-K-8's defensive-parse
+  // regex catches `\bdelete\b` in the last-member message and flips the
+  // confirm button from sky Confirm → rose Delete, which correctly matches
+  // the destructive verb on disk (_syncDeleteHouseholdDoc below). The
+  // closing "Continue?" question was sky-Confirm-era softener; under rose
+  // Delete the button itself is the answer prompt, so the close-line is
+  // dropped for tonal consistency. Multi-member message stays Confirm-toned
+  // and unchanged.
   var msg = memberCount <= 1
-    ? 'You are the last member. Leaving will delete all synced data permanently. Continue?'
+    ? 'You are the last member. Leaving will delete all synced data permanently.'
     : 'Leave this household? You can keep a local copy of your data.';
 
   confirmAction(msg, function() {

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -20071,7 +20071,13 @@ function confirmAction(msg, callback, btnText) {
   // missed forms like "Are you sure you want to delete this entry?" where the
   // destructive token isn't the leading word. Word-boundary match catches the
   // token anywhere in the message; explicit btnText still wins.
-  const label = btnText || (/\bdelete\b/i.test(msg) ? 'Delete' : 'Confirm');
+  // V-K-24 (PR-C, sync-discipline cycle) — widened to `delete|remove|clear`
+  // word-set. Catches the two live destructive callers at medical.js:2987
+  // (`Remove ${doctors[i].name}?`) and intelligence.js:17540 (`Remove this
+  // tracking? This cannot be undone.`) that the delete-only regex missed.
+  // Word-boundary preserves the "cleared" mid-word safety (the two `cleared`
+  // callers at core.js:690 + intelligence.js:8754 carry explicit btnText anyway).
+  const label = btnText || (/\b(delete|remove|clear)\b/i.test(msg) ? 'Delete' : 'Confirm');
   const btnCls = label === 'Delete' ? 'btn btn-rose' : label === 'Reset' ? 'btn btn-rose' : 'btn btn-sky';
   const overlay = document.createElement('div');
   overlay.className = 'confirm-overlay';
@@ -64250,8 +64256,16 @@ function syncLeaveHousehold() {
 
   // Check if last member (§4.5 #32)
   var memberCount = _syncHousehold ? Object.keys(_syncHousehold.members || {}).length : 0;
+  // V-K-23 disposition (PR-C sync-discipline cycle) — V-K-8's defensive-parse
+  // regex catches `\bdelete\b` in the last-member message and flips the
+  // confirm button from sky Confirm → rose Delete, which correctly matches
+  // the destructive verb on disk (_syncDeleteHouseholdDoc below). The
+  // closing "Continue?" question was sky-Confirm-era softener; under rose
+  // Delete the button itself is the answer prompt, so the close-line is
+  // dropped for tonal consistency. Multi-member message stays Confirm-toned
+  // and unchanged.
   var msg = memberCount <= 1
-    ? 'You are the last member. Leaving will delete all synced data permanently. Continue?'
+    ? 'You are the last member. Leaving will delete all synced data permanently.'
     : 'Leave this household? You can keep a local copy of your data.';
 
   confirmAction(msg, function() {


### PR DESCRIPTION
## Summary

Closes the sync-discipline cycle filed as carry-forward from s-2026-05-18-02 §6 entry 4 — the open thread the trilogy coda named after PR-A (#76) + PR-B (#77) merged.

**1. V-K-23 disposition ratify.** The Architect ratified the V-K-8 confirmAction flip on `sync.js:672-676` (last-member leave-household) as-is. The merged rose **Delete** button correctly matches `_syncDeleteHouseholdDoc` (`sync.js:683`) on disk. Added doctrine comment naming the V-K-23 reasoning, the design choice (drop the question-close on rose-Delete safety-tier messages — button itself is the answer prompt), and the asymmetry boundary (multi-member message stays Confirm-toned + question-close unchanged).

**2. V-K-24 synonym widening.** Widened the V-K-8 regex from `/\bdelete\b/i` to `/\b(delete|remove|clear)\b/i` at `split/core.js:3387`. Catches two live destructive callers:
- `medical.js:2987` — `confirmAction(\`Remove ${doctors[i].name}?\`, …)` → `doctors.splice(i, 1)` + `save(KEYS.doctors, doctors)` with no undo buffer
- `intelligence.js:17540` — `confirmAction('Remove this tracking? This cannot be undone.', …)` → CareTicket delete

Both flip from sky Confirm to rose Delete, matching destructive verb on disk. Word-boundary preserves the `cleared` / `resolved` mid-word safety: the four symptom-resolve callers (`intelligence.js:7419 / 8124 / 8522 / 8754`) are double-shielded (explicit `btnText='Resolve'` short-circuits regex; even unshielded, `cleared` wouldn't match `\bclear\b`).

**3. Copy refinement on last-member leave-household message.** Dropped `"Continue?"` close from `sync.js:681`. New text:
- *Last-member:* `'You are the last member. Leaving will delete all synced data permanently.'`
- *Multi-member (unchanged):* `'Leave this household? You can keep a local copy of your data.'`

Asymmetric framing is parent-facing-correct: last-member has no recovery path (the household doc is being deleted), so the message must not promise one.

## Audit chain (canon-cc-008)

Lyra build → Maren + Kael Mode-1 parallel → Lyra synthesis (nothing folded; both Governors verified clean as-shipped) → Cipher Edict V LGTM.

| Companion | Verdict | Key findings |
|---|---|---|
| Kael (Intelligence) | PASS-WITH-NOTES | V-K-28 blast-radius re-survey (24 callers cataloged; 2 NEW flips both correctly destructive); V-K-29 PR-D candidate (`replace\|overwrite\|restore` for `core.js:3990` import-backup + `core.js:3911` autosave-restore); V-K-30 false-positive shield double-confirmed; V-K-31 doctrine comment reads as contract; V-K-32 sibling-flow tonal re-survey clean; V-K-33 30K Rule headroom drift |
| Maren (Care) | PASS-WITH-NOTES | V-M-40 doctor-removal flip ratified; V-M-41 PR-D candidate (resolve-caller shield hardening — JSDoc / test guard locking `btnText='Resolve'`); V-M-42 last-member copy ratified |
| Cipher (Edict V) | **LGTM** | All HR-1 through HR-12 hold. Build artifact provenance verified. Sharpened V-K-33: Intelligence Region post-PR-C is 29,770 LOC, headroom 230 (CLAUDE.md quotes 284 — drift in flight). Three PR-D candidates filed as separate tickets per "different shapes, different blast-radii, different test surfaces." |

## PR-D candidates (separate tickets per Cipher framing)

1. **Regex extension to `replace|overwrite|restore`** — catches `core.js:3990` import-backup (currently `btnText='Import'`-shielded) + `core.js:3911` autosave-restore (currently falls through to sky Confirm despite all-data-overwrite consequence).
2. **Resolve-caller shield hardening** — the four symptom-resolve callers carry explicit `btnText='Resolve'` shields today; a future maintainer who refactors and drops the btnText would silently re-introduce tonal misclassification on health-restoration affirmations. JSDoc note + unit-test guard.
3. **Standing pre-existing HR-4 surface at `core.js:3437`** — `<p>${msg}</p>` confirm-dialog interpolation without escHtml. Not introduced by PR-C; flagged for the audit-chain ledger. Closest user-derived consumer is `doctors[i].name` at `medical.js:2987` — mitigated by `<p>` context + form-input source path, but worth fixing.

## CLAUDE.md drift (defer)

V-K-33 surfaced that CLAUDE.md's "≈284 LOC of headroom to 30K trigger" QA-chain line is now off by ~54 LOC after this PR's +8-line doctrine comment (true post-PR-C: 230 LOC headroom). Defer the doc-refresh to the next Kael-jurisdiction spec per Cipher's "merge train shouldn't pick up doc edits mid-cycle."

## Test plan

- [ ] `bash split/build.sh > split/sproutlab.html` — both ship-gates green (audit-emoji + audit-icon-text).
- [ ] Trigger doctor removal at `medical.js:2987` flow — confirm rose Delete button (was sky Confirm).
- [ ] Trigger CareTicket removal at `intelligence.js:17540` flow — confirm rose Delete button.
- [ ] Trigger leave-household last-member flow at `sync.js:676` — confirm message ends with period (no "Continue?") + rose Delete button.
- [ ] Trigger any of the four symptom-resolve flows (`intelligence.js:7419 / 8124 / 8522 / 8754`) — confirm sage/sky Resolve button (NOT rose Delete; shielded by explicit btnText).
- [ ] Trigger any sky-Confirm caller that contains the word `clear` mid-word (e.g., core.js:690 sign-out "Synced data will be cleared from this device.") — confirm sky button (shielded by btnText='Sign Out'; `cleared` wouldn't match `\bclear\b` anyway).

---

Closes the s-2026-05-17/-18 quadrilogy's last open thread (per `docs/handoffs/session-2026-05-18-pr-a-pr-b-closure.md` §6 entry 4).

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01UtT2QeJisuCmNrGkUWSzs3)_