### PR TITLE
PR-EF.1: 9 V-tag amendment fixes from post-merge roundtable (+ V-M-19 diet pref filter)

### DIFF
--- a/index.html
+++ b/index.html
@@ -11322,10 +11322,14 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
         </div>
       </div>
 
-      <!-- 5. Color Anomaly -->
+      <!-- 5. Stool Color Pattern (V-M-16 amendment: was "Color Anomaly" —
+           card body shows "All clear" most of the time, which contradicts
+           the alarming title. A parent should read the title and feel
+           informed, not primed for an alarm. Card renderer still surfaces
+           anomaly entries explicitly when present.) -->
       <div class="card card-daily col-full" id="infoPoopColorCard">
         <div class="card-header" data-collapse-target="infoPoopColorBody" data-collapse-chevron="infoPoopColorChevron">
-          <div class="card-title"><div class="icon icon-peach"><svg class="zi"><use href="#zi-palette"/></svg></div> Color Anomaly</div>
+          <div class="card-title"><div class="icon icon-peach"><svg class="zi"><use href="#zi-palette"/></svg></div> Stool Color Pattern</div>
           <span class="collapse-chevron" id="infoPoopColorChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
         </div>
         <div id="infoPoopColorSummary" class="mt-4"></div>
@@ -11525,10 +11529,17 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
         <div id="infoGrowthVelocitySummary" class="t-sm mt-4"></div>
         <div id="infoGrowthVelocityBody" class="collapse-body fx-col g8" style="display:none;">
           <div id="infoGrowthVelocityBar" class="mt-4"></div>
-          <div class="viz-chart-mount mt-8" style="height:200px;"><canvas id="growthChartInfo"></canvas></div>
           <div id="infoGrowthVelocityPercentile" class="mt-8"></div>
           <div id="infoGrowthVelocityGrid" class="mt-8"></div>
           <div id="infoGrowthVelocityInsight" class="mt-8"></div>
+          <!-- V-M-18 amendment: was a small Chart.js canvas ('growthChartInfo')
+               here showing the WHO percentile band at 200px tall. Per Maren —
+               the percentile bands were illegible at that size; the chart was
+               decoration, the text was signal. Removed the canvas; replaced
+               with a link to the full Medical-tab growth chart for inspection. -->
+          <div class="fx-row mt-8">
+            <button class="btn btn-ghost t-sm" data-action="switchTab" data-arg="medical" style="padding:var(--sp-4) var(--sp-10);">View full growth chart on Medical tab</button>
+          </div>
         </div>
       </div>
 
@@ -42978,13 +42989,29 @@ function renderInfoMilestoneVelocity() {
     // milestone categories (motor / social / language / cognitive) and within
     // each, the maturity mix (emerging / practicing / consistent / mastered).
     // Card-local layout + render; extraction deferred per PR-EF D10.
+    //
+    // V-K-31 / Cipher A2 amendment: original color scheme encoded STATUS in
+    // hue (--ms-emerging/practicing/consistent/mastered) and gave categories
+    // zero hue variation — the treemap's primary insight (category
+    // distribution at a glance) was lost because all 4 cats looked the same
+    // green family. Inverted: CATEGORY now encodes hue (using the 4 domain
+    // tones — sage / lav / sky / amber, mapped 1:1 to motor/social/language/
+    // cognitive), STATUS encodes opacity stepping (0.35 → 0.55 → 0.75 → 0.95).
+    // Parent's eye reads category-balance from the four color regions, then
+    // maturity-depth from the within-region density.
     const CATS = ['motor', 'social', 'language', 'cognitive'];
     const STATUSES = ['emerging', 'practicing', 'consistent', 'mastered'];
-    const STATUS_TOKEN = {
-      emerging:   'var(--ms-emerging)',
-      practicing: 'var(--ms-practicing)',
-      consistent: 'var(--ms-consistent)',
-      mastered:   'var(--ms-mastered)'
+    const CAT_HUE = {
+      motor:     'var(--tc-sage)',
+      social:    'var(--tc-lav)',
+      language:  'var(--tc-sky)',
+      cognitive: 'var(--tc-amber)'
+    };
+    const STATUS_OPACITY = {
+      emerging:   0.35,
+      practicing: 0.55,
+      consistent: 0.75,
+      mastered:   0.95
     };
     // Counts: cat → status → count
     const catTotals = {};
@@ -43024,21 +43051,34 @@ function renderInfoMilestoneVelocity() {
           return;
         }
         // Inside the cat block, lay out 4 status sub-rows (or fewer if some empty)
-        // by status weight. Use horizontal sub-strips.
+        // by status weight. Use horizontal sub-strips. Each sub-strip uses the
+        // CATEGORY hue with STATUS-tier opacity, so the parent reads
+        // category-balance from color regions and maturity-depth from intensity.
+        const hue = CAT_HUE[cat] || 'var(--tc-sage)';
         let cursorY = y;
         STATUSES.forEach(st => {
           const ct = catStatusCounts[cat][st];
           if (ct === 0) return;
           const subH = (ct / total) * h;
-          svg += '<rect x="' + x + '" y="' + cursorY.toFixed(1) + '" width="' + w + '" height="' + subH.toFixed(1) + '" fill="' + STATUS_TOKEN[st] + '" opacity="0.85" stroke="white" stroke-width="1"><title>' + cat + ' · ' + st + ' · ' + ct + '</title></rect>';
-          // Label if sub-block is large enough
-          if (subH >= 14 && w >= 40) {
-            svg += '<text x="' + (x + 4) + '" y="' + (cursorY + subH / 2 + 3).toFixed(1) + '" font-size="7" fill="white" font-family="Nunito" font-weight="500">' + st + ' (' + ct + ')</text>';
+          const opacity = STATUS_OPACITY[st] || 0.5;
+          svg += '<rect x="' + x + '" y="' + cursorY.toFixed(1) + '" width="' + w + '" height="' + subH.toFixed(1) + '" fill="' + hue + '" opacity="' + opacity + '" stroke="white" stroke-width="1"><title>' + cat + ' · ' + st + ' · ' + ct + '</title></rect>';
+          // Status label inside sub-strip only when it fits (V-K-31: avoid overflow).
+          // Conservative bounds: need subH >= 16 AND w >= 60 AND room for the
+          // cat-header at the top of the block (skip status label that lands in
+          // the top 16 px of the cat block to avoid colliding with the title).
+          const inHeaderZone = cursorY < y + 16;
+          if (subH >= 16 && w >= 60 && !inHeaderZone) {
+            svg += '<text x="' + (x + 4) + '" y="' + (cursorY + subH / 2 + 3).toFixed(1) + '" font-size="7" fill="white" font-family="Nunito" font-weight="500" style="text-shadow:0 0 2px rgba(0,0,0,0.3);">' + st + ' · ' + ct + '</text>';
           }
           cursorY += subH;
         });
-        // Cat label on top-left, overlaid
-        svg += '<text x="' + (x + 4) + '" y="' + (y + 10) + '" font-size="8" fill="white" font-family="Nunito" font-weight="700" style="text-shadow:0 0 2px rgba(0,0,0,0.4);">' + cat + ' (' + total + ')</text>';
+        // Cat label on top-left, overlaid. V-K-31: only render full label if
+        // the block is wide enough to hold "cognitive (8)" (the longest cat
+        // name). Otherwise abbreviate to first 3 letters + count.
+        const catLabel = (w >= 88)
+          ? cat + ' (' + total + ')'
+          : cat.slice(0, 3) + ' (' + total + ')';
+        svg += '<text x="' + (x + 4) + '" y="' + (y + 11) + '" font-size="9" fill="white" font-family="Nunito" font-weight="700" style="text-shadow:0 0 3px rgba(0,0,0,0.5);">' + catLabel + '</text>';
       }
       // Top row split between top pair
       const topW0 = topSum > 0 ? (catTotals[topPair[0]] / topSum) * VB_W : VB_W / 2;
@@ -43049,11 +43089,22 @@ function renderInfoMilestoneVelocity() {
       renderCatBlock(botPair[0], 0, topH, botW0, VB_H - topH);
       renderCatBlock(botPair[1], botW0, topH, VB_W - botW0, VB_H - topH);
       svg += '</svg>';
-      // Legend
-      svg += '<div class="fx-row g8 fx-row-wrap mt-4 t-xs t-light">';
-      STATUSES.forEach(st => {
-        svg += '<span><span style="display:inline-block;width:10px;height:10px;background:' + STATUS_TOKEN[st] + ';vertical-align:middle;margin-right:2px;"></span>' + st + '</span>';
+      // V-K-31 amendment: dual-legend — category hues + status-opacity ramp.
+      // Category legend names the 4 domain colors so the parent decodes
+      // which region is which milestone domain. Status legend uses a single
+      // hue with the 4 opacity stops so the maturity-depth encoding reads
+      // independently of category.
+      svg += '<div class="fx-col g4 mt-4 t-xs t-light">';
+      svg += '<div class="fx-row g8 fx-row-wrap"><span class="t-light" style="font-weight:500;">Category:</span>';
+      CATS.forEach(c => {
+        svg += '<span><span style="display:inline-block;width:10px;height:10px;background:' + CAT_HUE[c] + ';vertical-align:middle;margin-right:2px;opacity:0.85;"></span>' + c + '</span>';
       });
+      svg += '</div>';
+      svg += '<div class="fx-row g8 fx-row-wrap"><span class="t-light" style="font-weight:500;">Maturity:</span>';
+      STATUSES.forEach(st => {
+        svg += '<span><span style="display:inline-block;width:10px;height:10px;background:var(--tc-sage);opacity:' + STATUS_OPACITY[st] + ';vertical-align:middle;margin-right:2px;"></span>' + st + '</span>';
+      });
+      svg += '</div>';
       svg += '</div>';
       html += svg;
     }
@@ -44416,16 +44467,30 @@ function computeTextureProgression() {
   dates.forEach(d => {
     const day = feedingData[d];
     if (!day) return;
-    const meals = [day.breakfast, day.lunch, day.dinner, day.snack].filter(Boolean);
+    // V-M-15 amendment: filter SKIPPED_MEAL before classification — a parent
+    // who deliberately skipped a meal shouldn't see "skipped" surfaced as an
+    // unclassified-food entry. isRealMeal() lives in core.js and treats
+    // SKIPPED_MEAL ('—skipped—') as falsy.
+    const meals = [day.breakfast, day.lunch, day.dinner, day.snack].filter(isRealMeal);
     if (meals.length === 0) return;
 
     const rawTextures = meals.map(m => _classifyMealTexture(m));
-    // Collect unknown meal-text for the gap-flag UI
+    // Collect unknown meal-text for the gap-flag UI.
+    // V-M-15 dedup amendment: split each meal's comma/plus/&/with-and tokens
+    // into individual food names before adding to the Set, so "Orange" from
+    // "Orange, Watermelon" and a standalone "Orange" entry don't double-count.
     let dayHasUnknown = false;
     rawTextures.forEach((t, idx) => {
       if (t === 'unknown') {
         dayHasUnknown = true;
-        if (unclassifiedFoods.size < 5) unclassifiedFoods.add(meals[idx].slice(0, 40));
+        if (unclassifiedFoods.size < 5) {
+          const tokens = meals[idx].split(/[,+&]| with |\s+and\s+/i)
+            .map(s => s.trim().toLowerCase())
+            .filter(s => s.length > 1 && s !== '—skipped—');
+          tokens.forEach(tok => {
+            if (unclassifiedFoods.size < 5) unclassifiedFoods.add(tok);
+          });
+        }
       }
     });
     if (dayHasUnknown) unclassifiedDays++;
@@ -45592,19 +45657,15 @@ function renderInfoGrowthVelocity() {
     insightEl.innerHTML = iHtml;
   }
 
-  // PR-EF Viz #6: render the percentile-band growth chart into the info-tab
-  // canvas mount. drawChart() is the same Chart.js renderer the Medical tab
-  // uses; the canvasId parameter keeps the two instances isolated.
-  //
-  // V-M-9 synthesis: render is unconditional on every dispatcher pass (no
-  // lazy-init guard) — Maren's monitor-only verdict accepts this for now
-  // given Ziva's growth dataset is ~12 entries and Chart.js init at this
-  // size is sub-100ms in practice. Lazy-init (e.g., hook the chevron-open
-  // event in `data-collapse-target` machinery) becomes load-bearing only
-  // if parent reports lag on the info-tab; chronicle forward.
-  if (typeof drawChart === 'function' && document.getElementById('growthChartInfo')) {
-    drawChart('growthChartInfo');
-  }
+  // V-M-18 amendment: was rendering the WHO percentile-band chart via
+  // drawChart('growthChartInfo') into a 200px-tall canvas in this card.
+  // The bands were illegible at that size — Maren's verdict was that the
+  // chart was decoration and the insight text was the actual signal. Canvas
+  // mount removed from template.html; this card now surfaces the load-
+  // bearing text + a "View full growth chart" button that switches to the
+  // Medical tab where the chart renders at usable size. V-M-9 (lazy-init
+  // monitor-only) auto-closes because the unconditional canvas render is
+  // gone.
 }
 
 // ── Feature 4: Doctor Visit Preparation ──
@@ -58218,12 +58279,18 @@ function getUntriedSuggestions(n) {
   n = n || 5;
   const introduced = new Set((foods || []).map(f => f.name.toLowerCase().trim()));
   const ageM = ageAt().months;
+  // V-M-19 amendment: respect the user's diet preference. If settings has
+  // dietPref === 'veg', non-veg foods must not surface as "Foods to Try Next."
+  // A parent who set a dietary boundary expects the app to honor it everywhere.
+  const isVeg = (typeof getDietPref === 'function') && getDietPref() === 'veg';
 
   // Collect all taxonomy foods not yet introduced
   const candidates = [];
   _foodTaxFlat.forEach(item => {
     const key = item.key.toLowerCase().trim();
     if (introduced.has(key)) return;
+    // Diet-preference gate
+    if (isVeg && item.pid === 'nonveg') return;
     // Age gate: skip nuts for <8m (whole), skip honey for <12m
     if (key === 'honey' && ageM < 12) return;
     if (key === 'peanut' && ageM < 8) return;
@@ -60748,7 +60815,11 @@ function renderInfoFoodIntro() {
   const displayWeeks = data.weeks.slice(-8);
   const maxCount = Math.max(...displayWeeks.map(w => w.count), 1);
 
-  let chartHtml = '<div class="t-sm fe-sub-label" >Weekly Introduction Rate</div>';
+  // V-K-28 amendment: the bars carried floating numbers (5, 4, 6, ...) with
+  // no label naming the unit. A parent reading the chart couldn't tell whether
+  // the numbers were foods, meals, or combos. Add a "foods / week" sub-label
+  // under the chart title so the value-axis intent is explicit.
+  let chartHtml = '<div class="t-sm fe-sub-label" >Weekly Introduction Rate <span class="t-light" style="font-weight:400;">— foods / week</span></div>';
   chartHtml += '<div class="info-intro-chart">';
   displayWeeks.forEach(w => {
     const pct = Math.max((w.count / maxCount) * 100, 4);
@@ -60794,7 +60865,15 @@ function renderInfoFoodIntro() {
     Object.entries(groupMap).forEach(([label, idx]) => {
       const y = PAD_T + idx * laneH + laneH / 2;
       svg += '<line x1="' + PAD_L + '" y1="' + y + '" x2="' + (VB_W - PAD_R) + '" y2="' + y + '" stroke="var(--surface-alt)" stroke-width="0.5"/>';
-      svg += '<text x="' + (PAD_L - 4) + '" y="' + (y + 3) + '" text-anchor="end" font-size="7" fill="var(--mid)" font-family="Nunito">' + escHtml(label.slice(0, 8)) + '</text>';
+      // V-K-29 amendment: was `label.slice(0, 8)` — produced fragments like
+      // "Grains G", "Vegetab #" because the 8-char cut landed mid-word (and
+      // mid-ampersand for compound labels like "Grains & Cereals"). Now
+      // split on a word/ampersand boundary and take the leading token, which
+      // gives compact-but-complete lane labels (Grains, Vegetables, Fruits,
+      // Dairy, Nuts, Other, Spices). HR-10 spirit: no text-overflow,
+      // truncate at word boundaries instead.
+      const shortLabel = label.split(/\s*[&,]\s*|\s+/)[0];
+      svg += '<text x="' + (PAD_L - 4) + '" y="' + (y + 3) + '" text-anchor="end" font-size="7" fill="var(--mid)" font-family="Nunito">' + escHtml(shortLabel) + '</text>';
     });
     // Dots
     allFoods.forEach(f => {
@@ -60829,21 +60908,53 @@ function renderInfoFoodIntro() {
 
   chartEl.innerHTML = chartHtml;
 
-  // "Foods to Try" suggestions
-  const suggestions = getUntriedSuggestions(5);
+  // V-M-17 amendment: "Foods to Try" used to render one list-item per
+  // suggestion with `<strong>{name}</strong> · {group} · {reason}`. When
+  // multiple suggestions shared an identical reason (e.g. five non-veg foods
+  // all carrying "No non-veg in 7 days"), the parent saw five visually
+  // identical lines — stuck-state masquerading as recommendations. Now group
+  // by reason: one heading per gap, chips for each food. Fewer lines, clearer
+  // signal, and the eye reads "consider this category" rather than five
+  // duplicates.
+  const suggestions = getUntriedSuggestions(8);
   let tryHtml = '<div class="t-sm fe-sub-label" >Foods to Try Next</div>';
   if (suggestions.length === 0) {
     tryHtml += '<div class="t-sm t-light">Amazing — you\'ve covered the full taxonomy!</div>';
   } else {
-    tryHtml += '<div class="fx-col g4">';
+    // Group by reason text. Preserve first-occurrence order for stable rendering.
+    const groups = [];
+    const reasonIdx = {};
     suggestions.forEach(s => {
-      tryHtml += `
-        <div class="list-item li-row">
-          <div class="li-body">
-            <strong>${escHtml(s.name)}</strong>
-            <span class="t-sm t-light">${escHtml(s.groupLabel)} · ${escHtml(s.reason)}</span>
-          </div>
-        </div>`;
+      const key = (s.reason || 'Explore something new') + '||' + (s.groupLabel || '');
+      if (reasonIdx[key] == null) {
+        reasonIdx[key] = groups.length;
+        groups.push({ reason: s.reason || 'Explore something new', groupLabel: s.groupLabel || '', items: [] });
+      }
+      groups[reasonIdx[key]].items.push(s);
+    });
+    tryHtml += '<div class="fx-col g8">';
+    groups.forEach(g => {
+      // If the gap has 3+ suggestions, render as a category heading + chips.
+      // For 1-2 suggestions, keep the legacy list-item format so single
+      // recommendations don't lose their per-item visual weight.
+      if (g.items.length >= 3) {
+        tryHtml += '<div class="li-row" style="flex-direction:column;align-items:flex-start;gap:var(--sp-4);">';
+        tryHtml += '<div><strong>' + escHtml(g.reason) + '</strong>'
+          + (g.groupLabel ? ' <span class="t-sm t-light">· ' + escHtml(g.groupLabel) + '</span>' : '')
+          + '</div>';
+        tryHtml += '<div class="fx-wrap g4">';
+        g.items.forEach(it => {
+          tryHtml += '<span class="info-food-chip is-sage">' + escHtml(it.name) + '</span>';
+        });
+        tryHtml += '</div></div>';
+      } else {
+        g.items.forEach(s => {
+          tryHtml += '<div class="list-item li-row"><div class="li-body">'
+            + '<strong>' + escHtml(s.name) + '</strong>'
+            + '<span class="t-sm t-light">' + escHtml(s.groupLabel || '') + ' · ' + escHtml(s.reason || '') + '</span>'
+            + '</div></div>';
+        });
+      }
     });
     tryHtml += '</div>';
   }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.19-4",
+  "version": "2026.05.19-5",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/audit-viz-smoke.sh
+++ b/split/audit-viz-smoke.sh
@@ -25,7 +25,9 @@ REQUIRED_CARD_IDS = [
 REQUIRED_CONTAINER_IDS = [
     'infoFeedingIntakeChart',
     'infoVaccGanttChart',
-    'growthChartInfo',
+    # V-M-18 amendment: 'growthChartInfo' canvas removed from info-tab card
+    # (Chart.js percentile bands illegible at 200px; demoted to a Medical-tab
+    # link). Audit gate no longer requires the ID.
 ]
 REQUIRED_CSS_TOKENS = [
     '--cal-poor',

--- a/split/intelligence-cards.js
+++ b/split/intelligence-cards.js
@@ -1102,7 +1102,11 @@ function renderInfoFoodIntro() {
   const displayWeeks = data.weeks.slice(-8);
   const maxCount = Math.max(...displayWeeks.map(w => w.count), 1);
 
-  let chartHtml = '<div class="t-sm fe-sub-label" >Weekly Introduction Rate</div>';
+  // V-K-28 amendment: the bars carried floating numbers (5, 4, 6, ...) with
+  // no label naming the unit. A parent reading the chart couldn't tell whether
+  // the numbers were foods, meals, or combos. Add a "foods / week" sub-label
+  // under the chart title so the value-axis intent is explicit.
+  let chartHtml = '<div class="t-sm fe-sub-label" >Weekly Introduction Rate <span class="t-light" style="font-weight:400;">— foods / week</span></div>';
   chartHtml += '<div class="info-intro-chart">';
   displayWeeks.forEach(w => {
     const pct = Math.max((w.count / maxCount) * 100, 4);
@@ -1148,7 +1152,15 @@ function renderInfoFoodIntro() {
     Object.entries(groupMap).forEach(([label, idx]) => {
       const y = PAD_T + idx * laneH + laneH / 2;
       svg += '<line x1="' + PAD_L + '" y1="' + y + '" x2="' + (VB_W - PAD_R) + '" y2="' + y + '" stroke="var(--surface-alt)" stroke-width="0.5"/>';
-      svg += '<text x="' + (PAD_L - 4) + '" y="' + (y + 3) + '" text-anchor="end" font-size="7" fill="var(--mid)" font-family="Nunito">' + escHtml(label.slice(0, 8)) + '</text>';
+      // V-K-29 amendment: was `label.slice(0, 8)` — produced fragments like
+      // "Grains G", "Vegetab #" because the 8-char cut landed mid-word (and
+      // mid-ampersand for compound labels like "Grains & Cereals"). Now
+      // split on a word/ampersand boundary and take the leading token, which
+      // gives compact-but-complete lane labels (Grains, Vegetables, Fruits,
+      // Dairy, Nuts, Other, Spices). HR-10 spirit: no text-overflow,
+      // truncate at word boundaries instead.
+      const shortLabel = label.split(/\s*[&,]\s*|\s+/)[0];
+      svg += '<text x="' + (PAD_L - 4) + '" y="' + (y + 3) + '" text-anchor="end" font-size="7" fill="var(--mid)" font-family="Nunito">' + escHtml(shortLabel) + '</text>';
     });
     // Dots
     allFoods.forEach(f => {
@@ -1183,21 +1195,53 @@ function renderInfoFoodIntro() {
 
   chartEl.innerHTML = chartHtml;
 
-  // "Foods to Try" suggestions
-  const suggestions = getUntriedSuggestions(5);
+  // V-M-17 amendment: "Foods to Try" used to render one list-item per
+  // suggestion with `<strong>{name}</strong> · {group} · {reason}`. When
+  // multiple suggestions shared an identical reason (e.g. five non-veg foods
+  // all carrying "No non-veg in 7 days"), the parent saw five visually
+  // identical lines — stuck-state masquerading as recommendations. Now group
+  // by reason: one heading per gap, chips for each food. Fewer lines, clearer
+  // signal, and the eye reads "consider this category" rather than five
+  // duplicates.
+  const suggestions = getUntriedSuggestions(8);
   let tryHtml = '<div class="t-sm fe-sub-label" >Foods to Try Next</div>';
   if (suggestions.length === 0) {
     tryHtml += '<div class="t-sm t-light">Amazing — you\'ve covered the full taxonomy!</div>';
   } else {
-    tryHtml += '<div class="fx-col g4">';
+    // Group by reason text. Preserve first-occurrence order for stable rendering.
+    const groups = [];
+    const reasonIdx = {};
     suggestions.forEach(s => {
-      tryHtml += `
-        <div class="list-item li-row">
-          <div class="li-body">
-            <strong>${escHtml(s.name)}</strong>
-            <span class="t-sm t-light">${escHtml(s.groupLabel)} · ${escHtml(s.reason)}</span>
-          </div>
-        </div>`;
+      const key = (s.reason || 'Explore something new') + '||' + (s.groupLabel || '');
+      if (reasonIdx[key] == null) {
+        reasonIdx[key] = groups.length;
+        groups.push({ reason: s.reason || 'Explore something new', groupLabel: s.groupLabel || '', items: [] });
+      }
+      groups[reasonIdx[key]].items.push(s);
+    });
+    tryHtml += '<div class="fx-col g8">';
+    groups.forEach(g => {
+      // If the gap has 3+ suggestions, render as a category heading + chips.
+      // For 1-2 suggestions, keep the legacy list-item format so single
+      // recommendations don't lose their per-item visual weight.
+      if (g.items.length >= 3) {
+        tryHtml += '<div class="li-row" style="flex-direction:column;align-items:flex-start;gap:var(--sp-4);">';
+        tryHtml += '<div><strong>' + escHtml(g.reason) + '</strong>'
+          + (g.groupLabel ? ' <span class="t-sm t-light">· ' + escHtml(g.groupLabel) + '</span>' : '')
+          + '</div>';
+        tryHtml += '<div class="fx-wrap g4">';
+        g.items.forEach(it => {
+          tryHtml += '<span class="info-food-chip is-sage">' + escHtml(it.name) + '</span>';
+        });
+        tryHtml += '</div></div>';
+      } else {
+        g.items.forEach(s => {
+          tryHtml += '<div class="list-item li-row"><div class="li-body">'
+            + '<strong>' + escHtml(s.name) + '</strong>'
+            + '<span class="t-sm t-light">' + escHtml(s.groupLabel || '') + ' · ' + escHtml(s.reason || '') + '</span>'
+            + '</div></div>';
+        });
+      }
     });
     tryHtml += '</div>';
   }

--- a/split/intelligence-quicklog.js
+++ b/split/intelligence-quicklog.js
@@ -2927,12 +2927,18 @@ function getUntriedSuggestions(n) {
   n = n || 5;
   const introduced = new Set((foods || []).map(f => f.name.toLowerCase().trim()));
   const ageM = ageAt().months;
+  // V-M-19 amendment: respect the user's diet preference. If settings has
+  // dietPref === 'veg', non-veg foods must not surface as "Foods to Try Next."
+  // A parent who set a dietary boundary expects the app to honor it everywhere.
+  const isVeg = (typeof getDietPref === 'function') && getDietPref() === 'veg';
 
   // Collect all taxonomy foods not yet introduced
   const candidates = [];
   _foodTaxFlat.forEach(item => {
     const key = item.key.toLowerCase().trim();
     if (introduced.has(key)) return;
+    // Diet-preference gate
+    if (isVeg && item.pid === 'nonveg') return;
     // Age gate: skip nuts for <8m (whole), skip honey for <12m
     if (key === 'honey' && ageM < 12) return;
     if (key === 'peanut' && ageM < 8) return;

--- a/split/medical.js
+++ b/split/medical.js
@@ -7385,13 +7385,29 @@ function renderInfoMilestoneVelocity() {
     // milestone categories (motor / social / language / cognitive) and within
     // each, the maturity mix (emerging / practicing / consistent / mastered).
     // Card-local layout + render; extraction deferred per PR-EF D10.
+    //
+    // V-K-31 / Cipher A2 amendment: original color scheme encoded STATUS in
+    // hue (--ms-emerging/practicing/consistent/mastered) and gave categories
+    // zero hue variation — the treemap's primary insight (category
+    // distribution at a glance) was lost because all 4 cats looked the same
+    // green family. Inverted: CATEGORY now encodes hue (using the 4 domain
+    // tones — sage / lav / sky / amber, mapped 1:1 to motor/social/language/
+    // cognitive), STATUS encodes opacity stepping (0.35 → 0.55 → 0.75 → 0.95).
+    // Parent's eye reads category-balance from the four color regions, then
+    // maturity-depth from the within-region density.
     const CATS = ['motor', 'social', 'language', 'cognitive'];
     const STATUSES = ['emerging', 'practicing', 'consistent', 'mastered'];
-    const STATUS_TOKEN = {
-      emerging:   'var(--ms-emerging)',
-      practicing: 'var(--ms-practicing)',
-      consistent: 'var(--ms-consistent)',
-      mastered:   'var(--ms-mastered)'
+    const CAT_HUE = {
+      motor:     'var(--tc-sage)',
+      social:    'var(--tc-lav)',
+      language:  'var(--tc-sky)',
+      cognitive: 'var(--tc-amber)'
+    };
+    const STATUS_OPACITY = {
+      emerging:   0.35,
+      practicing: 0.55,
+      consistent: 0.75,
+      mastered:   0.95
     };
     // Counts: cat → status → count
     const catTotals = {};
@@ -7431,21 +7447,34 @@ function renderInfoMilestoneVelocity() {
           return;
         }
         // Inside the cat block, lay out 4 status sub-rows (or fewer if some empty)
-        // by status weight. Use horizontal sub-strips.
+        // by status weight. Use horizontal sub-strips. Each sub-strip uses the
+        // CATEGORY hue with STATUS-tier opacity, so the parent reads
+        // category-balance from color regions and maturity-depth from intensity.
+        const hue = CAT_HUE[cat] || 'var(--tc-sage)';
         let cursorY = y;
         STATUSES.forEach(st => {
           const ct = catStatusCounts[cat][st];
           if (ct === 0) return;
           const subH = (ct / total) * h;
-          svg += '<rect x="' + x + '" y="' + cursorY.toFixed(1) + '" width="' + w + '" height="' + subH.toFixed(1) + '" fill="' + STATUS_TOKEN[st] + '" opacity="0.85" stroke="white" stroke-width="1"><title>' + cat + ' · ' + st + ' · ' + ct + '</title></rect>';
-          // Label if sub-block is large enough
-          if (subH >= 14 && w >= 40) {
-            svg += '<text x="' + (x + 4) + '" y="' + (cursorY + subH / 2 + 3).toFixed(1) + '" font-size="7" fill="white" font-family="Nunito" font-weight="500">' + st + ' (' + ct + ')</text>';
+          const opacity = STATUS_OPACITY[st] || 0.5;
+          svg += '<rect x="' + x + '" y="' + cursorY.toFixed(1) + '" width="' + w + '" height="' + subH.toFixed(1) + '" fill="' + hue + '" opacity="' + opacity + '" stroke="white" stroke-width="1"><title>' + cat + ' · ' + st + ' · ' + ct + '</title></rect>';
+          // Status label inside sub-strip only when it fits (V-K-31: avoid overflow).
+          // Conservative bounds: need subH >= 16 AND w >= 60 AND room for the
+          // cat-header at the top of the block (skip status label that lands in
+          // the top 16 px of the cat block to avoid colliding with the title).
+          const inHeaderZone = cursorY < y + 16;
+          if (subH >= 16 && w >= 60 && !inHeaderZone) {
+            svg += '<text x="' + (x + 4) + '" y="' + (cursorY + subH / 2 + 3).toFixed(1) + '" font-size="7" fill="white" font-family="Nunito" font-weight="500" style="text-shadow:0 0 2px rgba(0,0,0,0.3);">' + st + ' · ' + ct + '</text>';
           }
           cursorY += subH;
         });
-        // Cat label on top-left, overlaid
-        svg += '<text x="' + (x + 4) + '" y="' + (y + 10) + '" font-size="8" fill="white" font-family="Nunito" font-weight="700" style="text-shadow:0 0 2px rgba(0,0,0,0.4);">' + cat + ' (' + total + ')</text>';
+        // Cat label on top-left, overlaid. V-K-31: only render full label if
+        // the block is wide enough to hold "cognitive (8)" (the longest cat
+        // name). Otherwise abbreviate to first 3 letters + count.
+        const catLabel = (w >= 88)
+          ? cat + ' (' + total + ')'
+          : cat.slice(0, 3) + ' (' + total + ')';
+        svg += '<text x="' + (x + 4) + '" y="' + (y + 11) + '" font-size="9" fill="white" font-family="Nunito" font-weight="700" style="text-shadow:0 0 3px rgba(0,0,0,0.5);">' + catLabel + '</text>';
       }
       // Top row split between top pair
       const topW0 = topSum > 0 ? (catTotals[topPair[0]] / topSum) * VB_W : VB_W / 2;
@@ -7456,11 +7485,22 @@ function renderInfoMilestoneVelocity() {
       renderCatBlock(botPair[0], 0, topH, botW0, VB_H - topH);
       renderCatBlock(botPair[1], botW0, topH, VB_W - botW0, VB_H - topH);
       svg += '</svg>';
-      // Legend
-      svg += '<div class="fx-row g8 fx-row-wrap mt-4 t-xs t-light">';
-      STATUSES.forEach(st => {
-        svg += '<span><span style="display:inline-block;width:10px;height:10px;background:' + STATUS_TOKEN[st] + ';vertical-align:middle;margin-right:2px;"></span>' + st + '</span>';
+      // V-K-31 amendment: dual-legend — category hues + status-opacity ramp.
+      // Category legend names the 4 domain colors so the parent decodes
+      // which region is which milestone domain. Status legend uses a single
+      // hue with the 4 opacity stops so the maturity-depth encoding reads
+      // independently of category.
+      svg += '<div class="fx-col g4 mt-4 t-xs t-light">';
+      svg += '<div class="fx-row g8 fx-row-wrap"><span class="t-light" style="font-weight:500;">Category:</span>';
+      CATS.forEach(c => {
+        svg += '<span><span style="display:inline-block;width:10px;height:10px;background:' + CAT_HUE[c] + ';vertical-align:middle;margin-right:2px;opacity:0.85;"></span>' + c + '</span>';
       });
+      svg += '</div>';
+      svg += '<div class="fx-row g8 fx-row-wrap"><span class="t-light" style="font-weight:500;">Maturity:</span>';
+      STATUSES.forEach(st => {
+        svg += '<span><span style="display:inline-block;width:10px;height:10px;background:var(--tc-sage);opacity:' + STATUS_OPACITY[st] + ';vertical-align:middle;margin-right:2px;"></span>' + st + '</span>';
+      });
+      svg += '</div>';
       svg += '</div>';
       html += svg;
     }
@@ -8823,16 +8863,30 @@ function computeTextureProgression() {
   dates.forEach(d => {
     const day = feedingData[d];
     if (!day) return;
-    const meals = [day.breakfast, day.lunch, day.dinner, day.snack].filter(Boolean);
+    // V-M-15 amendment: filter SKIPPED_MEAL before classification — a parent
+    // who deliberately skipped a meal shouldn't see "skipped" surfaced as an
+    // unclassified-food entry. isRealMeal() lives in core.js and treats
+    // SKIPPED_MEAL ('—skipped—') as falsy.
+    const meals = [day.breakfast, day.lunch, day.dinner, day.snack].filter(isRealMeal);
     if (meals.length === 0) return;
 
     const rawTextures = meals.map(m => _classifyMealTexture(m));
-    // Collect unknown meal-text for the gap-flag UI
+    // Collect unknown meal-text for the gap-flag UI.
+    // V-M-15 dedup amendment: split each meal's comma/plus/&/with-and tokens
+    // into individual food names before adding to the Set, so "Orange" from
+    // "Orange, Watermelon" and a standalone "Orange" entry don't double-count.
     let dayHasUnknown = false;
     rawTextures.forEach((t, idx) => {
       if (t === 'unknown') {
         dayHasUnknown = true;
-        if (unclassifiedFoods.size < 5) unclassifiedFoods.add(meals[idx].slice(0, 40));
+        if (unclassifiedFoods.size < 5) {
+          const tokens = meals[idx].split(/[,+&]| with |\s+and\s+/i)
+            .map(s => s.trim().toLowerCase())
+            .filter(s => s.length > 1 && s !== '—skipped—');
+          tokens.forEach(tok => {
+            if (unclassifiedFoods.size < 5) unclassifiedFoods.add(tok);
+          });
+        }
       }
     });
     if (dayHasUnknown) unclassifiedDays++;
@@ -9999,19 +10053,15 @@ function renderInfoGrowthVelocity() {
     insightEl.innerHTML = iHtml;
   }
 
-  // PR-EF Viz #6: render the percentile-band growth chart into the info-tab
-  // canvas mount. drawChart() is the same Chart.js renderer the Medical tab
-  // uses; the canvasId parameter keeps the two instances isolated.
-  //
-  // V-M-9 synthesis: render is unconditional on every dispatcher pass (no
-  // lazy-init guard) — Maren's monitor-only verdict accepts this for now
-  // given Ziva's growth dataset is ~12 entries and Chart.js init at this
-  // size is sub-100ms in practice. Lazy-init (e.g., hook the chevron-open
-  // event in `data-collapse-target` machinery) becomes load-bearing only
-  // if parent reports lag on the info-tab; chronicle forward.
-  if (typeof drawChart === 'function' && document.getElementById('growthChartInfo')) {
-    drawChart('growthChartInfo');
-  }
+  // V-M-18 amendment: was rendering the WHO percentile-band chart via
+  // drawChart('growthChartInfo') into a 200px-tall canvas in this card.
+  // The bands were illegible at that size — Maren's verdict was that the
+  // chart was decoration and the insight text was the actual signal. Canvas
+  // mount removed from template.html; this card now surfaces the load-
+  // bearing text + a "View full growth chart" button that switches to the
+  // Medical tab where the chart renders at usable size. V-M-9 (lazy-init
+  // monitor-only) auto-closes because the unconditional canvas render is
+  // gone.
 }
 
 // ── Feature 4: Doctor Visit Preparation ──

--- a/split/template.html
+++ b/split/template.html
@@ -1853,10 +1853,14 @@
         </div>
       </div>
 
-      <!-- 5. Color Anomaly -->
+      <!-- 5. Stool Color Pattern (V-M-16 amendment: was "Color Anomaly" —
+           card body shows "All clear" most of the time, which contradicts
+           the alarming title. A parent should read the title and feel
+           informed, not primed for an alarm. Card renderer still surfaces
+           anomaly entries explicitly when present.) -->
       <div class="card card-daily col-full" id="infoPoopColorCard">
         <div class="card-header" data-collapse-target="infoPoopColorBody" data-collapse-chevron="infoPoopColorChevron">
-          <div class="card-title"><div class="icon icon-peach"><svg class="zi"><use href="#zi-palette"/></svg></div> Color Anomaly</div>
+          <div class="card-title"><div class="icon icon-peach"><svg class="zi"><use href="#zi-palette"/></svg></div> Stool Color Pattern</div>
           <span class="collapse-chevron" id="infoPoopColorChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
         </div>
         <div id="infoPoopColorSummary" class="mt-4"></div>
@@ -2056,10 +2060,17 @@
         <div id="infoGrowthVelocitySummary" class="t-sm mt-4"></div>
         <div id="infoGrowthVelocityBody" class="collapse-body fx-col g8" style="display:none;">
           <div id="infoGrowthVelocityBar" class="mt-4"></div>
-          <div class="viz-chart-mount mt-8" style="height:200px;"><canvas id="growthChartInfo"></canvas></div>
           <div id="infoGrowthVelocityPercentile" class="mt-8"></div>
           <div id="infoGrowthVelocityGrid" class="mt-8"></div>
           <div id="infoGrowthVelocityInsight" class="mt-8"></div>
+          <!-- V-M-18 amendment: was a small Chart.js canvas ('growthChartInfo')
+               here showing the WHO percentile band at 200px tall. Per Maren —
+               the percentile bands were illegible at that size; the chart was
+               decoration, the text was signal. Removed the canvas; replaced
+               with a link to the full Medical-tab growth chart for inspection. -->
+          <div class="fx-row mt-8">
+            <button class="btn btn-ghost t-sm" data-action="switchTab" data-arg="medical" style="padding:var(--sp-4) var(--sp-10);">View full growth chart on Medical tab</button>
+          </div>
         </div>
       </div>
 

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -11322,10 +11322,14 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
         </div>
       </div>
 
-      <!-- 5. Color Anomaly -->
+      <!-- 5. Stool Color Pattern (V-M-16 amendment: was "Color Anomaly" —
+           card body shows "All clear" most of the time, which contradicts
+           the alarming title. A parent should read the title and feel
+           informed, not primed for an alarm. Card renderer still surfaces
+           anomaly entries explicitly when present.) -->
       <div class="card card-daily col-full" id="infoPoopColorCard">
         <div class="card-header" data-collapse-target="infoPoopColorBody" data-collapse-chevron="infoPoopColorChevron">
-          <div class="card-title"><div class="icon icon-peach"><svg class="zi"><use href="#zi-palette"/></svg></div> Color Anomaly</div>
+          <div class="card-title"><div class="icon icon-peach"><svg class="zi"><use href="#zi-palette"/></svg></div> Stool Color Pattern</div>
           <span class="collapse-chevron" id="infoPoopColorChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
         </div>
         <div id="infoPoopColorSummary" class="mt-4"></div>
@@ -11525,10 +11529,17 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
         <div id="infoGrowthVelocitySummary" class="t-sm mt-4"></div>
         <div id="infoGrowthVelocityBody" class="collapse-body fx-col g8" style="display:none;">
           <div id="infoGrowthVelocityBar" class="mt-4"></div>
-          <div class="viz-chart-mount mt-8" style="height:200px;"><canvas id="growthChartInfo"></canvas></div>
           <div id="infoGrowthVelocityPercentile" class="mt-8"></div>
           <div id="infoGrowthVelocityGrid" class="mt-8"></div>
           <div id="infoGrowthVelocityInsight" class="mt-8"></div>
+          <!-- V-M-18 amendment: was a small Chart.js canvas ('growthChartInfo')
+               here showing the WHO percentile band at 200px tall. Per Maren —
+               the percentile bands were illegible at that size; the chart was
+               decoration, the text was signal. Removed the canvas; replaced
+               with a link to the full Medical-tab growth chart for inspection. -->
+          <div class="fx-row mt-8">
+            <button class="btn btn-ghost t-sm" data-action="switchTab" data-arg="medical" style="padding:var(--sp-4) var(--sp-10);">View full growth chart on Medical tab</button>
+          </div>
         </div>
       </div>
 
@@ -42978,13 +42989,29 @@ function renderInfoMilestoneVelocity() {
     // milestone categories (motor / social / language / cognitive) and within
     // each, the maturity mix (emerging / practicing / consistent / mastered).
     // Card-local layout + render; extraction deferred per PR-EF D10.
+    //
+    // V-K-31 / Cipher A2 amendment: original color scheme encoded STATUS in
+    // hue (--ms-emerging/practicing/consistent/mastered) and gave categories
+    // zero hue variation — the treemap's primary insight (category
+    // distribution at a glance) was lost because all 4 cats looked the same
+    // green family. Inverted: CATEGORY now encodes hue (using the 4 domain
+    // tones — sage / lav / sky / amber, mapped 1:1 to motor/social/language/
+    // cognitive), STATUS encodes opacity stepping (0.35 → 0.55 → 0.75 → 0.95).
+    // Parent's eye reads category-balance from the four color regions, then
+    // maturity-depth from the within-region density.
     const CATS = ['motor', 'social', 'language', 'cognitive'];
     const STATUSES = ['emerging', 'practicing', 'consistent', 'mastered'];
-    const STATUS_TOKEN = {
-      emerging:   'var(--ms-emerging)',
-      practicing: 'var(--ms-practicing)',
-      consistent: 'var(--ms-consistent)',
-      mastered:   'var(--ms-mastered)'
+    const CAT_HUE = {
+      motor:     'var(--tc-sage)',
+      social:    'var(--tc-lav)',
+      language:  'var(--tc-sky)',
+      cognitive: 'var(--tc-amber)'
+    };
+    const STATUS_OPACITY = {
+      emerging:   0.35,
+      practicing: 0.55,
+      consistent: 0.75,
+      mastered:   0.95
     };
     // Counts: cat → status → count
     const catTotals = {};
@@ -43024,21 +43051,34 @@ function renderInfoMilestoneVelocity() {
           return;
         }
         // Inside the cat block, lay out 4 status sub-rows (or fewer if some empty)
-        // by status weight. Use horizontal sub-strips.
+        // by status weight. Use horizontal sub-strips. Each sub-strip uses the
+        // CATEGORY hue with STATUS-tier opacity, so the parent reads
+        // category-balance from color regions and maturity-depth from intensity.
+        const hue = CAT_HUE[cat] || 'var(--tc-sage)';
         let cursorY = y;
         STATUSES.forEach(st => {
           const ct = catStatusCounts[cat][st];
           if (ct === 0) return;
           const subH = (ct / total) * h;
-          svg += '<rect x="' + x + '" y="' + cursorY.toFixed(1) + '" width="' + w + '" height="' + subH.toFixed(1) + '" fill="' + STATUS_TOKEN[st] + '" opacity="0.85" stroke="white" stroke-width="1"><title>' + cat + ' · ' + st + ' · ' + ct + '</title></rect>';
-          // Label if sub-block is large enough
-          if (subH >= 14 && w >= 40) {
-            svg += '<text x="' + (x + 4) + '" y="' + (cursorY + subH / 2 + 3).toFixed(1) + '" font-size="7" fill="white" font-family="Nunito" font-weight="500">' + st + ' (' + ct + ')</text>';
+          const opacity = STATUS_OPACITY[st] || 0.5;
+          svg += '<rect x="' + x + '" y="' + cursorY.toFixed(1) + '" width="' + w + '" height="' + subH.toFixed(1) + '" fill="' + hue + '" opacity="' + opacity + '" stroke="white" stroke-width="1"><title>' + cat + ' · ' + st + ' · ' + ct + '</title></rect>';
+          // Status label inside sub-strip only when it fits (V-K-31: avoid overflow).
+          // Conservative bounds: need subH >= 16 AND w >= 60 AND room for the
+          // cat-header at the top of the block (skip status label that lands in
+          // the top 16 px of the cat block to avoid colliding with the title).
+          const inHeaderZone = cursorY < y + 16;
+          if (subH >= 16 && w >= 60 && !inHeaderZone) {
+            svg += '<text x="' + (x + 4) + '" y="' + (cursorY + subH / 2 + 3).toFixed(1) + '" font-size="7" fill="white" font-family="Nunito" font-weight="500" style="text-shadow:0 0 2px rgba(0,0,0,0.3);">' + st + ' · ' + ct + '</text>';
           }
           cursorY += subH;
         });
-        // Cat label on top-left, overlaid
-        svg += '<text x="' + (x + 4) + '" y="' + (y + 10) + '" font-size="8" fill="white" font-family="Nunito" font-weight="700" style="text-shadow:0 0 2px rgba(0,0,0,0.4);">' + cat + ' (' + total + ')</text>';
+        // Cat label on top-left, overlaid. V-K-31: only render full label if
+        // the block is wide enough to hold "cognitive (8)" (the longest cat
+        // name). Otherwise abbreviate to first 3 letters + count.
+        const catLabel = (w >= 88)
+          ? cat + ' (' + total + ')'
+          : cat.slice(0, 3) + ' (' + total + ')';
+        svg += '<text x="' + (x + 4) + '" y="' + (y + 11) + '" font-size="9" fill="white" font-family="Nunito" font-weight="700" style="text-shadow:0 0 3px rgba(0,0,0,0.5);">' + catLabel + '</text>';
       }
       // Top row split between top pair
       const topW0 = topSum > 0 ? (catTotals[topPair[0]] / topSum) * VB_W : VB_W / 2;
@@ -43049,11 +43089,22 @@ function renderInfoMilestoneVelocity() {
       renderCatBlock(botPair[0], 0, topH, botW0, VB_H - topH);
       renderCatBlock(botPair[1], botW0, topH, VB_W - botW0, VB_H - topH);
       svg += '</svg>';
-      // Legend
-      svg += '<div class="fx-row g8 fx-row-wrap mt-4 t-xs t-light">';
-      STATUSES.forEach(st => {
-        svg += '<span><span style="display:inline-block;width:10px;height:10px;background:' + STATUS_TOKEN[st] + ';vertical-align:middle;margin-right:2px;"></span>' + st + '</span>';
+      // V-K-31 amendment: dual-legend — category hues + status-opacity ramp.
+      // Category legend names the 4 domain colors so the parent decodes
+      // which region is which milestone domain. Status legend uses a single
+      // hue with the 4 opacity stops so the maturity-depth encoding reads
+      // independently of category.
+      svg += '<div class="fx-col g4 mt-4 t-xs t-light">';
+      svg += '<div class="fx-row g8 fx-row-wrap"><span class="t-light" style="font-weight:500;">Category:</span>';
+      CATS.forEach(c => {
+        svg += '<span><span style="display:inline-block;width:10px;height:10px;background:' + CAT_HUE[c] + ';vertical-align:middle;margin-right:2px;opacity:0.85;"></span>' + c + '</span>';
       });
+      svg += '</div>';
+      svg += '<div class="fx-row g8 fx-row-wrap"><span class="t-light" style="font-weight:500;">Maturity:</span>';
+      STATUSES.forEach(st => {
+        svg += '<span><span style="display:inline-block;width:10px;height:10px;background:var(--tc-sage);opacity:' + STATUS_OPACITY[st] + ';vertical-align:middle;margin-right:2px;"></span>' + st + '</span>';
+      });
+      svg += '</div>';
       svg += '</div>';
       html += svg;
     }
@@ -44416,16 +44467,30 @@ function computeTextureProgression() {
   dates.forEach(d => {
     const day = feedingData[d];
     if (!day) return;
-    const meals = [day.breakfast, day.lunch, day.dinner, day.snack].filter(Boolean);
+    // V-M-15 amendment: filter SKIPPED_MEAL before classification — a parent
+    // who deliberately skipped a meal shouldn't see "skipped" surfaced as an
+    // unclassified-food entry. isRealMeal() lives in core.js and treats
+    // SKIPPED_MEAL ('—skipped—') as falsy.
+    const meals = [day.breakfast, day.lunch, day.dinner, day.snack].filter(isRealMeal);
     if (meals.length === 0) return;
 
     const rawTextures = meals.map(m => _classifyMealTexture(m));
-    // Collect unknown meal-text for the gap-flag UI
+    // Collect unknown meal-text for the gap-flag UI.
+    // V-M-15 dedup amendment: split each meal's comma/plus/&/with-and tokens
+    // into individual food names before adding to the Set, so "Orange" from
+    // "Orange, Watermelon" and a standalone "Orange" entry don't double-count.
     let dayHasUnknown = false;
     rawTextures.forEach((t, idx) => {
       if (t === 'unknown') {
         dayHasUnknown = true;
-        if (unclassifiedFoods.size < 5) unclassifiedFoods.add(meals[idx].slice(0, 40));
+        if (unclassifiedFoods.size < 5) {
+          const tokens = meals[idx].split(/[,+&]| with |\s+and\s+/i)
+            .map(s => s.trim().toLowerCase())
+            .filter(s => s.length > 1 && s !== '—skipped—');
+          tokens.forEach(tok => {
+            if (unclassifiedFoods.size < 5) unclassifiedFoods.add(tok);
+          });
+        }
       }
     });
     if (dayHasUnknown) unclassifiedDays++;
@@ -45592,19 +45657,15 @@ function renderInfoGrowthVelocity() {
     insightEl.innerHTML = iHtml;
   }
 
-  // PR-EF Viz #6: render the percentile-band growth chart into the info-tab
-  // canvas mount. drawChart() is the same Chart.js renderer the Medical tab
-  // uses; the canvasId parameter keeps the two instances isolated.
-  //
-  // V-M-9 synthesis: render is unconditional on every dispatcher pass (no
-  // lazy-init guard) — Maren's monitor-only verdict accepts this for now
-  // given Ziva's growth dataset is ~12 entries and Chart.js init at this
-  // size is sub-100ms in practice. Lazy-init (e.g., hook the chevron-open
-  // event in `data-collapse-target` machinery) becomes load-bearing only
-  // if parent reports lag on the info-tab; chronicle forward.
-  if (typeof drawChart === 'function' && document.getElementById('growthChartInfo')) {
-    drawChart('growthChartInfo');
-  }
+  // V-M-18 amendment: was rendering the WHO percentile-band chart via
+  // drawChart('growthChartInfo') into a 200px-tall canvas in this card.
+  // The bands were illegible at that size — Maren's verdict was that the
+  // chart was decoration and the insight text was the actual signal. Canvas
+  // mount removed from template.html; this card now surfaces the load-
+  // bearing text + a "View full growth chart" button that switches to the
+  // Medical tab where the chart renders at usable size. V-M-9 (lazy-init
+  // monitor-only) auto-closes because the unconditional canvas render is
+  // gone.
 }
 
 // ── Feature 4: Doctor Visit Preparation ──
@@ -58218,12 +58279,18 @@ function getUntriedSuggestions(n) {
   n = n || 5;
   const introduced = new Set((foods || []).map(f => f.name.toLowerCase().trim()));
   const ageM = ageAt().months;
+  // V-M-19 amendment: respect the user's diet preference. If settings has
+  // dietPref === 'veg', non-veg foods must not surface as "Foods to Try Next."
+  // A parent who set a dietary boundary expects the app to honor it everywhere.
+  const isVeg = (typeof getDietPref === 'function') && getDietPref() === 'veg';
 
   // Collect all taxonomy foods not yet introduced
   const candidates = [];
   _foodTaxFlat.forEach(item => {
     const key = item.key.toLowerCase().trim();
     if (introduced.has(key)) return;
+    // Diet-preference gate
+    if (isVeg && item.pid === 'nonveg') return;
     // Age gate: skip nuts for <8m (whole), skip honey for <12m
     if (key === 'honey' && ageM < 12) return;
     if (key === 'peanut' && ageM < 8) return;
@@ -60748,7 +60815,11 @@ function renderInfoFoodIntro() {
   const displayWeeks = data.weeks.slice(-8);
   const maxCount = Math.max(...displayWeeks.map(w => w.count), 1);
 
-  let chartHtml = '<div class="t-sm fe-sub-label" >Weekly Introduction Rate</div>';
+  // V-K-28 amendment: the bars carried floating numbers (5, 4, 6, ...) with
+  // no label naming the unit. A parent reading the chart couldn't tell whether
+  // the numbers were foods, meals, or combos. Add a "foods / week" sub-label
+  // under the chart title so the value-axis intent is explicit.
+  let chartHtml = '<div class="t-sm fe-sub-label" >Weekly Introduction Rate <span class="t-light" style="font-weight:400;">— foods / week</span></div>';
   chartHtml += '<div class="info-intro-chart">';
   displayWeeks.forEach(w => {
     const pct = Math.max((w.count / maxCount) * 100, 4);
@@ -60794,7 +60865,15 @@ function renderInfoFoodIntro() {
     Object.entries(groupMap).forEach(([label, idx]) => {
       const y = PAD_T + idx * laneH + laneH / 2;
       svg += '<line x1="' + PAD_L + '" y1="' + y + '" x2="' + (VB_W - PAD_R) + '" y2="' + y + '" stroke="var(--surface-alt)" stroke-width="0.5"/>';
-      svg += '<text x="' + (PAD_L - 4) + '" y="' + (y + 3) + '" text-anchor="end" font-size="7" fill="var(--mid)" font-family="Nunito">' + escHtml(label.slice(0, 8)) + '</text>';
+      // V-K-29 amendment: was `label.slice(0, 8)` — produced fragments like
+      // "Grains G", "Vegetab #" because the 8-char cut landed mid-word (and
+      // mid-ampersand for compound labels like "Grains & Cereals"). Now
+      // split on a word/ampersand boundary and take the leading token, which
+      // gives compact-but-complete lane labels (Grains, Vegetables, Fruits,
+      // Dairy, Nuts, Other, Spices). HR-10 spirit: no text-overflow,
+      // truncate at word boundaries instead.
+      const shortLabel = label.split(/\s*[&,]\s*|\s+/)[0];
+      svg += '<text x="' + (PAD_L - 4) + '" y="' + (y + 3) + '" text-anchor="end" font-size="7" fill="var(--mid)" font-family="Nunito">' + escHtml(shortLabel) + '</text>';
     });
     // Dots
     allFoods.forEach(f => {
@@ -60829,21 +60908,53 @@ function renderInfoFoodIntro() {
 
   chartEl.innerHTML = chartHtml;
 
-  // "Foods to Try" suggestions
-  const suggestions = getUntriedSuggestions(5);
+  // V-M-17 amendment: "Foods to Try" used to render one list-item per
+  // suggestion with `<strong>{name}</strong> · {group} · {reason}`. When
+  // multiple suggestions shared an identical reason (e.g. five non-veg foods
+  // all carrying "No non-veg in 7 days"), the parent saw five visually
+  // identical lines — stuck-state masquerading as recommendations. Now group
+  // by reason: one heading per gap, chips for each food. Fewer lines, clearer
+  // signal, and the eye reads "consider this category" rather than five
+  // duplicates.
+  const suggestions = getUntriedSuggestions(8);
   let tryHtml = '<div class="t-sm fe-sub-label" >Foods to Try Next</div>';
   if (suggestions.length === 0) {
     tryHtml += '<div class="t-sm t-light">Amazing — you\'ve covered the full taxonomy!</div>';
   } else {
-    tryHtml += '<div class="fx-col g4">';
+    // Group by reason text. Preserve first-occurrence order for stable rendering.
+    const groups = [];
+    const reasonIdx = {};
     suggestions.forEach(s => {
-      tryHtml += `
-        <div class="list-item li-row">
-          <div class="li-body">
-            <strong>${escHtml(s.name)}</strong>
-            <span class="t-sm t-light">${escHtml(s.groupLabel)} · ${escHtml(s.reason)}</span>
-          </div>
-        </div>`;
+      const key = (s.reason || 'Explore something new') + '||' + (s.groupLabel || '');
+      if (reasonIdx[key] == null) {
+        reasonIdx[key] = groups.length;
+        groups.push({ reason: s.reason || 'Explore something new', groupLabel: s.groupLabel || '', items: [] });
+      }
+      groups[reasonIdx[key]].items.push(s);
+    });
+    tryHtml += '<div class="fx-col g8">';
+    groups.forEach(g => {
+      // If the gap has 3+ suggestions, render as a category heading + chips.
+      // For 1-2 suggestions, keep the legacy list-item format so single
+      // recommendations don't lose their per-item visual weight.
+      if (g.items.length >= 3) {
+        tryHtml += '<div class="li-row" style="flex-direction:column;align-items:flex-start;gap:var(--sp-4);">';
+        tryHtml += '<div><strong>' + escHtml(g.reason) + '</strong>'
+          + (g.groupLabel ? ' <span class="t-sm t-light">· ' + escHtml(g.groupLabel) + '</span>' : '')
+          + '</div>';
+        tryHtml += '<div class="fx-wrap g4">';
+        g.items.forEach(it => {
+          tryHtml += '<span class="info-food-chip is-sage">' + escHtml(it.name) + '</span>';
+        });
+        tryHtml += '</div></div>';
+      } else {
+        g.items.forEach(s => {
+          tryHtml += '<div class="list-item li-row"><div class="li-body">'
+            + '<strong>' + escHtml(s.name) + '</strong>'
+            + '<span class="t-sm t-light">' + escHtml(s.groupLabel || '') + ' · ' + escHtml(s.reason || '') + '</span>'
+            + '</div></div>';
+        });
+      }
     });
     tryHtml += '</div>';
   }


### PR DESCRIPTION
## Summary

Post-merge roundtable amendment to PR-EF (#82). The architect rated PR-EF's shipped state 3.5/10 and convened a Lyra + Cipher + Maren + Kael review; 9 V-tag findings surfaced, plus one new finding (V-M-19 diet-preference filter) the user added directly. This PR closes all of them.

**Not a full PR-H** — that pivots to the viz-interactivity layer (tap-to-open detail popup on every viz card, fixing the "you see dots but can't tell what each dot is" problem). PR-H scope is reframed; the amendment lands first to restore Care-Region trust.

## Findings closed

### Care-region (Maren)

- **V-M-15 — Texture progression skipped-meal leak.** `filter(Boolean)` kept `SKIPPED_MEAL` ('—skipped—') as a non-null string; classifier returned 'unknown'; "skipped" surfaced in the unclassified-foods gap-flag. Fix: filter via `isRealMeal()` before classification.
- **V-M-15 dedup amendment — Texture unclassified foods.** Set deduped on meal-text-excerpt not food-name → "Orange" alone and "Orange, Watermelon" double-counted. Fix: split unknown meal-text on comma/plus/&/with/and boundaries before dedup.
- **V-M-16 — "Color Anomaly" title/body tonal mismatch.** Title said "Color Anomaly", body said "All clear." Title primed alarm, body reversed it — safety-tier copy failure on a Care card. Renamed to **"Stool Color Pattern"**.
- **V-M-17 — "Foods to Try Next" stuck-state copy.** 5 suggestions all carrying identical "No non-veg in 7 days" reason rendered as 5 visually identical rows. Now grouped by reason: ≥3 items sharing a reason render as a category heading + chip row.
- **V-M-18 — Growth velocity chart demote.** WHO percentile bands illegible at 200px canvas in info tab. Chart was decoration; text was signal. Removed canvas + drawChart call; added "View full growth chart on Medical tab" link. V-M-9 (lazy-init monitor-only) auto-closes — unconditional Chart.js render is gone.
- **V-M-19 (NEW from architect) — Diet preference filter.** `getUntriedSuggestions()` did not consult `getDietPref()`. Veg-pref users saw egg/chicken/fish/prawn/shrimp suggestions. Filter added.

### Intelligence-region (Kael)

- **V-K-28 — Weekly Introduction Rate value-axis label.** Bars carried floating numbers with no unit label. Added "— foods / week" sub-label.
- **V-K-29 — Food Intro Timeline lane-label truncation.** `escHtml(label.slice(0, 8))` produced fragments like "Grains G", "Vegetab #", "Nuts &" — 8-char cut landed mid-word and mid-ampersand. Now split on word/ampersand boundary, take leading token.
- **V-K-31 / Cipher A2 — Milestone treemap color encoding.** Original scheme encoded STATUS in hue and gave categories zero hue variation — primary insight (category distribution) was lost. **Inverted:** CATEGORY encodes hue (sage/lav/sky/amber 1:1 with motor/social/language/cognitive); STATUS encodes opacity (0.35 → 0.55 → 0.75 → 0.95). Dual-legend rendered. Label-overflow fixed: cat-label abbreviates to 3 chars if block too narrow; status labels skip the header zone.

## Carry-forward (to PR-EF.2 / Interactivity)

- **V-K-30** — Vaccination Gantt wrong-shape primitive. 12 lanes for 8 months of data clusters left and goes sparse right. Bigger redesign; not amendment-shape.
- **V-K-32** — Info-tab hierarchy primary-surface gap. Layout-level question (no card signals "this is today's headline"). Not amendment-shape.
- **The interactivity layer itself** — every viz card should be tappable to open a detail popup. Architect's stated direction. Generic `vizDetailPopup` primitive + per-cell `data-action="vizShowDetail"` wiring. ~200-300 LOC of new primitive + ~10-20 LOC per card. PR-EF.2 / PR-H pivot.

## Ship-gate status

All four green:
- `audit-emoji.sh` — 0 HR-1 violations
- `audit-icon-text` — 0 unannotated `(label|text|reason|detail): zi(` field-assignments
- `audit-resolve-shield` — 4 callers in `intelligence-illness.js`
- `audit-viz-smoke` — 4 ids + 5 tokens (down from 5; `growthChartInfo` removed per V-M-18; ship-gate updated)

## Audit chain shape

Light — this is pure amendment work on already-audited surfaces. Recommended:
- **Maren pair-note** — verify V-M-15 / V-M-16 / V-M-17 / V-M-18 / V-M-19 close cleanly. Care-region jurisdiction.
- **Kael pair-note** — verify V-K-28 / V-K-29 / V-K-31. Intelligence-region jurisdiction.
- **Cipher Edict V** — A2 endorsement confirmation + chain seal.

## Test plan

- [x] Build passes; all four ship-gates green
- [ ] Manual: open Food Intelligence card — lane labels read "Grains / Vegetables / Fruits / Dairy / Nuts / Other / Spices" (no fragments)
- [ ] Manual: open Texture Progression — `—skipped—` NOT in unclassified-foods list; duplicates collapsed
- [ ] Manual: settings → set dietPref to 'veg' → Food Intro card → Foods to Try Next does NOT show egg/chicken/fish/prawn/shrimp
- [ ] Manual: open Milestone Velocity treemap — 4 distinct hues across motor (sage) / social (lav) / language (sky) / cognitive (amber); maturity reads as opacity within each region
- [ ] Manual: stool card title reads "Stool Color Pattern" (not "Color Anomaly")
- [ ] Manual: growth velocity card shows insight text + "View full growth chart on Medical tab" button; no inline chart

https://claude.ai/code/session_01UtT2QeJisuCmNrGkUWSzs3

---
_Generated by [Claude Code](https://claude.ai/code/session_01UtT2QeJisuCmNrGkUWSzs3)_