### PR TITLE
PR-J — Home-tab hotfix: trend-pill SVG leak + stuck win alerts

### DIFF
--- a/index.html
+++ b/index.html
@@ -21643,9 +21643,10 @@ function updateStatPillTrends() {
       if (prev.date === latest.date && wtEntries.length >= 2) prev = wtEntries[wtEntries.length - 2];
       const trend = getTrend(latest.wt, prev.wt, 0.05, 2);
       wtTrendEl.className = 'hsp-trend ' + trend.cls;
-      wtTrendEl.textContent = trend.text ? trend.text + ' kg' : '';
+      // getTrend().text carries an SVG icon (iconText) — HR-7: set via innerHTML.
+      wtTrendEl.innerHTML = trend.text ? trend.text + ' kg' : '';
     } else {
-      wtTrendEl.textContent = '';
+      wtTrendEl.innerHTML = '';
     }
   }
 
@@ -21665,9 +21666,10 @@ function updateStatPillTrends() {
       if (prev.date === latest.date && htEntries.length >= 2) prev = htEntries[htEntries.length - 2];
       const trend = getTrend(latest.ht, prev.ht, 0.5, 1);
       htTrendEl.className = 'hsp-trend ' + trend.cls;
-      htTrendEl.textContent = trend.text ? trend.text + ' cm' : '';
+      // getTrend().text carries an SVG icon (iconText) — HR-7: set via innerHTML.
+      htTrendEl.innerHTML = trend.text ? trend.text + ' cm' : '';
     } else {
-      htTrendEl.textContent = '';
+      htTrendEl.innerHTML = '';
     }
   }
 
@@ -21678,9 +21680,10 @@ function updateStatPillTrends() {
     if (sleepT.score.current != null && sleepT.score.previous != null) {
       const t = sleepT.score.trend;
       slTrendEl.className = 'hsp-trend ' + t.cls;
-      slTrendEl.textContent = t.text ? t.text + ' pts' : '';
+      // getTrend().text carries an SVG icon (iconText) — HR-7: set via innerHTML.
+      slTrendEl.innerHTML = t.text ? t.text + ' pts' : '';
     } else {
-      slTrendEl.textContent = '';
+      slTrendEl.innerHTML = '';
     }
   }
 
@@ -29758,7 +29761,7 @@ function computeAlerts() {
       body: 'Ziva slept through the night with zero wake-ups for the first time ever! This is a huge milestone.',
       tip: 'This doesn\'t mean every night will be like this — but it shows she CAN do it. Keep the same bedtime routine that worked.',
       action: { label: 'View Sleep', fn: 'switchTab("sleep")' },
-      tab: 'sleep', dismissable: false
+      tab: 'sleep', dismissable: true
     });
   }
 
@@ -29772,7 +29775,7 @@ function computeAlerts() {
       title: msg,
       body: 'Sleep score has been 75+ for ' + bl.sleepGoodStreak + ' consecutive days. Whatever you\'re doing is working.',
       tip: 'Consistency is key — keep the same bedtime, routine, and sleep environment. Note what\'s working so you can replicate it.',
-      action: null, tab: 'sleep', dismissable: false
+      action: null, tab: 'sleep', dismissable: true
     });
   }
 
@@ -29785,7 +29788,7 @@ function computeAlerts() {
       title: 'Digestion has been stable for ' + bl.poopConsistentStreak + '+ entries',
       body: 'All recent poops have been normal or soft consistency. Ziva\'s tummy is happy!',
       tip: 'Stable digestion means her gut is adjusting well to her current diet. A great time to try a new food if you haven\'t recently.',
-      action: null, tab: 'poop', dismissable: false
+      action: null, tab: 'poop', dismissable: true
     });
   }
 
@@ -29798,7 +29801,7 @@ function computeAlerts() {
       title: bl.newFoodsThisWeek + ' new foods this week!',
       body: 'Great variety — exposure to different tastes and textures in the first year shapes lifelong food preferences.',
       tip: 'Keep it up! Remember the 3-day rule for each new food to spot any reactions.',
-      action: null, tab: 'diet', dismissable: false
+      action: null, tab: 'diet', dismissable: true
     });
   }
 
@@ -29811,7 +29814,7 @@ function computeAlerts() {
       title: bl.mealLoggingStreak + '-day meal logging streak!',
       body: 'All 3 meals logged for ' + bl.mealLoggingStreak + ' consecutive days. Consistent tracking gives the best insights.',
       tip: 'Your data is building a clear picture of Ziva\'s eating patterns. The more consistent the logging, the better the insights.',
-      action: null, tab: 'diet', dismissable: false
+      action: null, tab: 'diet', dismissable: true
     });
   }
 
@@ -29824,7 +29827,7 @@ function computeAlerts() {
       title: 'Growth on track for ' + bl.growthConsistentWeeks + '+ weeks',
       body: 'Weight velocity (' + bl.wtGPerWeek + ' g/week) is within the healthy range. Ziva is growing beautifully.',
       tip: 'Consistent, healthy weight gain is more important than hitting a specific number. Keep up the balanced nutrition.',
-      action: null, tab: 'growth', dismissable: false
+      action: null, tab: 'growth', dismissable: true
     });
   }
 
@@ -29846,7 +29849,7 @@ function computeAlerts() {
         title: milestoneLabel + ' of consistent ' + m.name + '!',
         body: streak + '-day streak. ' + milestoneMsg,
         tip: getD3Tip(streak),
-        action: null, tab: 'medical', dismissable: false
+        action: null, tab: 'medical', dismissable: true
       });
     }
   });
@@ -29860,7 +29863,7 @@ function computeAlerts() {
       title: 'Iron-rich week — ' + bl.ironDays7d + '/7 days!',
       body: 'Ziva had iron-rich foods on ' + bl.ironDays7d + ' of the last 7 days. This is excellent for preventing anaemia and supporting brain development.',
       tip: bl.ironVitCPairCount >= 2 ? 'And you paired iron with Vitamin C ' + bl.ironVitCPairCount + ' times — maximum absorption!' : 'Tip: pair iron meals with Vitamin C (lemon, amla, orange) to boost absorption even further.',
-      action: null, tab: 'diet', dismissable: false
+      action: null, tab: 'diet', dismissable: true
     });
   }
 
@@ -29875,7 +29878,7 @@ function computeAlerts() {
       body: 'Great nutritional diversity: ' + covered + '. A balanced diet supports all-round development.',
       tip: 'You\'re covering most key nutrients. To complete the picture, look for any gaps in: ' +
         KEY_NUTRIENTS.filter(n => (bl.nutrientDays || {})[n] < 2).join(', ') + '.',
-      action: null, tab: 'diet', dismissable: false
+      action: null, tab: 'diet', dismissable: true
     });
   }
 
@@ -29888,7 +29891,7 @@ function computeAlerts() {
       title: 'Iron + Vitamin C paired ' + bl.ironVitCPairCount + ' times this week!',
       body: 'Pairing iron-rich foods with Vitamin C can double iron absorption. You\'re doing this consistently — excellent practice.',
       tip: 'This is one of the most impactful nutrition habits for babies. Keep it up — lemon on khichdi, amla after ragi, or mango with dal all work perfectly.',
-      action: null, tab: 'diet', dismissable: false
+      action: null, tab: 'diet', dismissable: true
     });
   }
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.21-1",
+  "version": "2026.05.21-2",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -4843,9 +4843,10 @@ function updateStatPillTrends() {
       if (prev.date === latest.date && wtEntries.length >= 2) prev = wtEntries[wtEntries.length - 2];
       const trend = getTrend(latest.wt, prev.wt, 0.05, 2);
       wtTrendEl.className = 'hsp-trend ' + trend.cls;
-      wtTrendEl.textContent = trend.text ? trend.text + ' kg' : '';
+      // getTrend().text carries an SVG icon (iconText) — HR-7: set via innerHTML.
+      wtTrendEl.innerHTML = trend.text ? trend.text + ' kg' : '';
     } else {
-      wtTrendEl.textContent = '';
+      wtTrendEl.innerHTML = '';
     }
   }
 
@@ -4865,9 +4866,10 @@ function updateStatPillTrends() {
       if (prev.date === latest.date && htEntries.length >= 2) prev = htEntries[htEntries.length - 2];
       const trend = getTrend(latest.ht, prev.ht, 0.5, 1);
       htTrendEl.className = 'hsp-trend ' + trend.cls;
-      htTrendEl.textContent = trend.text ? trend.text + ' cm' : '';
+      // getTrend().text carries an SVG icon (iconText) — HR-7: set via innerHTML.
+      htTrendEl.innerHTML = trend.text ? trend.text + ' cm' : '';
     } else {
-      htTrendEl.textContent = '';
+      htTrendEl.innerHTML = '';
     }
   }
 
@@ -4878,9 +4880,10 @@ function updateStatPillTrends() {
     if (sleepT.score.current != null && sleepT.score.previous != null) {
       const t = sleepT.score.trend;
       slTrendEl.className = 'hsp-trend ' + t.cls;
-      slTrendEl.textContent = t.text ? t.text + ' pts' : '';
+      // getTrend().text carries an SVG icon (iconText) — HR-7: set via innerHTML.
+      slTrendEl.innerHTML = t.text ? t.text + ' pts' : '';
     } else {
-      slTrendEl.textContent = '';
+      slTrendEl.innerHTML = '';
     }
   }
 

--- a/split/home.js
+++ b/split/home.js
@@ -7540,7 +7540,7 @@ function computeAlerts() {
       body: 'Ziva slept through the night with zero wake-ups for the first time ever! This is a huge milestone.',
       tip: 'This doesn\'t mean every night will be like this — but it shows she CAN do it. Keep the same bedtime routine that worked.',
       action: { label: 'View Sleep', fn: 'switchTab("sleep")' },
-      tab: 'sleep', dismissable: false
+      tab: 'sleep', dismissable: true
     });
   }
 
@@ -7554,7 +7554,7 @@ function computeAlerts() {
       title: msg,
       body: 'Sleep score has been 75+ for ' + bl.sleepGoodStreak + ' consecutive days. Whatever you\'re doing is working.',
       tip: 'Consistency is key — keep the same bedtime, routine, and sleep environment. Note what\'s working so you can replicate it.',
-      action: null, tab: 'sleep', dismissable: false
+      action: null, tab: 'sleep', dismissable: true
     });
   }
 
@@ -7567,7 +7567,7 @@ function computeAlerts() {
       title: 'Digestion has been stable for ' + bl.poopConsistentStreak + '+ entries',
       body: 'All recent poops have been normal or soft consistency. Ziva\'s tummy is happy!',
       tip: 'Stable digestion means her gut is adjusting well to her current diet. A great time to try a new food if you haven\'t recently.',
-      action: null, tab: 'poop', dismissable: false
+      action: null, tab: 'poop', dismissable: true
     });
   }
 
@@ -7580,7 +7580,7 @@ function computeAlerts() {
       title: bl.newFoodsThisWeek + ' new foods this week!',
       body: 'Great variety — exposure to different tastes and textures in the first year shapes lifelong food preferences.',
       tip: 'Keep it up! Remember the 3-day rule for each new food to spot any reactions.',
-      action: null, tab: 'diet', dismissable: false
+      action: null, tab: 'diet', dismissable: true
     });
   }
 
@@ -7593,7 +7593,7 @@ function computeAlerts() {
       title: bl.mealLoggingStreak + '-day meal logging streak!',
       body: 'All 3 meals logged for ' + bl.mealLoggingStreak + ' consecutive days. Consistent tracking gives the best insights.',
       tip: 'Your data is building a clear picture of Ziva\'s eating patterns. The more consistent the logging, the better the insights.',
-      action: null, tab: 'diet', dismissable: false
+      action: null, tab: 'diet', dismissable: true
     });
   }
 
@@ -7606,7 +7606,7 @@ function computeAlerts() {
       title: 'Growth on track for ' + bl.growthConsistentWeeks + '+ weeks',
       body: 'Weight velocity (' + bl.wtGPerWeek + ' g/week) is within the healthy range. Ziva is growing beautifully.',
       tip: 'Consistent, healthy weight gain is more important than hitting a specific number. Keep up the balanced nutrition.',
-      action: null, tab: 'growth', dismissable: false
+      action: null, tab: 'growth', dismissable: true
     });
   }
 
@@ -7628,7 +7628,7 @@ function computeAlerts() {
         title: milestoneLabel + ' of consistent ' + m.name + '!',
         body: streak + '-day streak. ' + milestoneMsg,
         tip: getD3Tip(streak),
-        action: null, tab: 'medical', dismissable: false
+        action: null, tab: 'medical', dismissable: true
       });
     }
   });
@@ -7642,7 +7642,7 @@ function computeAlerts() {
       title: 'Iron-rich week — ' + bl.ironDays7d + '/7 days!',
       body: 'Ziva had iron-rich foods on ' + bl.ironDays7d + ' of the last 7 days. This is excellent for preventing anaemia and supporting brain development.',
       tip: bl.ironVitCPairCount >= 2 ? 'And you paired iron with Vitamin C ' + bl.ironVitCPairCount + ' times — maximum absorption!' : 'Tip: pair iron meals with Vitamin C (lemon, amla, orange) to boost absorption even further.',
-      action: null, tab: 'diet', dismissable: false
+      action: null, tab: 'diet', dismissable: true
     });
   }
 
@@ -7657,7 +7657,7 @@ function computeAlerts() {
       body: 'Great nutritional diversity: ' + covered + '. A balanced diet supports all-round development.',
       tip: 'You\'re covering most key nutrients. To complete the picture, look for any gaps in: ' +
         KEY_NUTRIENTS.filter(n => (bl.nutrientDays || {})[n] < 2).join(', ') + '.',
-      action: null, tab: 'diet', dismissable: false
+      action: null, tab: 'diet', dismissable: true
     });
   }
 
@@ -7670,7 +7670,7 @@ function computeAlerts() {
       title: 'Iron + Vitamin C paired ' + bl.ironVitCPairCount + ' times this week!',
       body: 'Pairing iron-rich foods with Vitamin C can double iron absorption. You\'re doing this consistently — excellent practice.',
       tip: 'This is one of the most impactful nutrition habits for babies. Keep it up — lemon on khichdi, amla after ragi, or mango with dal all work perfectly.',
-      action: null, tab: 'diet', dismissable: false
+      action: null, tab: 'diet', dismissable: true
     });
   }
 

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -21643,9 +21643,10 @@ function updateStatPillTrends() {
       if (prev.date === latest.date && wtEntries.length >= 2) prev = wtEntries[wtEntries.length - 2];
       const trend = getTrend(latest.wt, prev.wt, 0.05, 2);
       wtTrendEl.className = 'hsp-trend ' + trend.cls;
-      wtTrendEl.textContent = trend.text ? trend.text + ' kg' : '';
+      // getTrend().text carries an SVG icon (iconText) — HR-7: set via innerHTML.
+      wtTrendEl.innerHTML = trend.text ? trend.text + ' kg' : '';
     } else {
-      wtTrendEl.textContent = '';
+      wtTrendEl.innerHTML = '';
     }
   }
 
@@ -21665,9 +21666,10 @@ function updateStatPillTrends() {
       if (prev.date === latest.date && htEntries.length >= 2) prev = htEntries[htEntries.length - 2];
       const trend = getTrend(latest.ht, prev.ht, 0.5, 1);
       htTrendEl.className = 'hsp-trend ' + trend.cls;
-      htTrendEl.textContent = trend.text ? trend.text + ' cm' : '';
+      // getTrend().text carries an SVG icon (iconText) — HR-7: set via innerHTML.
+      htTrendEl.innerHTML = trend.text ? trend.text + ' cm' : '';
     } else {
-      htTrendEl.textContent = '';
+      htTrendEl.innerHTML = '';
     }
   }
 
@@ -21678,9 +21680,10 @@ function updateStatPillTrends() {
     if (sleepT.score.current != null && sleepT.score.previous != null) {
       const t = sleepT.score.trend;
       slTrendEl.className = 'hsp-trend ' + t.cls;
-      slTrendEl.textContent = t.text ? t.text + ' pts' : '';
+      // getTrend().text carries an SVG icon (iconText) — HR-7: set via innerHTML.
+      slTrendEl.innerHTML = t.text ? t.text + ' pts' : '';
     } else {
-      slTrendEl.textContent = '';
+      slTrendEl.innerHTML = '';
     }
   }
 
@@ -29758,7 +29761,7 @@ function computeAlerts() {
       body: 'Ziva slept through the night with zero wake-ups for the first time ever! This is a huge milestone.',
       tip: 'This doesn\'t mean every night will be like this — but it shows she CAN do it. Keep the same bedtime routine that worked.',
       action: { label: 'View Sleep', fn: 'switchTab("sleep")' },
-      tab: 'sleep', dismissable: false
+      tab: 'sleep', dismissable: true
     });
   }
 
@@ -29772,7 +29775,7 @@ function computeAlerts() {
       title: msg,
       body: 'Sleep score has been 75+ for ' + bl.sleepGoodStreak + ' consecutive days. Whatever you\'re doing is working.',
       tip: 'Consistency is key — keep the same bedtime, routine, and sleep environment. Note what\'s working so you can replicate it.',
-      action: null, tab: 'sleep', dismissable: false
+      action: null, tab: 'sleep', dismissable: true
     });
   }
 
@@ -29785,7 +29788,7 @@ function computeAlerts() {
       title: 'Digestion has been stable for ' + bl.poopConsistentStreak + '+ entries',
       body: 'All recent poops have been normal or soft consistency. Ziva\'s tummy is happy!',
       tip: 'Stable digestion means her gut is adjusting well to her current diet. A great time to try a new food if you haven\'t recently.',
-      action: null, tab: 'poop', dismissable: false
+      action: null, tab: 'poop', dismissable: true
     });
   }
 
@@ -29798,7 +29801,7 @@ function computeAlerts() {
       title: bl.newFoodsThisWeek + ' new foods this week!',
       body: 'Great variety — exposure to different tastes and textures in the first year shapes lifelong food preferences.',
       tip: 'Keep it up! Remember the 3-day rule for each new food to spot any reactions.',
-      action: null, tab: 'diet', dismissable: false
+      action: null, tab: 'diet', dismissable: true
     });
   }
 
@@ -29811,7 +29814,7 @@ function computeAlerts() {
       title: bl.mealLoggingStreak + '-day meal logging streak!',
       body: 'All 3 meals logged for ' + bl.mealLoggingStreak + ' consecutive days. Consistent tracking gives the best insights.',
       tip: 'Your data is building a clear picture of Ziva\'s eating patterns. The more consistent the logging, the better the insights.',
-      action: null, tab: 'diet', dismissable: false
+      action: null, tab: 'diet', dismissable: true
     });
   }
 
@@ -29824,7 +29827,7 @@ function computeAlerts() {
       title: 'Growth on track for ' + bl.growthConsistentWeeks + '+ weeks',
       body: 'Weight velocity (' + bl.wtGPerWeek + ' g/week) is within the healthy range. Ziva is growing beautifully.',
       tip: 'Consistent, healthy weight gain is more important than hitting a specific number. Keep up the balanced nutrition.',
-      action: null, tab: 'growth', dismissable: false
+      action: null, tab: 'growth', dismissable: true
     });
   }
 
@@ -29846,7 +29849,7 @@ function computeAlerts() {
         title: milestoneLabel + ' of consistent ' + m.name + '!',
         body: streak + '-day streak. ' + milestoneMsg,
         tip: getD3Tip(streak),
-        action: null, tab: 'medical', dismissable: false
+        action: null, tab: 'medical', dismissable: true
       });
     }
   });
@@ -29860,7 +29863,7 @@ function computeAlerts() {
       title: 'Iron-rich week — ' + bl.ironDays7d + '/7 days!',
       body: 'Ziva had iron-rich foods on ' + bl.ironDays7d + ' of the last 7 days. This is excellent for preventing anaemia and supporting brain development.',
       tip: bl.ironVitCPairCount >= 2 ? 'And you paired iron with Vitamin C ' + bl.ironVitCPairCount + ' times — maximum absorption!' : 'Tip: pair iron meals with Vitamin C (lemon, amla, orange) to boost absorption even further.',
-      action: null, tab: 'diet', dismissable: false
+      action: null, tab: 'diet', dismissable: true
     });
   }
 
@@ -29875,7 +29878,7 @@ function computeAlerts() {
       body: 'Great nutritional diversity: ' + covered + '. A balanced diet supports all-round development.',
       tip: 'You\'re covering most key nutrients. To complete the picture, look for any gaps in: ' +
         KEY_NUTRIENTS.filter(n => (bl.nutrientDays || {})[n] < 2).join(', ') + '.',
-      action: null, tab: 'diet', dismissable: false
+      action: null, tab: 'diet', dismissable: true
     });
   }
 
@@ -29888,7 +29891,7 @@ function computeAlerts() {
       title: 'Iron + Vitamin C paired ' + bl.ironVitCPairCount + ' times this week!',
       body: 'Pairing iron-rich foods with Vitamin C can double iron absorption. You\'re doing this consistently — excellent practice.',
       tip: 'This is one of the most impactful nutrition habits for babies. Keep it up — lemon on khichdi, amla after ragi, or mango with dal all work perfectly.',
-      action: null, tab: 'diet', dismissable: false
+      action: null, tab: 'diet', dismissable: true
     });
   }
 

--- a/tests/e2e/home-hotfix.spec.ts
+++ b/tests/e2e/home-hotfix.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+// PR-J hotfix — verifies two shipped Home-tab defects are fixed:
+//  1. Regression: getTrend().text carries an SVG icon; updateStatPillTrends
+//     assigned it via .textContent, so raw <svg> markup rendered as text on
+//     the Weight / Sleep-Score pills (HR-7 violation).
+//  2. Stuck alerts: positive/win alerts shipped dismissable:false, so good
+//     news was permanently un-clearable in "What's Happening".
+
+test('trend pills render the SVG icon as an element, not literal text', async ({ page }) => {
+  await page.goto('/index.html?nosync');
+  // Home is the default tab; trend pills populate from seed growth/sleep data.
+  const wt = page.locator('#homeTrendWeight');
+  await wt.waitFor({ state: 'attached' });
+  // Allow the stat-pill trend updater to run.
+  await page.waitForTimeout(800);
+
+  for (const id of ['#homeTrendWeight', '#homeTrendSleep']) {
+    const el = page.locator(id);
+    const txt = (await el.textContent()) || '';
+    // The regression symptom: literal markup in the text layer.
+    expect(txt, `${id} must not contain literal SVG markup`).not.toContain('<svg');
+    expect(txt, `${id} must not contain a literal <use href`).not.toContain('href="#zi-');
+    const innerHTML = (await el.innerHTML()) || '';
+    if (innerHTML.trim().length > 0) {
+      // When populated, the icon must be a real <svg> element.
+      expect(await el.locator('svg').count(), `${id} renders an <svg> element`).toBeGreaterThan(0);
+    }
+  }
+});
+
+test('positive/win alerts in What\'s Happening carry a dismiss control', async ({ page }) => {
+  await page.goto('/index.html?nosync');
+  await page.locator('#homeUnifiedAlertsCard, #homeZenState').first().waitFor({ state: 'attached' });
+  await page.waitForTimeout(800);
+
+  // Win cards render with the 'hmw-' scope prefix → id="ca-hmw-...".
+  const winCards = page.locator('[id^="ca-hmw-"]');
+  const n = await winCards.count();
+  // Seed data may or may not surface wins; only assert when present.
+  for (let i = 0; i < n; i++) {
+    await expect(
+      winCards.nth(i).locator('.ctx-alert-dismiss'),
+      'each win alert has a dismiss control',
+    ).toHaveCount(1);
+  }
+});


### PR DESCRIPTION
## Summary

PR-J — the hotfix half of the Home-tab roundtable split (Cipher's verdict: ship the shipped defects now, the redesign follows as its own PR). Two defects surfaced from the Architect's screenshots:

### 1. Regression — raw SVG markup on the trend pills
`getTrend()` (`core.js`) returns `.text` built by `iconText()`, which carries an `<svg>` icon. `updateStatPillTrends()` assigned it via **`.textContent`**, so the Weight and Sleep-Score pills rendered literal `<svg class="zi"><use href="#zi-trending-up"/></svg> +0.20 kg` as visible text — an **HR-7 violation shipped by PR-EF** that all four ship-gates missed. The three sinks (weight / height / sleep) now use `.innerHTML`.

### 2. Stuck win alerts
Every positive/win alert in "What's Happening" shipped `dismissable: false`, so good news ("Digestion has been stable", "4 new foods this week") was **permanently un-clearable** and the panel overflowed. Win alerts are now dismissable.

**Safety boundary:** action/safety alerts (vaccine due, Vit D3) remain non-dismissable — a vaccine-due alert must not be silenceable (Maren V-M-17). The full 4-mode interaction model (action / acknowledge / snooze / cluster) is the **follow-on design PR**, not this hotfix.

## Roundtable provenance
This hotfix is the ratified output of the Home-tab roundtable (Maren V-M-15/16/17, Kael V-K-33/34/35, Cipher). The Architect ratified: two PRs (hotfix now / design after), a "Today for Ziva" hero as the Home primary surface, and the 4-mode alert model — all of which belong to the **next** PR.

## Test plan
- [x] Four ship-gates pass (audit-emoji, audit-icon-text, audit-resolve-shield, audit-viz-smoke)
- [x] New e2e suite `tests/e2e/home-hotfix.spec.ts` — 2 tests green: trend pills render `<svg>` as an element with no literal `<svg` text; win alerts carry a dismiss control
- [x] Visual check — no raw markup leaking on the Home pills

## Deferred to the design PR (PR-K)
- "Today for Ziva" hero card as the Home primary surface (V-K-32 / V-K-35)
- Full 4-mode alert model + safety-lock + clustering (V-K-34)
- Vaccination Gantt reshape (V-K-30)
- Cipher's `audit-icon-text-sink` ship-gate + `getTrend()` return-shape restructure (so HTML can't sit in a field named `.text`)

https://claude.ai/code/session_01Dv3JNVewvj1PUg8i8PzRkB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dv3JNVewvj1PUg8i8PzRkB)_