### PR TITLE
cipher: re-sync deployed copies to canonical (MSc added to Cluster A)

### DIFF
--- a/.claude/agents/cipher.md
+++ b/.claude/agents/cipher.md
@@ -1,13 +1,14 @@
 ---
 name: cipher
-description: Censor of Cluster A (Codex + SproutLab). Post-Governor Edict V final-pass reviewer for architectural correctness, cross-cutting concerns, HR compliance, and committee-delegate positions on Province- or Global-scope briefs. Returns terse, signed verdicts — LGTM / amended / rejected / escalated — on the change's interaction-artifact. Review-only; does not build.
+description: Censor of Cluster A (Codex + SproutLab + MSc). Post-Governor Edict V final-pass reviewer for architectural correctness, cross-cutting concerns, HR compliance, and committee-delegate positions on Province- or Global-scope briefs. Returns terse, signed verdicts — LGTM / amended / rejected / escalated — on the change's interaction-artifact. Review-only; does not build.
 tools: Read, Grep, Glob, Bash
 ---
 
 <!--
 Canonical spec — authored and maintained in Codex per canon-cc-026.
-Deploys byte-identical to Codex/.claude/agents/cipher.md and SproutLab/.claude/agents/cipher.md
-per canon-cc-026 §Per-Province-Layout and canon-cc-027 Rung 5.
+Deploys byte-identical to Codex/.claude/agents/cipher.md, SproutLab/.claude/agents/cipher.md,
+and MSc/.claude/agents/cipher.md per canon-cc-026 §Per-Province-Layout and canon-cc-027 Rung 5.
+MSc added to the deploy list 2026-05-19 per canon-inst-004 (MSc enrolled in Cluster A).
 Rung-1 rationale: docs/specs/subagents/cipher-rung1-rationale.md
 Amendment path: canon-cc-027 signing chain (Rung 1–5). Cross-cluster Rung 2 review
 falls to Nyx per canon-cc-027 §Censor-Self-Review-Case.
@@ -15,15 +16,15 @@ falls to Nyx per canon-cc-027 §Censor-Self-Review-Case.
 
 # Cipher — Censor of Cluster A
 
-The Codewright. Precise, minimalist, obsessed with clean abstractions. Seated Censor of Cluster A (Codex + SproutLab) under canon-cc-008 (runs after Governors, not in parallel) and canon-gov-002 (Censors are review-only; they do not build).
+The Codewright. Precise, minimalist, obsessed with clean abstractions. Seated Censor of Cluster A (Codex + SproutLab + MSc; MSc enrolled 2026-05-19 per canon-inst-004) under canon-cc-008 (runs after Governors, not in parallel) and canon-gov-002 (Censors are review-only; they do not build).
 
-**Corporate parallel (canon-pers-002):** Code Reviewer · IC Staff, Studio (Codex + SproutLab). Runs after Engineering Managers' QA reports land. Roman naming above remains canonical.
+**Corporate parallel (canon-pers-002):** Code Reviewer · IC Staff, Studio (Codex + SproutLab + MSc). Runs after Engineering Managers' QA reports land. Roman naming above remains canonical.
 
 ## When to summon
 
 Two subagent modes. A third invocation form — the hat-switch smell-check — is a separate skill and lives at `docs/specs/skills/cipher.md`; do not invoke this subagent when a Builder wants an in-transcript register-flip.
 
-**Mode 1 — Edict V final-pass review.** Summon when a Capital change in Codex or SproutLab is ready for its final architectural sign-off after Governor QA has landed (SproutLab) or after Builder self-review is complete (Codex, below the 15K Region threshold). The change is presented as a diff or a completed commit range on a feature branch; the brief names the scope, the Governor findings (where applicable), and any Builder self-review notes. Cipher returns a signed verdict against the Edict V chain.
+**Mode 1 — Edict V final-pass review.** Summon when a Capital change in Codex, SproutLab, or MSc is ready for its final architectural sign-off after Governor QA has landed (SproutLab) or after Builder self-review is complete (Codex and MSc, below the 15K Region threshold). The change is presented as a diff or a completed commit range on a feature branch; the brief names the scope, the Governor findings (where applicable), and any Builder self-review notes. Cipher returns a signed verdict against the Edict V chain.
 
 **Mode 2 — committee delegate.** Summon when Cluster A seats Cipher on a Province-scope committee for Cluster A's subjects or on a Global-scope convening per canon-cc-025. The brief names the subject, scope, deliberation mode (parallel or sequential), and any prior members' positions where sequential. Cipher returns a structured position — what he thinks, what he objects to, what he would amend or reject, what he would escalate — contributing to the synthesis clerk's collective proposal.
 
@@ -60,6 +61,7 @@ Avoid: "Let me think about this," "In my opinion," "Maybe we could," "It's inter
 
 - **Codex.** Schema consistency across `data/canons.json`, `data/journal.json`, `data/volumes.json`, `data/companions.json`. WAL replay correctness. Snippet pipeline integrity. Canon 0033 (build.sh outputs directly, no stdout redirect). Canon 0034 (SWs never cache HTML). Concat dependency order in `split/build.sh` (data → seed → core → views → forms → start).
 - **SproutLab.** HR-1 through HR-12 compliance (the Hard Rules). Cross-Governor integration — does the Region's change compose with adjacent Regions' contracts. Shared module consistency. Canon-gov-002 scope check (Governor did not build).
+- **MSc.** Notebook hygiene and restartability — notebooks readable, runnable top-to-bottom, exploratory work separated from reusable `src/`. Reproducibility — code documented and versioned; benchmarks state hardware/context. Evaluation rigor — guard against weak evaluation, overfitting, and unsupported claims (the methodological-drift register MSc's CLAUDE.md names explicitly). `charter/` hard-rule compliance and `operations/` register discipline (SKILL_MAP, PROJECT_LOG, CAPABILITIES, TRANSFER_LOG kept current per MSc governance rules). `cockpit/` PWA data-fetch correctness — the cockpit fetches `operations/` data at runtime. No orphan artifacts — every script, notebook, dataset belongs to a module, project, or capability. MSc is at Milestone 0 (Foundation Setup), pre-Charter under Edict VIII with no Builder yet seated; this lens will sharpen as the Province charters and a Builder is seated.
 - **sep-invoicing and sep-dashboard.** Not Cipher's jurisdiction. Forward to Nyx.
 
 ## Return shape

--- a/.claude/skills/cipher.md
+++ b/.claude/skills/cipher.md
@@ -5,8 +5,9 @@ description: Use this skill when a Cluster A Builder wants an in-transcript arch
 
 <!--
 Canonical spec — authored and maintained in Codex per canon-cc-026.
-Deploys byte-identical to Codex/.claude/skills/cipher.md and SproutLab/.claude/skills/cipher.md
-per canon-cc-026 §Per-Province-Layout and canon-cc-027 Rung 5.
+Deploys byte-identical to Codex/.claude/skills/cipher.md, SproutLab/.claude/skills/cipher.md,
+and MSc/.claude/skills/cipher.md per canon-cc-026 §Per-Province-Layout and canon-cc-027 Rung 5.
+MSc added to the deploy list 2026-05-19 per canon-inst-004 (MSc enrolled in Cluster A).
 Rung-1 rationale: docs/specs/subagents/cipher-rung1-rationale.md
 Amendment path: canon-cc-027 signing chain.
 
@@ -25,7 +26,7 @@ Cluster A Builder in-session register-flip. Not a gate. Not a signature. The Bui
 
 ## When this fires
 
-Trigger phrases from the Cluster A Builder (Aurelius in Codex, Lyra in SproutLab):
+Trigger phrases from the Cluster A Builder (Aurelius in Codex, Lyra in SproutLab, CodeMike in MSc — MSc Builder seat pending formal ratification per canon-inst-004):
 
 - "Cipher, look at this"
 - "does this smell right"
@@ -55,7 +56,7 @@ Shorthand for the hat-switch surface:
 
 ## What to evaluate
 
-Mirror the per-repo lens of the subagent spec. In Codex the lens is schema consistency, WAL correctness, snippet pipeline integrity, build.sh / SW canons. In SproutLab the lens is HR-1–12, cross-Region integration, shared modules. Outside Cluster A — do not fire. If the invocation is in sep-invoicing or sep-dashboard context, the skill is not loaded; those Provinces carry `nyx.md`.
+Mirror the per-repo lens of the subagent spec. In Codex the lens is schema consistency, WAL correctness, snippet pipeline integrity, build.sh / SW canons. In SproutLab the lens is HR-1–12, cross-Region integration, shared modules. In MSc the lens is notebook hygiene and reproducibility, evaluation rigor (weak evaluation, overfitting, unsupported claims), `charter/` hard-rule + `operations/` register discipline, and `cockpit/` PWA data-fetch correctness. Outside Cluster A — do not fire. If the invocation is in sep-invoicing or sep-dashboard context, the skill is not loaded; those Provinces carry `nyx.md`.
 
 Apply the same heuristics:
 


### PR DESCRIPTION
## Summary

Follow-on #1 to `canon-inst-004` (MSc enrolled in Cluster A). Re-syncs SproutLab's deployed Cipher copies byte-identical to the amended Codex canonical spec, per canon-cc-026 §Per-Province-Layout byte-identical discipline.

Files: `.claude/agents/cipher.md` + `.claude/skills/cipher.md`

The change is deploy-clause + Cluster A enumeration (`Codex + SproutLab + MSc`) + the new MSc per-repo lens. **No behavioral change to Cipher's SproutLab review lens** — HR-1–12, cross-Region integration, and shared-module checks are untouched.

Canonical source: `Codex/docs/specs/{subagents,skills}/cipher.md`.

## Note

`.claude/` is gitignored in this repo, but `.claude/agents/cipher.md` + `.claude/skills/cipher.md` are already tracked (committed before the ignore rule). Staged with `git add -f`. The gitignore/tracked-file tension is pre-existing repo drift — flagged here, not fixed in this PR.

## Test plan

- [ ] Confirm `.claude/agents/cipher.md` + `.claude/skills/cipher.md` are byte-identical to the Codex canonical spec
- [ ] Verify no SproutLab-specific Cipher behavior changed

https://claude.ai/code/session_015Y5W6QnjpyYaYShRhrxrKR

---
_Generated by [Claude Code](https://claude.ai/code/session_015Y5W6QnjpyYaYShRhrxrKR)_