### PR TITLE
PR-K — Home design PR: Today hero, 4-mode alerts, vaccination Gantt

### DIFF
--- a/index.html
+++ b/index.html
@@ -2239,6 +2239,51 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
   .stat-pills-grid { grid-template-columns:repeat(3, 1fr); gap:var(--sp-8); }
 }
 
+/* ─── "Today for Ziva" — the Home lede (PR-K) ─── */
+.today-hero {
+  background:linear-gradient(135deg, var(--peach-light), var(--warm));
+  border:1px solid rgba(250,212,180,0.5);
+}
+.th-head { display:flex; align-items:baseline; justify-content:space-between; gap:var(--sp-8); }
+.th-title {
+  font-family:'Fraunces', serif; font-size:var(--fs-xl); font-weight:600;
+  color:var(--text); line-height:1.2;
+}
+.th-age { font-size:var(--fs-sm); font-weight:600; color:var(--mid); flex-shrink:0; }
+.th-date { font-size:var(--fs-sm); color:var(--light); margin-top:var(--sp-2); }
+.th-focus { margin-top:var(--sp-12); }
+.th-focus-row {
+  display:flex; align-items:center; gap:var(--sp-10);
+  padding:var(--sp-10) var(--sp-12); border-radius:var(--r-lg);
+  background:var(--white); border-left:3px solid var(--sage);
+}
+.th-focus-row.thf-action { border-left-color:var(--rose); }
+.th-focus-row.thf-watch  { border-left-color:var(--amber); }
+.th-focus-row.thf-clear  { border-left-color:var(--sage); }
+.th-focus-icon {
+  width:36px; height:36px; flex-shrink:0; border-radius:var(--r-full);
+  background:var(--peach-light); display:flex; align-items:center; justify-content:center;
+}
+.th-focus-icon .zi { width:var(--icon-md); height:var(--icon-md); }
+.th-focus-body { flex:1; min-width:0; }
+.th-focus-label {
+  font-size:var(--fs-2xs); font-weight:700; letter-spacing:0.04em;
+  text-transform:uppercase; color:var(--light);
+}
+.th-focus-text { font-size:var(--fs-sm); font-weight:600; color:var(--text); margin-top:var(--sp-2); }
+.th-focus-btn {
+  flex-shrink:0; font-size:var(--fs-sm); font-weight:600;
+  padding:var(--sp-6) var(--sp-12); border-radius:var(--r-full);
+  border:none; background:var(--text); color:var(--white); cursor:pointer;
+}
+.th-focus-btn:active { transform:scale(0.95); }
+[data-theme="dark"] .today-hero {
+  background:linear-gradient(135deg, rgba(250,212,180,0.10), rgba(255,255,255,0.03));
+  border-color:rgba(250,212,180,0.2);
+}
+[data-theme="dark"] .th-focus-row { background:var(--mid); }
+[data-theme="dark"] .th-focus-icon { background:rgba(250,212,180,0.14); }
+
 .home-stat-pill {
   border-radius:var(--r-xl); padding:var(--sp-12);
   text-align:center; min-width:0;
@@ -9817,6 +9862,16 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
           <div class="wg-dots" id="wgDots"></div>
           <button class="btn btn-rose wg-btn" id="wgNext" data-wgnav="1">Next →</button>
         </div>
+      </div>
+
+      <!-- ─── TODAY FOR ZIVA — the Home lede (PR-K) ─── -->
+      <div class="card col-full today-hero" id="todayHeroCard" style="display:none;">
+        <div class="th-head">
+          <div class="th-title">Today for Ziva</div>
+          <div class="th-age" id="thAge">—</div>
+        </div>
+        <div class="th-date" id="thDate">—</div>
+        <div class="th-focus" id="thFocus"></div>
       </div>
 
       <!-- ─── TIER 1: COMPACT VITALS (expandable) ─── -->
@@ -22611,10 +22666,58 @@ function renderVaccWeatherAdvisory(wx, daysTo, apptDate) {
 // ─────────────────────────────────────────
 // HOME TAB RENDER
 // ─────────────────────────────────────────
+// ── "Today for Ziva" — the Home lede (PR-K) ──
+// A warm, scannable card that answers the one question a tired parent opens
+// the app with: what matters today? Headline + age + date, then the single
+// highest-priority item (an action or watch alert) — or a calm all-clear.
+function renderTodayHero() {
+  const card = document.getElementById('todayHeroCard');
+  if (!card) return;
+  const ageEl = document.getElementById('thAge');
+  const dateEl = document.getElementById('thDate');
+  const focusEl = document.getElementById('thFocus');
+
+  // Age + date line
+  const a = ageAt();
+  let ageStr = a.months + (a.months === 1 ? ' month' : ' months');
+  if (a.days) ageStr += ', ' + a.days + (a.days === 1 ? ' day' : ' days');
+  if (ageEl) ageEl.textContent = ageStr + ' old';
+  if (dateEl) dateEl.textContent = new Date().toLocaleDateString('en-IN', { weekday: 'long', day: 'numeric', month: 'long' });
+
+  // The one thing that matters today — highest-priority alert, else all-clear.
+  let focusHTML = '';
+  try {
+    const alerts = computeAlerts();
+    const top = alerts.find(x => x.severity === 'action') || alerts.find(x => x.severity === 'watch');
+    if (top) {
+      const sevCls = top.severity === 'action' ? 'thf-action' : 'thf-watch';
+      focusHTML = `<div class="th-focus-row ${sevCls}">
+        <div class="th-focus-icon">${top.icon || zi('bell')}</div>
+        <div class="th-focus-body">
+          <div class="th-focus-label">Today's focus</div>
+          <div class="th-focus-text">${escHtml(top.title)}</div>
+        </div>
+        ${top.tab ? `<button class="th-focus-btn" data-action="switchTab" data-arg="${escAttr(top.tab)}" data-stop="1">View</button>` : ''}
+      </div>`;
+    } else {
+      focusHTML = `<div class="th-focus-row thf-clear">
+        <div class="th-focus-icon">${zi('sparkle')}</div>
+        <div class="th-focus-body">
+          <div class="th-focus-label">All clear</div>
+          <div class="th-focus-text">Nothing needs your attention today — enjoy the time together.</div>
+        </div>
+      </div>`;
+    }
+  } catch (e) { console.error('todayHero focus:', e); }
+  if (focusEl) focusEl.innerHTML = focusHTML;
+  card.style.display = focusHTML ? '' : 'none';
+}
+
 function renderHome() {
   _clearModifierCache();
   _postVaccCached = null;
   updateHeader();
+  renderTodayHero();
   renderHomeFeverBanner();
   renderHomeDiarrhoeaBanner();
   renderHomeVomitingBanner();

--- a/index.html
+++ b/index.html
@@ -21190,15 +21190,20 @@ function getChartTheme() {
 // INSIGHTS — TREND ENGINE (v2.0a)
 // ─────────────────────────────────────────
 
-// Generic trend calculator: compare two values, return arrow + delta + direction
+// Generic trend calculator: compare two values, return arrow + delta + direction.
+// Return shape (V-K-14): `.label` is PLAIN text (textContent-safe); `.html`
+// is icon+label markup (innerHTML-only); `.arrow` is the bare icon SVG. HTML
+// never lives in a field named `.text` — that illegal-state shape shipped the
+// PR-EF trend-pill regression that PR-J hotfixed.
 function getTrend(current, previous, threshold, decimals) {
-  if (current == null || previous == null) return { arrow:'', delta:0, direction:'flat', cls:'trend-flat', text:'' };
+  if (current == null || previous == null) return { arrow:'', delta:0, direction:'flat', cls:'trend-flat', label:'', html:'' };
   const dec = decimals != null ? decimals : 1;
   const delta = +(current - previous).toFixed(dec);
   const absDelta = Math.abs(delta);
-  if (absDelta <= threshold) return { arrow: zi('trending-flat'), delta:0, direction:'flat', cls:'trend-flat', text: iconText('trending-flat', 'stable') };
-  if (delta > 0) return { arrow: zi('trending-up'), delta, direction:'up', cls:'trend-up', text: iconText('trending-up', '+' + absDelta.toFixed(dec)) };
-  return { arrow: zi('trending-down'), delta, direction:'down', cls:'trend-down', text: iconText('trending-down', '-' + absDelta.toFixed(dec)) };
+  if (absDelta <= threshold) return { arrow: zi('trending-flat'), delta:0, direction:'flat', cls:'trend-flat', label:'stable', html: iconText('trending-flat', 'stable') };
+  if (delta > 0) { const l = '+' + absDelta.toFixed(dec); return { arrow: zi('trending-up'), delta, direction:'up', cls:'trend-up', label:l, html: iconText('trending-up', l) }; }
+  const l = '-' + absDelta.toFixed(dec);
+  return { arrow: zi('trending-down'), delta, direction:'down', cls:'trend-down', label:l, html: iconText('trending-down', l) };
 }
 
 // Get dates array for a window ending at offsetDays before today
@@ -21643,8 +21648,8 @@ function updateStatPillTrends() {
       if (prev.date === latest.date && wtEntries.length >= 2) prev = wtEntries[wtEntries.length - 2];
       const trend = getTrend(latest.wt, prev.wt, 0.05, 2);
       wtTrendEl.className = 'hsp-trend ' + trend.cls;
-      // getTrend().text carries an SVG icon (iconText) — HR-7: set via innerHTML.
-      wtTrendEl.innerHTML = trend.text ? trend.text + ' kg' : '';
+      // getTrend().html carries an SVG icon (iconText) — HR-7: set via innerHTML.
+      wtTrendEl.innerHTML = trend.html ? trend.html + ' kg' : '';
     } else {
       wtTrendEl.innerHTML = '';
     }
@@ -21666,8 +21671,8 @@ function updateStatPillTrends() {
       if (prev.date === latest.date && htEntries.length >= 2) prev = htEntries[htEntries.length - 2];
       const trend = getTrend(latest.ht, prev.ht, 0.5, 1);
       htTrendEl.className = 'hsp-trend ' + trend.cls;
-      // getTrend().text carries an SVG icon (iconText) — HR-7: set via innerHTML.
-      htTrendEl.innerHTML = trend.text ? trend.text + ' cm' : '';
+      // getTrend().html carries an SVG icon (iconText) — HR-7: set via innerHTML.
+      htTrendEl.innerHTML = trend.html ? trend.html + ' cm' : '';
     } else {
       htTrendEl.innerHTML = '';
     }
@@ -21680,8 +21685,8 @@ function updateStatPillTrends() {
     if (sleepT.score.current != null && sleepT.score.previous != null) {
       const t = sleepT.score.trend;
       slTrendEl.className = 'hsp-trend ' + t.cls;
-      // getTrend().text carries an SVG icon (iconText) — HR-7: set via innerHTML.
-      slTrendEl.innerHTML = t.text ? t.text + ' pts' : '';
+      // getTrend().html carries an SVG icon (iconText) — HR-7: set via innerHTML.
+      slTrendEl.innerHTML = t.html ? t.html + ' pts' : '';
     } else {
       slTrendEl.innerHTML = '';
     }
@@ -30226,14 +30231,14 @@ function renderTodayPlan() {
         items.push({
           time: apptDaysTo === 1 ? 'Tmrw' : apptDaysTo + 'd',
           icon: zi('syringe'), title: upcomingVacc.name,
-          detail: iconText('check', 'Booked — ' + getVaccApptLabel(bookedData)),
+          detail: iconText('check', 'Booked — ' + getVaccApptLabel(bookedData)), // raw-html-ok
           tag: 'med', done: true, htmlDetail: true
         });
       } else if (apptDaysTo < 0) {
         // Appointment was in the past but vaccine not given yet — overdue
         items.push({
           time: 'Due', icon: zi('syringe'), title: upcomingVacc.name,
-          detail: iconText('warn', 'Appointment was ' + formatDate(bookedData.apptDate) + ' — reschedule'),
+          detail: iconText('warn', 'Appointment was ' + formatDate(bookedData.apptDate) + ' — reschedule'), // raw-html-ok
           tag: 'med', done: false, htmlDetail: true
         });
       }
@@ -30242,7 +30247,7 @@ function renderTodayPlan() {
       // Booked but no details — nudge to add date
       items.push({
         time: zi('clock'), icon: zi('syringe'), title: upcomingVacc.name,
-        detail: iconText('check', 'Booked — tap to add appointment date & time'),
+        detail: iconText('check', 'Booked — tap to add appointment date & time'), // raw-html-ok
         tag: 'med', done: false, htmlDetail: true,
         action: { name: 'openVaccApptModal', arg: upcomingVacc.name }
       });
@@ -30693,7 +30698,7 @@ function renderTrendChips() {
   if (sleepT.score.current != null) {
     const cls = sleepT.score.current >= 70 ? 'tc-good' : sleepT.score.current >= 40 ? 'tc-warn' : 'tc-bad';
     const arrow = sleepT.score.trend.arrow || '';
-    chips.push({ icon:zi('moon'), label:'Sleep', value: sleepT.score.current + '/100' + (arrow ? ' ' + arrow : ''), delta: sleepT.score.trend.text || '', cls, tab:'sleep' });
+    chips.push({ icon:zi('moon'), label:'Sleep', value: sleepT.score.current + '/100' + (arrow ? ' ' + arrow : ''), delta: sleepT.score.trend.html || '', cls, tab:'sleep' });
   } else {
     chips.push({ icon:zi('moon'), label:'Sleep', value:'No data yet', delta:'—', cls:'tc-neutral', tab:'sleep' });
   }
@@ -31011,7 +31016,7 @@ function renderInsightsSleep() { /* v2.4: DORMANT — insights cards replaced by
     if (trend.score.current != null) {
       const cls = trend.score.current >= 70 ? 'ipp-good' : trend.score.current >= 40 ? 'ipp-warn' : 'ipp-bad';
       pills += `<span class="ins-preview-pill ${cls}">${zi('zzz')} ${trend.score.current}/100</span>`;
-      if (trend.score.trend.arrow) pills += `<span class="ins-preview-pill ipp-neutral">${trend.score.trend.text}</span>`;
+      if (trend.score.trend.arrow) pills += `<span class="ins-preview-pill ipp-neutral">${trend.score.trend.html}</span>`;
     }
     if (trend.wakes.current != null) {
       const cls = trend.wakes.current <= 1 ? 'ipp-good' : trend.wakes.current <= 2 ? 'ipp-warn' : 'ipp-bad';
@@ -31029,7 +31034,7 @@ function renderInsightsSleep() { /* v2.4: DORMANT — insights cards replaced by
       <div class="ir-icon">${emoji}</div>
       <div class="ir-body">
         <div class="ir-label">Sleep score (7-day avg)</div>
-        <div class="ir-value">${trend.score.current}/100 <span class="ir-delta ${trend.score.trend.cls}">${trend.score.trend.text ? trend.score.trend.text + ' pts' : ''}</span></div>
+        <div class="ir-value">${trend.score.current}/100 <span class="ir-delta ${trend.score.trend.cls}">${trend.score.trend.html ? trend.score.trend.html + ' pts' : ''}</span></div>
       </div>
     </div>`;
   }
@@ -31085,7 +31090,7 @@ function renderInsightsSleep() { /* v2.4: DORMANT — insights cards replaced by
       <div class="ir-icon">${zi('clock')}</div>
       <div class="ir-body">
         <div class="ir-label">Avg wake-ups / night</div>
-        <div class="ir-value">${trend.wakes.current} <span class="ir-delta ${wakeCls}">${trend.wakes.trend.text || ''}</span></div>
+        <div class="ir-value">${trend.wakes.current} <span class="ir-delta ${wakeCls}">${trend.wakes.trend.html || ''}</span></div>
       </div>
     </div>`;
   }
@@ -31276,7 +31281,7 @@ function renderInsightsPoop() { /* v2.4: DORMANT — insights cards replaced by 
     <div class="ir-icon">${zi('chart')}</div>
     <div class="ir-body">
       <div class="ir-label">Daily frequency (7-day avg)</div>
-      <div class="ir-value">${trend.freq.current}/day <span class="ir-delta ${trend.freq.trend.cls}">${trend.freq.trend.text ? trend.freq.trend.text + '/d' : ''}</span></div>
+      <div class="ir-value">${trend.freq.current}/day <span class="ir-delta ${trend.freq.trend.cls}">${trend.freq.trend.html ? trend.freq.trend.html + '/d' : ''}</span></div>
     </div>
   </div>`;
 
@@ -31399,7 +31404,7 @@ function renderInsightsFeed() { /* v2.4: DORMANT — insights cards replaced by 
     <div class="ir-icon">${zi('bowl')}</div>
     <div class="ir-body">
       <div class="ir-label">Meals logged (7 days)</div>
-      <div class="ir-value">${trend.meals.current} / 21 <span class="ir-delta ${trend.meals.trend.cls}">${trend.meals.trend.text || ''}</span></div>
+      <div class="ir-value">${trend.meals.current} / 21 <span class="ir-delta ${trend.meals.trend.cls}">${trend.meals.trend.html || ''}</span></div>
     </div>
   </div>`;
 
@@ -31408,7 +31413,7 @@ function renderInsightsFeed() { /* v2.4: DORMANT — insights cards replaced by 
     <div class="ir-icon">${zi('rainbow')}</div>
     <div class="ir-body">
       <div class="ir-label">Unique foods this week</div>
-      <div class="ir-value">${trend.variety.current} <span class="ir-delta ${trend.variety.trend.cls}">${trend.variety.trend.text || ''}</span></div>
+      <div class="ir-value">${trend.variety.current} <span class="ir-delta ${trend.variety.trend.cls}">${trend.variety.trend.html || ''}</span></div>
     </div>
   </div>`;
 
@@ -43584,7 +43589,8 @@ function computeIllnessFrequency() {
         seenPairs.add(pairKey);
         insights.push({
           type: 'info',
-          text: iconText(recent[i].iconKey, recent[i].illnessType) + ' and ' + iconText(recent[j].iconKey, recent[j].illnessType) + ' overlapped around ' +
+          // iconText() escapes the illness label; this `text` is rendered via innerHTML.
+          text: iconText(recent[i].iconKey, recent[i].illnessType) + ' and ' + iconText(recent[j].iconKey, recent[j].illnessType) + ' overlapped around ' + // raw-html-ok
             formatDate(recent[i].startedAt).replace(/, \d{4}$/, '') + '. Co-occurring illnesses can be harder on babies — good to flag with your doctor.'
         });
         if (seenPairs.size >= 2) break coLoop; // cap at 2 overlap insights

--- a/index.html
+++ b/index.html
@@ -3891,6 +3891,14 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
 .ctx-alert-btn.cab-secondary {
   background:transparent; color:var(--mid); border:1px solid var(--card-border);
 }
+/* PR-K 4-mode controls: acknowledge ("Got it") + snooze */
+.ctx-alert-btn.cab-ack {
+  background:var(--sage-light); color:var(--tc-sage); border:1px solid var(--sage);
+}
+.ctx-alert-btn.cab-snooze {
+  background:transparent; color:var(--mid); border:1px solid var(--card-border);
+}
+.ctx-alert-btn .zi { width:var(--icon-xs); height:var(--icon-xs); vertical-align:-1px; }
 .ctx-alert-dismiss {
   position:absolute; top:8px; right:8px; width:24px; height:24px;
   border:none; background:transparent; cursor:pointer; font-size:var(--icon-sm);
@@ -6647,6 +6655,8 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 [data-theme="dark"] .ctx-alert-sev.sev-action { background:rgba(176,72,94,0.15); border-color:rgba(176,72,94,0.25); }
 [data-theme="dark"] .ctx-alert-btn.cab-primary { background:var(--mid); }
 [data-theme="dark"] .ctx-alert-btn.cab-secondary { border-color:rgba(255,255,255,0.12); color:var(--light); }
+[data-theme="dark"] .ctx-alert-btn.cab-snooze { border-color:rgba(255,255,255,0.12); color:var(--light); }
+[data-theme="dark"] .ctx-alert-btn.cab-ack { background:rgba(181,213,197,0.14); border-color:rgba(181,213,197,0.3); }
 [data-theme="dark"] .ctx-alert-dismiss:hover { background:rgba(255,255,255,0.08); }
 [data-theme="dark"] .ca-view-all:hover { background:rgba(168,207,224,0.1); }
 [data-theme="dark"] .alert-hist-item { border-bottom-color:rgba(255,255,255,0.05); }
@@ -17467,6 +17477,8 @@ function init() {
     else if (action === 'feHomeBannerLog') feHomeBannerLog();
     else if (action === 'deLogStoolQuick') deLogStoolQuick(arg);
     else if (action === 'dismissAlert') dismissAlert(arg, arg2);
+    else if (action === 'acknowledgeAlert') acknowledgeAlert(arg, arg2);
+    else if (action === 'snoozeAlert') snoozeAlert(arg, arg2);
     else if (action === 'toggleAlertTip') toggleAlertTip(arg);
     else if (action === 'execAlertAction') execAlertAction(arg);
     else if (action === 'skipMeals') { try { skipMeals(JSON.parse(arg)); } catch(ex) {} }
@@ -28826,7 +28838,17 @@ function renderScrapbookHistory() {
 // ══════════════════════════════════════════════════════════════
 
 // ── Storage ──
-function loadAlertState()   { return load(KEYS.alertsActive, { dismissed: {} }); }
+// Alert clear-state has three buckets (PR-K 4-mode model): `dismissed` and
+// `acknowledged` are long-lived clears; `snoozed` is a short deferral. Each
+// entry stores an EXPIRY timestamp, never a bare flag — so a cleared alert
+// always self-restores after its TTL and can never be permanently lost.
+function loadAlertState() {
+  const s = load(KEYS.alertsActive, { dismissed: {}, snoozed: {}, acknowledged: {} });
+  if (!s.dismissed)    s.dismissed = {};
+  if (!s.snoozed)      s.snoozed = {};
+  if (!s.acknowledged) s.acknowledged = {};
+  return s;
+}
 function saveAlertState(s)  { save(KEYS.alertsActive, s); }
 function loadAlertHistory() { return load(KEYS.alertsHistory, []); }
 function saveAlertHistory(h){ save(KEYS.alertsHistory, h); }
@@ -28839,26 +28861,32 @@ function logAlertEvent(alertKey, eventType, alertTitle, alertSeverity) {
   saveAlertHistory(h);
 }
 
-function dismissAlert(alertKey, alertTitle) {
+// ── 4-mode alert clearing (PR-K) ──
+// dismiss / acknowledge persist for 30d; snooze defers for 3d. Storing the
+// expiry (not the action time) means the auto-clear GC is a pure timestamp
+// check with no dependency on which alerts happen to be active this render.
+const ALERT_TTL_DAYS = { dismissed: 30, acknowledged: 30, snoozed: 3 };
+
+function _clearAlert(bucket, alertKey, alertTitle, eventType) {
   const state = loadAlertState();
-  state.dismissed[alertKey] = new Date().toISOString();
+  const ttl = ALERT_TTL_DAYS[bucket] || 30;
+  state[bucket][alertKey] = new Date(Date.now() + ttl * 86400000).toISOString();
   saveAlertState(state);
-  logAlertEvent(alertKey, 'dismissed', alertTitle);
-  // Animate out all scoped instances
+  logAlertEvent(alertKey, eventType, alertTitle);
+  // Animate out all scoped instances, then re-render every alert surface.
   const safePart = alertKey.replace(/[^a-zA-Z0-9-]/g, '_');
   let found = false;
   ['ins-', 'insw-', 'hm-', 'hmw-', ''].forEach(scope => {
     const el = document.getElementById('ca-' + scope + safePart);
     if (el) { el.classList.add('dismissing'); found = true; }
   });
-  if (found) {
-    setTimeout(() => { renderRemindersAndAlerts(); renderHomeContextAlerts(); renderInsightsAlerts(); }, 300);
-  } else {
-    renderRemindersAndAlerts();
-    renderHomeContextAlerts();
-    renderInsightsAlerts();
-  }
+  const rerender = () => { renderRemindersAndAlerts(); renderHomeContextAlerts(); renderInsightsAlerts(); };
+  if (found) setTimeout(rerender, 300); else rerender();
 }
+
+function dismissAlert(alertKey, alertTitle)     { _clearAlert('dismissed', alertKey, alertTitle, 'dismissed'); }
+function acknowledgeAlert(alertKey, alertTitle) { _clearAlert('acknowledged', alertKey, alertTitle, 'acknowledged'); }
+function snoozeAlert(alertKey, alertTitle)      { _clearAlert('snoozed', alertKey, alertTitle, 'snoozed'); }
 
 function toggleAlertTip(alertKey) {
   const el = document.getElementById('ca-tip-' + alertKey.replace(/[^a-zA-Z0-9-]/g, '_'));
@@ -28870,6 +28898,22 @@ const SEV_ORDER = { action: 0, watch: 1, info: 2, positive: 3 };
 const SEV_CLASS = { action: 'ca-action', watch: 'ca-watch', info: 'ca-info', positive: 'ca-positive' };
 const SEV_BADGE = { action: 'sev-action', watch: 'sev-watch', info: 'sev-info', positive: 'sev-positive' };
 const SEV_LABEL = { action: zi('siren') + ' Action', watch: zi('warn') + ' Watch', info: zi('check') + ' Info', positive: zi('party') + ' Win' };
+
+// ── 4-mode interaction model (PR-K) ──
+// Each alert resolves to exactly one interaction mode, derived from severity:
+//   action      → CTA only, no clear control — the parent must act on it
+//   snooze      → deferrable; re-surfaces automatically after the snooze TTL
+//   acknowledge → a win; a warm "Got it" permanently clears it
+//   dismiss     → low-stakes info; the corner × permanently clears it
+// safetyLocked alerts (upcoming-vaccine / dev-checkup reminders) are forced
+// to 'snooze' regardless of severity: they can be deferred but never
+// permanently dismissed or acknowledged away — Maren V-M-17 doctrine.
+const ALERT_MODE = { action: 'action', watch: 'snooze', positive: 'acknowledge', info: 'dismiss' };
+function getAlertMode(a) {
+  const base = ALERT_MODE[a.severity] || 'dismiss';
+  if (a.safetyLocked && base !== 'action') return 'snooze';
+  return base;
+}
 
 // Sanitize alert keys to safe alphanumeric + dash only
 function sanitizeAlertKey(s) { return s.replace(/[^a-zA-Z0-9-]/g, '_'); }
@@ -29269,8 +29313,15 @@ function computeAlerts() {
   const state = loadAlertState();
   const bl = computeBaselines();
 
-  // Helper: check if dismissed
-  function isDismissed(key) { return !!state.dismissed[key]; }
+  // Helper: is this alert currently cleared from view? True if dismissed,
+  // acknowledged, or snoozed AND that clear-state has not yet expired. The
+  // single predicate gates every alert (warnings at their push sites,
+  // positives in a sweep below) so all three modes take effect uniformly.
+  function isDismissed(key) {
+    const now = Date.now();
+    const live = b => { const v = state[b] && state[b][key]; return !!v && now < new Date(v).getTime(); };
+    return live('dismissed') || live('acknowledged') || live('snoozed');
+  }
 
   // ═══════════════════════════════════════
   // WARNING ALERTS (with escalating tips)
@@ -29448,7 +29499,7 @@ function computeAlerts() {
             body: 'Well-baby visits at ' + mo + ' months cover growth assessment, developmental milestones, and vaccination review.',
             tip: getEscalatedTip('dev-checkup-due'),
             action: { label: 'View Medical', fn: 'switchTab("medical")' },
-            tab: 'medical', dismissable: true
+            tab: 'medical', dismissable: true, safetyLocked: true
           });
         }
       }
@@ -29492,7 +29543,7 @@ function computeAlerts() {
           body: 'Scheduled for ' + formatDate(upcoming.date) + '. Book the appointment if you haven\'t already.',
           tip: getEscalatedTip('vacc-reminder'),
           action: { label: 'View Vaccines', fn: 'switchTab("medical")' },
-          tab: 'medical', dismissable: true
+          tab: 'medical', dismissable: true, safetyLocked: true
         });
       }
     }
@@ -29927,6 +29978,14 @@ function computeAlerts() {
   // SORT, SYNTHESIS, AUTO-CLEAR, LOG
   // ═══════════════════════════════════════
 
+  // ── Gate positives through the same clear-predicate as warnings ──
+  // Warnings are gated at their individual push sites; positive alerts push
+  // unconditionally, so sweep them here. Without this, acknowledge / dismiss
+  // on a win has no effect — the very gap PR-J's win-× exposed (V-M-32).
+  for (let i = alerts.length - 1; i >= 0; i--) {
+    if (alerts[i].severity === 'positive' && isDismissed(alerts[i].key)) alerts.splice(i, 1);
+  }
+
   // ── Sort by severity (action → watch → info → positive) ──
   alerts.sort((a, b) => (SEV_ORDER[a.severity] || 3) - (SEV_ORDER[b.severity] || 3));
 
@@ -29936,17 +29995,22 @@ function computeAlerts() {
   const { alerts: synthesizedWarnings, synthesisNarrative } = applyCrossSynthesis(warningAlerts);
   const finalAlerts = [...synthesizedWarnings, ...positiveAlerts];
 
-  // ── Auto-clear: remove dismissed entries whose condition no longer exists ──
+  // ── Auto-clear: drop expired clear-state entries ──
+  // dismiss / acknowledge / snooze all store an expiry timestamp, so GC is a
+  // pure time check — once past expiry the alert self-restores. No dependency
+  // on the active set, so a still-true alert that was cleared stays cleared
+  // for its full TTL (the activeKeys-based GC silently un-cleared it early).
   const activeKeys = new Set(finalAlerts.map(a => a.key));
   const st = loadAlertState();
   let changed = false;
-  for (const dKey of Object.keys(st.dismissed)) {
-    if (!activeKeys.has(dKey)) {
-      logAlertEvent(dKey, 'resolved', dKey);
-      delete st.dismissed[dKey];
-      changed = true;
+  ['dismissed', 'acknowledged', 'snoozed'].forEach(bucket => {
+    for (const k of Object.keys(st[bucket])) {
+      if (Date.now() >= new Date(st[bucket][k]).getTime()) {
+        delete st[bucket][k];
+        changed = true;
+      }
     }
-  }
+  });
   if (changed) saveAlertState(st);
 
   // ── Auto-resolve: mark previously triggered alerts as resolved if condition cleared ──
@@ -30007,8 +30071,10 @@ function renderAlertCardHTML(a, scope) {
   const sevLabel = SEV_LABEL[a.severity] || zi('check') + ' Info';
   // Register action fn safely
   if (a.action && a.action.fn) _alertActionRegistry[safeKey] = a.action.fn;
+  // Interaction mode (PR-K): drives which clear control the card carries.
+  const mode = getAlertMode(a);
   return `<div class="ctx-alert ${sevClass}" id="ca-${safeKey}">
-    ${a.dismissable ? `<button class="ctx-alert-dismiss" data-action="dismissAlert" data-stop="1" data-arg="${escAttr(a.key)}" data-arg2="${escAttr(a.title)}" aria-label="Dismiss">&times;</button>` : ''}
+    ${mode === 'dismiss' ? `<button class="ctx-alert-dismiss" data-action="dismissAlert" data-stop="1" data-arg="${escAttr(a.key)}" data-arg2="${escAttr(a.title)}" aria-label="Dismiss">&times;</button>` : ''}
     <div class="ctx-alert-top">
       <div class="ctx-alert-icon">${a.icon}</div>
       <div class="ctx-alert-body">
@@ -30019,6 +30085,8 @@ function renderAlertCardHTML(a, scope) {
         <div class="ctx-alert-actions">
           ${a.action ? `<button class="ctx-alert-btn cab-primary" data-action="execAlertAction" data-arg="${safeKey}" data-stop="1">${escHtml(a.action.label)}</button>` : ''}
           ${a.tab ? `<button class="ctx-alert-btn cab-secondary" data-action="switchTab" data-arg="${escAttr(a.tab)}" data-stop="1">View details</button>` : ''}
+          ${mode === 'acknowledge' ? `<button class="ctx-alert-btn cab-ack" data-action="acknowledgeAlert" data-stop="1" data-arg="${escAttr(a.key)}" data-arg2="${escAttr(a.title)}">${zi('check')} Got it</button>` : ''}
+          ${mode === 'snooze' ? `<button class="ctx-alert-btn cab-snooze" data-action="snoozeAlert" data-stop="1" data-arg="${escAttr(a.key)}" data-arg2="${escAttr(a.title)}">${zi('clock')} Snooze 3d</button>` : ''}
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -1146,6 +1146,53 @@ svg.zi { width:16px; height:16px; vertical-align:-2px; flex-shrink:0; }
   vertical-align: middle;
 }
 .ml-6 { margin-left: var(--sp-6); }
+
+/* ─── Vaccination timeline — Gantt reshape (PR-K) ─── */
+.vc-gantt { padding: var(--sp-4) 0; }
+.vc-gantt-rows { display: flex; flex-direction: column; }
+.vc-gantt-row { display: flex; gap: var(--sp-10); }
+.vc-gantt-spine {
+  display: flex; flex-direction: column; align-items: center;
+  width: 18px; flex-shrink: 0;
+}
+.vc-gantt-node {
+  width: 16px; height: 16px; border-radius: var(--r-full); flex-shrink: 0;
+  display: flex; align-items: center; justify-content: center;
+  margin-top: var(--sp-2); border: 2px solid var(--tc-lav);
+}
+.vc-gantt-node-done { background: var(--tc-lav); color: var(--white); }
+.vc-gantt-node-done .zi { width: 9px; height: 9px; }
+.vc-gantt-node-pending { background: var(--card-bg); border-style: dashed; }
+.vc-gantt-spine::after {
+  content: ''; flex: 1; width: 2px;
+  background: rgba(110,94,154,0.2); margin: var(--sp-2) 0;
+}
+.vc-gantt-row:last-child .vc-gantt-spine::after { display: none; }
+.vc-gantt-rowbody { flex: 1; min-width: 0; padding-bottom: var(--sp-16); }
+.vc-gantt-age {
+  font-size: var(--fs-2xs); font-weight: 700; color: var(--tc-lav);
+  text-transform: uppercase; letter-spacing: 0.03em; margin-bottom: var(--sp-6);
+}
+.vc-gantt-chips { display: flex; flex-wrap: wrap; gap: var(--sp-6); }
+.vc-gantt-chip {
+  display: inline-flex; align-items: center; gap: var(--sp-6);
+  padding: var(--sp-4) var(--sp-10); border-radius: var(--r-full);
+  border: 1px solid var(--card-border); background: var(--card-bg);
+  font-size: var(--fs-xs); font-weight: 600; color: var(--text);
+  cursor: pointer; position: relative;
+  transition: transform var(--ease-fast);
+}
+.vc-gantt-chip:active { transform: scale(0.96); }
+.vc-timeline-dot.vc-gantt-chipdot { width: 12px; height: 12px; }
+.vc-gantt-chip-name { white-space: nowrap; }
+.vc-gantt-delay {
+  width: 12px; height: 12px; border-radius: var(--r-full);
+  background: var(--tc-amber); color: #fff; font-size: 7px; font-weight: 700;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+[data-theme="dark"] .vc-gantt-chip { background: var(--surface); border-color: rgba(255,255,255,0.1); }
+[data-theme="dark"] .vc-gantt-spine::after { background: rgba(184,168,224,0.25); }
+
 .vc-timeline-detail {
   position: fixed;
   bottom: 0;
@@ -39903,20 +39950,22 @@ function renderVaccTimeline() {
   var hasAnyPast = vaccData.some(function(v) { return !v.upcoming; });
   if (!hasAnyPast) { el.innerHTML = ''; return; }
 
-  var cols = '';
+  // PR-K Gantt reshape: one row per IAP age group, read top-to-bottom along a
+  // spine. Each vaccine is a named, status-coloured chip (was a bare dot, with
+  // the name hidden in a title attribute). The reaction-status derivation and
+  // the vaccTimelineTap handler are unchanged — only the layout is reshaped.
+  var rows = '';
   ageOrder.forEach(function(age) {
     var names = ageGroups[age];
     if (!names || names.length === 0) return;
-    // Check if any vaccine in this group has data
     var hasSomeData = names.some(function(n) { return vaccByName[n.toLowerCase()]; });
     var hasSomeUpcoming = names.some(function(n) {
       var v = vaccByName[n.toLowerCase()];
       return v && v.upcoming;
     });
-    // Only show columns up to current age + 1 group ahead
     if (!hasSomeData && !hasSomeUpcoming) return;
 
-    var dots = names.map(function(name) {
+    var chips = names.map(function(name) {
       var v = vaccByName[name.toLowerCase()];
       if (!v) return '';
       var dotClass = 'vc-dot-nodata';
@@ -39935,28 +39984,36 @@ function renderVaccTimeline() {
       var delayBadge = '';
       if (!v.upcoming && v.scheduledDate && v.date) {
         var delayDays = Math.floor((new Date(v.date) - new Date(v.scheduledDate)) / 86400000);
-        if (delayDays > 7) delayBadge = '<span class="vc-timeline-delay">D</span>';
+        if (delayDays > 7) delayBadge = '<span class="vc-gantt-delay" title="Given over a week late">D</span>';
       }
       var idx = vaccData.indexOf(v);
-      return '<div class="vc-timeline-dot ' + dotClass + '" data-action="vaccTimelineTap" data-arg="' + idx + '" title="' + escAttr(name) + '">' +
+      return '<button class="vc-gantt-chip" data-action="vaccTimelineTap" data-arg="' + idx + '" title="' + escAttr(name) + '">' +
+        '<span class="vc-timeline-dot ' + dotClass + ' vc-gantt-chipdot"></span>' +
+        '<span class="vc-gantt-chip-name">' + escHtml(name) + '</span>' +
         delayBadge +
-        '</div>';
+        '</button>';
     }).filter(Boolean).join('');
+    if (!chips) return;
 
-    if (dots) {
-      var shortAge = age.replace(' months', 'm').replace(' weeks', 'w').replace(' years', 'y');
-      cols += '<div class="vc-timeline-col">' +
-        '<div class="vc-timeline-label">' + escHtml(shortAge) + '</div>' +
-        '<div class="vc-timeline-dots">' + dots + '</div>' +
-        '</div>';
-    }
+    var allDone = names.every(function(n) {
+      var v = vaccByName[n.toLowerCase()];
+      return v && !v.upcoming;
+    });
+    var nodeClass = allDone ? 'vc-gantt-node-done' : 'vc-gantt-node-pending';
+    rows += '<div class="vc-gantt-row">' +
+      '<div class="vc-gantt-spine"><span class="vc-gantt-node ' + nodeClass + '">' +
+        (allDone ? zi('check') : '') + '</span></div>' +
+      '<div class="vc-gantt-rowbody">' +
+        '<div class="vc-gantt-age">' + escHtml(age) + '</div>' +
+        '<div class="vc-gantt-chips">' + chips + '</div>' +
+      '</div></div>';
   });
 
-  if (!cols) { el.innerHTML = ''; return; }
+  if (!rows) { el.innerHTML = ''; return; }
 
-  el.innerHTML = '<div class="vc-timeline mt-8 mb-8">' +
+  el.innerHTML = '<div class="vc-gantt mt-8 mb-8">' +
     '<div class="fs-2xs fw-600 tc-lav mb-4">VACCINATION TIMELINE</div>' +
-    '<div class="vc-timeline-scroll">' + cols + '</div>' +
+    '<div class="vc-gantt-rows">' + rows + '</div>' +
     '<div class="fs-2xs tc-light mt-4">' +
     '<span class="vc-timeline-dot vc-dot-none vc-legend-dot"></span> No reaction ' +
     '<span class="vc-timeline-dot vc-dot-mild vc-legend-dot ml-6"></span> Mild ' +

--- a/index.html
+++ b/index.html
@@ -29059,9 +29059,14 @@ const SEV_LABEL = { action: zi('siren') + ' Action', watch: zi('warn') + ' Watch
 // to 'snooze' regardless of severity: they can be deferred but never
 // permanently dismissed or acknowledged away — Maren V-M-17 doctrine.
 const ALERT_MODE = { action: 'action', watch: 'snooze', positive: 'acknowledge', info: 'dismiss' };
+// Keys that must never resolve to a permanently-clearing mode, independent of
+// the safetyLocked flag (V-M-33 backstop): if a future edit drops safetyLocked
+// from a vaccine / checkup reminder, this still forces it to 'snooze'.
+const SAFETY_LOCKED_KEY = /^(vacc-reminder|dev-checkup)/;
 function getAlertMode(a) {
   const base = ALERT_MODE[a.severity] || 'dismiss';
-  if (a.safetyLocked && base !== 'action') return 'snooze';
+  const locked = a.safetyLocked || SAFETY_LOCKED_KEY.test(a.key || '');
+  if (locked && base !== 'action') return 'snooze';
   return base;
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.21-4",
+  "version": "2026.05.21-5",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.21-3",
+  "version": "2026.05.21-4",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.21-6",
+  "version": "2026.05.21-8",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.21-2",
+  "version": "2026.05.21-3",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.21-5",
+  "version": "2026.05.21-6",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/audit-icon-text.sh
+++ b/split/audit-icon-text.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 # audit-icon-text.sh — V-K-10 lint pattern (PR-A icon-data-shape closure)
-# Flags `(label|text|reason|detail):\s*zi\(` field-assignments in split/*.js,
-# the canonical bug shape from V-M-9 / V-M-10 / V-M-16 surfaced across PR
-# #74 + #75: an SVG fragment lands in a field that downstream renderers
-# pass through escHtml() at the boundary, collapsing the <use href=...>
-# element into &lt;use&gt; and absorbing the user-readable text into the
-# closing SVG tag. Adopt iconText(name, text) from core.js to escape the
-# text component at helper-time and emit the SVG as raw HTML, OR annotate
-# the line with `// raw-html-ok` when the surrounding render path is a
-# sanctioned raw-HTML emit (htmlDetail: true, ins.text, etc.).
+# Flags `(label|text|reason|detail):\s*(zi|iconText)\(` field-assignments in
+# split/*.js, the canonical bug shape from V-M-9 / V-M-10 / V-M-16 surfaced
+# across PR #74 + #75: an SVG fragment lands in a field that downstream
+# renderers pass through escHtml() at the boundary, collapsing the
+# <use href=...> element into &lt;use&gt; and absorbing the user-readable
+# text into the closing SVG tag. Adopt iconText(name, text) from core.js to
+# escape the text component at helper-time and emit the SVG as raw HTML, OR
+# annotate the line with `// raw-html-ok` when the surrounding render path is
+# a sanctioned raw-HTML emit (htmlDetail: true, ins.text, etc.).
+#
+# PR-K (V-K-14) widened the call match from `zi(` to `(zi|iconText)(`: a
+# field named `text`/`label`/`detail` carrying iconText() output still holds
+# HTML, and naming it like plain text invites the next `.textContent`
+# consumer to re-ship the PR-EF trend-pill regression. HTML-bearing fields
+# must be named `.html`/`.icon`, OR carry the `// raw-html-ok` opt-in.
 #
 # Usage:   bash split/audit-icon-text.sh   (0 = pass)
 # Returns: exit 0 if 0 unannotated hits; exit 1 otherwise.
@@ -23,10 +29,10 @@ cd "$(dirname "$0")/.."
 python3 - << 'PYEOF'
 import re, os, sys
 
-# Brief-specified pattern (s-2026-05-18 PR-A): `(label|text|reason|detail):
-# zi(`. Anchored to the start of the field token to skip incidental
-# occurrences inside strings or comments.
-pattern = re.compile(r'\b(label|text|reason|detail)\s*:\s*zi\s*\(')
+# Brief-specified pattern (s-2026-05-18 PR-A), widened by PR-K V-K-14:
+# `(label|text|reason|detail):\s*(zi|iconText)\(`. Anchored to the start of
+# the field token to skip incidental occurrences inside strings or comments.
+pattern = re.compile(r'\b(label|text|reason|detail)\s*:\s*(zi|iconText)\s*\(')
 
 # Sanctioned raw-HTML opt-in marker. Mirror the comment-annotation pattern
 # audit-emoji.sh uses for its defensive sanitizer carve-outs.
@@ -58,7 +64,7 @@ for scope in scopes:
             total_hits += len(hits)
 
 if total_hits == 0:
-    print('audit-icon-text: PASS (0 unannotated `(label|text|reason|detail): zi(` field-assignments)')
+    print('audit-icon-text: PASS (0 unannotated `(label|text|reason|detail): (zi|iconText)(` field-assignments)')
     sys.exit(0)
 
 print(f'audit-icon-text: FAIL ({total_hits} unannotated hits across {len(per_file)} files)')

--- a/split/core.js
+++ b/split/core.js
@@ -4390,15 +4390,20 @@ function getChartTheme() {
 // INSIGHTS — TREND ENGINE (v2.0a)
 // ─────────────────────────────────────────
 
-// Generic trend calculator: compare two values, return arrow + delta + direction
+// Generic trend calculator: compare two values, return arrow + delta + direction.
+// Return shape (V-K-14): `.label` is PLAIN text (textContent-safe); `.html`
+// is icon+label markup (innerHTML-only); `.arrow` is the bare icon SVG. HTML
+// never lives in a field named `.text` — that illegal-state shape shipped the
+// PR-EF trend-pill regression that PR-J hotfixed.
 function getTrend(current, previous, threshold, decimals) {
-  if (current == null || previous == null) return { arrow:'', delta:0, direction:'flat', cls:'trend-flat', text:'' };
+  if (current == null || previous == null) return { arrow:'', delta:0, direction:'flat', cls:'trend-flat', label:'', html:'' };
   const dec = decimals != null ? decimals : 1;
   const delta = +(current - previous).toFixed(dec);
   const absDelta = Math.abs(delta);
-  if (absDelta <= threshold) return { arrow: zi('trending-flat'), delta:0, direction:'flat', cls:'trend-flat', text: iconText('trending-flat', 'stable') };
-  if (delta > 0) return { arrow: zi('trending-up'), delta, direction:'up', cls:'trend-up', text: iconText('trending-up', '+' + absDelta.toFixed(dec)) };
-  return { arrow: zi('trending-down'), delta, direction:'down', cls:'trend-down', text: iconText('trending-down', '-' + absDelta.toFixed(dec)) };
+  if (absDelta <= threshold) return { arrow: zi('trending-flat'), delta:0, direction:'flat', cls:'trend-flat', label:'stable', html: iconText('trending-flat', 'stable') };
+  if (delta > 0) { const l = '+' + absDelta.toFixed(dec); return { arrow: zi('trending-up'), delta, direction:'up', cls:'trend-up', label:l, html: iconText('trending-up', l) }; }
+  const l = '-' + absDelta.toFixed(dec);
+  return { arrow: zi('trending-down'), delta, direction:'down', cls:'trend-down', label:l, html: iconText('trending-down', l) };
 }
 
 // Get dates array for a window ending at offsetDays before today
@@ -4843,8 +4848,8 @@ function updateStatPillTrends() {
       if (prev.date === latest.date && wtEntries.length >= 2) prev = wtEntries[wtEntries.length - 2];
       const trend = getTrend(latest.wt, prev.wt, 0.05, 2);
       wtTrendEl.className = 'hsp-trend ' + trend.cls;
-      // getTrend().text carries an SVG icon (iconText) — HR-7: set via innerHTML.
-      wtTrendEl.innerHTML = trend.text ? trend.text + ' kg' : '';
+      // getTrend().html carries an SVG icon (iconText) — HR-7: set via innerHTML.
+      wtTrendEl.innerHTML = trend.html ? trend.html + ' kg' : '';
     } else {
       wtTrendEl.innerHTML = '';
     }
@@ -4866,8 +4871,8 @@ function updateStatPillTrends() {
       if (prev.date === latest.date && htEntries.length >= 2) prev = htEntries[htEntries.length - 2];
       const trend = getTrend(latest.ht, prev.ht, 0.5, 1);
       htTrendEl.className = 'hsp-trend ' + trend.cls;
-      // getTrend().text carries an SVG icon (iconText) — HR-7: set via innerHTML.
-      htTrendEl.innerHTML = trend.text ? trend.text + ' cm' : '';
+      // getTrend().html carries an SVG icon (iconText) — HR-7: set via innerHTML.
+      htTrendEl.innerHTML = trend.html ? trend.html + ' cm' : '';
     } else {
       htTrendEl.innerHTML = '';
     }
@@ -4880,8 +4885,8 @@ function updateStatPillTrends() {
     if (sleepT.score.current != null && sleepT.score.previous != null) {
       const t = sleepT.score.trend;
       slTrendEl.className = 'hsp-trend ' + t.cls;
-      // getTrend().text carries an SVG icon (iconText) — HR-7: set via innerHTML.
-      slTrendEl.innerHTML = t.text ? t.text + ' pts' : '';
+      // getTrend().html carries an SVG icon (iconText) — HR-7: set via innerHTML.
+      slTrendEl.innerHTML = t.html ? t.html + ' pts' : '';
     } else {
       slTrendEl.innerHTML = '';
     }

--- a/split/core.js
+++ b/split/core.js
@@ -667,6 +667,8 @@ function init() {
     else if (action === 'feHomeBannerLog') feHomeBannerLog();
     else if (action === 'deLogStoolQuick') deLogStoolQuick(arg);
     else if (action === 'dismissAlert') dismissAlert(arg, arg2);
+    else if (action === 'acknowledgeAlert') acknowledgeAlert(arg, arg2);
+    else if (action === 'snoozeAlert') snoozeAlert(arg, arg2);
     else if (action === 'toggleAlertTip') toggleAlertTip(arg);
     else if (action === 'execAlertAction') execAlertAction(arg);
     else if (action === 'skipMeals') { try { skipMeals(JSON.parse(arg)); } catch(ex) {} }

--- a/split/home.js
+++ b/split/home.js
@@ -6719,9 +6719,14 @@ const SEV_LABEL = { action: zi('siren') + ' Action', watch: zi('warn') + ' Watch
 // to 'snooze' regardless of severity: they can be deferred but never
 // permanently dismissed or acknowledged away — Maren V-M-17 doctrine.
 const ALERT_MODE = { action: 'action', watch: 'snooze', positive: 'acknowledge', info: 'dismiss' };
+// Keys that must never resolve to a permanently-clearing mode, independent of
+// the safetyLocked flag (V-M-33 backstop): if a future edit drops safetyLocked
+// from a vaccine / checkup reminder, this still forces it to 'snooze'.
+const SAFETY_LOCKED_KEY = /^(vacc-reminder|dev-checkup)/;
 function getAlertMode(a) {
   const base = ALERT_MODE[a.severity] || 'dismiss';
-  if (a.safetyLocked && base !== 'action') return 'snooze';
+  const locked = a.safetyLocked || SAFETY_LOCKED_KEY.test(a.key || '');
+  if (locked && base !== 'action') return 'snooze';
   return base;
 }
 

--- a/split/home.js
+++ b/split/home.js
@@ -8005,14 +8005,14 @@ function renderTodayPlan() {
         items.push({
           time: apptDaysTo === 1 ? 'Tmrw' : apptDaysTo + 'd',
           icon: zi('syringe'), title: upcomingVacc.name,
-          detail: iconText('check', 'Booked — ' + getVaccApptLabel(bookedData)),
+          detail: iconText('check', 'Booked — ' + getVaccApptLabel(bookedData)), // raw-html-ok
           tag: 'med', done: true, htmlDetail: true
         });
       } else if (apptDaysTo < 0) {
         // Appointment was in the past but vaccine not given yet — overdue
         items.push({
           time: 'Due', icon: zi('syringe'), title: upcomingVacc.name,
-          detail: iconText('warn', 'Appointment was ' + formatDate(bookedData.apptDate) + ' — reschedule'),
+          detail: iconText('warn', 'Appointment was ' + formatDate(bookedData.apptDate) + ' — reschedule'), // raw-html-ok
           tag: 'med', done: false, htmlDetail: true
         });
       }
@@ -8021,7 +8021,7 @@ function renderTodayPlan() {
       // Booked but no details — nudge to add date
       items.push({
         time: zi('clock'), icon: zi('syringe'), title: upcomingVacc.name,
-        detail: iconText('check', 'Booked — tap to add appointment date & time'),
+        detail: iconText('check', 'Booked — tap to add appointment date & time'), // raw-html-ok
         tag: 'med', done: false, htmlDetail: true,
         action: { name: 'openVaccApptModal', arg: upcomingVacc.name }
       });
@@ -8472,7 +8472,7 @@ function renderTrendChips() {
   if (sleepT.score.current != null) {
     const cls = sleepT.score.current >= 70 ? 'tc-good' : sleepT.score.current >= 40 ? 'tc-warn' : 'tc-bad';
     const arrow = sleepT.score.trend.arrow || '';
-    chips.push({ icon:zi('moon'), label:'Sleep', value: sleepT.score.current + '/100' + (arrow ? ' ' + arrow : ''), delta: sleepT.score.trend.text || '', cls, tab:'sleep' });
+    chips.push({ icon:zi('moon'), label:'Sleep', value: sleepT.score.current + '/100' + (arrow ? ' ' + arrow : ''), delta: sleepT.score.trend.html || '', cls, tab:'sleep' });
   } else {
     chips.push({ icon:zi('moon'), label:'Sleep', value:'No data yet', delta:'—', cls:'tc-neutral', tab:'sleep' });
   }
@@ -8790,7 +8790,7 @@ function renderInsightsSleep() { /* v2.4: DORMANT — insights cards replaced by
     if (trend.score.current != null) {
       const cls = trend.score.current >= 70 ? 'ipp-good' : trend.score.current >= 40 ? 'ipp-warn' : 'ipp-bad';
       pills += `<span class="ins-preview-pill ${cls}">${zi('zzz')} ${trend.score.current}/100</span>`;
-      if (trend.score.trend.arrow) pills += `<span class="ins-preview-pill ipp-neutral">${trend.score.trend.text}</span>`;
+      if (trend.score.trend.arrow) pills += `<span class="ins-preview-pill ipp-neutral">${trend.score.trend.html}</span>`;
     }
     if (trend.wakes.current != null) {
       const cls = trend.wakes.current <= 1 ? 'ipp-good' : trend.wakes.current <= 2 ? 'ipp-warn' : 'ipp-bad';
@@ -8808,7 +8808,7 @@ function renderInsightsSleep() { /* v2.4: DORMANT — insights cards replaced by
       <div class="ir-icon">${emoji}</div>
       <div class="ir-body">
         <div class="ir-label">Sleep score (7-day avg)</div>
-        <div class="ir-value">${trend.score.current}/100 <span class="ir-delta ${trend.score.trend.cls}">${trend.score.trend.text ? trend.score.trend.text + ' pts' : ''}</span></div>
+        <div class="ir-value">${trend.score.current}/100 <span class="ir-delta ${trend.score.trend.cls}">${trend.score.trend.html ? trend.score.trend.html + ' pts' : ''}</span></div>
       </div>
     </div>`;
   }
@@ -8864,7 +8864,7 @@ function renderInsightsSleep() { /* v2.4: DORMANT — insights cards replaced by
       <div class="ir-icon">${zi('clock')}</div>
       <div class="ir-body">
         <div class="ir-label">Avg wake-ups / night</div>
-        <div class="ir-value">${trend.wakes.current} <span class="ir-delta ${wakeCls}">${trend.wakes.trend.text || ''}</span></div>
+        <div class="ir-value">${trend.wakes.current} <span class="ir-delta ${wakeCls}">${trend.wakes.trend.html || ''}</span></div>
       </div>
     </div>`;
   }
@@ -9055,7 +9055,7 @@ function renderInsightsPoop() { /* v2.4: DORMANT — insights cards replaced by 
     <div class="ir-icon">${zi('chart')}</div>
     <div class="ir-body">
       <div class="ir-label">Daily frequency (7-day avg)</div>
-      <div class="ir-value">${trend.freq.current}/day <span class="ir-delta ${trend.freq.trend.cls}">${trend.freq.trend.text ? trend.freq.trend.text + '/d' : ''}</span></div>
+      <div class="ir-value">${trend.freq.current}/day <span class="ir-delta ${trend.freq.trend.cls}">${trend.freq.trend.html ? trend.freq.trend.html + '/d' : ''}</span></div>
     </div>
   </div>`;
 
@@ -9178,7 +9178,7 @@ function renderInsightsFeed() { /* v2.4: DORMANT — insights cards replaced by 
     <div class="ir-icon">${zi('bowl')}</div>
     <div class="ir-body">
       <div class="ir-label">Meals logged (7 days)</div>
-      <div class="ir-value">${trend.meals.current} / 21 <span class="ir-delta ${trend.meals.trend.cls}">${trend.meals.trend.text || ''}</span></div>
+      <div class="ir-value">${trend.meals.current} / 21 <span class="ir-delta ${trend.meals.trend.cls}">${trend.meals.trend.html || ''}</span></div>
     </div>
   </div>`;
 
@@ -9187,7 +9187,7 @@ function renderInsightsFeed() { /* v2.4: DORMANT — insights cards replaced by 
     <div class="ir-icon">${zi('rainbow')}</div>
     <div class="ir-body">
       <div class="ir-label">Unique foods this week</div>
-      <div class="ir-value">${trend.variety.current} <span class="ir-delta ${trend.variety.trend.cls}">${trend.variety.trend.text || ''}</span></div>
+      <div class="ir-value">${trend.variety.current} <span class="ir-delta ${trend.variety.trend.cls}">${trend.variety.trend.html || ''}</span></div>
     </div>
   </div>`;
 

--- a/split/home.js
+++ b/split/home.js
@@ -6600,7 +6600,17 @@ function renderScrapbookHistory() {
 // ══════════════════════════════════════════════════════════════
 
 // ── Storage ──
-function loadAlertState()   { return load(KEYS.alertsActive, { dismissed: {} }); }
+// Alert clear-state has three buckets (PR-K 4-mode model): `dismissed` and
+// `acknowledged` are long-lived clears; `snoozed` is a short deferral. Each
+// entry stores an EXPIRY timestamp, never a bare flag — so a cleared alert
+// always self-restores after its TTL and can never be permanently lost.
+function loadAlertState() {
+  const s = load(KEYS.alertsActive, { dismissed: {}, snoozed: {}, acknowledged: {} });
+  if (!s.dismissed)    s.dismissed = {};
+  if (!s.snoozed)      s.snoozed = {};
+  if (!s.acknowledged) s.acknowledged = {};
+  return s;
+}
 function saveAlertState(s)  { save(KEYS.alertsActive, s); }
 function loadAlertHistory() { return load(KEYS.alertsHistory, []); }
 function saveAlertHistory(h){ save(KEYS.alertsHistory, h); }
@@ -6613,26 +6623,32 @@ function logAlertEvent(alertKey, eventType, alertTitle, alertSeverity) {
   saveAlertHistory(h);
 }
 
-function dismissAlert(alertKey, alertTitle) {
+// ── 4-mode alert clearing (PR-K) ──
+// dismiss / acknowledge persist for 30d; snooze defers for 3d. Storing the
+// expiry (not the action time) means the auto-clear GC is a pure timestamp
+// check with no dependency on which alerts happen to be active this render.
+const ALERT_TTL_DAYS = { dismissed: 30, acknowledged: 30, snoozed: 3 };
+
+function _clearAlert(bucket, alertKey, alertTitle, eventType) {
   const state = loadAlertState();
-  state.dismissed[alertKey] = new Date().toISOString();
+  const ttl = ALERT_TTL_DAYS[bucket] || 30;
+  state[bucket][alertKey] = new Date(Date.now() + ttl * 86400000).toISOString();
   saveAlertState(state);
-  logAlertEvent(alertKey, 'dismissed', alertTitle);
-  // Animate out all scoped instances
+  logAlertEvent(alertKey, eventType, alertTitle);
+  // Animate out all scoped instances, then re-render every alert surface.
   const safePart = alertKey.replace(/[^a-zA-Z0-9-]/g, '_');
   let found = false;
   ['ins-', 'insw-', 'hm-', 'hmw-', ''].forEach(scope => {
     const el = document.getElementById('ca-' + scope + safePart);
     if (el) { el.classList.add('dismissing'); found = true; }
   });
-  if (found) {
-    setTimeout(() => { renderRemindersAndAlerts(); renderHomeContextAlerts(); renderInsightsAlerts(); }, 300);
-  } else {
-    renderRemindersAndAlerts();
-    renderHomeContextAlerts();
-    renderInsightsAlerts();
-  }
+  const rerender = () => { renderRemindersAndAlerts(); renderHomeContextAlerts(); renderInsightsAlerts(); };
+  if (found) setTimeout(rerender, 300); else rerender();
 }
+
+function dismissAlert(alertKey, alertTitle)     { _clearAlert('dismissed', alertKey, alertTitle, 'dismissed'); }
+function acknowledgeAlert(alertKey, alertTitle) { _clearAlert('acknowledged', alertKey, alertTitle, 'acknowledged'); }
+function snoozeAlert(alertKey, alertTitle)      { _clearAlert('snoozed', alertKey, alertTitle, 'snoozed'); }
 
 function toggleAlertTip(alertKey) {
   const el = document.getElementById('ca-tip-' + alertKey.replace(/[^a-zA-Z0-9-]/g, '_'));
@@ -6644,6 +6660,22 @@ const SEV_ORDER = { action: 0, watch: 1, info: 2, positive: 3 };
 const SEV_CLASS = { action: 'ca-action', watch: 'ca-watch', info: 'ca-info', positive: 'ca-positive' };
 const SEV_BADGE = { action: 'sev-action', watch: 'sev-watch', info: 'sev-info', positive: 'sev-positive' };
 const SEV_LABEL = { action: zi('siren') + ' Action', watch: zi('warn') + ' Watch', info: zi('check') + ' Info', positive: zi('party') + ' Win' };
+
+// ── 4-mode interaction model (PR-K) ──
+// Each alert resolves to exactly one interaction mode, derived from severity:
+//   action      → CTA only, no clear control — the parent must act on it
+//   snooze      → deferrable; re-surfaces automatically after the snooze TTL
+//   acknowledge → a win; a warm "Got it" permanently clears it
+//   dismiss     → low-stakes info; the corner × permanently clears it
+// safetyLocked alerts (upcoming-vaccine / dev-checkup reminders) are forced
+// to 'snooze' regardless of severity: they can be deferred but never
+// permanently dismissed or acknowledged away — Maren V-M-17 doctrine.
+const ALERT_MODE = { action: 'action', watch: 'snooze', positive: 'acknowledge', info: 'dismiss' };
+function getAlertMode(a) {
+  const base = ALERT_MODE[a.severity] || 'dismiss';
+  if (a.safetyLocked && base !== 'action') return 'snooze';
+  return base;
+}
 
 // Sanitize alert keys to safe alphanumeric + dash only
 function sanitizeAlertKey(s) { return s.replace(/[^a-zA-Z0-9-]/g, '_'); }
@@ -7043,8 +7075,15 @@ function computeAlerts() {
   const state = loadAlertState();
   const bl = computeBaselines();
 
-  // Helper: check if dismissed
-  function isDismissed(key) { return !!state.dismissed[key]; }
+  // Helper: is this alert currently cleared from view? True if dismissed,
+  // acknowledged, or snoozed AND that clear-state has not yet expired. The
+  // single predicate gates every alert (warnings at their push sites,
+  // positives in a sweep below) so all three modes take effect uniformly.
+  function isDismissed(key) {
+    const now = Date.now();
+    const live = b => { const v = state[b] && state[b][key]; return !!v && now < new Date(v).getTime(); };
+    return live('dismissed') || live('acknowledged') || live('snoozed');
+  }
 
   // ═══════════════════════════════════════
   // WARNING ALERTS (with escalating tips)
@@ -7222,7 +7261,7 @@ function computeAlerts() {
             body: 'Well-baby visits at ' + mo + ' months cover growth assessment, developmental milestones, and vaccination review.',
             tip: getEscalatedTip('dev-checkup-due'),
             action: { label: 'View Medical', fn: 'switchTab("medical")' },
-            tab: 'medical', dismissable: true
+            tab: 'medical', dismissable: true, safetyLocked: true
           });
         }
       }
@@ -7266,7 +7305,7 @@ function computeAlerts() {
           body: 'Scheduled for ' + formatDate(upcoming.date) + '. Book the appointment if you haven\'t already.',
           tip: getEscalatedTip('vacc-reminder'),
           action: { label: 'View Vaccines', fn: 'switchTab("medical")' },
-          tab: 'medical', dismissable: true
+          tab: 'medical', dismissable: true, safetyLocked: true
         });
       }
     }
@@ -7701,6 +7740,14 @@ function computeAlerts() {
   // SORT, SYNTHESIS, AUTO-CLEAR, LOG
   // ═══════════════════════════════════════
 
+  // ── Gate positives through the same clear-predicate as warnings ──
+  // Warnings are gated at their individual push sites; positive alerts push
+  // unconditionally, so sweep them here. Without this, acknowledge / dismiss
+  // on a win has no effect — the very gap PR-J's win-× exposed (V-M-32).
+  for (let i = alerts.length - 1; i >= 0; i--) {
+    if (alerts[i].severity === 'positive' && isDismissed(alerts[i].key)) alerts.splice(i, 1);
+  }
+
   // ── Sort by severity (action → watch → info → positive) ──
   alerts.sort((a, b) => (SEV_ORDER[a.severity] || 3) - (SEV_ORDER[b.severity] || 3));
 
@@ -7710,17 +7757,22 @@ function computeAlerts() {
   const { alerts: synthesizedWarnings, synthesisNarrative } = applyCrossSynthesis(warningAlerts);
   const finalAlerts = [...synthesizedWarnings, ...positiveAlerts];
 
-  // ── Auto-clear: remove dismissed entries whose condition no longer exists ──
+  // ── Auto-clear: drop expired clear-state entries ──
+  // dismiss / acknowledge / snooze all store an expiry timestamp, so GC is a
+  // pure time check — once past expiry the alert self-restores. No dependency
+  // on the active set, so a still-true alert that was cleared stays cleared
+  // for its full TTL (the activeKeys-based GC silently un-cleared it early).
   const activeKeys = new Set(finalAlerts.map(a => a.key));
   const st = loadAlertState();
   let changed = false;
-  for (const dKey of Object.keys(st.dismissed)) {
-    if (!activeKeys.has(dKey)) {
-      logAlertEvent(dKey, 'resolved', dKey);
-      delete st.dismissed[dKey];
-      changed = true;
+  ['dismissed', 'acknowledged', 'snoozed'].forEach(bucket => {
+    for (const k of Object.keys(st[bucket])) {
+      if (Date.now() >= new Date(st[bucket][k]).getTime()) {
+        delete st[bucket][k];
+        changed = true;
+      }
     }
-  }
+  });
   if (changed) saveAlertState(st);
 
   // ── Auto-resolve: mark previously triggered alerts as resolved if condition cleared ──
@@ -7781,8 +7833,10 @@ function renderAlertCardHTML(a, scope) {
   const sevLabel = SEV_LABEL[a.severity] || zi('check') + ' Info';
   // Register action fn safely
   if (a.action && a.action.fn) _alertActionRegistry[safeKey] = a.action.fn;
+  // Interaction mode (PR-K): drives which clear control the card carries.
+  const mode = getAlertMode(a);
   return `<div class="ctx-alert ${sevClass}" id="ca-${safeKey}">
-    ${a.dismissable ? `<button class="ctx-alert-dismiss" data-action="dismissAlert" data-stop="1" data-arg="${escAttr(a.key)}" data-arg2="${escAttr(a.title)}" aria-label="Dismiss">&times;</button>` : ''}
+    ${mode === 'dismiss' ? `<button class="ctx-alert-dismiss" data-action="dismissAlert" data-stop="1" data-arg="${escAttr(a.key)}" data-arg2="${escAttr(a.title)}" aria-label="Dismiss">&times;</button>` : ''}
     <div class="ctx-alert-top">
       <div class="ctx-alert-icon">${a.icon}</div>
       <div class="ctx-alert-body">
@@ -7793,6 +7847,8 @@ function renderAlertCardHTML(a, scope) {
         <div class="ctx-alert-actions">
           ${a.action ? `<button class="ctx-alert-btn cab-primary" data-action="execAlertAction" data-arg="${safeKey}" data-stop="1">${escHtml(a.action.label)}</button>` : ''}
           ${a.tab ? `<button class="ctx-alert-btn cab-secondary" data-action="switchTab" data-arg="${escAttr(a.tab)}" data-stop="1">View details</button>` : ''}
+          ${mode === 'acknowledge' ? `<button class="ctx-alert-btn cab-ack" data-action="acknowledgeAlert" data-stop="1" data-arg="${escAttr(a.key)}" data-arg2="${escAttr(a.title)}">${zi('check')} Got it</button>` : ''}
+          ${mode === 'snooze' ? `<button class="ctx-alert-btn cab-snooze" data-action="snoozeAlert" data-stop="1" data-arg="${escAttr(a.key)}" data-arg2="${escAttr(a.title)}">${zi('clock')} Snooze 3d</button>` : ''}
         </div>
       </div>
     </div>

--- a/split/home.js
+++ b/split/home.js
@@ -373,10 +373,58 @@ function renderVaccWeatherAdvisory(wx, daysTo, apptDate) {
 // ─────────────────────────────────────────
 // HOME TAB RENDER
 // ─────────────────────────────────────────
+// ── "Today for Ziva" — the Home lede (PR-K) ──
+// A warm, scannable card that answers the one question a tired parent opens
+// the app with: what matters today? Headline + age + date, then the single
+// highest-priority item (an action or watch alert) — or a calm all-clear.
+function renderTodayHero() {
+  const card = document.getElementById('todayHeroCard');
+  if (!card) return;
+  const ageEl = document.getElementById('thAge');
+  const dateEl = document.getElementById('thDate');
+  const focusEl = document.getElementById('thFocus');
+
+  // Age + date line
+  const a = ageAt();
+  let ageStr = a.months + (a.months === 1 ? ' month' : ' months');
+  if (a.days) ageStr += ', ' + a.days + (a.days === 1 ? ' day' : ' days');
+  if (ageEl) ageEl.textContent = ageStr + ' old';
+  if (dateEl) dateEl.textContent = new Date().toLocaleDateString('en-IN', { weekday: 'long', day: 'numeric', month: 'long' });
+
+  // The one thing that matters today — highest-priority alert, else all-clear.
+  let focusHTML = '';
+  try {
+    const alerts = computeAlerts();
+    const top = alerts.find(x => x.severity === 'action') || alerts.find(x => x.severity === 'watch');
+    if (top) {
+      const sevCls = top.severity === 'action' ? 'thf-action' : 'thf-watch';
+      focusHTML = `<div class="th-focus-row ${sevCls}">
+        <div class="th-focus-icon">${top.icon || zi('bell')}</div>
+        <div class="th-focus-body">
+          <div class="th-focus-label">Today's focus</div>
+          <div class="th-focus-text">${escHtml(top.title)}</div>
+        </div>
+        ${top.tab ? `<button class="th-focus-btn" data-action="switchTab" data-arg="${escAttr(top.tab)}" data-stop="1">View</button>` : ''}
+      </div>`;
+    } else {
+      focusHTML = `<div class="th-focus-row thf-clear">
+        <div class="th-focus-icon">${zi('sparkle')}</div>
+        <div class="th-focus-body">
+          <div class="th-focus-label">All clear</div>
+          <div class="th-focus-text">Nothing needs your attention today — enjoy the time together.</div>
+        </div>
+      </div>`;
+    }
+  } catch (e) { console.error('todayHero focus:', e); }
+  if (focusEl) focusEl.innerHTML = focusHTML;
+  card.style.display = focusHTML ? '' : 'none';
+}
+
 function renderHome() {
   _clearModifierCache();
   _postVaccCached = null;
   updateHeader();
+  renderTodayHero();
   renderHomeFeverBanner();
   renderHomeDiarrhoeaBanner();
   renderHomeVomitingBanner();

--- a/split/medical.js
+++ b/split/medical.js
@@ -7816,7 +7816,8 @@ function computeIllnessFrequency() {
         seenPairs.add(pairKey);
         insights.push({
           type: 'info',
-          text: iconText(recent[i].iconKey, recent[i].illnessType) + ' and ' + iconText(recent[j].iconKey, recent[j].illnessType) + ' overlapped around ' +
+          // iconText() escapes the illness label; this `text` is rendered via innerHTML.
+          text: iconText(recent[i].iconKey, recent[i].illnessType) + ' and ' + iconText(recent[j].iconKey, recent[j].illnessType) + ' overlapped around ' + // raw-html-ok
             formatDate(recent[i].startedAt).replace(/, \d{4}$/, '') + '. Co-occurring illnesses can be harder on babies — good to flag with your doctor.'
         });
         if (seenPairs.size >= 2) break coLoop; // cap at 2 overlap insights

--- a/split/medical.js
+++ b/split/medical.js
@@ -3959,20 +3959,22 @@ function renderVaccTimeline() {
   var hasAnyPast = vaccData.some(function(v) { return !v.upcoming; });
   if (!hasAnyPast) { el.innerHTML = ''; return; }
 
-  var cols = '';
+  // PR-K Gantt reshape: one row per IAP age group, read top-to-bottom along a
+  // spine. Each vaccine is a named, status-coloured chip (was a bare dot, with
+  // the name hidden in a title attribute). The reaction-status derivation and
+  // the vaccTimelineTap handler are unchanged — only the layout is reshaped.
+  var rows = '';
   ageOrder.forEach(function(age) {
     var names = ageGroups[age];
     if (!names || names.length === 0) return;
-    // Check if any vaccine in this group has data
     var hasSomeData = names.some(function(n) { return vaccByName[n.toLowerCase()]; });
     var hasSomeUpcoming = names.some(function(n) {
       var v = vaccByName[n.toLowerCase()];
       return v && v.upcoming;
     });
-    // Only show columns up to current age + 1 group ahead
     if (!hasSomeData && !hasSomeUpcoming) return;
 
-    var dots = names.map(function(name) {
+    var chips = names.map(function(name) {
       var v = vaccByName[name.toLowerCase()];
       if (!v) return '';
       var dotClass = 'vc-dot-nodata';
@@ -3991,28 +3993,36 @@ function renderVaccTimeline() {
       var delayBadge = '';
       if (!v.upcoming && v.scheduledDate && v.date) {
         var delayDays = Math.floor((new Date(v.date) - new Date(v.scheduledDate)) / 86400000);
-        if (delayDays > 7) delayBadge = '<span class="vc-timeline-delay">D</span>';
+        if (delayDays > 7) delayBadge = '<span class="vc-gantt-delay" title="Given over a week late">D</span>';
       }
       var idx = vaccData.indexOf(v);
-      return '<div class="vc-timeline-dot ' + dotClass + '" data-action="vaccTimelineTap" data-arg="' + idx + '" title="' + escAttr(name) + '">' +
+      return '<button class="vc-gantt-chip" data-action="vaccTimelineTap" data-arg="' + idx + '" title="' + escAttr(name) + '">' +
+        '<span class="vc-timeline-dot ' + dotClass + ' vc-gantt-chipdot"></span>' +
+        '<span class="vc-gantt-chip-name">' + escHtml(name) + '</span>' +
         delayBadge +
-        '</div>';
+        '</button>';
     }).filter(Boolean).join('');
+    if (!chips) return;
 
-    if (dots) {
-      var shortAge = age.replace(' months', 'm').replace(' weeks', 'w').replace(' years', 'y');
-      cols += '<div class="vc-timeline-col">' +
-        '<div class="vc-timeline-label">' + escHtml(shortAge) + '</div>' +
-        '<div class="vc-timeline-dots">' + dots + '</div>' +
-        '</div>';
-    }
+    var allDone = names.every(function(n) {
+      var v = vaccByName[n.toLowerCase()];
+      return v && !v.upcoming;
+    });
+    var nodeClass = allDone ? 'vc-gantt-node-done' : 'vc-gantt-node-pending';
+    rows += '<div class="vc-gantt-row">' +
+      '<div class="vc-gantt-spine"><span class="vc-gantt-node ' + nodeClass + '">' +
+        (allDone ? zi('check') : '') + '</span></div>' +
+      '<div class="vc-gantt-rowbody">' +
+        '<div class="vc-gantt-age">' + escHtml(age) + '</div>' +
+        '<div class="vc-gantt-chips">' + chips + '</div>' +
+      '</div></div>';
   });
 
-  if (!cols) { el.innerHTML = ''; return; }
+  if (!rows) { el.innerHTML = ''; return; }
 
-  el.innerHTML = '<div class="vc-timeline mt-8 mb-8">' +
+  el.innerHTML = '<div class="vc-gantt mt-8 mb-8">' +
     '<div class="fs-2xs fw-600 tc-lav mb-4">VACCINATION TIMELINE</div>' +
-    '<div class="vc-timeline-scroll">' + cols + '</div>' +
+    '<div class="vc-gantt-rows">' + rows + '</div>' +
     '<div class="fs-2xs tc-light mt-4">' +
     '<span class="vc-timeline-dot vc-dot-none vc-legend-dot"></span> No reaction ' +
     '<span class="vc-timeline-dot vc-dot-mild vc-legend-dot ml-6"></span> Mild ' +

--- a/split/styles.css
+++ b/split/styles.css
@@ -1139,6 +1139,53 @@ svg.zi { width:16px; height:16px; vertical-align:-2px; flex-shrink:0; }
   vertical-align: middle;
 }
 .ml-6 { margin-left: var(--sp-6); }
+
+/* ─── Vaccination timeline — Gantt reshape (PR-K) ─── */
+.vc-gantt { padding: var(--sp-4) 0; }
+.vc-gantt-rows { display: flex; flex-direction: column; }
+.vc-gantt-row { display: flex; gap: var(--sp-10); }
+.vc-gantt-spine {
+  display: flex; flex-direction: column; align-items: center;
+  width: 18px; flex-shrink: 0;
+}
+.vc-gantt-node {
+  width: 16px; height: 16px; border-radius: var(--r-full); flex-shrink: 0;
+  display: flex; align-items: center; justify-content: center;
+  margin-top: var(--sp-2); border: 2px solid var(--tc-lav);
+}
+.vc-gantt-node-done { background: var(--tc-lav); color: var(--white); }
+.vc-gantt-node-done .zi { width: 9px; height: 9px; }
+.vc-gantt-node-pending { background: var(--card-bg); border-style: dashed; }
+.vc-gantt-spine::after {
+  content: ''; flex: 1; width: 2px;
+  background: rgba(110,94,154,0.2); margin: var(--sp-2) 0;
+}
+.vc-gantt-row:last-child .vc-gantt-spine::after { display: none; }
+.vc-gantt-rowbody { flex: 1; min-width: 0; padding-bottom: var(--sp-16); }
+.vc-gantt-age {
+  font-size: var(--fs-2xs); font-weight: 700; color: var(--tc-lav);
+  text-transform: uppercase; letter-spacing: 0.03em; margin-bottom: var(--sp-6);
+}
+.vc-gantt-chips { display: flex; flex-wrap: wrap; gap: var(--sp-6); }
+.vc-gantt-chip {
+  display: inline-flex; align-items: center; gap: var(--sp-6);
+  padding: var(--sp-4) var(--sp-10); border-radius: var(--r-full);
+  border: 1px solid var(--card-border); background: var(--card-bg);
+  font-size: var(--fs-xs); font-weight: 600; color: var(--text);
+  cursor: pointer; position: relative;
+  transition: transform var(--ease-fast);
+}
+.vc-gantt-chip:active { transform: scale(0.96); }
+.vc-timeline-dot.vc-gantt-chipdot { width: 12px; height: 12px; }
+.vc-gantt-chip-name { white-space: nowrap; }
+.vc-gantt-delay {
+  width: 12px; height: 12px; border-radius: var(--r-full);
+  background: var(--tc-amber); color: #fff; font-size: 7px; font-weight: 700;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+[data-theme="dark"] .vc-gantt-chip { background: var(--surface); border-color: rgba(255,255,255,0.1); }
+[data-theme="dark"] .vc-gantt-spine::after { background: rgba(184,168,224,0.25); }
+
 .vc-timeline-detail {
   position: fixed;
   bottom: 0;

--- a/split/styles.css
+++ b/split/styles.css
@@ -3884,6 +3884,14 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
 .ctx-alert-btn.cab-secondary {
   background:transparent; color:var(--mid); border:1px solid var(--card-border);
 }
+/* PR-K 4-mode controls: acknowledge ("Got it") + snooze */
+.ctx-alert-btn.cab-ack {
+  background:var(--sage-light); color:var(--tc-sage); border:1px solid var(--sage);
+}
+.ctx-alert-btn.cab-snooze {
+  background:transparent; color:var(--mid); border:1px solid var(--card-border);
+}
+.ctx-alert-btn .zi { width:var(--icon-xs); height:var(--icon-xs); vertical-align:-1px; }
 .ctx-alert-dismiss {
   position:absolute; top:8px; right:8px; width:24px; height:24px;
   border:none; background:transparent; cursor:pointer; font-size:var(--icon-sm);
@@ -6640,6 +6648,8 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 [data-theme="dark"] .ctx-alert-sev.sev-action { background:rgba(176,72,94,0.15); border-color:rgba(176,72,94,0.25); }
 [data-theme="dark"] .ctx-alert-btn.cab-primary { background:var(--mid); }
 [data-theme="dark"] .ctx-alert-btn.cab-secondary { border-color:rgba(255,255,255,0.12); color:var(--light); }
+[data-theme="dark"] .ctx-alert-btn.cab-snooze { border-color:rgba(255,255,255,0.12); color:var(--light); }
+[data-theme="dark"] .ctx-alert-btn.cab-ack { background:rgba(181,213,197,0.14); border-color:rgba(181,213,197,0.3); }
 [data-theme="dark"] .ctx-alert-dismiss:hover { background:rgba(255,255,255,0.08); }
 [data-theme="dark"] .ca-view-all:hover { background:rgba(168,207,224,0.1); }
 [data-theme="dark"] .alert-hist-item { border-bottom-color:rgba(255,255,255,0.05); }

--- a/split/styles.css
+++ b/split/styles.css
@@ -2232,6 +2232,51 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
   .stat-pills-grid { grid-template-columns:repeat(3, 1fr); gap:var(--sp-8); }
 }
 
+/* ─── "Today for Ziva" — the Home lede (PR-K) ─── */
+.today-hero {
+  background:linear-gradient(135deg, var(--peach-light), var(--warm));
+  border:1px solid rgba(250,212,180,0.5);
+}
+.th-head { display:flex; align-items:baseline; justify-content:space-between; gap:var(--sp-8); }
+.th-title {
+  font-family:'Fraunces', serif; font-size:var(--fs-xl); font-weight:600;
+  color:var(--text); line-height:1.2;
+}
+.th-age { font-size:var(--fs-sm); font-weight:600; color:var(--mid); flex-shrink:0; }
+.th-date { font-size:var(--fs-sm); color:var(--light); margin-top:var(--sp-2); }
+.th-focus { margin-top:var(--sp-12); }
+.th-focus-row {
+  display:flex; align-items:center; gap:var(--sp-10);
+  padding:var(--sp-10) var(--sp-12); border-radius:var(--r-lg);
+  background:var(--white); border-left:3px solid var(--sage);
+}
+.th-focus-row.thf-action { border-left-color:var(--rose); }
+.th-focus-row.thf-watch  { border-left-color:var(--amber); }
+.th-focus-row.thf-clear  { border-left-color:var(--sage); }
+.th-focus-icon {
+  width:36px; height:36px; flex-shrink:0; border-radius:var(--r-full);
+  background:var(--peach-light); display:flex; align-items:center; justify-content:center;
+}
+.th-focus-icon .zi { width:var(--icon-md); height:var(--icon-md); }
+.th-focus-body { flex:1; min-width:0; }
+.th-focus-label {
+  font-size:var(--fs-2xs); font-weight:700; letter-spacing:0.04em;
+  text-transform:uppercase; color:var(--light);
+}
+.th-focus-text { font-size:var(--fs-sm); font-weight:600; color:var(--text); margin-top:var(--sp-2); }
+.th-focus-btn {
+  flex-shrink:0; font-size:var(--fs-sm); font-weight:600;
+  padding:var(--sp-6) var(--sp-12); border-radius:var(--r-full);
+  border:none; background:var(--text); color:var(--white); cursor:pointer;
+}
+.th-focus-btn:active { transform:scale(0.95); }
+[data-theme="dark"] .today-hero {
+  background:linear-gradient(135deg, rgba(250,212,180,0.10), rgba(255,255,255,0.03));
+  border-color:rgba(250,212,180,0.2);
+}
+[data-theme="dark"] .th-focus-row { background:var(--mid); }
+[data-theme="dark"] .th-focus-icon { background:rgba(250,212,180,0.14); }
+
 .home-stat-pill {
   border-radius:var(--r-xl); padding:var(--sp-12);
   text-align:center; min-width:0;

--- a/split/template.html
+++ b/split/template.html
@@ -262,6 +262,16 @@
         </div>
       </div>
 
+      <!-- ─── TODAY FOR ZIVA — the Home lede (PR-K) ─── -->
+      <div class="card col-full today-hero" id="todayHeroCard" style="display:none;">
+        <div class="th-head">
+          <div class="th-title">Today for Ziva</div>
+          <div class="th-age" id="thAge">—</div>
+        </div>
+        <div class="th-date" id="thDate">—</div>
+        <div class="th-focus" id="thFocus"></div>
+      </div>
+
       <!-- ─── TIER 1: COMPACT VITALS (expandable) ─── -->
       <div class="card col-full card-hero hero-home ptr" id="homeVitalsCard" data-action="toggleHomeVitals" >
         <!-- Avatar blurred background (Essential Mode only, set via JS) -->

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -2239,6 +2239,51 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
   .stat-pills-grid { grid-template-columns:repeat(3, 1fr); gap:var(--sp-8); }
 }
 
+/* ─── "Today for Ziva" — the Home lede (PR-K) ─── */
+.today-hero {
+  background:linear-gradient(135deg, var(--peach-light), var(--warm));
+  border:1px solid rgba(250,212,180,0.5);
+}
+.th-head { display:flex; align-items:baseline; justify-content:space-between; gap:var(--sp-8); }
+.th-title {
+  font-family:'Fraunces', serif; font-size:var(--fs-xl); font-weight:600;
+  color:var(--text); line-height:1.2;
+}
+.th-age { font-size:var(--fs-sm); font-weight:600; color:var(--mid); flex-shrink:0; }
+.th-date { font-size:var(--fs-sm); color:var(--light); margin-top:var(--sp-2); }
+.th-focus { margin-top:var(--sp-12); }
+.th-focus-row {
+  display:flex; align-items:center; gap:var(--sp-10);
+  padding:var(--sp-10) var(--sp-12); border-radius:var(--r-lg);
+  background:var(--white); border-left:3px solid var(--sage);
+}
+.th-focus-row.thf-action { border-left-color:var(--rose); }
+.th-focus-row.thf-watch  { border-left-color:var(--amber); }
+.th-focus-row.thf-clear  { border-left-color:var(--sage); }
+.th-focus-icon {
+  width:36px; height:36px; flex-shrink:0; border-radius:var(--r-full);
+  background:var(--peach-light); display:flex; align-items:center; justify-content:center;
+}
+.th-focus-icon .zi { width:var(--icon-md); height:var(--icon-md); }
+.th-focus-body { flex:1; min-width:0; }
+.th-focus-label {
+  font-size:var(--fs-2xs); font-weight:700; letter-spacing:0.04em;
+  text-transform:uppercase; color:var(--light);
+}
+.th-focus-text { font-size:var(--fs-sm); font-weight:600; color:var(--text); margin-top:var(--sp-2); }
+.th-focus-btn {
+  flex-shrink:0; font-size:var(--fs-sm); font-weight:600;
+  padding:var(--sp-6) var(--sp-12); border-radius:var(--r-full);
+  border:none; background:var(--text); color:var(--white); cursor:pointer;
+}
+.th-focus-btn:active { transform:scale(0.95); }
+[data-theme="dark"] .today-hero {
+  background:linear-gradient(135deg, rgba(250,212,180,0.10), rgba(255,255,255,0.03));
+  border-color:rgba(250,212,180,0.2);
+}
+[data-theme="dark"] .th-focus-row { background:var(--mid); }
+[data-theme="dark"] .th-focus-icon { background:rgba(250,212,180,0.14); }
+
 .home-stat-pill {
   border-radius:var(--r-xl); padding:var(--sp-12);
   text-align:center; min-width:0;
@@ -9817,6 +9862,16 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
           <div class="wg-dots" id="wgDots"></div>
           <button class="btn btn-rose wg-btn" id="wgNext" data-wgnav="1">Next →</button>
         </div>
+      </div>
+
+      <!-- ─── TODAY FOR ZIVA — the Home lede (PR-K) ─── -->
+      <div class="card col-full today-hero" id="todayHeroCard" style="display:none;">
+        <div class="th-head">
+          <div class="th-title">Today for Ziva</div>
+          <div class="th-age" id="thAge">—</div>
+        </div>
+        <div class="th-date" id="thDate">—</div>
+        <div class="th-focus" id="thFocus"></div>
       </div>
 
       <!-- ─── TIER 1: COMPACT VITALS (expandable) ─── -->
@@ -22611,10 +22666,58 @@ function renderVaccWeatherAdvisory(wx, daysTo, apptDate) {
 // ─────────────────────────────────────────
 // HOME TAB RENDER
 // ─────────────────────────────────────────
+// ── "Today for Ziva" — the Home lede (PR-K) ──
+// A warm, scannable card that answers the one question a tired parent opens
+// the app with: what matters today? Headline + age + date, then the single
+// highest-priority item (an action or watch alert) — or a calm all-clear.
+function renderTodayHero() {
+  const card = document.getElementById('todayHeroCard');
+  if (!card) return;
+  const ageEl = document.getElementById('thAge');
+  const dateEl = document.getElementById('thDate');
+  const focusEl = document.getElementById('thFocus');
+
+  // Age + date line
+  const a = ageAt();
+  let ageStr = a.months + (a.months === 1 ? ' month' : ' months');
+  if (a.days) ageStr += ', ' + a.days + (a.days === 1 ? ' day' : ' days');
+  if (ageEl) ageEl.textContent = ageStr + ' old';
+  if (dateEl) dateEl.textContent = new Date().toLocaleDateString('en-IN', { weekday: 'long', day: 'numeric', month: 'long' });
+
+  // The one thing that matters today — highest-priority alert, else all-clear.
+  let focusHTML = '';
+  try {
+    const alerts = computeAlerts();
+    const top = alerts.find(x => x.severity === 'action') || alerts.find(x => x.severity === 'watch');
+    if (top) {
+      const sevCls = top.severity === 'action' ? 'thf-action' : 'thf-watch';
+      focusHTML = `<div class="th-focus-row ${sevCls}">
+        <div class="th-focus-icon">${top.icon || zi('bell')}</div>
+        <div class="th-focus-body">
+          <div class="th-focus-label">Today's focus</div>
+          <div class="th-focus-text">${escHtml(top.title)}</div>
+        </div>
+        ${top.tab ? `<button class="th-focus-btn" data-action="switchTab" data-arg="${escAttr(top.tab)}" data-stop="1">View</button>` : ''}
+      </div>`;
+    } else {
+      focusHTML = `<div class="th-focus-row thf-clear">
+        <div class="th-focus-icon">${zi('sparkle')}</div>
+        <div class="th-focus-body">
+          <div class="th-focus-label">All clear</div>
+          <div class="th-focus-text">Nothing needs your attention today — enjoy the time together.</div>
+        </div>
+      </div>`;
+    }
+  } catch (e) { console.error('todayHero focus:', e); }
+  if (focusEl) focusEl.innerHTML = focusHTML;
+  card.style.display = focusHTML ? '' : 'none';
+}
+
 function renderHome() {
   _clearModifierCache();
   _postVaccCached = null;
   updateHeader();
+  renderTodayHero();
   renderHomeFeverBanner();
   renderHomeDiarrhoeaBanner();
   renderHomeVomitingBanner();

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -21190,15 +21190,20 @@ function getChartTheme() {
 // INSIGHTS — TREND ENGINE (v2.0a)
 // ─────────────────────────────────────────
 
-// Generic trend calculator: compare two values, return arrow + delta + direction
+// Generic trend calculator: compare two values, return arrow + delta + direction.
+// Return shape (V-K-14): `.label` is PLAIN text (textContent-safe); `.html`
+// is icon+label markup (innerHTML-only); `.arrow` is the bare icon SVG. HTML
+// never lives in a field named `.text` — that illegal-state shape shipped the
+// PR-EF trend-pill regression that PR-J hotfixed.
 function getTrend(current, previous, threshold, decimals) {
-  if (current == null || previous == null) return { arrow:'', delta:0, direction:'flat', cls:'trend-flat', text:'' };
+  if (current == null || previous == null) return { arrow:'', delta:0, direction:'flat', cls:'trend-flat', label:'', html:'' };
   const dec = decimals != null ? decimals : 1;
   const delta = +(current - previous).toFixed(dec);
   const absDelta = Math.abs(delta);
-  if (absDelta <= threshold) return { arrow: zi('trending-flat'), delta:0, direction:'flat', cls:'trend-flat', text: iconText('trending-flat', 'stable') };
-  if (delta > 0) return { arrow: zi('trending-up'), delta, direction:'up', cls:'trend-up', text: iconText('trending-up', '+' + absDelta.toFixed(dec)) };
-  return { arrow: zi('trending-down'), delta, direction:'down', cls:'trend-down', text: iconText('trending-down', '-' + absDelta.toFixed(dec)) };
+  if (absDelta <= threshold) return { arrow: zi('trending-flat'), delta:0, direction:'flat', cls:'trend-flat', label:'stable', html: iconText('trending-flat', 'stable') };
+  if (delta > 0) { const l = '+' + absDelta.toFixed(dec); return { arrow: zi('trending-up'), delta, direction:'up', cls:'trend-up', label:l, html: iconText('trending-up', l) }; }
+  const l = '-' + absDelta.toFixed(dec);
+  return { arrow: zi('trending-down'), delta, direction:'down', cls:'trend-down', label:l, html: iconText('trending-down', l) };
 }
 
 // Get dates array for a window ending at offsetDays before today
@@ -21643,8 +21648,8 @@ function updateStatPillTrends() {
       if (prev.date === latest.date && wtEntries.length >= 2) prev = wtEntries[wtEntries.length - 2];
       const trend = getTrend(latest.wt, prev.wt, 0.05, 2);
       wtTrendEl.className = 'hsp-trend ' + trend.cls;
-      // getTrend().text carries an SVG icon (iconText) — HR-7: set via innerHTML.
-      wtTrendEl.innerHTML = trend.text ? trend.text + ' kg' : '';
+      // getTrend().html carries an SVG icon (iconText) — HR-7: set via innerHTML.
+      wtTrendEl.innerHTML = trend.html ? trend.html + ' kg' : '';
     } else {
       wtTrendEl.innerHTML = '';
     }
@@ -21666,8 +21671,8 @@ function updateStatPillTrends() {
       if (prev.date === latest.date && htEntries.length >= 2) prev = htEntries[htEntries.length - 2];
       const trend = getTrend(latest.ht, prev.ht, 0.5, 1);
       htTrendEl.className = 'hsp-trend ' + trend.cls;
-      // getTrend().text carries an SVG icon (iconText) — HR-7: set via innerHTML.
-      htTrendEl.innerHTML = trend.text ? trend.text + ' cm' : '';
+      // getTrend().html carries an SVG icon (iconText) — HR-7: set via innerHTML.
+      htTrendEl.innerHTML = trend.html ? trend.html + ' cm' : '';
     } else {
       htTrendEl.innerHTML = '';
     }
@@ -21680,8 +21685,8 @@ function updateStatPillTrends() {
     if (sleepT.score.current != null && sleepT.score.previous != null) {
       const t = sleepT.score.trend;
       slTrendEl.className = 'hsp-trend ' + t.cls;
-      // getTrend().text carries an SVG icon (iconText) — HR-7: set via innerHTML.
-      slTrendEl.innerHTML = t.text ? t.text + ' pts' : '';
+      // getTrend().html carries an SVG icon (iconText) — HR-7: set via innerHTML.
+      slTrendEl.innerHTML = t.html ? t.html + ' pts' : '';
     } else {
       slTrendEl.innerHTML = '';
     }
@@ -30226,14 +30231,14 @@ function renderTodayPlan() {
         items.push({
           time: apptDaysTo === 1 ? 'Tmrw' : apptDaysTo + 'd',
           icon: zi('syringe'), title: upcomingVacc.name,
-          detail: iconText('check', 'Booked — ' + getVaccApptLabel(bookedData)),
+          detail: iconText('check', 'Booked — ' + getVaccApptLabel(bookedData)), // raw-html-ok
           tag: 'med', done: true, htmlDetail: true
         });
       } else if (apptDaysTo < 0) {
         // Appointment was in the past but vaccine not given yet — overdue
         items.push({
           time: 'Due', icon: zi('syringe'), title: upcomingVacc.name,
-          detail: iconText('warn', 'Appointment was ' + formatDate(bookedData.apptDate) + ' — reschedule'),
+          detail: iconText('warn', 'Appointment was ' + formatDate(bookedData.apptDate) + ' — reschedule'), // raw-html-ok
           tag: 'med', done: false, htmlDetail: true
         });
       }
@@ -30242,7 +30247,7 @@ function renderTodayPlan() {
       // Booked but no details — nudge to add date
       items.push({
         time: zi('clock'), icon: zi('syringe'), title: upcomingVacc.name,
-        detail: iconText('check', 'Booked — tap to add appointment date & time'),
+        detail: iconText('check', 'Booked — tap to add appointment date & time'), // raw-html-ok
         tag: 'med', done: false, htmlDetail: true,
         action: { name: 'openVaccApptModal', arg: upcomingVacc.name }
       });
@@ -30693,7 +30698,7 @@ function renderTrendChips() {
   if (sleepT.score.current != null) {
     const cls = sleepT.score.current >= 70 ? 'tc-good' : sleepT.score.current >= 40 ? 'tc-warn' : 'tc-bad';
     const arrow = sleepT.score.trend.arrow || '';
-    chips.push({ icon:zi('moon'), label:'Sleep', value: sleepT.score.current + '/100' + (arrow ? ' ' + arrow : ''), delta: sleepT.score.trend.text || '', cls, tab:'sleep' });
+    chips.push({ icon:zi('moon'), label:'Sleep', value: sleepT.score.current + '/100' + (arrow ? ' ' + arrow : ''), delta: sleepT.score.trend.html || '', cls, tab:'sleep' });
   } else {
     chips.push({ icon:zi('moon'), label:'Sleep', value:'No data yet', delta:'—', cls:'tc-neutral', tab:'sleep' });
   }
@@ -31011,7 +31016,7 @@ function renderInsightsSleep() { /* v2.4: DORMANT — insights cards replaced by
     if (trend.score.current != null) {
       const cls = trend.score.current >= 70 ? 'ipp-good' : trend.score.current >= 40 ? 'ipp-warn' : 'ipp-bad';
       pills += `<span class="ins-preview-pill ${cls}">${zi('zzz')} ${trend.score.current}/100</span>`;
-      if (trend.score.trend.arrow) pills += `<span class="ins-preview-pill ipp-neutral">${trend.score.trend.text}</span>`;
+      if (trend.score.trend.arrow) pills += `<span class="ins-preview-pill ipp-neutral">${trend.score.trend.html}</span>`;
     }
     if (trend.wakes.current != null) {
       const cls = trend.wakes.current <= 1 ? 'ipp-good' : trend.wakes.current <= 2 ? 'ipp-warn' : 'ipp-bad';
@@ -31029,7 +31034,7 @@ function renderInsightsSleep() { /* v2.4: DORMANT — insights cards replaced by
       <div class="ir-icon">${emoji}</div>
       <div class="ir-body">
         <div class="ir-label">Sleep score (7-day avg)</div>
-        <div class="ir-value">${trend.score.current}/100 <span class="ir-delta ${trend.score.trend.cls}">${trend.score.trend.text ? trend.score.trend.text + ' pts' : ''}</span></div>
+        <div class="ir-value">${trend.score.current}/100 <span class="ir-delta ${trend.score.trend.cls}">${trend.score.trend.html ? trend.score.trend.html + ' pts' : ''}</span></div>
       </div>
     </div>`;
   }
@@ -31085,7 +31090,7 @@ function renderInsightsSleep() { /* v2.4: DORMANT — insights cards replaced by
       <div class="ir-icon">${zi('clock')}</div>
       <div class="ir-body">
         <div class="ir-label">Avg wake-ups / night</div>
-        <div class="ir-value">${trend.wakes.current} <span class="ir-delta ${wakeCls}">${trend.wakes.trend.text || ''}</span></div>
+        <div class="ir-value">${trend.wakes.current} <span class="ir-delta ${wakeCls}">${trend.wakes.trend.html || ''}</span></div>
       </div>
     </div>`;
   }
@@ -31276,7 +31281,7 @@ function renderInsightsPoop() { /* v2.4: DORMANT — insights cards replaced by 
     <div class="ir-icon">${zi('chart')}</div>
     <div class="ir-body">
       <div class="ir-label">Daily frequency (7-day avg)</div>
-      <div class="ir-value">${trend.freq.current}/day <span class="ir-delta ${trend.freq.trend.cls}">${trend.freq.trend.text ? trend.freq.trend.text + '/d' : ''}</span></div>
+      <div class="ir-value">${trend.freq.current}/day <span class="ir-delta ${trend.freq.trend.cls}">${trend.freq.trend.html ? trend.freq.trend.html + '/d' : ''}</span></div>
     </div>
   </div>`;
 
@@ -31399,7 +31404,7 @@ function renderInsightsFeed() { /* v2.4: DORMANT — insights cards replaced by 
     <div class="ir-icon">${zi('bowl')}</div>
     <div class="ir-body">
       <div class="ir-label">Meals logged (7 days)</div>
-      <div class="ir-value">${trend.meals.current} / 21 <span class="ir-delta ${trend.meals.trend.cls}">${trend.meals.trend.text || ''}</span></div>
+      <div class="ir-value">${trend.meals.current} / 21 <span class="ir-delta ${trend.meals.trend.cls}">${trend.meals.trend.html || ''}</span></div>
     </div>
   </div>`;
 
@@ -31408,7 +31413,7 @@ function renderInsightsFeed() { /* v2.4: DORMANT — insights cards replaced by 
     <div class="ir-icon">${zi('rainbow')}</div>
     <div class="ir-body">
       <div class="ir-label">Unique foods this week</div>
-      <div class="ir-value">${trend.variety.current} <span class="ir-delta ${trend.variety.trend.cls}">${trend.variety.trend.text || ''}</span></div>
+      <div class="ir-value">${trend.variety.current} <span class="ir-delta ${trend.variety.trend.cls}">${trend.variety.trend.html || ''}</span></div>
     </div>
   </div>`;
 
@@ -43584,7 +43589,8 @@ function computeIllnessFrequency() {
         seenPairs.add(pairKey);
         insights.push({
           type: 'info',
-          text: iconText(recent[i].iconKey, recent[i].illnessType) + ' and ' + iconText(recent[j].iconKey, recent[j].illnessType) + ' overlapped around ' +
+          // iconText() escapes the illness label; this `text` is rendered via innerHTML.
+          text: iconText(recent[i].iconKey, recent[i].illnessType) + ' and ' + iconText(recent[j].iconKey, recent[j].illnessType) + ' overlapped around ' + // raw-html-ok
             formatDate(recent[i].startedAt).replace(/, \d{4}$/, '') + '. Co-occurring illnesses can be harder on babies — good to flag with your doctor.'
         });
         if (seenPairs.size >= 2) break coLoop; // cap at 2 overlap insights

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -3891,6 +3891,14 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
 .ctx-alert-btn.cab-secondary {
   background:transparent; color:var(--mid); border:1px solid var(--card-border);
 }
+/* PR-K 4-mode controls: acknowledge ("Got it") + snooze */
+.ctx-alert-btn.cab-ack {
+  background:var(--sage-light); color:var(--tc-sage); border:1px solid var(--sage);
+}
+.ctx-alert-btn.cab-snooze {
+  background:transparent; color:var(--mid); border:1px solid var(--card-border);
+}
+.ctx-alert-btn .zi { width:var(--icon-xs); height:var(--icon-xs); vertical-align:-1px; }
 .ctx-alert-dismiss {
   position:absolute; top:8px; right:8px; width:24px; height:24px;
   border:none; background:transparent; cursor:pointer; font-size:var(--icon-sm);
@@ -6647,6 +6655,8 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 [data-theme="dark"] .ctx-alert-sev.sev-action { background:rgba(176,72,94,0.15); border-color:rgba(176,72,94,0.25); }
 [data-theme="dark"] .ctx-alert-btn.cab-primary { background:var(--mid); }
 [data-theme="dark"] .ctx-alert-btn.cab-secondary { border-color:rgba(255,255,255,0.12); color:var(--light); }
+[data-theme="dark"] .ctx-alert-btn.cab-snooze { border-color:rgba(255,255,255,0.12); color:var(--light); }
+[data-theme="dark"] .ctx-alert-btn.cab-ack { background:rgba(181,213,197,0.14); border-color:rgba(181,213,197,0.3); }
 [data-theme="dark"] .ctx-alert-dismiss:hover { background:rgba(255,255,255,0.08); }
 [data-theme="dark"] .ca-view-all:hover { background:rgba(168,207,224,0.1); }
 [data-theme="dark"] .alert-hist-item { border-bottom-color:rgba(255,255,255,0.05); }
@@ -17467,6 +17477,8 @@ function init() {
     else if (action === 'feHomeBannerLog') feHomeBannerLog();
     else if (action === 'deLogStoolQuick') deLogStoolQuick(arg);
     else if (action === 'dismissAlert') dismissAlert(arg, arg2);
+    else if (action === 'acknowledgeAlert') acknowledgeAlert(arg, arg2);
+    else if (action === 'snoozeAlert') snoozeAlert(arg, arg2);
     else if (action === 'toggleAlertTip') toggleAlertTip(arg);
     else if (action === 'execAlertAction') execAlertAction(arg);
     else if (action === 'skipMeals') { try { skipMeals(JSON.parse(arg)); } catch(ex) {} }
@@ -28826,7 +28838,17 @@ function renderScrapbookHistory() {
 // ══════════════════════════════════════════════════════════════
 
 // ── Storage ──
-function loadAlertState()   { return load(KEYS.alertsActive, { dismissed: {} }); }
+// Alert clear-state has three buckets (PR-K 4-mode model): `dismissed` and
+// `acknowledged` are long-lived clears; `snoozed` is a short deferral. Each
+// entry stores an EXPIRY timestamp, never a bare flag — so a cleared alert
+// always self-restores after its TTL and can never be permanently lost.
+function loadAlertState() {
+  const s = load(KEYS.alertsActive, { dismissed: {}, snoozed: {}, acknowledged: {} });
+  if (!s.dismissed)    s.dismissed = {};
+  if (!s.snoozed)      s.snoozed = {};
+  if (!s.acknowledged) s.acknowledged = {};
+  return s;
+}
 function saveAlertState(s)  { save(KEYS.alertsActive, s); }
 function loadAlertHistory() { return load(KEYS.alertsHistory, []); }
 function saveAlertHistory(h){ save(KEYS.alertsHistory, h); }
@@ -28839,26 +28861,32 @@ function logAlertEvent(alertKey, eventType, alertTitle, alertSeverity) {
   saveAlertHistory(h);
 }
 
-function dismissAlert(alertKey, alertTitle) {
+// ── 4-mode alert clearing (PR-K) ──
+// dismiss / acknowledge persist for 30d; snooze defers for 3d. Storing the
+// expiry (not the action time) means the auto-clear GC is a pure timestamp
+// check with no dependency on which alerts happen to be active this render.
+const ALERT_TTL_DAYS = { dismissed: 30, acknowledged: 30, snoozed: 3 };
+
+function _clearAlert(bucket, alertKey, alertTitle, eventType) {
   const state = loadAlertState();
-  state.dismissed[alertKey] = new Date().toISOString();
+  const ttl = ALERT_TTL_DAYS[bucket] || 30;
+  state[bucket][alertKey] = new Date(Date.now() + ttl * 86400000).toISOString();
   saveAlertState(state);
-  logAlertEvent(alertKey, 'dismissed', alertTitle);
-  // Animate out all scoped instances
+  logAlertEvent(alertKey, eventType, alertTitle);
+  // Animate out all scoped instances, then re-render every alert surface.
   const safePart = alertKey.replace(/[^a-zA-Z0-9-]/g, '_');
   let found = false;
   ['ins-', 'insw-', 'hm-', 'hmw-', ''].forEach(scope => {
     const el = document.getElementById('ca-' + scope + safePart);
     if (el) { el.classList.add('dismissing'); found = true; }
   });
-  if (found) {
-    setTimeout(() => { renderRemindersAndAlerts(); renderHomeContextAlerts(); renderInsightsAlerts(); }, 300);
-  } else {
-    renderRemindersAndAlerts();
-    renderHomeContextAlerts();
-    renderInsightsAlerts();
-  }
+  const rerender = () => { renderRemindersAndAlerts(); renderHomeContextAlerts(); renderInsightsAlerts(); };
+  if (found) setTimeout(rerender, 300); else rerender();
 }
+
+function dismissAlert(alertKey, alertTitle)     { _clearAlert('dismissed', alertKey, alertTitle, 'dismissed'); }
+function acknowledgeAlert(alertKey, alertTitle) { _clearAlert('acknowledged', alertKey, alertTitle, 'acknowledged'); }
+function snoozeAlert(alertKey, alertTitle)      { _clearAlert('snoozed', alertKey, alertTitle, 'snoozed'); }
 
 function toggleAlertTip(alertKey) {
   const el = document.getElementById('ca-tip-' + alertKey.replace(/[^a-zA-Z0-9-]/g, '_'));
@@ -28870,6 +28898,22 @@ const SEV_ORDER = { action: 0, watch: 1, info: 2, positive: 3 };
 const SEV_CLASS = { action: 'ca-action', watch: 'ca-watch', info: 'ca-info', positive: 'ca-positive' };
 const SEV_BADGE = { action: 'sev-action', watch: 'sev-watch', info: 'sev-info', positive: 'sev-positive' };
 const SEV_LABEL = { action: zi('siren') + ' Action', watch: zi('warn') + ' Watch', info: zi('check') + ' Info', positive: zi('party') + ' Win' };
+
+// ── 4-mode interaction model (PR-K) ──
+// Each alert resolves to exactly one interaction mode, derived from severity:
+//   action      → CTA only, no clear control — the parent must act on it
+//   snooze      → deferrable; re-surfaces automatically after the snooze TTL
+//   acknowledge → a win; a warm "Got it" permanently clears it
+//   dismiss     → low-stakes info; the corner × permanently clears it
+// safetyLocked alerts (upcoming-vaccine / dev-checkup reminders) are forced
+// to 'snooze' regardless of severity: they can be deferred but never
+// permanently dismissed or acknowledged away — Maren V-M-17 doctrine.
+const ALERT_MODE = { action: 'action', watch: 'snooze', positive: 'acknowledge', info: 'dismiss' };
+function getAlertMode(a) {
+  const base = ALERT_MODE[a.severity] || 'dismiss';
+  if (a.safetyLocked && base !== 'action') return 'snooze';
+  return base;
+}
 
 // Sanitize alert keys to safe alphanumeric + dash only
 function sanitizeAlertKey(s) { return s.replace(/[^a-zA-Z0-9-]/g, '_'); }
@@ -29269,8 +29313,15 @@ function computeAlerts() {
   const state = loadAlertState();
   const bl = computeBaselines();
 
-  // Helper: check if dismissed
-  function isDismissed(key) { return !!state.dismissed[key]; }
+  // Helper: is this alert currently cleared from view? True if dismissed,
+  // acknowledged, or snoozed AND that clear-state has not yet expired. The
+  // single predicate gates every alert (warnings at their push sites,
+  // positives in a sweep below) so all three modes take effect uniformly.
+  function isDismissed(key) {
+    const now = Date.now();
+    const live = b => { const v = state[b] && state[b][key]; return !!v && now < new Date(v).getTime(); };
+    return live('dismissed') || live('acknowledged') || live('snoozed');
+  }
 
   // ═══════════════════════════════════════
   // WARNING ALERTS (with escalating tips)
@@ -29448,7 +29499,7 @@ function computeAlerts() {
             body: 'Well-baby visits at ' + mo + ' months cover growth assessment, developmental milestones, and vaccination review.',
             tip: getEscalatedTip('dev-checkup-due'),
             action: { label: 'View Medical', fn: 'switchTab("medical")' },
-            tab: 'medical', dismissable: true
+            tab: 'medical', dismissable: true, safetyLocked: true
           });
         }
       }
@@ -29492,7 +29543,7 @@ function computeAlerts() {
           body: 'Scheduled for ' + formatDate(upcoming.date) + '. Book the appointment if you haven\'t already.',
           tip: getEscalatedTip('vacc-reminder'),
           action: { label: 'View Vaccines', fn: 'switchTab("medical")' },
-          tab: 'medical', dismissable: true
+          tab: 'medical', dismissable: true, safetyLocked: true
         });
       }
     }
@@ -29927,6 +29978,14 @@ function computeAlerts() {
   // SORT, SYNTHESIS, AUTO-CLEAR, LOG
   // ═══════════════════════════════════════
 
+  // ── Gate positives through the same clear-predicate as warnings ──
+  // Warnings are gated at their individual push sites; positive alerts push
+  // unconditionally, so sweep them here. Without this, acknowledge / dismiss
+  // on a win has no effect — the very gap PR-J's win-× exposed (V-M-32).
+  for (let i = alerts.length - 1; i >= 0; i--) {
+    if (alerts[i].severity === 'positive' && isDismissed(alerts[i].key)) alerts.splice(i, 1);
+  }
+
   // ── Sort by severity (action → watch → info → positive) ──
   alerts.sort((a, b) => (SEV_ORDER[a.severity] || 3) - (SEV_ORDER[b.severity] || 3));
 
@@ -29936,17 +29995,22 @@ function computeAlerts() {
   const { alerts: synthesizedWarnings, synthesisNarrative } = applyCrossSynthesis(warningAlerts);
   const finalAlerts = [...synthesizedWarnings, ...positiveAlerts];
 
-  // ── Auto-clear: remove dismissed entries whose condition no longer exists ──
+  // ── Auto-clear: drop expired clear-state entries ──
+  // dismiss / acknowledge / snooze all store an expiry timestamp, so GC is a
+  // pure time check — once past expiry the alert self-restores. No dependency
+  // on the active set, so a still-true alert that was cleared stays cleared
+  // for its full TTL (the activeKeys-based GC silently un-cleared it early).
   const activeKeys = new Set(finalAlerts.map(a => a.key));
   const st = loadAlertState();
   let changed = false;
-  for (const dKey of Object.keys(st.dismissed)) {
-    if (!activeKeys.has(dKey)) {
-      logAlertEvent(dKey, 'resolved', dKey);
-      delete st.dismissed[dKey];
-      changed = true;
+  ['dismissed', 'acknowledged', 'snoozed'].forEach(bucket => {
+    for (const k of Object.keys(st[bucket])) {
+      if (Date.now() >= new Date(st[bucket][k]).getTime()) {
+        delete st[bucket][k];
+        changed = true;
+      }
     }
-  }
+  });
   if (changed) saveAlertState(st);
 
   // ── Auto-resolve: mark previously triggered alerts as resolved if condition cleared ──
@@ -30007,8 +30071,10 @@ function renderAlertCardHTML(a, scope) {
   const sevLabel = SEV_LABEL[a.severity] || zi('check') + ' Info';
   // Register action fn safely
   if (a.action && a.action.fn) _alertActionRegistry[safeKey] = a.action.fn;
+  // Interaction mode (PR-K): drives which clear control the card carries.
+  const mode = getAlertMode(a);
   return `<div class="ctx-alert ${sevClass}" id="ca-${safeKey}">
-    ${a.dismissable ? `<button class="ctx-alert-dismiss" data-action="dismissAlert" data-stop="1" data-arg="${escAttr(a.key)}" data-arg2="${escAttr(a.title)}" aria-label="Dismiss">&times;</button>` : ''}
+    ${mode === 'dismiss' ? `<button class="ctx-alert-dismiss" data-action="dismissAlert" data-stop="1" data-arg="${escAttr(a.key)}" data-arg2="${escAttr(a.title)}" aria-label="Dismiss">&times;</button>` : ''}
     <div class="ctx-alert-top">
       <div class="ctx-alert-icon">${a.icon}</div>
       <div class="ctx-alert-body">
@@ -30019,6 +30085,8 @@ function renderAlertCardHTML(a, scope) {
         <div class="ctx-alert-actions">
           ${a.action ? `<button class="ctx-alert-btn cab-primary" data-action="execAlertAction" data-arg="${safeKey}" data-stop="1">${escHtml(a.action.label)}</button>` : ''}
           ${a.tab ? `<button class="ctx-alert-btn cab-secondary" data-action="switchTab" data-arg="${escAttr(a.tab)}" data-stop="1">View details</button>` : ''}
+          ${mode === 'acknowledge' ? `<button class="ctx-alert-btn cab-ack" data-action="acknowledgeAlert" data-stop="1" data-arg="${escAttr(a.key)}" data-arg2="${escAttr(a.title)}">${zi('check')} Got it</button>` : ''}
+          ${mode === 'snooze' ? `<button class="ctx-alert-btn cab-snooze" data-action="snoozeAlert" data-stop="1" data-arg="${escAttr(a.key)}" data-arg2="${escAttr(a.title)}">${zi('clock')} Snooze 3d</button>` : ''}
         </div>
       </div>
     </div>

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -1146,6 +1146,53 @@ svg.zi { width:16px; height:16px; vertical-align:-2px; flex-shrink:0; }
   vertical-align: middle;
 }
 .ml-6 { margin-left: var(--sp-6); }
+
+/* ─── Vaccination timeline — Gantt reshape (PR-K) ─── */
+.vc-gantt { padding: var(--sp-4) 0; }
+.vc-gantt-rows { display: flex; flex-direction: column; }
+.vc-gantt-row { display: flex; gap: var(--sp-10); }
+.vc-gantt-spine {
+  display: flex; flex-direction: column; align-items: center;
+  width: 18px; flex-shrink: 0;
+}
+.vc-gantt-node {
+  width: 16px; height: 16px; border-radius: var(--r-full); flex-shrink: 0;
+  display: flex; align-items: center; justify-content: center;
+  margin-top: var(--sp-2); border: 2px solid var(--tc-lav);
+}
+.vc-gantt-node-done { background: var(--tc-lav); color: var(--white); }
+.vc-gantt-node-done .zi { width: 9px; height: 9px; }
+.vc-gantt-node-pending { background: var(--card-bg); border-style: dashed; }
+.vc-gantt-spine::after {
+  content: ''; flex: 1; width: 2px;
+  background: rgba(110,94,154,0.2); margin: var(--sp-2) 0;
+}
+.vc-gantt-row:last-child .vc-gantt-spine::after { display: none; }
+.vc-gantt-rowbody { flex: 1; min-width: 0; padding-bottom: var(--sp-16); }
+.vc-gantt-age {
+  font-size: var(--fs-2xs); font-weight: 700; color: var(--tc-lav);
+  text-transform: uppercase; letter-spacing: 0.03em; margin-bottom: var(--sp-6);
+}
+.vc-gantt-chips { display: flex; flex-wrap: wrap; gap: var(--sp-6); }
+.vc-gantt-chip {
+  display: inline-flex; align-items: center; gap: var(--sp-6);
+  padding: var(--sp-4) var(--sp-10); border-radius: var(--r-full);
+  border: 1px solid var(--card-border); background: var(--card-bg);
+  font-size: var(--fs-xs); font-weight: 600; color: var(--text);
+  cursor: pointer; position: relative;
+  transition: transform var(--ease-fast);
+}
+.vc-gantt-chip:active { transform: scale(0.96); }
+.vc-timeline-dot.vc-gantt-chipdot { width: 12px; height: 12px; }
+.vc-gantt-chip-name { white-space: nowrap; }
+.vc-gantt-delay {
+  width: 12px; height: 12px; border-radius: var(--r-full);
+  background: var(--tc-amber); color: #fff; font-size: 7px; font-weight: 700;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+[data-theme="dark"] .vc-gantt-chip { background: var(--surface); border-color: rgba(255,255,255,0.1); }
+[data-theme="dark"] .vc-gantt-spine::after { background: rgba(184,168,224,0.25); }
+
 .vc-timeline-detail {
   position: fixed;
   bottom: 0;
@@ -39903,20 +39950,22 @@ function renderVaccTimeline() {
   var hasAnyPast = vaccData.some(function(v) { return !v.upcoming; });
   if (!hasAnyPast) { el.innerHTML = ''; return; }
 
-  var cols = '';
+  // PR-K Gantt reshape: one row per IAP age group, read top-to-bottom along a
+  // spine. Each vaccine is a named, status-coloured chip (was a bare dot, with
+  // the name hidden in a title attribute). The reaction-status derivation and
+  // the vaccTimelineTap handler are unchanged — only the layout is reshaped.
+  var rows = '';
   ageOrder.forEach(function(age) {
     var names = ageGroups[age];
     if (!names || names.length === 0) return;
-    // Check if any vaccine in this group has data
     var hasSomeData = names.some(function(n) { return vaccByName[n.toLowerCase()]; });
     var hasSomeUpcoming = names.some(function(n) {
       var v = vaccByName[n.toLowerCase()];
       return v && v.upcoming;
     });
-    // Only show columns up to current age + 1 group ahead
     if (!hasSomeData && !hasSomeUpcoming) return;
 
-    var dots = names.map(function(name) {
+    var chips = names.map(function(name) {
       var v = vaccByName[name.toLowerCase()];
       if (!v) return '';
       var dotClass = 'vc-dot-nodata';
@@ -39935,28 +39984,36 @@ function renderVaccTimeline() {
       var delayBadge = '';
       if (!v.upcoming && v.scheduledDate && v.date) {
         var delayDays = Math.floor((new Date(v.date) - new Date(v.scheduledDate)) / 86400000);
-        if (delayDays > 7) delayBadge = '<span class="vc-timeline-delay">D</span>';
+        if (delayDays > 7) delayBadge = '<span class="vc-gantt-delay" title="Given over a week late">D</span>';
       }
       var idx = vaccData.indexOf(v);
-      return '<div class="vc-timeline-dot ' + dotClass + '" data-action="vaccTimelineTap" data-arg="' + idx + '" title="' + escAttr(name) + '">' +
+      return '<button class="vc-gantt-chip" data-action="vaccTimelineTap" data-arg="' + idx + '" title="' + escAttr(name) + '">' +
+        '<span class="vc-timeline-dot ' + dotClass + ' vc-gantt-chipdot"></span>' +
+        '<span class="vc-gantt-chip-name">' + escHtml(name) + '</span>' +
         delayBadge +
-        '</div>';
+        '</button>';
     }).filter(Boolean).join('');
+    if (!chips) return;
 
-    if (dots) {
-      var shortAge = age.replace(' months', 'm').replace(' weeks', 'w').replace(' years', 'y');
-      cols += '<div class="vc-timeline-col">' +
-        '<div class="vc-timeline-label">' + escHtml(shortAge) + '</div>' +
-        '<div class="vc-timeline-dots">' + dots + '</div>' +
-        '</div>';
-    }
+    var allDone = names.every(function(n) {
+      var v = vaccByName[n.toLowerCase()];
+      return v && !v.upcoming;
+    });
+    var nodeClass = allDone ? 'vc-gantt-node-done' : 'vc-gantt-node-pending';
+    rows += '<div class="vc-gantt-row">' +
+      '<div class="vc-gantt-spine"><span class="vc-gantt-node ' + nodeClass + '">' +
+        (allDone ? zi('check') : '') + '</span></div>' +
+      '<div class="vc-gantt-rowbody">' +
+        '<div class="vc-gantt-age">' + escHtml(age) + '</div>' +
+        '<div class="vc-gantt-chips">' + chips + '</div>' +
+      '</div></div>';
   });
 
-  if (!cols) { el.innerHTML = ''; return; }
+  if (!rows) { el.innerHTML = ''; return; }
 
-  el.innerHTML = '<div class="vc-timeline mt-8 mb-8">' +
+  el.innerHTML = '<div class="vc-gantt mt-8 mb-8">' +
     '<div class="fs-2xs fw-600 tc-lav mb-4">VACCINATION TIMELINE</div>' +
-    '<div class="vc-timeline-scroll">' + cols + '</div>' +
+    '<div class="vc-gantt-rows">' + rows + '</div>' +
     '<div class="fs-2xs tc-light mt-4">' +
     '<span class="vc-timeline-dot vc-dot-none vc-legend-dot"></span> No reaction ' +
     '<span class="vc-timeline-dot vc-dot-mild vc-legend-dot ml-6"></span> Mild ' +

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -29059,9 +29059,14 @@ const SEV_LABEL = { action: zi('siren') + ' Action', watch: zi('warn') + ' Watch
 // to 'snooze' regardless of severity: they can be deferred but never
 // permanently dismissed or acknowledged away — Maren V-M-17 doctrine.
 const ALERT_MODE = { action: 'action', watch: 'snooze', positive: 'acknowledge', info: 'dismiss' };
+// Keys that must never resolve to a permanently-clearing mode, independent of
+// the safetyLocked flag (V-M-33 backstop): if a future edit drops safetyLocked
+// from a vaccine / checkup reminder, this still forces it to 'snooze'.
+const SAFETY_LOCKED_KEY = /^(vacc-reminder|dev-checkup)/;
 function getAlertMode(a) {
   const base = ALERT_MODE[a.severity] || 'dismiss';
-  if (a.safetyLocked && base !== 'action') return 'snooze';
+  const locked = a.safetyLocked || SAFETY_LOCKED_KEY.test(a.key || '');
+  if (locked && base !== 'action') return 'snooze';
   return base;
 }
 

--- a/tests/e2e/alert-modes.spec.ts
+++ b/tests/e2e/alert-modes.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+
+// PR-K Phase 2 — the 4-mode alert model.
+// Verifies: mode-derived clear controls render correctly; dismiss / acknowledge
+// / snooze actually persist (the gap PR-J's win-× exposed — positive alerts
+// pushed unconditionally with no filter); safety-locked alerts cannot be
+// permanently silenced.
+
+test('alert cards render the clear control derived from their mode', async ({ page }) => {
+  await page.goto('/index.html?nosync');
+  await page.locator('#homeUnifiedAlertsCard, #homeZenState').first().waitFor({ state: 'attached' });
+  await page.waitForTimeout(800);
+
+  // Win cards (id ca-hmw-...) carry a warm "Got it", never a corner ×.
+  const winCards = page.locator('[id^="ca-hmw-"]');
+  for (let i = 0; i < await winCards.count(); i++) {
+    const card = winCards.nth(i);
+    await expect(card.locator('.cab-ack'), 'win card has a "Got it" control').toHaveCount(1);
+    await expect(card.locator('.ctx-alert-dismiss'), 'win card has no corner ×').toHaveCount(0);
+  }
+});
+
+test('dismiss / acknowledge / snooze persist across recompute', async ({ page }) => {
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(800);
+
+  const result = await page.evaluate(() => {
+    const alerts = computeAlerts();
+    // Pick the first alert that is NOT safety-locked — those resist clearing.
+    const target = alerts.find(a => !a.safetyLocked);
+    if (!target) return { skipped: true };
+    const mode = getAlertMode(target);
+    const before = computeAlerts().some(a => a.key === target.key);
+    if (mode === 'acknowledge') acknowledgeAlert(target.key, target.title);
+    else if (mode === 'snooze') snoozeAlert(target.key, target.title);
+    else dismissAlert(target.key, target.title);
+    const after = computeAlerts().some(a => a.key === target.key);
+    return { skipped: false, mode, before, after };
+  });
+
+  if (result.skipped) test.skip(true, 'seed produced no clearable alert');
+  expect(result.before, 'alert was present before clearing').toBe(true);
+  expect(result.after, `alert is gone after ${result.mode}`).toBe(false);
+});
+
+test('safety-locked alerts cannot be permanently dismissed', async ({ page }) => {
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(800);
+
+  const result = await page.evaluate(() => {
+    // A safety-locked alert always resolves to 'snooze' mode, never 'dismiss'.
+    const locked = { severity: 'info', safetyLocked: true, key: 'x', title: 't' };
+    const plainInfo = { severity: 'info', key: 'y', title: 't' };
+    const lockedAction = { severity: 'action', safetyLocked: true, key: 'z', title: 't' };
+    return {
+      lockedMode: getAlertMode(locked),
+      plainMode: getAlertMode(plainInfo),
+      actionMode: getAlertMode(lockedAction),
+    };
+  });
+
+  expect(result.lockedMode, 'safety-locked info → snooze, never dismiss').toBe('snooze');
+  expect(result.plainMode, 'plain info → dismiss').toBe('dismiss');
+  expect(result.actionMode, 'action stays action even when locked').toBe('action');
+});

--- a/tests/e2e/home-hotfix.spec.ts
+++ b/tests/e2e/home-hotfix.spec.ts
@@ -29,19 +29,20 @@ test('trend pills render the SVG icon as an element, not literal text', async ({
   }
 });
 
-test('positive/win alerts in What\'s Happening carry a dismiss control', async ({ page }) => {
+test('positive/win alerts in What\'s Happening carry a clear control', async ({ page }) => {
   await page.goto('/index.html?nosync');
   await page.locator('#homeUnifiedAlertsCard, #homeZenState').first().waitFor({ state: 'attached' });
   await page.waitForTimeout(800);
 
   // Win cards render with the 'hmw-' scope prefix → id="ca-hmw-...".
+  // PR-K replaced the cold corner × with the warm "Got it" (acknowledge)
+  // control — either counts as a clear affordance, so the win is not stuck.
   const winCards = page.locator('[id^="ca-hmw-"]');
   const n = await winCards.count();
-  // Seed data may or may not surface wins; only assert when present.
   for (let i = 0; i < n; i++) {
     await expect(
-      winCards.nth(i).locator('.ctx-alert-dismiss'),
-      'each win alert has a dismiss control',
+      winCards.nth(i).locator('.ctx-alert-dismiss, .cab-ack'),
+      'each win alert has a clear control',
     ).toHaveCount(1);
   }
 });

--- a/tests/e2e/today-hero.spec.ts
+++ b/tests/e2e/today-hero.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+
+// PR-K Phase 3 — the "Today for Ziva" hero card, the Home tab's lede.
+
+test('Today for Ziva card renders as the Home lede', async ({ page }) => {
+  await page.goto('/index.html?nosync');
+  const card = page.locator('#todayHeroCard');
+  await card.waitFor({ state: 'visible' });
+
+  // Headline, age and date are all populated (no placeholder dashes).
+  await expect(page.locator('.th-title')).toHaveText('Today for Ziva');
+  await expect(page.locator('#thAge')).not.toHaveText('—');
+  await expect(page.locator('#thAge')).toContainText('old');
+  await expect(page.locator('#thDate')).not.toHaveText('—');
+
+  // Exactly one focus row — a priority alert OR the calm all-clear.
+  await expect(page.locator('#thFocus .th-focus-row')).toHaveCount(1);
+  await expect(page.locator('#thFocus .th-focus-label')).toBeVisible();
+
+  // The card sits above the score/vitals card in document order.
+  const heroBox = await card.boundingBox();
+  const vitalsBox = await page.locator('#homeVitalsCard').boundingBox();
+  expect(heroBox!.y).toBeLessThan(vitalsBox!.y);
+});
+
+test('focus row links through to its tab when an alert drives it', async ({ page }) => {
+  await page.goto('/index.html?nosync');
+  await page.locator('#todayHeroCard').waitFor({ state: 'visible' });
+
+  const viewBtn = page.locator('#thFocus .th-focus-btn');
+  if (await viewBtn.count() === 0) test.skip(true, 'all-clear state — no focus alert');
+
+  const targetTab = await page.locator('#thFocus .th-focus-row[class*="thf-"]').first().getAttribute('class');
+  expect(targetTab).toMatch(/thf-(action|watch)/);
+});

--- a/tests/e2e/vacc-gantt.spec.ts
+++ b/tests/e2e/vacc-gantt.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+// PR-K Phase 4 — vaccination timeline reshaped into a vertical Gantt:
+// one row per IAP age group, each vaccine a named status-coloured chip.
+
+test('vaccination timeline renders as a row-per-age-group Gantt', async ({ page }) => {
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(1000);
+
+  const data = await page.evaluate(() => {
+    (window as any).switchTab('medical');
+    const tl = document.getElementById('vaccTimeline');
+    const rows = tl ? tl.querySelectorAll('.vc-gantt-row') : [];
+    const chips = tl ? tl.querySelectorAll('.vc-gantt-chip') : [];
+    // Every chip carries a named label and a status-coloured dot.
+    let allChipsNamed = true;
+    let allChipsHaveStatus = true;
+    chips.forEach((c) => {
+      if (!c.querySelector('.vc-gantt-chip-name')?.textContent?.trim()) allChipsNamed = false;
+      const dot = c.querySelector('.vc-timeline-dot.vc-gantt-chipdot');
+      const known = ['vc-dot-none', 'vc-dot-mild', 'vc-dot-moderate', 'vc-dot-severe', 'vc-dot-upcoming', 'vc-dot-nodata'];
+      if (!dot || !known.some((k) => dot.classList.contains(k))) allChipsHaveStatus = false;
+    });
+    // The tap handler must survive the reshape.
+    const firstChip = chips[0] as HTMLElement | undefined;
+    return {
+      rowCount: rows.length,
+      chipCount: chips.length,
+      allChipsNamed,
+      allChipsHaveStatus,
+      tapWired: !!firstChip && firstChip.getAttribute('data-action') === 'vaccTimelineTap',
+    };
+  });
+
+  expect(data.rowCount, 'at least one age-group row').toBeGreaterThan(0);
+  expect(data.chipCount, 'at least one vaccine chip').toBeGreaterThan(0);
+  expect(data.allChipsNamed, 'every chip shows the vaccine name').toBe(true);
+  expect(data.allChipsHaveStatus, 'every chip carries a reaction-status colour').toBe(true);
+  expect(data.tapWired, 'chips keep the vaccTimelineTap handler').toBe(true);
+});


### PR DESCRIPTION
## Summary

PR-K is the design half of the Home-tab roundtable split (PR-J shipped the hotfix). It gives the Home tab the lede it lacked, rebuilds the alert interaction model, reshapes the vaccination timeline, and closes the `getTrend()` data-shape footgun. Four phases, each committed and e2e-tested separately.

### Phase 1 — `getTrend()` return-shape restructure (V-K-14)
`getTrend()` returned its icon+label markup in a field named `.text` — an illegal-state shape that shipped the PR-EF trend-pill regression. The return is now `.label` (plain text, `textContent`-safe), `.html` (icon+label markup, `innerHTML`-only), `.arrow`/`.cls`/`.delta`/`.direction` unchanged. All 10 consumers updated. `audit-icon-text.sh` widened from `(field): zi(` to `(field): (zi|iconText)(` so the shape is caught at build time.

### Phase 2 — 4-mode alert model + safety lock
The binary `dismissable` flag is replaced by an interaction mode derived from severity:
- **action** — CTA only, no clear control
- **snooze** — watch alerts; defers 3 days then self-restores
- **acknowledge** — wins; a warm "Got it" clears them
- **dismiss** — info; the corner × clears them

**Fixes a latent bug**: positive alerts pushed into `computeAlerts()` unconditionally with nothing filtering cleared ones — so PR-J's win-× set `state.dismissed` but the win re-rendered anyway (V-M-32). Clear-state is restructured into three buckets (`dismissed`/`acknowledged`/`snoozed`), each storing an **expiry timestamp**, so the auto-clear GC is a pure time check and a still-true cleared alert stays cleared for its full TTL.

**Safety lock**: `vacc-reminder` and `dev-checkup-due` carry `safetyLocked`, which forces `snooze` mode — deferrable but never permanently dismissed or acknowledged away (Maren V-M-17). Action-tier alerts stay non-clearable.

### Phase 3 — "Today for Ziva" hero card
The Home tab opened on a score ring and a stat-pill grid — data, no lede. Adds the "Today for Ziva" card as the first surface: a Fraunces headline, Ziva's age and the date, then a single focus row — the highest-priority action/watch alert with a one-tap View, or a calm all-clear. The focus row reuses `computeAlerts()` so it always agrees with "What's Happening".

### Phase 4 — vaccination timeline Gantt reshape
The vaccination timeline was a horizontal-scroll grid of bare coloured dots (vaccine name hidden in a `title` attr). Reshaped into a vertical Gantt: one row per IAP age group along a connecting spine, each vaccine a named status-coloured chip. The reaction-status derivation, delay badge, and `vaccTimelineTap` handler are unchanged — only the layout; the chip status dot reuses the existing `vc-dot-*` colour classes so a severity can never be mis-coloured.

## Test plan
- [x] Four ship-gates pass (audit-emoji, audit-icon-text, audit-resolve-shield, audit-viz-smoke)
- [x] New e2e: `alert-modes.spec.ts` (3), `today-hero.spec.ts` (2), `vacc-gantt.spec.ts` (1); `home-hotfix.spec.ts` updated for the warm "Got it" control
- [x] Full suite: 102 passed
- [ ] **5 pre-existing smoke failures** — `Service Worker precache`, `Polish-2/6/10a/10c` — all reference `/split/intelligence.js`, deleted by the PR-G split. Stale tests, not PR-K regressions; flagged for a separate test-hygiene pass.

## Notes for review
- `dismissable` flags on alert objects are now inert (mode derives from severity) — left in place rather than touching ~40 alert defs; can be swept later.
- Old `.vc-timeline-col/-scroll/-label/-dots` CSS is now dead (the Gantt replaced the column grid); `.vc-timeline-dot` + `.vc-dot-*` are still live (legend + chip status dots).

https://claude.ai/code/session_01Dv3JNVewvj1PUg8i8PzRkB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dv3JNVewvj1PUg8i8PzRkB)_