### PR TITLE
Home feedback fixes — dark-mode hero, alert re-routing

### DIFF
--- a/index.html
+++ b/index.html
@@ -2302,7 +2302,9 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
 .th-focus-row {
   display:flex; align-items:center; gap:var(--sp-10);
   padding:var(--sp-10) var(--sp-12); border-radius:var(--r-lg);
-  background:var(--white); border-left:3px solid var(--sage);
+  /* translucent so the row settles into the warm card rather than reading
+     as a stark white block floating on top of it */
+  background:rgba(255,255,255,0.62); border-left:3px solid var(--sage);
 }
 .th-focus-row.thf-action { border-left-color:var(--rose); }
 .th-focus-row.thf-watch  { border-left-color:var(--amber); }
@@ -2321,14 +2323,19 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
 .th-focus-btn {
   flex-shrink:0; font-size:var(--fs-sm); font-weight:600;
   padding:var(--sp-6) var(--sp-12); border-radius:var(--r-full);
-  border:none; background:var(--text); color:var(--white); cursor:pointer;
+  /* soft card-toned pill — calmer than a hard dark button, themes correctly */
+  border:1px solid var(--card-border); background:var(--card-bg); color:var(--text);
+  cursor:pointer;
 }
 .th-focus-btn:active { transform:scale(0.95); }
 [data-theme="dark"] .today-hero {
   background:linear-gradient(135deg, rgba(250,212,180,0.10), rgba(255,255,255,0.03));
   border-color:rgba(250,212,180,0.2);
 }
-[data-theme="dark"] .th-focus-row { background:var(--mid); }
+/* dark: a subtle elevated surface — NOT var(--mid), which is a light mauve
+   in dark mode and rendered the row as a glaring pale block (feedback fix) */
+[data-theme="dark"] .th-focus-row { background:rgba(255,255,255,0.05); }
+[data-theme="dark"] .th-focus-btn { background:rgba(255,255,255,0.08); border-color:rgba(255,255,255,0.12); }
 [data-theme="dark"] .th-focus-icon { background:rgba(250,212,180,0.14); }
 
 .home-stat-pill {
@@ -19975,6 +19982,17 @@ function switchTab(name) {
   window.scrollTo({ top: 0 });
 }
 
+// Switch to a tab, then smooth-scroll a specific card into view. For
+// dynamically rendered links (e.g. alert action buttons) where the static
+// [data-tab-scroll] binding wired up at init does not apply.
+function gotoCard(tab, cardId) {
+  switchTab(tab);
+  setTimeout(() => {
+    const c = document.getElementById(cardId);
+    if (c) c.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, 140);
+}
+
 function switchTrackSub(sub) {
   if (!TRACK_SUB_ORDER.includes(sub)) sub = 'diet';
   _activeTrackSub = sub;
@@ -29734,8 +29752,8 @@ function computeAlerts() {
             title: m.name + ' streak broken after ' + priorStreak + ' days',
             body: 'Yesterday\'s dose was missed or skipped, breaking a ' + priorStreak + '-day streak.',
             tip: getEscalatedTip('supp-streak-broken'),
-            action: { label: 'View Medical', fn: 'switchTab("medical")' },
-            tab: 'medical', dismissable: true
+            action: { label: 'View 30-day history', fn: 'gotoCard("info","infoSupplementCard")' },
+            tab: 'info', dismissable: true
           });
         }
       }
@@ -29864,7 +29882,7 @@ function computeAlerts() {
       title: capitalize(r.food) + ' linked to ' + (conTypes || 'abnormal') + ' stool (' + pct + '%)',
       body: capitalize(r.food) + ' has been followed by unusual poop ' + r.abnormalAfter + ' out of ' + r.totalOccurrences + ' times (' + r.confidence + ' confidence).',
       tip: getEscalatedTip('food-correlation'),
-      action: { label: 'View Evidence', fn: 'switchTab("insights")' },
+      action: { label: 'View Evidence', fn: 'gotoCard("insights","insightsCorrelationCard")' },
       tab: 'insights', dismissable: true
     });
   });

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.21-8",
+  "version": "2026.05.21-9",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -3063,6 +3063,17 @@ function switchTab(name) {
   window.scrollTo({ top: 0 });
 }
 
+// Switch to a tab, then smooth-scroll a specific card into view. For
+// dynamically rendered links (e.g. alert action buttons) where the static
+// [data-tab-scroll] binding wired up at init does not apply.
+function gotoCard(tab, cardId) {
+  switchTab(tab);
+  setTimeout(() => {
+    const c = document.getElementById(cardId);
+    if (c) c.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, 140);
+}
+
 function switchTrackSub(sub) {
   if (!TRACK_SUB_ORDER.includes(sub)) sub = 'diet';
   _activeTrackSub = sub;

--- a/split/home.js
+++ b/split/home.js
@@ -7394,8 +7394,8 @@ function computeAlerts() {
             title: m.name + ' streak broken after ' + priorStreak + ' days',
             body: 'Yesterday\'s dose was missed or skipped, breaking a ' + priorStreak + '-day streak.',
             tip: getEscalatedTip('supp-streak-broken'),
-            action: { label: 'View Medical', fn: 'switchTab("medical")' },
-            tab: 'medical', dismissable: true
+            action: { label: 'View 30-day history', fn: 'gotoCard("info","infoSupplementCard")' },
+            tab: 'info', dismissable: true
           });
         }
       }
@@ -7524,7 +7524,7 @@ function computeAlerts() {
       title: capitalize(r.food) + ' linked to ' + (conTypes || 'abnormal') + ' stool (' + pct + '%)',
       body: capitalize(r.food) + ' has been followed by unusual poop ' + r.abnormalAfter + ' out of ' + r.totalOccurrences + ' times (' + r.confidence + ' confidence).',
       tip: getEscalatedTip('food-correlation'),
-      action: { label: 'View Evidence', fn: 'switchTab("insights")' },
+      action: { label: 'View Evidence', fn: 'gotoCard("insights","insightsCorrelationCard")' },
       tab: 'insights', dismissable: true
     });
   });

--- a/split/styles.css
+++ b/split/styles.css
@@ -2295,7 +2295,9 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
 .th-focus-row {
   display:flex; align-items:center; gap:var(--sp-10);
   padding:var(--sp-10) var(--sp-12); border-radius:var(--r-lg);
-  background:var(--white); border-left:3px solid var(--sage);
+  /* translucent so the row settles into the warm card rather than reading
+     as a stark white block floating on top of it */
+  background:rgba(255,255,255,0.62); border-left:3px solid var(--sage);
 }
 .th-focus-row.thf-action { border-left-color:var(--rose); }
 .th-focus-row.thf-watch  { border-left-color:var(--amber); }
@@ -2314,14 +2316,19 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
 .th-focus-btn {
   flex-shrink:0; font-size:var(--fs-sm); font-weight:600;
   padding:var(--sp-6) var(--sp-12); border-radius:var(--r-full);
-  border:none; background:var(--text); color:var(--white); cursor:pointer;
+  /* soft card-toned pill — calmer than a hard dark button, themes correctly */
+  border:1px solid var(--card-border); background:var(--card-bg); color:var(--text);
+  cursor:pointer;
 }
 .th-focus-btn:active { transform:scale(0.95); }
 [data-theme="dark"] .today-hero {
   background:linear-gradient(135deg, rgba(250,212,180,0.10), rgba(255,255,255,0.03));
   border-color:rgba(250,212,180,0.2);
 }
-[data-theme="dark"] .th-focus-row { background:var(--mid); }
+/* dark: a subtle elevated surface — NOT var(--mid), which is a light mauve
+   in dark mode and rendered the row as a glaring pale block (feedback fix) */
+[data-theme="dark"] .th-focus-row { background:rgba(255,255,255,0.05); }
+[data-theme="dark"] .th-focus-btn { background:rgba(255,255,255,0.08); border-color:rgba(255,255,255,0.12); }
 [data-theme="dark"] .th-focus-icon { background:rgba(250,212,180,0.14); }
 
 .home-stat-pill {

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -2302,7 +2302,9 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
 .th-focus-row {
   display:flex; align-items:center; gap:var(--sp-10);
   padding:var(--sp-10) var(--sp-12); border-radius:var(--r-lg);
-  background:var(--white); border-left:3px solid var(--sage);
+  /* translucent so the row settles into the warm card rather than reading
+     as a stark white block floating on top of it */
+  background:rgba(255,255,255,0.62); border-left:3px solid var(--sage);
 }
 .th-focus-row.thf-action { border-left-color:var(--rose); }
 .th-focus-row.thf-watch  { border-left-color:var(--amber); }
@@ -2321,14 +2323,19 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
 .th-focus-btn {
   flex-shrink:0; font-size:var(--fs-sm); font-weight:600;
   padding:var(--sp-6) var(--sp-12); border-radius:var(--r-full);
-  border:none; background:var(--text); color:var(--white); cursor:pointer;
+  /* soft card-toned pill — calmer than a hard dark button, themes correctly */
+  border:1px solid var(--card-border); background:var(--card-bg); color:var(--text);
+  cursor:pointer;
 }
 .th-focus-btn:active { transform:scale(0.95); }
 [data-theme="dark"] .today-hero {
   background:linear-gradient(135deg, rgba(250,212,180,0.10), rgba(255,255,255,0.03));
   border-color:rgba(250,212,180,0.2);
 }
-[data-theme="dark"] .th-focus-row { background:var(--mid); }
+/* dark: a subtle elevated surface — NOT var(--mid), which is a light mauve
+   in dark mode and rendered the row as a glaring pale block (feedback fix) */
+[data-theme="dark"] .th-focus-row { background:rgba(255,255,255,0.05); }
+[data-theme="dark"] .th-focus-btn { background:rgba(255,255,255,0.08); border-color:rgba(255,255,255,0.12); }
 [data-theme="dark"] .th-focus-icon { background:rgba(250,212,180,0.14); }
 
 .home-stat-pill {
@@ -19975,6 +19982,17 @@ function switchTab(name) {
   window.scrollTo({ top: 0 });
 }
 
+// Switch to a tab, then smooth-scroll a specific card into view. For
+// dynamically rendered links (e.g. alert action buttons) where the static
+// [data-tab-scroll] binding wired up at init does not apply.
+function gotoCard(tab, cardId) {
+  switchTab(tab);
+  setTimeout(() => {
+    const c = document.getElementById(cardId);
+    if (c) c.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, 140);
+}
+
 function switchTrackSub(sub) {
   if (!TRACK_SUB_ORDER.includes(sub)) sub = 'diet';
   _activeTrackSub = sub;
@@ -29734,8 +29752,8 @@ function computeAlerts() {
             title: m.name + ' streak broken after ' + priorStreak + ' days',
             body: 'Yesterday\'s dose was missed or skipped, breaking a ' + priorStreak + '-day streak.',
             tip: getEscalatedTip('supp-streak-broken'),
-            action: { label: 'View Medical', fn: 'switchTab("medical")' },
-            tab: 'medical', dismissable: true
+            action: { label: 'View 30-day history', fn: 'gotoCard("info","infoSupplementCard")' },
+            tab: 'info', dismissable: true
           });
         }
       }
@@ -29864,7 +29882,7 @@ function computeAlerts() {
       title: capitalize(r.food) + ' linked to ' + (conTypes || 'abnormal') + ' stool (' + pct + '%)',
       body: capitalize(r.food) + ' has been followed by unusual poop ' + r.abnormalAfter + ' out of ' + r.totalOccurrences + ' times (' + r.confidence + ' confidence).',
       tip: getEscalatedTip('food-correlation'),
-      action: { label: 'View Evidence', fn: 'switchTab("insights")' },
+      action: { label: 'View Evidence', fn: 'gotoCard("insights","insightsCorrelationCard")' },
       tab: 'insights', dismissable: true
     });
   });

--- a/tests/e2e/home-feedback.spec.ts
+++ b/tests/e2e/home-feedback.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+// PR-M — Home feedback fixes: dark-mode hero, alert re-routing.
+
+test('gotoCard switches tab and scrolls the target card into view', async ({ page }) => {
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  await page.evaluate(() => gotoCard('info', 'infoSupplementCard'));
+  await page.waitForTimeout(500);
+  await expect(page.locator('#tab-info')).toHaveClass(/active/);
+  await expect(page.locator('#infoSupplementCard')).toBeInViewport({ ratio: 0.1 });
+});
+
+test('D3 + food-correlation alerts route to where their data actually lives', async ({ page }) => {
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const routes = await page.evaluate(() => {
+    const alerts = computeAlerts();
+    const d3 = alerts.find((a) => a.id === 'supp-streak-broken');
+    const corr = alerts.find((a) => a.id === 'food-correlation');
+    return {
+      d3: d3 ? { fn: d3.action && d3.action.fn, tab: d3.tab } : null,
+      corr: corr ? { fn: corr.action && corr.action.fn, tab: corr.tab } : null,
+    };
+  });
+
+  // The D3 streak alert's 30-day data lives in the Info-tab supplement card,
+  // not the Medical tab — the old "View Medical" route was a stub.
+  if (routes.d3) {
+    expect(routes.d3.fn).toBe('gotoCard("info","infoSupplementCard")');
+    expect(routes.d3.tab).toBe('info');
+  }
+  // The food-correlation evidence trail lives in the Insights correlation card.
+  if (routes.corr) {
+    expect(routes.corr.fn).toBe('gotoCard("insights","insightsCorrelationCard")');
+  }
+});
+
+test('the today-hero focus row is not a glaring light block in dark mode', async ({ page }) => {
+  await page.goto('/index.html?nosync');
+  await page.locator('#todayHeroCard').waitFor({ state: 'visible' });
+  await page.evaluate(() => document.documentElement.setAttribute('data-theme', 'dark'));
+  await page.waitForTimeout(300);
+
+  const bg = await page.locator('#thFocus .th-focus-row').evaluate(
+    (el) => getComputedStyle(el).backgroundColor,
+  );
+  // The bug: var(--mid) dark = #b0a0b8 — an OPAQUE light mauve, computed as
+  // rgb(176,160,184) (no alpha). The fix is rgba(255,255,255,0.05): a faint
+  // overlay that composites to a near-dark tone on the dark hero card.
+  const m = bg.match(/rgba?\(([^)]+)\)/);
+  expect(m, 'background is an rgb/rgba colour').toBeTruthy();
+  const parts = m![1].split(',').map((n) => parseFloat(n));
+  const alpha = parts.length === 4 ? parts[3] : 1;
+  expect(alpha, 'focus-row background is a faint overlay, not an opaque light block').toBeLessThan(0.2);
+});


### PR DESCRIPTION
## Summary

The quick-fix half of the PR-K feedback (the food-chemistry + educational-content work follows as its own PR).

### Dark-mode hero bug
The "Today for Ziva" focus row used `background: var(--mid)` — fine in light mode, but `--mid` is a light mauve (`#b0a0b8`) in dark mode, so the row rendered as a glaring pale block on the dark hero card. Now a faint `rgba(255,255,255,0.05)` overlay.

### Hero softening (design brief: warm, sturdy, calm)
- Focus row is translucent rather than stark white, so it settles into the warm card instead of reading as a separate block floating on top.
- The "View" button is a calm card-toned pill instead of a hard near-black button.

| | Before | After |
|--|--------|-------|
| Dark mode | bright mauve block | faint dark overlay |
| Light mode | stark white card-on-card | translucent, integrated |

### Alert re-routing
Two alerts pointed at stub destinations:
- **Vitamin D3 streak** linked "View Medical" → the Medical tab, but the 30-day adherence data lives in the **Info tab's supplement card** (`renderInfoSupplementAdherence` — a 30-day calendar already exists). Now routes there.
- **Food-correlation** ("Turmeric linked to hard stool") switched to the Insights tab but scrolled to nothing; it now lands on the **correlation evidence card** where the actual per-occurrence dates are shown.

New `gotoCard(tab, cardId)` helper switches tab then smooth-scrolls a card into view — for dynamically rendered links where the static `[data-tab-scroll]` binding doesn't apply.

## Test plan
- [x] Four ship-gates pass
- [x] `tests/e2e/home-feedback.spec.ts` — `gotoCard` mechanism, alert route config, dark-mode focus-row is a faint overlay (not the opaque-mauve bug)
- [x] today-hero + alert-mode suites still green
- [x] Verified light + dark hero screenshots — calm in both

## Not in this PR (next PR)
Comprehensive food-chemistry data model + the richer educational tips (why D3 daily, graduated missed-dose guidance, food-compound mechanisms) — being spec'd separately, with the clinical content drafted conservatively and run through the Care-governor audit.

https://claude.ai/code/session_01Dv3JNVewvj1PUg8i8PzRkB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dv3JNVewvj1PUg8i8PzRkB)_