### PR TITLE
Accurate alert interactivity — routing, card expand, breadcrumb back

### DIFF
--- a/index.html
+++ b/index.html
@@ -17588,6 +17588,7 @@ function init() {
     else if (action === 'dismissAlert') dismissAlert(arg, arg2);
     else if (action === 'acknowledgeAlert') acknowledgeAlert(arg, arg2);
     else if (action === 'snoozeAlert') snoozeAlert(arg, arg2);
+    else if (action === 'gotoCard') gotoCard(arg, arg2);
     else if (action === 'toggleAlertTip') toggleAlertTip(arg);
     else if (action === 'execAlertAction') execAlertAction(arg);
     else if (action === 'skipMeals') { try { skipMeals(JSON.parse(arg)); } catch(ex) {} }
@@ -19939,6 +19940,9 @@ function getAlertNavAction(alertKey, alertTitle) {
 }
 
 function switchTab(name) {
+  // A manual tab switch (tab bar, not a gotoCard jump) abandons the
+  // card-navigation breadcrumb — back should not then rewind a stale trail.
+  if (!_gotoCardActive) _cardNavStack = [];
   _islClearAll();
   _clearModifierCache();
   _tsfExpandedId = null;
@@ -19982,15 +19986,44 @@ function switchTab(name) {
   window.scrollTo({ top: 0 });
 }
 
-// Switch to a tab, then smooth-scroll a specific card into view. For
-// dynamically rendered links (e.g. alert action buttons) where the static
+// ── Card navigation with a breadcrumb trail (PR-O) ──
+// gotoCard() switches tab, expands the target card and scrolls it into view —
+// and remembers where it came from so the back gesture returns there (e.g.
+// back to the alert that triggered the jump).
+let _cardNavStack = [];
+let _gotoCardActive = false;
+
+// Expand a collapsed card so the caller lands on its content, not its header.
+function _expandCard(card) {
+  const hdr = card.querySelector('[data-collapse-target]');
+  if (!hdr) return;
+  const body = document.getElementById(hdr.dataset.collapseTarget);
+  if (body && !body.classList.contains('open')) {
+    toggleHistoryCard(hdr.dataset.collapseTarget, hdr.dataset.collapseChevron);
+  }
+}
+
+// Switch to a tab, expand + scroll a specific card into view. For dynamically
+// rendered links (e.g. alert action buttons) where the static
 // [data-tab-scroll] binding wired up at init does not apply.
 function gotoCard(tab, cardId) {
+  // Breadcrumb: remember the current location so popstate can return to it.
+  const activePanel = document.querySelector('.tab-panel.active');
+  const fromTab = activePanel ? activePanel.id.replace('tab-', '') : 'home';
+  _cardNavStack.push({ tab: fromTab, scrollY: window.scrollY });
+  history.pushState({ slCardNav: _cardNavStack.length }, '');
+
+  _gotoCardActive = true;
   switchTab(tab);
+  _gotoCardActive = false;
+
   setTimeout(() => {
     const c = document.getElementById(cardId);
-    if (c) c.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  }, 140);
+    if (c) {
+      _expandCard(c);
+      c.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, 160);
 }
 
 function switchTrackSub(sub) {
@@ -20352,6 +20385,16 @@ window.addEventListener('popstate', e => {
   // Close any open confirm dialog
   const confirm = document.querySelector('.confirm-overlay');
   if (confirm) { confirm.remove(); return; }
+  // Card-navigation breadcrumb (PR-O): back returns to the origin — e.g. the
+  // alert that triggered a gotoCard() jump. Unwinds one trail hop per back.
+  if (_cardNavStack.length) {
+    const ret = _cardNavStack.pop();
+    _gotoCardActive = true;
+    switchTab(ret.tab);
+    _gotoCardActive = false;
+    setTimeout(() => window.scrollTo({ top: ret.scrollY, behavior: 'smooth' }), 60);
+    return;
+  }
 });
 
 function confirmAction(msg, callback, btnText) {
@@ -29091,6 +29134,43 @@ function getAlertMode(a) {
 // Sanitize alert keys to safe alphanumeric + dash only
 function sanitizeAlertKey(s) { return s.replace(/[^a-zA-Z0-9-]/g, '_'); }
 
+// ── Alert → evidence-card routing (PR-O) ──
+// Every alert's "View details" button (and any bare switchTab() primary)
+// should land on the specific card where that alert's data actually lives,
+// not a context-free tab switch. Keyed by alert id; { tab, card } drives
+// gotoCard(). Card ids verified present in template.html.
+const ALERT_CARD = {
+  // ── warnings ──
+  'poop-gap':           { tab: 'poop',     card: 'poopChartCard' },
+  'hard-stool-streak':  { tab: 'poop',     card: 'poopChartCard' },
+  'sleep-score-drop':   { tab: 'sleep',    card: 'sleepChartCard' },
+  'food-reaction':      { tab: 'info',     card: 'infoFoodReactionCard' },
+  'dev-checkup-due':    { tab: 'medical',  card: 'medVaccCard' },
+  'food-variety-stale': { tab: 'info',     card: 'infoFoodIntroCard' },
+  'vacc-reminder':      { tab: 'medical',  card: 'medVaccCard' },
+  'supp-streak-broken': { tab: 'info',     card: 'infoSupplementCard' },
+  'low-iron':           { tab: 'info',     card: 'infoNutrientHeatmapCard' },
+  'low-calcium':        { tab: 'info',     card: 'infoNutrientHeatmapCard' },
+  'low-protein':        { tab: 'info',     card: 'infoNutrientHeatmapCard' },
+  'iron-no-vitc':       { tab: 'info',     card: 'infoSmartPairingCard' },
+  'meal-monotony':      { tab: 'info',     card: 'infoRepetitionCard' },
+  'food-correlation':   { tab: 'insights', card: 'insightsCorrelationCard' },
+  'food-group-gap':     { tab: 'info',     card: 'infoNutrientHeatmapCard' },
+  'dinner-bed-gap':     { tab: 'sleep',    card: 'sleepChartCard' },
+  'reaction-window':    { tab: 'info',     card: 'infoFoodIntroCard' },
+  // ── wins ──
+  'first-sleepthrough': { tab: 'sleep',    card: 'sleepChartCard' },
+  'sleep-streak':       { tab: 'sleep',    card: 'sleepChartCard' },
+  'consistent-digestion':{ tab: 'poop',    card: 'poopChartCard' },
+  'food-variety-win':   { tab: 'info',     card: 'infoFoodIntroCard' },
+  'meal-logging-streak':{ tab: 'info',     card: 'infoMealBreakdownCard' },
+  'growth-on-track':    { tab: 'growth',   card: 'growthHeroCard' },
+  'supp-streak':        { tab: 'info',     card: 'infoSupplementCard' },
+  'iron-rich-week':     { tab: 'info',     card: 'infoNutrientHeatmapCard' },
+  'nutrient-balance':   { tab: 'info',     card: 'infoNutrientHeatmapCard' },
+  'iron-vitc-synergy':  { tab: 'info',     card: 'infoSmartPairingCard' },
+};
+
 // ══════════════════════════════════════════════════════════
 // ██ PERSONALIZED BASELINES ENGINE
 // ══════════════════════════════════════════════════════════
@@ -30215,8 +30295,16 @@ function renderAlertCardHTML(a, scope) {
   const sevClass = SEV_CLASS[a.severity] || 'ca-info';
   const sevBadge = SEV_BADGE[a.severity] || 'sev-info';
   const sevLabel = SEV_LABEL[a.severity] || zi('check') + ' Info';
-  // Register action fn safely
-  if (a.action && a.action.fn) _alertActionRegistry[safeKey] = a.action.fn;
+  // Evidence-card route (PR-O): where this alert's data actually lives.
+  const route = ALERT_CARD[a.id];
+  // Register action fn safely. A bare switchTab() primary is upgraded to
+  // land on the evidence card; genuinely actionable primaries (openQuickModal,
+  // gotoCard) are left intact.
+  if (a.action && a.action.fn) {
+    let fn = a.action.fn;
+    if (route && /^switchTab\(/.test(fn)) fn = `gotoCard("${route.tab}","${route.card}")`;
+    _alertActionRegistry[safeKey] = fn;
+  }
   // Interaction mode (PR-K): drives which clear control the card carries.
   const mode = getAlertMode(a);
   return `<div class="ctx-alert ${sevClass}" id="ca-${safeKey}">
@@ -30230,7 +30318,9 @@ function renderAlertCardHTML(a, scope) {
         <div class="ctx-alert-tip" id="ca-tip-${safeKey}">${escHtml(a.tip)}</div>` : ''}
         <div class="ctx-alert-actions">
           ${a.action ? `<button class="ctx-alert-btn cab-primary" data-action="execAlertAction" data-arg="${safeKey}" data-stop="1">${escHtml(a.action.label)}</button>` : ''}
-          ${a.tab ? `<button class="ctx-alert-btn cab-secondary" data-action="switchTab" data-arg="${escAttr(a.tab)}" data-stop="1">View details</button>` : ''}
+          ${a.tab ? (route
+            ? `<button class="ctx-alert-btn cab-secondary" data-action="gotoCard" data-arg="${escAttr(route.tab)}" data-arg2="${escAttr(route.card)}" data-stop="1">View details</button>`
+            : `<button class="ctx-alert-btn cab-secondary" data-action="switchTab" data-arg="${escAttr(a.tab)}" data-stop="1">View details</button>`) : ''}
           ${mode === 'acknowledge' ? `<button class="ctx-alert-btn cab-ack" data-action="acknowledgeAlert" data-stop="1" data-arg="${escAttr(a.key)}" data-arg2="${escAttr(a.title)}">${zi('check')} Got it</button>` : ''}
           ${mode === 'snooze' ? `<button class="ctx-alert-btn cab-snooze" data-action="snoozeAlert" data-stop="1" data-arg="${escAttr(a.key)}" data-arg2="${escAttr(a.title)}">${zi('clock')} Snooze 3d</button>` : ''}
         </div>
@@ -30316,7 +30406,7 @@ function renderHomeContextAlerts() {
   // Warning alerts
   contextHTML += homeWarnings.map(a => renderAlertCardHTML(a, 'hm-')).join('');
   if (remainingWarnings > 0) {
-    contextHTML += `<div class="ca-view-all" data-tab-scroll="insights" data-scroll-to="insightsAlertsCard" data-scroll-block="center">+ ${remainingWarnings} more alert${remainingWarnings !== 1 ? 's' : ''} in Insights <span class="ca-badge">${remainingWarnings}</span> →</div>`;
+    contextHTML += `<div class="ca-view-all" data-action="gotoCard" data-arg="insights" data-arg2="insightsAlertsCard" data-stop="1">+ ${remainingWarnings} more alert${remainingWarnings !== 1 ? 's' : ''} in Insights <span class="ca-badge">${remainingWarnings}</span> →</div>`;
   }
 
   // Combine: reminders first (urgent), then context alerts, then wins
@@ -30336,7 +30426,7 @@ function renderHomeContextAlerts() {
   // Wins
   combined += homePositives.map(a => renderAlertCardHTML(a, 'hmw-')).join('');
   if (remainingPositives > 0) {
-    combined += `<div class="ca-view-all" data-tab-scroll="insights" data-scroll-to="insightsWinsCard" data-scroll-block="center">+ ${remainingPositives} more win${remainingPositives !== 1 ? 's' : ''} in Insights →</div>`;
+    combined += `<div class="ca-view-all" data-action="gotoCard" data-arg="insights" data-arg2="insightsWinsCard" data-stop="1">+ ${remainingPositives} more win${remainingPositives !== 1 ? 's' : ''} in Insights →</div>`;
   }
 
   const hasAnything = combined.trim().length > 0;

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.21-10",
+  "version": "2026.05.21-12",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -669,6 +669,7 @@ function init() {
     else if (action === 'dismissAlert') dismissAlert(arg, arg2);
     else if (action === 'acknowledgeAlert') acknowledgeAlert(arg, arg2);
     else if (action === 'snoozeAlert') snoozeAlert(arg, arg2);
+    else if (action === 'gotoCard') gotoCard(arg, arg2);
     else if (action === 'toggleAlertTip') toggleAlertTip(arg);
     else if (action === 'execAlertAction') execAlertAction(arg);
     else if (action === 'skipMeals') { try { skipMeals(JSON.parse(arg)); } catch(ex) {} }
@@ -3020,6 +3021,9 @@ function getAlertNavAction(alertKey, alertTitle) {
 }
 
 function switchTab(name) {
+  // A manual tab switch (tab bar, not a gotoCard jump) abandons the
+  // card-navigation breadcrumb — back should not then rewind a stale trail.
+  if (!_gotoCardActive) _cardNavStack = [];
   _islClearAll();
   _clearModifierCache();
   _tsfExpandedId = null;
@@ -3063,15 +3067,44 @@ function switchTab(name) {
   window.scrollTo({ top: 0 });
 }
 
-// Switch to a tab, then smooth-scroll a specific card into view. For
-// dynamically rendered links (e.g. alert action buttons) where the static
+// ── Card navigation with a breadcrumb trail (PR-O) ──
+// gotoCard() switches tab, expands the target card and scrolls it into view —
+// and remembers where it came from so the back gesture returns there (e.g.
+// back to the alert that triggered the jump).
+let _cardNavStack = [];
+let _gotoCardActive = false;
+
+// Expand a collapsed card so the caller lands on its content, not its header.
+function _expandCard(card) {
+  const hdr = card.querySelector('[data-collapse-target]');
+  if (!hdr) return;
+  const body = document.getElementById(hdr.dataset.collapseTarget);
+  if (body && !body.classList.contains('open')) {
+    toggleHistoryCard(hdr.dataset.collapseTarget, hdr.dataset.collapseChevron);
+  }
+}
+
+// Switch to a tab, expand + scroll a specific card into view. For dynamically
+// rendered links (e.g. alert action buttons) where the static
 // [data-tab-scroll] binding wired up at init does not apply.
 function gotoCard(tab, cardId) {
+  // Breadcrumb: remember the current location so popstate can return to it.
+  const activePanel = document.querySelector('.tab-panel.active');
+  const fromTab = activePanel ? activePanel.id.replace('tab-', '') : 'home';
+  _cardNavStack.push({ tab: fromTab, scrollY: window.scrollY });
+  history.pushState({ slCardNav: _cardNavStack.length }, '');
+
+  _gotoCardActive = true;
   switchTab(tab);
+  _gotoCardActive = false;
+
   setTimeout(() => {
     const c = document.getElementById(cardId);
-    if (c) c.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  }, 140);
+    if (c) {
+      _expandCard(c);
+      c.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, 160);
 }
 
 function switchTrackSub(sub) {
@@ -3433,6 +3466,16 @@ window.addEventListener('popstate', e => {
   // Close any open confirm dialog
   const confirm = document.querySelector('.confirm-overlay');
   if (confirm) { confirm.remove(); return; }
+  // Card-navigation breadcrumb (PR-O): back returns to the origin — e.g. the
+  // alert that triggered a gotoCard() jump. Unwinds one trail hop per back.
+  if (_cardNavStack.length) {
+    const ret = _cardNavStack.pop();
+    _gotoCardActive = true;
+    switchTab(ret.tab);
+    _gotoCardActive = false;
+    setTimeout(() => window.scrollTo({ top: ret.scrollY, behavior: 'smooth' }), 60);
+    return;
+  }
 });
 
 function confirmAction(msg, callback, btnText) {

--- a/split/home.js
+++ b/split/home.js
@@ -6733,6 +6733,43 @@ function getAlertMode(a) {
 // Sanitize alert keys to safe alphanumeric + dash only
 function sanitizeAlertKey(s) { return s.replace(/[^a-zA-Z0-9-]/g, '_'); }
 
+// ── Alert → evidence-card routing (PR-O) ──
+// Every alert's "View details" button (and any bare switchTab() primary)
+// should land on the specific card where that alert's data actually lives,
+// not a context-free tab switch. Keyed by alert id; { tab, card } drives
+// gotoCard(). Card ids verified present in template.html.
+const ALERT_CARD = {
+  // ── warnings ──
+  'poop-gap':           { tab: 'poop',     card: 'poopChartCard' },
+  'hard-stool-streak':  { tab: 'poop',     card: 'poopChartCard' },
+  'sleep-score-drop':   { tab: 'sleep',    card: 'sleepChartCard' },
+  'food-reaction':      { tab: 'info',     card: 'infoFoodReactionCard' },
+  'dev-checkup-due':    { tab: 'medical',  card: 'medVaccCard' },
+  'food-variety-stale': { tab: 'info',     card: 'infoFoodIntroCard' },
+  'vacc-reminder':      { tab: 'medical',  card: 'medVaccCard' },
+  'supp-streak-broken': { tab: 'info',     card: 'infoSupplementCard' },
+  'low-iron':           { tab: 'info',     card: 'infoNutrientHeatmapCard' },
+  'low-calcium':        { tab: 'info',     card: 'infoNutrientHeatmapCard' },
+  'low-protein':        { tab: 'info',     card: 'infoNutrientHeatmapCard' },
+  'iron-no-vitc':       { tab: 'info',     card: 'infoSmartPairingCard' },
+  'meal-monotony':      { tab: 'info',     card: 'infoRepetitionCard' },
+  'food-correlation':   { tab: 'insights', card: 'insightsCorrelationCard' },
+  'food-group-gap':     { tab: 'info',     card: 'infoNutrientHeatmapCard' },
+  'dinner-bed-gap':     { tab: 'sleep',    card: 'sleepChartCard' },
+  'reaction-window':    { tab: 'info',     card: 'infoFoodIntroCard' },
+  // ── wins ──
+  'first-sleepthrough': { tab: 'sleep',    card: 'sleepChartCard' },
+  'sleep-streak':       { tab: 'sleep',    card: 'sleepChartCard' },
+  'consistent-digestion':{ tab: 'poop',    card: 'poopChartCard' },
+  'food-variety-win':   { tab: 'info',     card: 'infoFoodIntroCard' },
+  'meal-logging-streak':{ tab: 'info',     card: 'infoMealBreakdownCard' },
+  'growth-on-track':    { tab: 'growth',   card: 'growthHeroCard' },
+  'supp-streak':        { tab: 'info',     card: 'infoSupplementCard' },
+  'iron-rich-week':     { tab: 'info',     card: 'infoNutrientHeatmapCard' },
+  'nutrient-balance':   { tab: 'info',     card: 'infoNutrientHeatmapCard' },
+  'iron-vitc-synergy':  { tab: 'info',     card: 'infoSmartPairingCard' },
+};
+
 // ══════════════════════════════════════════════════════════
 // ██ PERSONALIZED BASELINES ENGINE
 // ══════════════════════════════════════════════════════════
@@ -7857,8 +7894,16 @@ function renderAlertCardHTML(a, scope) {
   const sevClass = SEV_CLASS[a.severity] || 'ca-info';
   const sevBadge = SEV_BADGE[a.severity] || 'sev-info';
   const sevLabel = SEV_LABEL[a.severity] || zi('check') + ' Info';
-  // Register action fn safely
-  if (a.action && a.action.fn) _alertActionRegistry[safeKey] = a.action.fn;
+  // Evidence-card route (PR-O): where this alert's data actually lives.
+  const route = ALERT_CARD[a.id];
+  // Register action fn safely. A bare switchTab() primary is upgraded to
+  // land on the evidence card; genuinely actionable primaries (openQuickModal,
+  // gotoCard) are left intact.
+  if (a.action && a.action.fn) {
+    let fn = a.action.fn;
+    if (route && /^switchTab\(/.test(fn)) fn = `gotoCard("${route.tab}","${route.card}")`;
+    _alertActionRegistry[safeKey] = fn;
+  }
   // Interaction mode (PR-K): drives which clear control the card carries.
   const mode = getAlertMode(a);
   return `<div class="ctx-alert ${sevClass}" id="ca-${safeKey}">
@@ -7872,7 +7917,9 @@ function renderAlertCardHTML(a, scope) {
         <div class="ctx-alert-tip" id="ca-tip-${safeKey}">${escHtml(a.tip)}</div>` : ''}
         <div class="ctx-alert-actions">
           ${a.action ? `<button class="ctx-alert-btn cab-primary" data-action="execAlertAction" data-arg="${safeKey}" data-stop="1">${escHtml(a.action.label)}</button>` : ''}
-          ${a.tab ? `<button class="ctx-alert-btn cab-secondary" data-action="switchTab" data-arg="${escAttr(a.tab)}" data-stop="1">View details</button>` : ''}
+          ${a.tab ? (route
+            ? `<button class="ctx-alert-btn cab-secondary" data-action="gotoCard" data-arg="${escAttr(route.tab)}" data-arg2="${escAttr(route.card)}" data-stop="1">View details</button>`
+            : `<button class="ctx-alert-btn cab-secondary" data-action="switchTab" data-arg="${escAttr(a.tab)}" data-stop="1">View details</button>`) : ''}
           ${mode === 'acknowledge' ? `<button class="ctx-alert-btn cab-ack" data-action="acknowledgeAlert" data-stop="1" data-arg="${escAttr(a.key)}" data-arg2="${escAttr(a.title)}">${zi('check')} Got it</button>` : ''}
           ${mode === 'snooze' ? `<button class="ctx-alert-btn cab-snooze" data-action="snoozeAlert" data-stop="1" data-arg="${escAttr(a.key)}" data-arg2="${escAttr(a.title)}">${zi('clock')} Snooze 3d</button>` : ''}
         </div>
@@ -7958,7 +8005,7 @@ function renderHomeContextAlerts() {
   // Warning alerts
   contextHTML += homeWarnings.map(a => renderAlertCardHTML(a, 'hm-')).join('');
   if (remainingWarnings > 0) {
-    contextHTML += `<div class="ca-view-all" data-tab-scroll="insights" data-scroll-to="insightsAlertsCard" data-scroll-block="center">+ ${remainingWarnings} more alert${remainingWarnings !== 1 ? 's' : ''} in Insights <span class="ca-badge">${remainingWarnings}</span> →</div>`;
+    contextHTML += `<div class="ca-view-all" data-action="gotoCard" data-arg="insights" data-arg2="insightsAlertsCard" data-stop="1">+ ${remainingWarnings} more alert${remainingWarnings !== 1 ? 's' : ''} in Insights <span class="ca-badge">${remainingWarnings}</span> →</div>`;
   }
 
   // Combine: reminders first (urgent), then context alerts, then wins
@@ -7978,7 +8025,7 @@ function renderHomeContextAlerts() {
   // Wins
   combined += homePositives.map(a => renderAlertCardHTML(a, 'hmw-')).join('');
   if (remainingPositives > 0) {
-    combined += `<div class="ca-view-all" data-tab-scroll="insights" data-scroll-to="insightsWinsCard" data-scroll-block="center">+ ${remainingPositives} more win${remainingPositives !== 1 ? 's' : ''} in Insights →</div>`;
+    combined += `<div class="ca-view-all" data-action="gotoCard" data-arg="insights" data-arg2="insightsWinsCard" data-stop="1">+ ${remainingPositives} more win${remainingPositives !== 1 ? 's' : ''} in Insights →</div>`;
   }
 
   const hasAnything = combined.trim().length > 0;

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -17588,6 +17588,7 @@ function init() {
     else if (action === 'dismissAlert') dismissAlert(arg, arg2);
     else if (action === 'acknowledgeAlert') acknowledgeAlert(arg, arg2);
     else if (action === 'snoozeAlert') snoozeAlert(arg, arg2);
+    else if (action === 'gotoCard') gotoCard(arg, arg2);
     else if (action === 'toggleAlertTip') toggleAlertTip(arg);
     else if (action === 'execAlertAction') execAlertAction(arg);
     else if (action === 'skipMeals') { try { skipMeals(JSON.parse(arg)); } catch(ex) {} }
@@ -19939,6 +19940,9 @@ function getAlertNavAction(alertKey, alertTitle) {
 }
 
 function switchTab(name) {
+  // A manual tab switch (tab bar, not a gotoCard jump) abandons the
+  // card-navigation breadcrumb — back should not then rewind a stale trail.
+  if (!_gotoCardActive) _cardNavStack = [];
   _islClearAll();
   _clearModifierCache();
   _tsfExpandedId = null;
@@ -19982,15 +19986,44 @@ function switchTab(name) {
   window.scrollTo({ top: 0 });
 }
 
-// Switch to a tab, then smooth-scroll a specific card into view. For
-// dynamically rendered links (e.g. alert action buttons) where the static
+// ── Card navigation with a breadcrumb trail (PR-O) ──
+// gotoCard() switches tab, expands the target card and scrolls it into view —
+// and remembers where it came from so the back gesture returns there (e.g.
+// back to the alert that triggered the jump).
+let _cardNavStack = [];
+let _gotoCardActive = false;
+
+// Expand a collapsed card so the caller lands on its content, not its header.
+function _expandCard(card) {
+  const hdr = card.querySelector('[data-collapse-target]');
+  if (!hdr) return;
+  const body = document.getElementById(hdr.dataset.collapseTarget);
+  if (body && !body.classList.contains('open')) {
+    toggleHistoryCard(hdr.dataset.collapseTarget, hdr.dataset.collapseChevron);
+  }
+}
+
+// Switch to a tab, expand + scroll a specific card into view. For dynamically
+// rendered links (e.g. alert action buttons) where the static
 // [data-tab-scroll] binding wired up at init does not apply.
 function gotoCard(tab, cardId) {
+  // Breadcrumb: remember the current location so popstate can return to it.
+  const activePanel = document.querySelector('.tab-panel.active');
+  const fromTab = activePanel ? activePanel.id.replace('tab-', '') : 'home';
+  _cardNavStack.push({ tab: fromTab, scrollY: window.scrollY });
+  history.pushState({ slCardNav: _cardNavStack.length }, '');
+
+  _gotoCardActive = true;
   switchTab(tab);
+  _gotoCardActive = false;
+
   setTimeout(() => {
     const c = document.getElementById(cardId);
-    if (c) c.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  }, 140);
+    if (c) {
+      _expandCard(c);
+      c.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, 160);
 }
 
 function switchTrackSub(sub) {
@@ -20352,6 +20385,16 @@ window.addEventListener('popstate', e => {
   // Close any open confirm dialog
   const confirm = document.querySelector('.confirm-overlay');
   if (confirm) { confirm.remove(); return; }
+  // Card-navigation breadcrumb (PR-O): back returns to the origin — e.g. the
+  // alert that triggered a gotoCard() jump. Unwinds one trail hop per back.
+  if (_cardNavStack.length) {
+    const ret = _cardNavStack.pop();
+    _gotoCardActive = true;
+    switchTab(ret.tab);
+    _gotoCardActive = false;
+    setTimeout(() => window.scrollTo({ top: ret.scrollY, behavior: 'smooth' }), 60);
+    return;
+  }
 });
 
 function confirmAction(msg, callback, btnText) {
@@ -29091,6 +29134,43 @@ function getAlertMode(a) {
 // Sanitize alert keys to safe alphanumeric + dash only
 function sanitizeAlertKey(s) { return s.replace(/[^a-zA-Z0-9-]/g, '_'); }
 
+// ── Alert → evidence-card routing (PR-O) ──
+// Every alert's "View details" button (and any bare switchTab() primary)
+// should land on the specific card where that alert's data actually lives,
+// not a context-free tab switch. Keyed by alert id; { tab, card } drives
+// gotoCard(). Card ids verified present in template.html.
+const ALERT_CARD = {
+  // ── warnings ──
+  'poop-gap':           { tab: 'poop',     card: 'poopChartCard' },
+  'hard-stool-streak':  { tab: 'poop',     card: 'poopChartCard' },
+  'sleep-score-drop':   { tab: 'sleep',    card: 'sleepChartCard' },
+  'food-reaction':      { tab: 'info',     card: 'infoFoodReactionCard' },
+  'dev-checkup-due':    { tab: 'medical',  card: 'medVaccCard' },
+  'food-variety-stale': { tab: 'info',     card: 'infoFoodIntroCard' },
+  'vacc-reminder':      { tab: 'medical',  card: 'medVaccCard' },
+  'supp-streak-broken': { tab: 'info',     card: 'infoSupplementCard' },
+  'low-iron':           { tab: 'info',     card: 'infoNutrientHeatmapCard' },
+  'low-calcium':        { tab: 'info',     card: 'infoNutrientHeatmapCard' },
+  'low-protein':        { tab: 'info',     card: 'infoNutrientHeatmapCard' },
+  'iron-no-vitc':       { tab: 'info',     card: 'infoSmartPairingCard' },
+  'meal-monotony':      { tab: 'info',     card: 'infoRepetitionCard' },
+  'food-correlation':   { tab: 'insights', card: 'insightsCorrelationCard' },
+  'food-group-gap':     { tab: 'info',     card: 'infoNutrientHeatmapCard' },
+  'dinner-bed-gap':     { tab: 'sleep',    card: 'sleepChartCard' },
+  'reaction-window':    { tab: 'info',     card: 'infoFoodIntroCard' },
+  // ── wins ──
+  'first-sleepthrough': { tab: 'sleep',    card: 'sleepChartCard' },
+  'sleep-streak':       { tab: 'sleep',    card: 'sleepChartCard' },
+  'consistent-digestion':{ tab: 'poop',    card: 'poopChartCard' },
+  'food-variety-win':   { tab: 'info',     card: 'infoFoodIntroCard' },
+  'meal-logging-streak':{ tab: 'info',     card: 'infoMealBreakdownCard' },
+  'growth-on-track':    { tab: 'growth',   card: 'growthHeroCard' },
+  'supp-streak':        { tab: 'info',     card: 'infoSupplementCard' },
+  'iron-rich-week':     { tab: 'info',     card: 'infoNutrientHeatmapCard' },
+  'nutrient-balance':   { tab: 'info',     card: 'infoNutrientHeatmapCard' },
+  'iron-vitc-synergy':  { tab: 'info',     card: 'infoSmartPairingCard' },
+};
+
 // ══════════════════════════════════════════════════════════
 // ██ PERSONALIZED BASELINES ENGINE
 // ══════════════════════════════════════════════════════════
@@ -30215,8 +30295,16 @@ function renderAlertCardHTML(a, scope) {
   const sevClass = SEV_CLASS[a.severity] || 'ca-info';
   const sevBadge = SEV_BADGE[a.severity] || 'sev-info';
   const sevLabel = SEV_LABEL[a.severity] || zi('check') + ' Info';
-  // Register action fn safely
-  if (a.action && a.action.fn) _alertActionRegistry[safeKey] = a.action.fn;
+  // Evidence-card route (PR-O): where this alert's data actually lives.
+  const route = ALERT_CARD[a.id];
+  // Register action fn safely. A bare switchTab() primary is upgraded to
+  // land on the evidence card; genuinely actionable primaries (openQuickModal,
+  // gotoCard) are left intact.
+  if (a.action && a.action.fn) {
+    let fn = a.action.fn;
+    if (route && /^switchTab\(/.test(fn)) fn = `gotoCard("${route.tab}","${route.card}")`;
+    _alertActionRegistry[safeKey] = fn;
+  }
   // Interaction mode (PR-K): drives which clear control the card carries.
   const mode = getAlertMode(a);
   return `<div class="ctx-alert ${sevClass}" id="ca-${safeKey}">
@@ -30230,7 +30318,9 @@ function renderAlertCardHTML(a, scope) {
         <div class="ctx-alert-tip" id="ca-tip-${safeKey}">${escHtml(a.tip)}</div>` : ''}
         <div class="ctx-alert-actions">
           ${a.action ? `<button class="ctx-alert-btn cab-primary" data-action="execAlertAction" data-arg="${safeKey}" data-stop="1">${escHtml(a.action.label)}</button>` : ''}
-          ${a.tab ? `<button class="ctx-alert-btn cab-secondary" data-action="switchTab" data-arg="${escAttr(a.tab)}" data-stop="1">View details</button>` : ''}
+          ${a.tab ? (route
+            ? `<button class="ctx-alert-btn cab-secondary" data-action="gotoCard" data-arg="${escAttr(route.tab)}" data-arg2="${escAttr(route.card)}" data-stop="1">View details</button>`
+            : `<button class="ctx-alert-btn cab-secondary" data-action="switchTab" data-arg="${escAttr(a.tab)}" data-stop="1">View details</button>`) : ''}
           ${mode === 'acknowledge' ? `<button class="ctx-alert-btn cab-ack" data-action="acknowledgeAlert" data-stop="1" data-arg="${escAttr(a.key)}" data-arg2="${escAttr(a.title)}">${zi('check')} Got it</button>` : ''}
           ${mode === 'snooze' ? `<button class="ctx-alert-btn cab-snooze" data-action="snoozeAlert" data-stop="1" data-arg="${escAttr(a.key)}" data-arg2="${escAttr(a.title)}">${zi('clock')} Snooze 3d</button>` : ''}
         </div>
@@ -30316,7 +30406,7 @@ function renderHomeContextAlerts() {
   // Warning alerts
   contextHTML += homeWarnings.map(a => renderAlertCardHTML(a, 'hm-')).join('');
   if (remainingWarnings > 0) {
-    contextHTML += `<div class="ca-view-all" data-tab-scroll="insights" data-scroll-to="insightsAlertsCard" data-scroll-block="center">+ ${remainingWarnings} more alert${remainingWarnings !== 1 ? 's' : ''} in Insights <span class="ca-badge">${remainingWarnings}</span> →</div>`;
+    contextHTML += `<div class="ca-view-all" data-action="gotoCard" data-arg="insights" data-arg2="insightsAlertsCard" data-stop="1">+ ${remainingWarnings} more alert${remainingWarnings !== 1 ? 's' : ''} in Insights <span class="ca-badge">${remainingWarnings}</span> →</div>`;
   }
 
   // Combine: reminders first (urgent), then context alerts, then wins
@@ -30336,7 +30426,7 @@ function renderHomeContextAlerts() {
   // Wins
   combined += homePositives.map(a => renderAlertCardHTML(a, 'hmw-')).join('');
   if (remainingPositives > 0) {
-    combined += `<div class="ca-view-all" data-tab-scroll="insights" data-scroll-to="insightsWinsCard" data-scroll-block="center">+ ${remainingPositives} more win${remainingPositives !== 1 ? 's' : ''} in Insights →</div>`;
+    combined += `<div class="ca-view-all" data-action="gotoCard" data-arg="insights" data-arg2="insightsWinsCard" data-stop="1">+ ${remainingPositives} more win${remainingPositives !== 1 ? 's' : ''} in Insights →</div>`;
   }
 
   const hasAnything = combined.trim().length > 0;

--- a/tests/e2e/alert-routing.spec.ts
+++ b/tests/e2e/alert-routing.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from '@playwright/test';
+
+// PR-O — accurate interactivity: every alert "View" button lands on the card
+// where its data lives; the "+N more in Insights" links are no longer dead.
+
+test('every ALERT_CARD route points at a card that exists in the DOM', async ({ page }) => {
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const bad = await page.evaluate(() => {
+    const missing: string[] = [];
+    for (const id of Object.keys(ALERT_CARD)) {
+      const { card } = ALERT_CARD[id];
+      if (!document.getElementById(card)) missing.push(id + ' -> ' + card);
+    }
+    return missing;
+  });
+  expect(bad, 'all alert routes resolve to a real card').toEqual([]);
+});
+
+test('alert "View details" buttons carry a gotoCard route, not a bare tab switch', async ({ page }) => {
+  await page.goto('/index.html?nosync');
+  await page.locator('#homeUnifiedAlertsCard, #homeZenState').first().waitFor({ state: 'attached' });
+  await page.waitForTimeout(800);
+
+  const secondaries = page.locator('#unifiedAlertsContent .cab-secondary');
+  const n = await secondaries.count();
+  for (let i = 0; i < n; i++) {
+    const btn = secondaries.nth(i);
+    // Routed alerts use gotoCard with a card target; un-routed fall back to switchTab.
+    const act = await btn.getAttribute('data-action');
+    expect(['gotoCard', 'switchTab']).toContain(act);
+    if (act === 'gotoCard') {
+      expect(await btn.getAttribute('data-arg2'), 'gotoCard carries a card id').toBeTruthy();
+    }
+  }
+});
+
+test('the "+N more in Insights" link is no longer a dead click', async ({ page }) => {
+  // Skip the first-run guide; use full (non-essential) mode — Essential Mode
+  // hides .ca-view-all via CSS, so the overflow link only exists in full mode.
+  await page.addInitScript(() => {
+    localStorage.setItem('ziva_guide_seen', 'true');
+    localStorage.setItem('ziva_essential_mode', 'false');
+  });
+  await page.goto('/index.html?nosync');
+  await page.locator('#homeUnifiedAlertsCard, #homeZenState').first().waitFor({ state: 'attached' });
+  await page.waitForTimeout(800);
+
+  const viewAll = page.locator('.ca-view-all');
+  const n = await viewAll.count();
+  test.skip(n === 0, 'seed produced no alert/win overflow');
+
+  // It must carry a delegated data-action (the old data-tab-scroll binding
+  // is wired at init and never reaches this dynamically rendered element).
+  await expect(viewAll.first()).toHaveAttribute('data-action', 'gotoCard');
+  await viewAll.first().click();
+  await page.waitForTimeout(500);
+  await expect(page.locator('#tab-insights')).toHaveClass(/active/);
+});
+
+test('gotoCard expands the target card and back returns to the origin', async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem('ziva_guide_seen', 'true'));
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  // Jump to a collapsed card from the home tab.
+  await page.evaluate(() => gotoCard('insights', 'insightsCorrelationCard'));
+  await page.waitForTimeout(600);
+  await expect(page.locator('#tab-insights')).toHaveClass(/active/);
+  // The card's collapse body is expanded on arrival, not left collapsed.
+  await expect(page.locator('#insightsCorrBody')).toHaveClass(/open/);
+
+  // Back unwinds the breadcrumb to the origin tab.
+  await page.goBack();
+  await page.waitForTimeout(500);
+  await expect(page.locator('#tab-home')).toHaveClass(/active/);
+});


### PR DESCRIPTION
## Summary

Feedback: alert "View" buttons either dead-ended or dropped the parent on a context-free tab. This makes every alert interaction land where the data actually is.

### 1. Routing — alerts land on their evidence card
A central `ALERT_CARD` map (alert id → `{ tab, card }`) routes each alert's "View details" button — and any bare `switchTab()` primary — to the specific card where that alert's data lives:
- `food-correlation` ("Turmeric → hard stool") → the Insights correlation **evidence** card
- `food-variety-win` ("4 new foods") → the food-introduction timeline
- `low-iron` / `low-calcium` / `food-group-gap` → the nutrient heatmap
- `meal-logging-streak` → the meal breakdown
- …27 alert types mapped; every card id verified against `template.html`.

### 2. Dead "+N more in Insights" links fixed
The overflow links used `data-tab-scroll`, which is bound **once at init** via `querySelectorAll` — so it never reached these dynamically rendered elements. A guaranteed dead click. Now a delegated `data-action="gotoCard"`.

### 3. `gotoCard` — expand on arrival + breadcrumb back
- **Expand**: if the target card is collapsed, `gotoCard` expands it, so the parent lands on content, not a header.
- **Breadcrumb**: `gotoCard` pushes a history entry and records the origin; the **back gesture unwinds the trail** — back from a routed card returns to the alert that triggered it. A manual tab switch abandons the trail so back never rewinds a stale path.

## Test plan
- [x] Four ship-gates pass
- [x] `tests/e2e/alert-routing.spec.ts` — every route resolves to a real card; "View details" carries a `gotoCard` route; the "+N more" link is clickable and navigates; `gotoCard` expands the card and back returns to origin
- [x] Full e2e suite: **114 passed**

## Not in this PR
The deeper content asks — *which* new food / when / which meal slot, a genuinely rewarding streak view — need a `mealSlot` data field and new card content; that's content work for a later PR. This PR makes the existing destinations reachable and accurate.

https://claude.ai/code/session_01Dv3JNVewvj1PUg8i8PzRkB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dv3JNVewvj1PUg8i8PzRkB)_