### PR TITLE
Accuracy fixes — feeding-intake count, food-repetition staples, quieter sync

### DIFF
--- a/docs/CARETICKET_STATE_MACHINE.html
+++ b/docs/CARETICKET_STATE_MACHINE.html
@@ -91,7 +91,7 @@ code { font-family: var(--mono); font-size: 12px; color: var(--ink); }
 </head>
 <body>
 <h1>CareTicket State Machine</h1>
-<p class="subtitle">SproutLab — 6-transition lifecycle, spec vs implementation. Generated <code>2026-05-21</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on transition-layout snapshots</strong>; <code>CARETICKETS_SPEC_v5.md</code> wins on transition rationale; CLAUDE.md wins on rules, HRs, build commands, persona.</p>
+<p class="subtitle">SproutLab — 6-transition lifecycle, spec vs implementation. Generated <code>2026-05-22</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on transition-layout snapshots</strong>; <code>CARETICKETS_SPEC_v5.md</code> wins on transition rationale; CLAUDE.md wins on rules, HRs, build commands, persona.</p>
 
 <div class="diagram-wrap">
 <svg viewBox="0 0 520 420" width="520" height="420">

--- a/docs/POOP_COLOR_REFERENCE.html
+++ b/docs/POOP_COLOR_REFERENCE.html
@@ -108,7 +108,7 @@ code { font-family: var(--mono); font-size: 12px; color: var(--ink-soft); }
 </head>
 <body>
 <h1>Poop-Color Reference</h1>
-<p class="subtitle">SproutLab — token + render + contrast + lexicon snapshot. Generated <code>2026-05-21</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on token-value snapshots</strong>; CLAUDE.md wins on usage rules.</p>
+<p class="subtitle">SproutLab — token + render + contrast + lexicon snapshot. Generated <code>2026-05-22</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on token-value snapshots</strong>; CLAUDE.md wins on usage rules.</p>
 
 <div class="meta-bar">
   <span>light <code>--warm</code> <code>#fef6f0</code></span>

--- a/index.html
+++ b/index.html
@@ -44820,6 +44820,30 @@ function renderInfoFoodReaction() {
 // 7. FOOD REPETITION FATIGUE
 // ════════════════════════════════════════
 
+// Nourishing daily staples — fats, nuts, seeds, spices, grains & dals — are
+// EXEMPT from over-repetition flagging (feedback): giving ghee, almonds,
+// walnut, jeera etc. every day is intentional nutrition, not food fatigue.
+// Built from the FOOD_TAX categories that are staple food groups; fruits and
+// vegetables stay flaggable, since rotating those genuinely aids variety.
+const _STAPLE_FOOD_KEYS = (function () {
+  const set = new Set();
+  ['grains', 'dairy', 'nuts', 'spices'].forEach(cat => {
+    const c = (typeof FOOD_TAX !== 'undefined') && FOOD_TAX[cat];
+    if (!c || !c.subs) return;
+    Object.values(c.subs).forEach(sub => (sub.keys || []).forEach(k => set.add(k.toLowerCase())));
+  });
+  return set;
+})();
+function _isStapleFood(base) {
+  if (!base) return false;
+  const b = base.toLowerCase();
+  if (_STAPLE_FOOD_KEYS.has(b)) return true;
+  for (const k of _STAPLE_FOOD_KEYS) {
+    if (k.length >= 4 && b.includes(k)) return true;
+  }
+  return false;
+}
+
 function computeFoodRepetition() {
   const dates = Object.keys(feedingData).sort();
   if (dates.length < 5) return null;
@@ -44852,6 +44876,7 @@ function computeFoodRepetition() {
   // Find foods appearing in >60% of days over 5+ day stretches
   const fatigued = [];
   const warned = [];
+  const staples = []; // frequently-given staples — shown, but never flagged
 
   Object.entries(foodDayCount).forEach(([food, data]) => {
     const pct = Math.round((data.count / totalDays) * 100);
@@ -44871,17 +44896,22 @@ function computeFoodRepetition() {
       }
     }
 
-    if (pct >= 60 && maxStreak >= 5) {
-      fatigued.push({ food, pct, days: data.count, totalDays, streak: maxStreak });
+    const rec = { food, pct, days: data.count, totalDays, streak: maxStreak, staple: false };
+    if (_isStapleFood(food)) {
+      // A staple is never "over-repeated" — surface it only as context.
+      if (pct >= 60) staples.push(Object.assign(rec, { staple: true }));
+    } else if (pct >= 60 && maxStreak >= 5) {
+      fatigued.push(rec);
     } else if (pct >= 50 && maxStreak >= 4) {
-      warned.push({ food, pct, days: data.count, totalDays, streak: maxStreak });
+      warned.push(rec);
     }
   });
 
   // Sort by percentage descending
   fatigued.sort((a, b) => b.pct - a.pct);
   warned.sort((a, b) => b.pct - a.pct);
-  const all = [...fatigued, ...warned].slice(0, 8);
+  staples.sort((a, b) => b.pct - a.pct);
+  const all = [...fatigued, ...warned, ...staples].slice(0, 8);
 
   const insights = [];
   if (fatigued.length > 0) {
@@ -44891,14 +44921,21 @@ function computeFoodRepetition() {
         ' in most meals. Try rotating with alternatives to ensure nutrient variety and prevent food fatigue.'
     });
   }
-  if (fatigued.length === 0 && warned.length === 0) {
+  if (staples.length > 0) {
+    insights.push({
+      type: 'good',
+      text: staples.map(f => f.food).join(', ') + (staples.length === 1 ? ' appears' : ' appear') +
+        ' most days — these are nourishing daily staples (fats, nuts, grains, spices), so frequent use is intentional, not food fatigue.'
+    });
+  }
+  if (fatigued.length === 0 && warned.length === 0 && staples.length === 0) {
     insights.push({
       type: 'good',
       text: 'Good variety in the last 2 weeks — no food is dominating the diet.'
     });
   }
 
-  return { fatigued, warned, all, totalDays, insights };
+  return { fatigued, warned, staples, all, totalDays, insights };
 }
 
 function renderInfoRepetition() {
@@ -44930,15 +44967,21 @@ function renderInfoRepetition() {
   if (barsEl && data.all.length > 0) {
     let html = '<div class="t-xs t-light mb-4" >Food frequency over ' + data.totalDays + ' days (threshold: 60%)</div>';
     data.all.forEach(f => {
-      const isFatigued = f.pct >= 60 && f.streak >= 5;
-      const barColor = isFatigued ? 'var(--tc-rose)' : f.pct >= 50 ? 'var(--tc-amber)' : 'var(--tc-sage)';
+      // Staples are never "fatigued" — a frequent staple is shown in calm
+      // sage with a reassuring status, not flagged amber/rose as a concern.
+      const isFatigued = !f.staple && f.pct >= 60 && f.streak >= 5;
+      const isWarn = !f.staple && !isFatigued && f.pct >= 50;
+      const barColor = isFatigued ? 'var(--tc-rose)' : isWarn ? 'var(--tc-amber)' : 'var(--tc-sage)';
+      const status = f.staple ? 'Daily staple — fine to repeat'
+        : isFatigued ? 'Time to vary the menu'
+        : isWarn ? 'Coming up often' : 'Good variety';
       const repDetail = {
         title: f.food, subtitle: 'Last ' + data.totalDays + ' days',
-        domain: isFatigued ? 'rose' : f.pct >= 50 ? 'amber' : 'sage', icon: 'bowl',
+        domain: isFatigued ? 'rose' : isWarn ? 'amber' : 'sage', icon: 'bowl',
         rows: [
           { label: 'Appears on', value: f.pct + '% of days' },
           { label: 'Longest streak', value: f.streak + ' day' + (f.streak !== 1 ? 's' : '') },
-          { label: 'Status', value: isFatigued ? 'Time to vary the menu' : f.pct >= 50 ? 'Coming up often' : 'Good variety' }
+          { label: 'Status', value: status }
         ]
       };
       html += '<div class="mi-food-row" data-action="vizShowDetail" data-arg="' + vizArg(repDetail) + '">';
@@ -62666,10 +62709,15 @@ function renderInfoFeedingIntake() {
       const intake = entry[k + '_intake'];
       const hasMeal = !!entry[k] && entry[k] !== SKIPPED_MEAL;
       if (!hasMeal) return 'missing';
-      if (intake === 1 || intake === '1' || intake === 'full') return 'full';
-      if (intake === 0.5 || intake === '0.5' || intake === 'partial') return 'partial';
-      if (intake === 0 || intake === '0' || intake === 'none') return 'none';
-      return 'untagged'; // meal logged but intake not recorded
+      // Intake is logged on a 4-level scale (0.25 "Few bites" / 0.5 "Half" /
+      // 0.75 "Most" / 1 "All"); legacy entries may use 'full'/'partial'/'none'.
+      // The old classifier only matched 1/0.5/0, so meals tagged 0.25 or 0.75
+      // were wrongly counted as untagged.
+      const iv = intake === 'full' ? 1 : intake === 'partial' ? 0.5 : intake === 'none' ? 0 : parseFloat(intake);
+      if (isNaN(iv)) return 'untagged'; // meal logged but intake not recorded
+      if (iv >= 1) return 'full';
+      if (iv > 0) return 'partial';
+      return 'none';
     });
     // Parallel array of the logged food text per meal — fed into the
     // per-cell detail popup so a tap answers "what did she eat?".
@@ -67209,7 +67257,16 @@ function _syncNotifyVisibility() {
 function _syncUpdateStatusIndicator(snap) {
   var btn = document.getElementById('syncStatus');
   if (!btn) return;
-  if (btn.hasAttribute('hidden')) btn.removeAttribute('hidden');
+  // PR-P: the indicator is silent on success. Routine states (connecting /
+  // synced / syncing) no longer consume top-of-screen real estate — only the
+  // not-syncing states (offline / halted) surface the pill, so a parent still
+  // learns when their data is genuinely not backing up.
+  if (snap.state !== 'offline' && snap.state !== 'halted') {
+    btn.setAttribute('hidden', '');
+    btn.removeAttribute('data-action');
+    return;
+  }
+  btn.removeAttribute('hidden');
   btn.setAttribute('data-state', snap.state);
 
   // Copy table — one source of truth per logical state; CSS handles color.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.21-12",
+  "version": "2026.05.22-1",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/intelligence-cards.js
+++ b/split/intelligence-cards.js
@@ -2306,10 +2306,15 @@ function renderInfoFeedingIntake() {
       const intake = entry[k + '_intake'];
       const hasMeal = !!entry[k] && entry[k] !== SKIPPED_MEAL;
       if (!hasMeal) return 'missing';
-      if (intake === 1 || intake === '1' || intake === 'full') return 'full';
-      if (intake === 0.5 || intake === '0.5' || intake === 'partial') return 'partial';
-      if (intake === 0 || intake === '0' || intake === 'none') return 'none';
-      return 'untagged'; // meal logged but intake not recorded
+      // Intake is logged on a 4-level scale (0.25 "Few bites" / 0.5 "Half" /
+      // 0.75 "Most" / 1 "All"); legacy entries may use 'full'/'partial'/'none'.
+      // The old classifier only matched 1/0.5/0, so meals tagged 0.25 or 0.75
+      // were wrongly counted as untagged.
+      const iv = intake === 'full' ? 1 : intake === 'partial' ? 0.5 : intake === 'none' ? 0 : parseFloat(intake);
+      if (isNaN(iv)) return 'untagged'; // meal logged but intake not recorded
+      if (iv >= 1) return 'full';
+      if (iv > 0) return 'partial';
+      return 'none';
     });
     // Parallel array of the logged food text per meal — fed into the
     // per-cell detail popup so a tap answers "what did she eat?".

--- a/split/medical.js
+++ b/split/medical.js
@@ -8743,6 +8743,30 @@ function renderInfoFoodReaction() {
 // 7. FOOD REPETITION FATIGUE
 // ════════════════════════════════════════
 
+// Nourishing daily staples — fats, nuts, seeds, spices, grains & dals — are
+// EXEMPT from over-repetition flagging (feedback): giving ghee, almonds,
+// walnut, jeera etc. every day is intentional nutrition, not food fatigue.
+// Built from the FOOD_TAX categories that are staple food groups; fruits and
+// vegetables stay flaggable, since rotating those genuinely aids variety.
+const _STAPLE_FOOD_KEYS = (function () {
+  const set = new Set();
+  ['grains', 'dairy', 'nuts', 'spices'].forEach(cat => {
+    const c = (typeof FOOD_TAX !== 'undefined') && FOOD_TAX[cat];
+    if (!c || !c.subs) return;
+    Object.values(c.subs).forEach(sub => (sub.keys || []).forEach(k => set.add(k.toLowerCase())));
+  });
+  return set;
+})();
+function _isStapleFood(base) {
+  if (!base) return false;
+  const b = base.toLowerCase();
+  if (_STAPLE_FOOD_KEYS.has(b)) return true;
+  for (const k of _STAPLE_FOOD_KEYS) {
+    if (k.length >= 4 && b.includes(k)) return true;
+  }
+  return false;
+}
+
 function computeFoodRepetition() {
   const dates = Object.keys(feedingData).sort();
   if (dates.length < 5) return null;
@@ -8775,6 +8799,7 @@ function computeFoodRepetition() {
   // Find foods appearing in >60% of days over 5+ day stretches
   const fatigued = [];
   const warned = [];
+  const staples = []; // frequently-given staples — shown, but never flagged
 
   Object.entries(foodDayCount).forEach(([food, data]) => {
     const pct = Math.round((data.count / totalDays) * 100);
@@ -8794,17 +8819,22 @@ function computeFoodRepetition() {
       }
     }
 
-    if (pct >= 60 && maxStreak >= 5) {
-      fatigued.push({ food, pct, days: data.count, totalDays, streak: maxStreak });
+    const rec = { food, pct, days: data.count, totalDays, streak: maxStreak, staple: false };
+    if (_isStapleFood(food)) {
+      // A staple is never "over-repeated" — surface it only as context.
+      if (pct >= 60) staples.push(Object.assign(rec, { staple: true }));
+    } else if (pct >= 60 && maxStreak >= 5) {
+      fatigued.push(rec);
     } else if (pct >= 50 && maxStreak >= 4) {
-      warned.push({ food, pct, days: data.count, totalDays, streak: maxStreak });
+      warned.push(rec);
     }
   });
 
   // Sort by percentage descending
   fatigued.sort((a, b) => b.pct - a.pct);
   warned.sort((a, b) => b.pct - a.pct);
-  const all = [...fatigued, ...warned].slice(0, 8);
+  staples.sort((a, b) => b.pct - a.pct);
+  const all = [...fatigued, ...warned, ...staples].slice(0, 8);
 
   const insights = [];
   if (fatigued.length > 0) {
@@ -8814,14 +8844,21 @@ function computeFoodRepetition() {
         ' in most meals. Try rotating with alternatives to ensure nutrient variety and prevent food fatigue.'
     });
   }
-  if (fatigued.length === 0 && warned.length === 0) {
+  if (staples.length > 0) {
+    insights.push({
+      type: 'good',
+      text: staples.map(f => f.food).join(', ') + (staples.length === 1 ? ' appears' : ' appear') +
+        ' most days — these are nourishing daily staples (fats, nuts, grains, spices), so frequent use is intentional, not food fatigue.'
+    });
+  }
+  if (fatigued.length === 0 && warned.length === 0 && staples.length === 0) {
     insights.push({
       type: 'good',
       text: 'Good variety in the last 2 weeks — no food is dominating the diet.'
     });
   }
 
-  return { fatigued, warned, all, totalDays, insights };
+  return { fatigued, warned, staples, all, totalDays, insights };
 }
 
 function renderInfoRepetition() {
@@ -8853,15 +8890,21 @@ function renderInfoRepetition() {
   if (barsEl && data.all.length > 0) {
     let html = '<div class="t-xs t-light mb-4" >Food frequency over ' + data.totalDays + ' days (threshold: 60%)</div>';
     data.all.forEach(f => {
-      const isFatigued = f.pct >= 60 && f.streak >= 5;
-      const barColor = isFatigued ? 'var(--tc-rose)' : f.pct >= 50 ? 'var(--tc-amber)' : 'var(--tc-sage)';
+      // Staples are never "fatigued" — a frequent staple is shown in calm
+      // sage with a reassuring status, not flagged amber/rose as a concern.
+      const isFatigued = !f.staple && f.pct >= 60 && f.streak >= 5;
+      const isWarn = !f.staple && !isFatigued && f.pct >= 50;
+      const barColor = isFatigued ? 'var(--tc-rose)' : isWarn ? 'var(--tc-amber)' : 'var(--tc-sage)';
+      const status = f.staple ? 'Daily staple — fine to repeat'
+        : isFatigued ? 'Time to vary the menu'
+        : isWarn ? 'Coming up often' : 'Good variety';
       const repDetail = {
         title: f.food, subtitle: 'Last ' + data.totalDays + ' days',
-        domain: isFatigued ? 'rose' : f.pct >= 50 ? 'amber' : 'sage', icon: 'bowl',
+        domain: isFatigued ? 'rose' : isWarn ? 'amber' : 'sage', icon: 'bowl',
         rows: [
           { label: 'Appears on', value: f.pct + '% of days' },
           { label: 'Longest streak', value: f.streak + ' day' + (f.streak !== 1 ? 's' : '') },
-          { label: 'Status', value: isFatigued ? 'Time to vary the menu' : f.pct >= 50 ? 'Coming up often' : 'Good variety' }
+          { label: 'Status', value: status }
         ]
       };
       html += '<div class="mi-food-row" data-action="vizShowDetail" data-arg="' + vizArg(repDetail) + '">';

--- a/split/sync.js
+++ b/split/sync.js
@@ -2086,7 +2086,16 @@ function _syncNotifyVisibility() {
 function _syncUpdateStatusIndicator(snap) {
   var btn = document.getElementById('syncStatus');
   if (!btn) return;
-  if (btn.hasAttribute('hidden')) btn.removeAttribute('hidden');
+  // PR-P: the indicator is silent on success. Routine states (connecting /
+  // synced / syncing) no longer consume top-of-screen real estate — only the
+  // not-syncing states (offline / halted) surface the pill, so a parent still
+  // learns when their data is genuinely not backing up.
+  if (snap.state !== 'offline' && snap.state !== 'halted') {
+    btn.setAttribute('hidden', '');
+    btn.removeAttribute('data-action');
+    return;
+  }
+  btn.removeAttribute('hidden');
   btn.setAttribute('data-state', snap.state);
 
   // Copy table — one source of truth per logical state; CSS handles color.

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -44820,6 +44820,30 @@ function renderInfoFoodReaction() {
 // 7. FOOD REPETITION FATIGUE
 // ════════════════════════════════════════
 
+// Nourishing daily staples — fats, nuts, seeds, spices, grains & dals — are
+// EXEMPT from over-repetition flagging (feedback): giving ghee, almonds,
+// walnut, jeera etc. every day is intentional nutrition, not food fatigue.
+// Built from the FOOD_TAX categories that are staple food groups; fruits and
+// vegetables stay flaggable, since rotating those genuinely aids variety.
+const _STAPLE_FOOD_KEYS = (function () {
+  const set = new Set();
+  ['grains', 'dairy', 'nuts', 'spices'].forEach(cat => {
+    const c = (typeof FOOD_TAX !== 'undefined') && FOOD_TAX[cat];
+    if (!c || !c.subs) return;
+    Object.values(c.subs).forEach(sub => (sub.keys || []).forEach(k => set.add(k.toLowerCase())));
+  });
+  return set;
+})();
+function _isStapleFood(base) {
+  if (!base) return false;
+  const b = base.toLowerCase();
+  if (_STAPLE_FOOD_KEYS.has(b)) return true;
+  for (const k of _STAPLE_FOOD_KEYS) {
+    if (k.length >= 4 && b.includes(k)) return true;
+  }
+  return false;
+}
+
 function computeFoodRepetition() {
   const dates = Object.keys(feedingData).sort();
   if (dates.length < 5) return null;
@@ -44852,6 +44876,7 @@ function computeFoodRepetition() {
   // Find foods appearing in >60% of days over 5+ day stretches
   const fatigued = [];
   const warned = [];
+  const staples = []; // frequently-given staples — shown, but never flagged
 
   Object.entries(foodDayCount).forEach(([food, data]) => {
     const pct = Math.round((data.count / totalDays) * 100);
@@ -44871,17 +44896,22 @@ function computeFoodRepetition() {
       }
     }
 
-    if (pct >= 60 && maxStreak >= 5) {
-      fatigued.push({ food, pct, days: data.count, totalDays, streak: maxStreak });
+    const rec = { food, pct, days: data.count, totalDays, streak: maxStreak, staple: false };
+    if (_isStapleFood(food)) {
+      // A staple is never "over-repeated" — surface it only as context.
+      if (pct >= 60) staples.push(Object.assign(rec, { staple: true }));
+    } else if (pct >= 60 && maxStreak >= 5) {
+      fatigued.push(rec);
     } else if (pct >= 50 && maxStreak >= 4) {
-      warned.push({ food, pct, days: data.count, totalDays, streak: maxStreak });
+      warned.push(rec);
     }
   });
 
   // Sort by percentage descending
   fatigued.sort((a, b) => b.pct - a.pct);
   warned.sort((a, b) => b.pct - a.pct);
-  const all = [...fatigued, ...warned].slice(0, 8);
+  staples.sort((a, b) => b.pct - a.pct);
+  const all = [...fatigued, ...warned, ...staples].slice(0, 8);
 
   const insights = [];
   if (fatigued.length > 0) {
@@ -44891,14 +44921,21 @@ function computeFoodRepetition() {
         ' in most meals. Try rotating with alternatives to ensure nutrient variety and prevent food fatigue.'
     });
   }
-  if (fatigued.length === 0 && warned.length === 0) {
+  if (staples.length > 0) {
+    insights.push({
+      type: 'good',
+      text: staples.map(f => f.food).join(', ') + (staples.length === 1 ? ' appears' : ' appear') +
+        ' most days — these are nourishing daily staples (fats, nuts, grains, spices), so frequent use is intentional, not food fatigue.'
+    });
+  }
+  if (fatigued.length === 0 && warned.length === 0 && staples.length === 0) {
     insights.push({
       type: 'good',
       text: 'Good variety in the last 2 weeks — no food is dominating the diet.'
     });
   }
 
-  return { fatigued, warned, all, totalDays, insights };
+  return { fatigued, warned, staples, all, totalDays, insights };
 }
 
 function renderInfoRepetition() {
@@ -44930,15 +44967,21 @@ function renderInfoRepetition() {
   if (barsEl && data.all.length > 0) {
     let html = '<div class="t-xs t-light mb-4" >Food frequency over ' + data.totalDays + ' days (threshold: 60%)</div>';
     data.all.forEach(f => {
-      const isFatigued = f.pct >= 60 && f.streak >= 5;
-      const barColor = isFatigued ? 'var(--tc-rose)' : f.pct >= 50 ? 'var(--tc-amber)' : 'var(--tc-sage)';
+      // Staples are never "fatigued" — a frequent staple is shown in calm
+      // sage with a reassuring status, not flagged amber/rose as a concern.
+      const isFatigued = !f.staple && f.pct >= 60 && f.streak >= 5;
+      const isWarn = !f.staple && !isFatigued && f.pct >= 50;
+      const barColor = isFatigued ? 'var(--tc-rose)' : isWarn ? 'var(--tc-amber)' : 'var(--tc-sage)';
+      const status = f.staple ? 'Daily staple — fine to repeat'
+        : isFatigued ? 'Time to vary the menu'
+        : isWarn ? 'Coming up often' : 'Good variety';
       const repDetail = {
         title: f.food, subtitle: 'Last ' + data.totalDays + ' days',
-        domain: isFatigued ? 'rose' : f.pct >= 50 ? 'amber' : 'sage', icon: 'bowl',
+        domain: isFatigued ? 'rose' : isWarn ? 'amber' : 'sage', icon: 'bowl',
         rows: [
           { label: 'Appears on', value: f.pct + '% of days' },
           { label: 'Longest streak', value: f.streak + ' day' + (f.streak !== 1 ? 's' : '') },
-          { label: 'Status', value: isFatigued ? 'Time to vary the menu' : f.pct >= 50 ? 'Coming up often' : 'Good variety' }
+          { label: 'Status', value: status }
         ]
       };
       html += '<div class="mi-food-row" data-action="vizShowDetail" data-arg="' + vizArg(repDetail) + '">';
@@ -62666,10 +62709,15 @@ function renderInfoFeedingIntake() {
       const intake = entry[k + '_intake'];
       const hasMeal = !!entry[k] && entry[k] !== SKIPPED_MEAL;
       if (!hasMeal) return 'missing';
-      if (intake === 1 || intake === '1' || intake === 'full') return 'full';
-      if (intake === 0.5 || intake === '0.5' || intake === 'partial') return 'partial';
-      if (intake === 0 || intake === '0' || intake === 'none') return 'none';
-      return 'untagged'; // meal logged but intake not recorded
+      // Intake is logged on a 4-level scale (0.25 "Few bites" / 0.5 "Half" /
+      // 0.75 "Most" / 1 "All"); legacy entries may use 'full'/'partial'/'none'.
+      // The old classifier only matched 1/0.5/0, so meals tagged 0.25 or 0.75
+      // were wrongly counted as untagged.
+      const iv = intake === 'full' ? 1 : intake === 'partial' ? 0.5 : intake === 'none' ? 0 : parseFloat(intake);
+      if (isNaN(iv)) return 'untagged'; // meal logged but intake not recorded
+      if (iv >= 1) return 'full';
+      if (iv > 0) return 'partial';
+      return 'none';
     });
     // Parallel array of the logged food text per meal — fed into the
     // per-cell detail popup so a tap answers "what did she eat?".
@@ -67209,7 +67257,16 @@ function _syncNotifyVisibility() {
 function _syncUpdateStatusIndicator(snap) {
   var btn = document.getElementById('syncStatus');
   if (!btn) return;
-  if (btn.hasAttribute('hidden')) btn.removeAttribute('hidden');
+  // PR-P: the indicator is silent on success. Routine states (connecting /
+  // synced / syncing) no longer consume top-of-screen real estate — only the
+  // not-syncing states (offline / halted) surface the pill, so a parent still
+  // learns when their data is genuinely not backing up.
+  if (snap.state !== 'offline' && snap.state !== 'halted') {
+    btn.setAttribute('hidden', '');
+    btn.removeAttribute('data-action');
+    return;
+  }
+  btn.removeAttribute('hidden');
   btn.setAttribute('data-state', snap.state);
 
   // Copy table — one source of truth per logical state; CSS handles color.

--- a/tests/e2e/accuracy-fixes.spec.ts
+++ b/tests/e2e/accuracy-fixes.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+
+// PR-P — three accuracy fixes: feeding-intake classifier, food-repetition
+// staple exemption, sync indicator surfaced only when not syncing.
+
+test('feeding-intake counts the 0.25 / 0.75 intake levels (not just 0.5 / 1)', async ({ page }) => {
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const summary = await page.evaluate(() => {
+    const snap = JSON.stringify(feedingData);
+    const fd: Record<string, any> = {};
+    const today = new Date();
+    for (let i = 0; i < 10; i++) {
+      const d = new Date(today); d.setDate(d.getDate() - i);
+      const ds = d.toISOString().slice(0, 10);
+      // breakfast tagged "Most" (0.75) — the level the old classifier missed.
+      fd[ds] = { breakfast: 'ragi', breakfast_intake: 0.75, lunch: 'dal', lunch_intake: 1 };
+    }
+    Object.keys(feedingData).forEach((k) => delete feedingData[k]);
+    Object.assign(feedingData, fd);
+    renderInfoFeedingIntake();
+    const txt = document.getElementById('infoFeedingIntakeSummary')!.textContent || '';
+    Object.keys(feedingData).forEach((k) => delete feedingData[k]);
+    Object.assign(feedingData, JSON.parse(snap));
+    return txt;
+  });
+
+  // 10 days × 2 tagged meals = 20. The old code missed the ten 0.75 breakfasts.
+  expect(summary).toContain('20 tagged meals');
+});
+
+test('food-repetition exempts staple foods from over-repetition flagging', async ({ page }) => {
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const snap = JSON.stringify(feedingData);
+    const fd: Record<string, any> = {};
+    const today = new Date();
+    for (let i = 0; i < 14; i++) {
+      const d = new Date(today); d.setDate(d.getDate() - i);
+      const ds = d.toISOString().slice(0, 10);
+      // ghee = staple (dairy/fats); spinach = non-staple vegetable. Both daily.
+      // Foods within a meal are '+'-separated, matching how meals are logged.
+      fd[ds] = { breakfast: 'ragi + ghee', lunch: 'spinach + dal', dinner: 'spinach + khichdi' };
+    }
+    Object.keys(feedingData).forEach((k) => delete feedingData[k]);
+    Object.assign(feedingData, fd);
+    const res = computeFoodRepetition();
+    Object.keys(feedingData).forEach((k) => delete feedingData[k]);
+    Object.assign(feedingData, JSON.parse(snap));
+    return {
+      fatiguedFoods: (res?.fatigued || []).map((f: any) => f.food),
+      stapleFoods: (res?.staples || []).map((f: any) => f.food),
+    };
+  });
+
+  // ghee given every day must NOT be flagged as a concern — it is a staple.
+  expect(r.stapleFoods).toContain('ghee');
+  expect(r.fatiguedFoods).not.toContain('ghee');
+  // a non-staple vegetable given every day still surfaces as over-repeated.
+  expect(r.fatiguedFoods).toContain('spinach');
+});
+
+test('sync indicator is hidden on routine states, shown only when not syncing', async ({ page }) => {
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(500);
+
+  const r = await page.evaluate(() => {
+    const btn = document.getElementById('syncStatus')!;
+    _syncUpdateStatusIndicator({ state: 'syncing', pending: 2 });
+    const syncing = btn.hasAttribute('hidden');
+    _syncUpdateStatusIndicator({ state: 'online', pending: 0 });
+    const online = btn.hasAttribute('hidden');
+    _syncUpdateStatusIndicator({ state: 'halted', pending: 1 });
+    const halted = btn.hasAttribute('hidden');
+    return { syncing, online, halted };
+  });
+
+  expect(r.syncing, 'syncing state is silent').toBe(true);
+  expect(r.online, 'synced state is silent').toBe(true);
+  expect(r.halted, 'halted (failure) state surfaces the pill').toBe(false);
+});


### PR DESCRIPTION
## Summary

Three accuracy/UX fixes from feedback on the info-tab cards and the top status bar.

### 1. Feeding Intake — under-counted tagged meals
Meal intake is logged on a 4-level scale (`0.25` "Few bites" / `0.5` "Half" / `0.75` "Most" / `1` "All"), but the card's classifier only matched `1`, `0.5`, `0` — so **every meal tagged `0.25` or `0.75` was wrongly counted as untagged**, deflating the "N tagged meals" count. The classifier now reads the full scale: any value in `(0,1)` is partial. (Matches the reported "almost all meals are tagged but the card disagrees.")

### 2. Food Repetition — stopped flagging beneficial staples
The card flagged ghee, almonds, walnut and jeera as "over-repeated concerns" — but these are nourishing daily staples; giving them every day is intentional. Foods in the staple `FOOD_TAX` groups (**grains & dals, dairy & fats, nuts & seeds, spices**) are now exempt from over-repetition flagging — surfaced in calm sage with a *"daily staple — fine to repeat"* status and a reassuring note, not a warning. Fruits and vegetables stay flaggable, since rotating those genuinely aids variety.

### 3. Sync status — quieter, reclaims top real estate
The indicator pulsed `Syncing`/`Synced` permanently at the top of the screen. It is now **silent on success** — only the not-syncing states (`offline` / `halted`) surface the pill, so a parent still learns when data is genuinely not backing up, without the routine noise.

## Test plan
- [x] Four ship-gates pass
- [x] `tests/e2e/accuracy-fixes.spec.ts` — feeding-intake counts 0.75 meals; food-repetition routes ghee → staples / spinach → flagged; sync indicator hidden on syncing/online, shown on halted
- [x] Full e2e suite: 116 passed

## Note
The transient peer-activity pill (`#syncActivity`, "X synced an update") is left as-is — it auto-hides after 45s and signals co-parent activity, which is useful. Happy to suppress or shorten it too if you'd like.

https://claude.ai/code/session_01Dv3JNVewvj1PUg8i8PzRkB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dv3JNVewvj1PUg8i8PzRkB)_