### PR TITLE
Collapse the empty status strip when the sync indicator is silent

### DIFF
--- a/index.html
+++ b/index.html
@@ -4814,6 +4814,10 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
   border-radius:var(--r-lg);
   box-shadow:0 2px 10px var(--card-shadow);
 }
+/* Collapse the strip entirely when every child ([syncStatus], [syncActivity],
+   [update-toast]) is hidden — otherwise an empty band with background + shadow
+   lingers once the sync indicator goes silent (PR-P follow-up). */
+.status-strip:not(:has(> :not([hidden]))) { display:none; }
 
 /* Update-available toast (Phase 2 PR-5). Surfaced when SW emits
    'updatefound' AND the new worker reaches 'installed' state with an

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.22-1",
+  "version": "2026.05.22-2",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/styles.css
+++ b/split/styles.css
@@ -4807,6 +4807,10 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
   border-radius:var(--r-lg);
   box-shadow:0 2px 10px var(--card-shadow);
 }
+/* Collapse the strip entirely when every child ([syncStatus], [syncActivity],
+   [update-toast]) is hidden — otherwise an empty band with background + shadow
+   lingers once the sync indicator goes silent (PR-P follow-up). */
+.status-strip:not(:has(> :not([hidden]))) { display:none; }
 
 /* Update-available toast (Phase 2 PR-5). Surfaced when SW emits
    'updatefound' AND the new worker reaches 'installed' state with an

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -4814,6 +4814,10 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
   border-radius:var(--r-lg);
   box-shadow:0 2px 10px var(--card-shadow);
 }
+/* Collapse the strip entirely when every child ([syncStatus], [syncActivity],
+   [update-toast]) is hidden — otherwise an empty band with background + shadow
+   lingers once the sync indicator goes silent (PR-P follow-up). */
+.status-strip:not(:has(> :not([hidden]))) { display:none; }
 
 /* Update-available toast (Phase 2 PR-5). Surfaced when SW emits
    'updatefound' AND the new worker reaches 'installed' state with an

--- a/tests/e2e/status-strip.spec.ts
+++ b/tests/e2e/status-strip.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+// PR-P follow-up — the status strip must collapse entirely when its sync
+// indicator (and the other strip children) are hidden, leaving no empty band.
+
+test('status strip is collapsed when the sync indicator is silent', async ({ page }) => {
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const strip = page.locator('#statusStrip');
+  // Routine sync state → indicator hidden → strip must take no layout space.
+  await expect(strip).toBeHidden();
+
+  // A not-syncing state surfaces the indicator → the strip reappears.
+  await page.evaluate(() => _syncUpdateStatusIndicator({ state: 'halted', pending: 1 }));
+  await page.waitForTimeout(150);
+  await expect(strip).toBeVisible();
+  expect((await strip.boundingBox())!.height).toBeGreaterThan(0);
+
+  // Back to a routine state → strip collapses away again.
+  await page.evaluate(() => _syncUpdateStatusIndicator({ state: 'online', pending: 0 }));
+  await page.waitForTimeout(150);
+  await expect(strip).toBeHidden();
+});


### PR DESCRIPTION
## Summary

Follow-up to PR #94. PR-P made the sync indicator silent on routine states — but the `.status-strip` band that hosts it kept its `min-height: 28px`, padding, margin, background and shadow, so an **empty bar stayed parked at the top of the screen** even with nothing in it.

The strip now collapses to `display: none` whenever every child (`#syncStatus`, `#syncActivity`, the update toast) is `[hidden]`, via:

```css
.status-strip:not(:has(> :not([hidden]))) { display: none; }
```

It reappears the instant any child surfaces (offline/halted sync, a peer-activity pill, or an update toast). `:has()` is already used in `styles.css` (`.meal-card:has(...)`), so this is an established pattern.

## Test plan
- [x] Four ship-gates pass
- [x] `tests/e2e/status-strip.spec.ts` — strip is hidden on routine sync state; reappears on `halted`; collapses again on `online`
- [x] accuracy-fixes suite still green

https://claude.ai/code/session_01Dv3JNVewvj1PUg8i8PzRkB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dv3JNVewvj1PUg8i8PzRkB)_