### PR TITLE
Track→Sleep: collapsed Night/Nap log card, data-first layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -17416,6 +17416,7 @@ function init() {
     else if (action === 'startSleepNap') startSleepNow('nap');
     else if (action === 'addNapEntry') addNapEntry();
     else if (action === 'sleepLogMode') setSleepLogMode(arg);
+    else if (action === 'openSleepLog') openSleepLogForm(arg);
     else if (action === 'cancelPoopEdit') cancelPoopEdit();
     else if (action === 'addPoopEntry') addPoopEntry();
     else if (action === 'homeFabAction') homeFabAction();
@@ -41704,7 +41705,7 @@ function renderSleepStats() {
       <div class="hsp-val">${lastNightStr}</div>
       <div class="hsp-label">Last night</div>
     </div>
-    <div class="home-stat-pill ${napColor}" data-scroll-to="sleepLogFormCard" data-scroll-block="start">
+    <div class="home-stat-pill ${napColor}" data-action="openSleepLog" data-arg="nap">
       <div class="hsp-icon"><svg class="zi"><use href="#zi-sleep"/></svg></div>
       <div class="hsp-val">${todayNaps.length > 0 ? napH + 'h ' + napM + 'm' : '—'}</div>
       <div class="hsp-label">${todayNaps.length} nap${todayNaps.length !== 1 ? 's' : ''} today</div>

--- a/index.html
+++ b/index.html
@@ -4223,6 +4223,13 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
   font-size:var(--fs-base); font-weight:600; cursor:pointer; transition:all var(--ease-fast);
 }
 .sq-btn.active-sq { background:#5a6498; color:white; border-color:#5a6498; }
+.sleep-log-seg {
+  display:flex; gap:var(--sp-8);
+  margin:var(--sp-8) 0 var(--sp-16);
+}
+.sleep-log-seg .sq-btn {
+  flex:1; display:flex; align-items:center; justify-content:center; gap:var(--sp-6);
+}
 .sleep-stat-hero {
   font-family:'Fraunces',serif; font-size:var(--fs-3xl); font-weight:600;
   color:var(--tc-indigo); line-height:var(--lh-tight);
@@ -10922,92 +10929,116 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
       <div class="card col-full card-hero hero-sleep" id="sleepDomainHero" style="display:none;"></div>
 
       <!-- ─── TIER 1: STATS ─── -->
-      <!-- stat card wrapper removed -->
-        <div class="col-full stat-pills-grid" id="sleepStats"></div>
-
-      <!-- ─── TIER 2: ACTIONS ─── -->
-      <div class="home-section-label sec-t1 col-full">Log Sleep</div>
+      <div class="col-full stat-pills-grid" id="sleepStats"></div>
 
       <!-- In-progress sleep/nap banner -->
       <div class="col-full" id="sleepInProgressBanner" style="display:none;"></div>
 
-      <!-- SLEEP LOG FORM -->
-      <div class="card card-action col-full overflow-visible" id="sleepNightCard">
-        <div class="card-header">
-          <div class="card-title"><div class="icon icon-indigo"><svg class="zi"><use href="#zi-moon"/></svg></div> Log Night Sleep</div>
+      <!-- ─── TIER 2: LOG — collapsed by default, Night/Nap segmented ─── -->
+      <div class="card card-action col-full overflow-visible" id="sleepLogFormCard">
+        <div class="card-header" data-collapse-target="sleepLogFormBody" data-collapse-chevron="sleepLogFormChevron">
+          <div class="card-title"><div class="icon icon-indigo"><svg class="zi"><use href="#zi-moon"/></svg></div> Log Sleep</div>
+          <span class="collapse-chevron" id="sleepLogFormChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
         </div>
-        <div class="help-tip d-none" id="help-sleep">Track Ziva's bedtime and wake time. At 6–8 months, babies typically need 11–12 hours of night sleep plus 2–3 naps totalling 2–3 hours. Logging sleep helps spot patterns and ensure she's getting enough rest.</div>
-        <div class="fx-col g12 mt-8">
-          <div>
-            <label class="micro-label">Date</label>
-            <div class="d-flex items-center gap-8">
-              <input type="date" id="sleepDate" oninput="updateSleepDayLabel('sleepDate','sleepDayLabel')" class="form-input input-ctx-indigo flex-1">
-              <span id="sleepDayLabel" class="day-label day-label-indigo"></span>
+        <div id="sleepLogFormBody" class="collapse-body" style="display:none;">
+          <div class="sleep-log-seg">
+            <button class="sq-btn active-sq" id="sleepSeg-night" data-action="sleepLogMode" data-arg="night"><svg class="zi" aria-hidden="true"><use href="#zi-moon"/></svg> Night sleep</button>
+            <button class="sq-btn" id="sleepSeg-nap" data-action="sleepLogMode" data-arg="nap"><svg class="zi" aria-hidden="true"><use href="#zi-zzz"/></svg> Nap</button>
+          </div>
+
+          <!-- NIGHT FORM -->
+          <div id="sleepNightCard">
+            <div class="help-tip d-none" id="help-sleep">Track Ziva's bedtime and wake time. At 6–8 months, babies typically need 11–12 hours of night sleep plus 2–3 naps totalling 2–3 hours. Logging sleep helps spot patterns and ensure she's getting enough rest.</div>
+            <div class="fx-col g12">
+              <div>
+                <label class="micro-label">Date</label>
+                <div class="d-flex items-center gap-8">
+                  <input type="date" id="sleepDate" oninput="updateSleepDayLabel('sleepDate','sleepDayLabel')" class="form-input input-ctx-indigo flex-1">
+                  <span id="sleepDayLabel" class="day-label day-label-indigo"></span>
+                </div>
+              </div>
+              <div class="d-flex gap-12">
+                <div class="flex-1">
+                  <label class="micro-label">Bedtime</label>
+                  <input type="time" id="sleepBedtime" class="form-input input-ctx-indigo">
+                </div>
+                <div class="flex-1">
+                  <label class="micro-label">Wake time</label>
+                  <input type="time" id="sleepWakeTime" class="form-input input-ctx-indigo">
+                </div>
+              </div>
+              <div>
+                <label class="micro-label">Wake-ups</label>
+                <div class="d-flex items-center gap-8 mt-4">
+                  <button data-action="wakeDown" class="stepper-btn stepper-ctx-indigo">−</button>
+                  <span id="wakeCountVal" class="stepper-val stepper-ctx-indigo">0</span>
+                  <button data-action="wakeUp" class="stepper-btn stepper-ctx-indigo">+</button>
+                  <span class="t-sub" style="margin-left:4px;" id="wakeCountLabel">No wake-ups</span>
+                </div>
+              </div>
+              <div>
+                <label class="micro-label">Notes (optional)</label>
+                <input type="text" id="sleepNotes" placeholder="e.g. teething, restless..." class="form-input input-ctx-indigo">
+              </div>
+              <div class="d-flex gap-8 justify-end">
+                <button class="btn btn-ghost d-none" id="sleepCancelBtn" data-action="cancelSleepNight">Cancel</button>
+                <button class="btn btn-ghost" data-action="startSleepNight" id="sleepStartBtn" title="Uses entered time, or current time if empty"><svg class="zi"><use href="#zi-play"/></svg> Start</button>
+                <button class="btn-primary bp-indigo" data-action="addSleepEntry" id="sleepSaveBtn">Save Sleep Log</button>
+              </div>
             </div>
           </div>
-          <div class="d-flex gap-12">
-            <div class="flex-1">
-              <label class="micro-label">Bedtime</label>
-              <input type="time" id="sleepBedtime" class="form-input input-ctx-indigo">
+
+          <!-- NAP FORM -->
+          <div id="sleepNapCard" style="display:none;">
+            <div class="fx-col g12">
+              <div>
+                <label class="micro-label">Date</label>
+                <div class="d-flex items-center gap-8">
+                  <input type="date" id="napDate" oninput="updateSleepDayLabel('napDate','napDayLabel')" class="form-input input-ctx-indigo flex-1">
+                  <span id="napDayLabel" class="day-label day-label-indigo"></span>
+                </div>
+              </div>
+              <div class="d-flex gap-12">
+                <div class="flex-1">
+                  <label class="micro-label">Start</label>
+                  <input type="time" id="napStart" class="form-input input-ctx-indigo">
+                </div>
+                <div class="flex-1">
+                  <label class="micro-label">End</label>
+                  <input type="time" id="napEnd" class="form-input input-ctx-indigo">
+                </div>
+              </div>
+              <div>
+                <label class="micro-label">Notes (optional)</label>
+                <input type="text" id="napNotes" placeholder="e.g. contact nap, stroller, car seat..." class="form-input input-ctx-indigo">
+              </div>
+              <div class="d-flex gap-8 justify-end">
+                <button class="btn btn-ghost d-none" id="napCancelBtn" data-action="cancelSleepNap">Cancel</button>
+                <button class="btn btn-ghost" data-action="startSleepNap" id="napStartBtn" title="Uses entered time, or current time if empty"><svg class="zi"><use href="#zi-play"/></svg> Start</button>
+                <button class="btn-primary bp-indigo" data-action="addNapEntry" id="napSaveBtn">Save Nap</button>
+              </div>
             </div>
-            <div class="flex-1">
-              <label class="micro-label">Wake time</label>
-              <input type="time" id="sleepWakeTime" class="form-input input-ctx-indigo">
-            </div>
-          </div>
-          <div>
-            <label class="micro-label">Wake-ups</label>
-            <div class="d-flex items-center gap-8 mt-4">
-              <button data-action="wakeDown" class="stepper-btn stepper-ctx-indigo">−</button>
-              <span id="wakeCountVal" class="stepper-val stepper-ctx-indigo">0</span>
-              <button data-action="wakeUp" class="stepper-btn stepper-ctx-indigo">+</button>
-              <span class="t-sub" style="margin-left:4px;" id="wakeCountLabel">No wake-ups</span>
-            </div>
-          </div>
-          <div>
-            <label class="micro-label">Notes (optional)</label>
-            <input type="text" id="sleepNotes" placeholder="e.g. teething, restless..." class="form-input input-ctx-indigo">
-          </div>
-          <div class="d-flex gap-8 justify-end">
-            <button class="btn btn-ghost d-none" id="sleepCancelBtn" data-action="cancelSleepNight">Cancel</button>
-            <button class="btn btn-ghost" data-action="startSleepNight" id="sleepStartBtn" title="Uses entered time, or current time if empty"><svg class="zi"><use href="#zi-play"/></svg> Start</button>
-            <button class="btn-primary bp-indigo" data-action="addSleepEntry" id="sleepSaveBtn">Save Sleep Log</button>
           </div>
         </div>
       </div>
 
-      <!-- NAP LOG -->
-      <div class="card card-action col-full overflow-visible" id="sleepNapCard">
-        <div class="card-header">
-          <div class="card-title"><div class="icon icon-indigo"><svg class="zi"><use href="#zi-sleep"/></svg></div> Log Nap</div>
+      <!-- ─── TIER 2b: RECENT ENTRIES (promoted so the baby's data leads) ─── -->
+      <div class="card card-info col-full" id="sleepLogCard">
+        <div class="card-header" data-collapse-target="sleepLogBody" data-collapse-chevron="sleepLogChevron">
+          <div class="card-title"><div class="icon icon-indigo"><svg class="zi"><use href="#zi-list"/></svg></div> Sleep Logs</div>
+          <div class="d-flex items-center gap-8">
+            <span class="t-sub" id="sleepLogCount"></span>
+            <span class="collapse-chevron" id="sleepLogChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
+          </div>
         </div>
-        <div class="fx-col g12 mt-8">
-          <div>
-            <label class="micro-label">Date</label>
-            <div class="d-flex items-center gap-8">
-              <input type="date" id="napDate" oninput="updateSleepDayLabel('napDate','napDayLabel')" class="form-input input-ctx-indigo flex-1">
-              <span id="napDayLabel" class="day-label day-label-indigo"></span>
-            </div>
+        <div id="sleepLogPreview" class="mt-8"></div>
+        <div id="sleepLogBody" class="collapse-body" style="display:none;">
+          <div style="display:flex;gap:var(--sp-8);margin:8px 0;">
+            <button class="sq-btn active-sq" id="sleepLogFilter-all" data-sleep-filter="all">All</button>
+            <button class="sq-btn" id="sleepLogFilter-night" data-sleep-filter="night"><svg class="zi" aria-hidden="true"><use href="#zi-moon"/></svg> Night</button>
+            <button class="sq-btn" id="sleepLogFilter-nap" data-sleep-filter="nap"><svg class="zi" aria-hidden="true"><use href="#zi-zzz"/></svg> Naps</button>
           </div>
-          <div class="d-flex gap-12">
-            <div class="flex-1">
-              <label class="micro-label">Start</label>
-              <input type="time" id="napStart" class="form-input input-ctx-indigo">
-            </div>
-            <div class="flex-1">
-              <label class="micro-label">End</label>
-              <input type="time" id="napEnd" class="form-input input-ctx-indigo">
-            </div>
-          </div>
-          <div>
-            <label class="micro-label">Notes (optional)</label>
-            <input type="text" id="napNotes" placeholder="e.g. contact nap, stroller, car seat..." class="form-input input-ctx-indigo">
-          </div>
-          <div class="d-flex gap-8 justify-end">
-            <button class="btn btn-ghost d-none" id="napCancelBtn" data-action="cancelSleepNap">Cancel</button>
-            <button class="btn btn-ghost" data-action="startSleepNap" id="napStartBtn" title="Uses entered time, or current time if empty"><svg class="zi"><use href="#zi-play"/></svg> Start</button>
-            <button class="btn-primary bp-indigo" data-action="addNapEntry" id="napSaveBtn">Save Nap</button>
-          </div>
+          <div id="sleepLogList" class="fx-col g8 scroll-list"></div>
         </div>
       </div>
 
@@ -11033,26 +11064,6 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
         </div>
         <div id="sleepTipsBody" class="collapse-body" style="display:none;">
           <div id="sleepTips" class="fx-col g8 mt-8"></div>
-        </div>
-      </div>
-
-      <!-- RECENT ENTRIES (collapsible, split night/nap) -->
-      <div class="card card-info col-full" id="sleepLogCard">
-        <div class="card-header" data-collapse-target="sleepLogBody" data-collapse-chevron="sleepLogChevron">
-          <div class="card-title"><div class="icon icon-indigo"><svg class="zi"><use href="#zi-list"/></svg></div> Sleep Logs</div>
-          <div class="d-flex items-center gap-8">
-            <span class="t-sub" id="sleepLogCount"></span>
-            <span class="collapse-chevron" id="sleepLogChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
-          </div>
-        </div>
-        <div id="sleepLogPreview" class="mt-8"></div>
-        <div id="sleepLogBody" class="collapse-body" style="display:none;">
-          <div style="display:flex;gap:var(--sp-8);margin:8px 0;">
-            <button class="sq-btn active-sq" id="sleepLogFilter-all" data-sleep-filter="all">All</button>
-            <button class="sq-btn" id="sleepLogFilter-night" data-sleep-filter="night"><svg class="zi" aria-hidden="true"><use href="#zi-moon"/></svg> Night</button>
-            <button class="sq-btn" id="sleepLogFilter-nap" data-sleep-filter="nap"><svg class="zi" aria-hidden="true"><use href="#zi-zzz"/></svg> Naps</button>
-          </div>
-          <div id="sleepLogList" class="fx-col g8 scroll-list"></div>
         </div>
       </div>
 
@@ -17404,6 +17415,7 @@ function init() {
     else if (action === 'cancelSleepNap') cancelSleepEdit('nap');
     else if (action === 'startSleepNap') startSleepNow('nap');
     else if (action === 'addNapEntry') addNapEntry();
+    else if (action === 'sleepLogMode') setSleepLogMode(arg);
     else if (action === 'cancelPoopEdit') cancelPoopEdit();
     else if (action === 'addPoopEntry') addPoopEntry();
     else if (action === 'homeFabAction') homeFabAction();
@@ -41512,7 +41524,7 @@ function editSleepEntry(idx) {
     const btn = document.getElementById('sleepSaveBtn');
     btn.innerHTML = zi('check') + ' Update Sleep Log';
     document.getElementById('sleepCancelBtn').style.display = '';
-    document.getElementById('sleepNightCard').scrollIntoView({ behavior:'smooth', block:'start' });
+    openSleepLogForm('night');
   } else {
     document.getElementById('napDate').value = entry.date;
     document.getElementById('napStart').value = entry.bedtime;
@@ -41521,7 +41533,7 @@ function editSleepEntry(idx) {
     const btn = document.getElementById('napSaveBtn');
     btn.textContent = 'Update Nap';
     document.getElementById('napCancelBtn').style.display = '';
-    document.getElementById('sleepNapCard').scrollIntoView({ behavior:'smooth', block:'start' });
+    openSleepLogForm('nap');
   }
 }
 
@@ -41609,6 +41621,32 @@ function renderSleep() {
   renderSleepTips();
 }
 
+// ── Sleep log form: collapsed-by-default card, Night/Nap segmented ──
+let _sleepLogMode = 'night';
+
+function setSleepLogMode(mode) {
+  _sleepLogMode = mode === 'nap' ? 'nap' : 'night';
+  const nightForm = document.getElementById('sleepNightCard');
+  const napForm = document.getElementById('sleepNapCard');
+  if (nightForm) nightForm.style.display = _sleepLogMode === 'night' ? '' : 'none';
+  if (napForm) napForm.style.display = _sleepLogMode === 'nap' ? '' : 'none';
+  const segNight = document.getElementById('sleepSeg-night');
+  const segNap = document.getElementById('sleepSeg-nap');
+  if (segNight) segNight.classList.toggle('active-sq', _sleepLogMode === 'night');
+  if (segNap) segNap.classList.toggle('active-sq', _sleepLogMode === 'nap');
+}
+
+// Expand the collapsed Log card (if needed), pick a segment, scroll to it.
+function openSleepLogForm(mode) {
+  const body = document.getElementById('sleepLogFormBody');
+  if (body && !body.classList.contains('open')) {
+    toggleHistoryCard('sleepLogFormBody', 'sleepLogFormChevron');
+  }
+  setSleepLogMode(mode);
+  const card = document.getElementById('sleepLogFormCard');
+  if (card) setTimeout(() => card.scrollIntoView({ behavior: 'smooth', block: 'start' }), 80);
+}
+
 function renderSleepStats() {
   const el = document.getElementById('sleepStats');
   if (!el) return;
@@ -41666,7 +41704,7 @@ function renderSleepStats() {
       <div class="hsp-val">${lastNightStr}</div>
       <div class="hsp-label">Last night</div>
     </div>
-    <div class="home-stat-pill ${napColor}" data-scroll-to="sleepNapCard" data-scroll-block="start">
+    <div class="home-stat-pill ${napColor}" data-scroll-to="sleepLogFormCard" data-scroll-block="start">
       <div class="hsp-icon"><svg class="zi"><use href="#zi-sleep"/></svg></div>
       <div class="hsp-val">${todayNaps.length > 0 ? napH + 'h ' + napM + 'm' : '—'}</div>
       <div class="hsp-label">${todayNaps.length} nap${todayNaps.length !== 1 ? 's' : ''} today</div>

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.22-6",
+  "version": "2026.05.22-7",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.22-7",
+  "version": "2026.05.22-8",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -387,6 +387,7 @@ function init() {
     else if (action === 'startSleepNap') startSleepNow('nap');
     else if (action === 'addNapEntry') addNapEntry();
     else if (action === 'sleepLogMode') setSleepLogMode(arg);
+    else if (action === 'openSleepLog') openSleepLogForm(arg);
     else if (action === 'cancelPoopEdit') cancelPoopEdit();
     else if (action === 'addPoopEntry') addPoopEntry();
     else if (action === 'homeFabAction') homeFabAction();

--- a/split/core.js
+++ b/split/core.js
@@ -386,6 +386,7 @@ function init() {
     else if (action === 'cancelSleepNap') cancelSleepEdit('nap');
     else if (action === 'startSleepNap') startSleepNow('nap');
     else if (action === 'addNapEntry') addNapEntry();
+    else if (action === 'sleepLogMode') setSleepLogMode(arg);
     else if (action === 'cancelPoopEdit') cancelPoopEdit();
     else if (action === 'addPoopEntry') addPoopEntry();
     else if (action === 'homeFabAction') homeFabAction();

--- a/split/medical.js
+++ b/split/medical.js
@@ -5315,7 +5315,7 @@ function editSleepEntry(idx) {
     const btn = document.getElementById('sleepSaveBtn');
     btn.innerHTML = zi('check') + ' Update Sleep Log';
     document.getElementById('sleepCancelBtn').style.display = '';
-    document.getElementById('sleepNightCard').scrollIntoView({ behavior:'smooth', block:'start' });
+    openSleepLogForm('night');
   } else {
     document.getElementById('napDate').value = entry.date;
     document.getElementById('napStart').value = entry.bedtime;
@@ -5324,7 +5324,7 @@ function editSleepEntry(idx) {
     const btn = document.getElementById('napSaveBtn');
     btn.textContent = 'Update Nap';
     document.getElementById('napCancelBtn').style.display = '';
-    document.getElementById('sleepNapCard').scrollIntoView({ behavior:'smooth', block:'start' });
+    openSleepLogForm('nap');
   }
 }
 
@@ -5412,6 +5412,32 @@ function renderSleep() {
   renderSleepTips();
 }
 
+// ── Sleep log form: collapsed-by-default card, Night/Nap segmented ──
+let _sleepLogMode = 'night';
+
+function setSleepLogMode(mode) {
+  _sleepLogMode = mode === 'nap' ? 'nap' : 'night';
+  const nightForm = document.getElementById('sleepNightCard');
+  const napForm = document.getElementById('sleepNapCard');
+  if (nightForm) nightForm.style.display = _sleepLogMode === 'night' ? '' : 'none';
+  if (napForm) napForm.style.display = _sleepLogMode === 'nap' ? '' : 'none';
+  const segNight = document.getElementById('sleepSeg-night');
+  const segNap = document.getElementById('sleepSeg-nap');
+  if (segNight) segNight.classList.toggle('active-sq', _sleepLogMode === 'night');
+  if (segNap) segNap.classList.toggle('active-sq', _sleepLogMode === 'nap');
+}
+
+// Expand the collapsed Log card (if needed), pick a segment, scroll to it.
+function openSleepLogForm(mode) {
+  const body = document.getElementById('sleepLogFormBody');
+  if (body && !body.classList.contains('open')) {
+    toggleHistoryCard('sleepLogFormBody', 'sleepLogFormChevron');
+  }
+  setSleepLogMode(mode);
+  const card = document.getElementById('sleepLogFormCard');
+  if (card) setTimeout(() => card.scrollIntoView({ behavior: 'smooth', block: 'start' }), 80);
+}
+
 function renderSleepStats() {
   const el = document.getElementById('sleepStats');
   if (!el) return;
@@ -5469,7 +5495,7 @@ function renderSleepStats() {
       <div class="hsp-val">${lastNightStr}</div>
       <div class="hsp-label">Last night</div>
     </div>
-    <div class="home-stat-pill ${napColor}" data-scroll-to="sleepNapCard" data-scroll-block="start">
+    <div class="home-stat-pill ${napColor}" data-scroll-to="sleepLogFormCard" data-scroll-block="start">
       <div class="hsp-icon"><svg class="zi"><use href="#zi-sleep"/></svg></div>
       <div class="hsp-val">${todayNaps.length > 0 ? napH + 'h ' + napM + 'm' : '—'}</div>
       <div class="hsp-label">${todayNaps.length} nap${todayNaps.length !== 1 ? 's' : ''} today</div>

--- a/split/medical.js
+++ b/split/medical.js
@@ -5495,7 +5495,7 @@ function renderSleepStats() {
       <div class="hsp-val">${lastNightStr}</div>
       <div class="hsp-label">Last night</div>
     </div>
-    <div class="home-stat-pill ${napColor}" data-scroll-to="sleepLogFormCard" data-scroll-block="start">
+    <div class="home-stat-pill ${napColor}" data-action="openSleepLog" data-arg="nap">
       <div class="hsp-icon"><svg class="zi"><use href="#zi-sleep"/></svg></div>
       <div class="hsp-val">${todayNaps.length > 0 ? napH + 'h ' + napM + 'm' : '—'}</div>
       <div class="hsp-label">${todayNaps.length} nap${todayNaps.length !== 1 ? 's' : ''} today</div>

--- a/split/styles.css
+++ b/split/styles.css
@@ -4216,6 +4216,13 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
   font-size:var(--fs-base); font-weight:600; cursor:pointer; transition:all var(--ease-fast);
 }
 .sq-btn.active-sq { background:#5a6498; color:white; border-color:#5a6498; }
+.sleep-log-seg {
+  display:flex; gap:var(--sp-8);
+  margin:var(--sp-8) 0 var(--sp-16);
+}
+.sleep-log-seg .sq-btn {
+  flex:1; display:flex; align-items:center; justify-content:center; gap:var(--sp-6);
+}
 .sleep-stat-hero {
   font-family:'Fraunces',serif; font-size:var(--fs-3xl); font-weight:600;
   color:var(--tc-indigo); line-height:var(--lh-tight);

--- a/split/template.html
+++ b/split/template.html
@@ -1210,92 +1210,116 @@
       <div class="card col-full card-hero hero-sleep" id="sleepDomainHero" style="display:none;"></div>
 
       <!-- ─── TIER 1: STATS ─── -->
-      <!-- stat card wrapper removed -->
-        <div class="col-full stat-pills-grid" id="sleepStats"></div>
-
-      <!-- ─── TIER 2: ACTIONS ─── -->
-      <div class="home-section-label sec-t1 col-full">Log Sleep</div>
+      <div class="col-full stat-pills-grid" id="sleepStats"></div>
 
       <!-- In-progress sleep/nap banner -->
       <div class="col-full" id="sleepInProgressBanner" style="display:none;"></div>
 
-      <!-- SLEEP LOG FORM -->
-      <div class="card card-action col-full overflow-visible" id="sleepNightCard">
-        <div class="card-header">
-          <div class="card-title"><div class="icon icon-indigo"><svg class="zi"><use href="#zi-moon"/></svg></div> Log Night Sleep</div>
+      <!-- ─── TIER 2: LOG — collapsed by default, Night/Nap segmented ─── -->
+      <div class="card card-action col-full overflow-visible" id="sleepLogFormCard">
+        <div class="card-header" data-collapse-target="sleepLogFormBody" data-collapse-chevron="sleepLogFormChevron">
+          <div class="card-title"><div class="icon icon-indigo"><svg class="zi"><use href="#zi-moon"/></svg></div> Log Sleep</div>
+          <span class="collapse-chevron" id="sleepLogFormChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
         </div>
-        <div class="help-tip d-none" id="help-sleep">Track Ziva's bedtime and wake time. At 6–8 months, babies typically need 11–12 hours of night sleep plus 2–3 naps totalling 2–3 hours. Logging sleep helps spot patterns and ensure she's getting enough rest.</div>
-        <div class="fx-col g12 mt-8">
-          <div>
-            <label class="micro-label">Date</label>
-            <div class="d-flex items-center gap-8">
-              <input type="date" id="sleepDate" oninput="updateSleepDayLabel('sleepDate','sleepDayLabel')" class="form-input input-ctx-indigo flex-1">
-              <span id="sleepDayLabel" class="day-label day-label-indigo"></span>
+        <div id="sleepLogFormBody" class="collapse-body" style="display:none;">
+          <div class="sleep-log-seg">
+            <button class="sq-btn active-sq" id="sleepSeg-night" data-action="sleepLogMode" data-arg="night"><svg class="zi" aria-hidden="true"><use href="#zi-moon"/></svg> Night sleep</button>
+            <button class="sq-btn" id="sleepSeg-nap" data-action="sleepLogMode" data-arg="nap"><svg class="zi" aria-hidden="true"><use href="#zi-zzz"/></svg> Nap</button>
+          </div>
+
+          <!-- NIGHT FORM -->
+          <div id="sleepNightCard">
+            <div class="help-tip d-none" id="help-sleep">Track Ziva's bedtime and wake time. At 6–8 months, babies typically need 11–12 hours of night sleep plus 2–3 naps totalling 2–3 hours. Logging sleep helps spot patterns and ensure she's getting enough rest.</div>
+            <div class="fx-col g12">
+              <div>
+                <label class="micro-label">Date</label>
+                <div class="d-flex items-center gap-8">
+                  <input type="date" id="sleepDate" oninput="updateSleepDayLabel('sleepDate','sleepDayLabel')" class="form-input input-ctx-indigo flex-1">
+                  <span id="sleepDayLabel" class="day-label day-label-indigo"></span>
+                </div>
+              </div>
+              <div class="d-flex gap-12">
+                <div class="flex-1">
+                  <label class="micro-label">Bedtime</label>
+                  <input type="time" id="sleepBedtime" class="form-input input-ctx-indigo">
+                </div>
+                <div class="flex-1">
+                  <label class="micro-label">Wake time</label>
+                  <input type="time" id="sleepWakeTime" class="form-input input-ctx-indigo">
+                </div>
+              </div>
+              <div>
+                <label class="micro-label">Wake-ups</label>
+                <div class="d-flex items-center gap-8 mt-4">
+                  <button data-action="wakeDown" class="stepper-btn stepper-ctx-indigo">−</button>
+                  <span id="wakeCountVal" class="stepper-val stepper-ctx-indigo">0</span>
+                  <button data-action="wakeUp" class="stepper-btn stepper-ctx-indigo">+</button>
+                  <span class="t-sub" style="margin-left:4px;" id="wakeCountLabel">No wake-ups</span>
+                </div>
+              </div>
+              <div>
+                <label class="micro-label">Notes (optional)</label>
+                <input type="text" id="sleepNotes" placeholder="e.g. teething, restless..." class="form-input input-ctx-indigo">
+              </div>
+              <div class="d-flex gap-8 justify-end">
+                <button class="btn btn-ghost d-none" id="sleepCancelBtn" data-action="cancelSleepNight">Cancel</button>
+                <button class="btn btn-ghost" data-action="startSleepNight" id="sleepStartBtn" title="Uses entered time, or current time if empty"><svg class="zi"><use href="#zi-play"/></svg> Start</button>
+                <button class="btn-primary bp-indigo" data-action="addSleepEntry" id="sleepSaveBtn">Save Sleep Log</button>
+              </div>
             </div>
           </div>
-          <div class="d-flex gap-12">
-            <div class="flex-1">
-              <label class="micro-label">Bedtime</label>
-              <input type="time" id="sleepBedtime" class="form-input input-ctx-indigo">
+
+          <!-- NAP FORM -->
+          <div id="sleepNapCard" style="display:none;">
+            <div class="fx-col g12">
+              <div>
+                <label class="micro-label">Date</label>
+                <div class="d-flex items-center gap-8">
+                  <input type="date" id="napDate" oninput="updateSleepDayLabel('napDate','napDayLabel')" class="form-input input-ctx-indigo flex-1">
+                  <span id="napDayLabel" class="day-label day-label-indigo"></span>
+                </div>
+              </div>
+              <div class="d-flex gap-12">
+                <div class="flex-1">
+                  <label class="micro-label">Start</label>
+                  <input type="time" id="napStart" class="form-input input-ctx-indigo">
+                </div>
+                <div class="flex-1">
+                  <label class="micro-label">End</label>
+                  <input type="time" id="napEnd" class="form-input input-ctx-indigo">
+                </div>
+              </div>
+              <div>
+                <label class="micro-label">Notes (optional)</label>
+                <input type="text" id="napNotes" placeholder="e.g. contact nap, stroller, car seat..." class="form-input input-ctx-indigo">
+              </div>
+              <div class="d-flex gap-8 justify-end">
+                <button class="btn btn-ghost d-none" id="napCancelBtn" data-action="cancelSleepNap">Cancel</button>
+                <button class="btn btn-ghost" data-action="startSleepNap" id="napStartBtn" title="Uses entered time, or current time if empty"><svg class="zi"><use href="#zi-play"/></svg> Start</button>
+                <button class="btn-primary bp-indigo" data-action="addNapEntry" id="napSaveBtn">Save Nap</button>
+              </div>
             </div>
-            <div class="flex-1">
-              <label class="micro-label">Wake time</label>
-              <input type="time" id="sleepWakeTime" class="form-input input-ctx-indigo">
-            </div>
-          </div>
-          <div>
-            <label class="micro-label">Wake-ups</label>
-            <div class="d-flex items-center gap-8 mt-4">
-              <button data-action="wakeDown" class="stepper-btn stepper-ctx-indigo">−</button>
-              <span id="wakeCountVal" class="stepper-val stepper-ctx-indigo">0</span>
-              <button data-action="wakeUp" class="stepper-btn stepper-ctx-indigo">+</button>
-              <span class="t-sub" style="margin-left:4px;" id="wakeCountLabel">No wake-ups</span>
-            </div>
-          </div>
-          <div>
-            <label class="micro-label">Notes (optional)</label>
-            <input type="text" id="sleepNotes" placeholder="e.g. teething, restless..." class="form-input input-ctx-indigo">
-          </div>
-          <div class="d-flex gap-8 justify-end">
-            <button class="btn btn-ghost d-none" id="sleepCancelBtn" data-action="cancelSleepNight">Cancel</button>
-            <button class="btn btn-ghost" data-action="startSleepNight" id="sleepStartBtn" title="Uses entered time, or current time if empty"><svg class="zi"><use href="#zi-play"/></svg> Start</button>
-            <button class="btn-primary bp-indigo" data-action="addSleepEntry" id="sleepSaveBtn">Save Sleep Log</button>
           </div>
         </div>
       </div>
 
-      <!-- NAP LOG -->
-      <div class="card card-action col-full overflow-visible" id="sleepNapCard">
-        <div class="card-header">
-          <div class="card-title"><div class="icon icon-indigo"><svg class="zi"><use href="#zi-sleep"/></svg></div> Log Nap</div>
+      <!-- ─── TIER 2b: RECENT ENTRIES (promoted so the baby's data leads) ─── -->
+      <div class="card card-info col-full" id="sleepLogCard">
+        <div class="card-header" data-collapse-target="sleepLogBody" data-collapse-chevron="sleepLogChevron">
+          <div class="card-title"><div class="icon icon-indigo"><svg class="zi"><use href="#zi-list"/></svg></div> Sleep Logs</div>
+          <div class="d-flex items-center gap-8">
+            <span class="t-sub" id="sleepLogCount"></span>
+            <span class="collapse-chevron" id="sleepLogChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
+          </div>
         </div>
-        <div class="fx-col g12 mt-8">
-          <div>
-            <label class="micro-label">Date</label>
-            <div class="d-flex items-center gap-8">
-              <input type="date" id="napDate" oninput="updateSleepDayLabel('napDate','napDayLabel')" class="form-input input-ctx-indigo flex-1">
-              <span id="napDayLabel" class="day-label day-label-indigo"></span>
-            </div>
+        <div id="sleepLogPreview" class="mt-8"></div>
+        <div id="sleepLogBody" class="collapse-body" style="display:none;">
+          <div style="display:flex;gap:var(--sp-8);margin:8px 0;">
+            <button class="sq-btn active-sq" id="sleepLogFilter-all" data-sleep-filter="all">All</button>
+            <button class="sq-btn" id="sleepLogFilter-night" data-sleep-filter="night"><svg class="zi" aria-hidden="true"><use href="#zi-moon"/></svg> Night</button>
+            <button class="sq-btn" id="sleepLogFilter-nap" data-sleep-filter="nap"><svg class="zi" aria-hidden="true"><use href="#zi-zzz"/></svg> Naps</button>
           </div>
-          <div class="d-flex gap-12">
-            <div class="flex-1">
-              <label class="micro-label">Start</label>
-              <input type="time" id="napStart" class="form-input input-ctx-indigo">
-            </div>
-            <div class="flex-1">
-              <label class="micro-label">End</label>
-              <input type="time" id="napEnd" class="form-input input-ctx-indigo">
-            </div>
-          </div>
-          <div>
-            <label class="micro-label">Notes (optional)</label>
-            <input type="text" id="napNotes" placeholder="e.g. contact nap, stroller, car seat..." class="form-input input-ctx-indigo">
-          </div>
-          <div class="d-flex gap-8 justify-end">
-            <button class="btn btn-ghost d-none" id="napCancelBtn" data-action="cancelSleepNap">Cancel</button>
-            <button class="btn btn-ghost" data-action="startSleepNap" id="napStartBtn" title="Uses entered time, or current time if empty"><svg class="zi"><use href="#zi-play"/></svg> Start</button>
-            <button class="btn-primary bp-indigo" data-action="addNapEntry" id="napSaveBtn">Save Nap</button>
-          </div>
+          <div id="sleepLogList" class="fx-col g8 scroll-list"></div>
         </div>
       </div>
 
@@ -1321,26 +1345,6 @@
         </div>
         <div id="sleepTipsBody" class="collapse-body" style="display:none;">
           <div id="sleepTips" class="fx-col g8 mt-8"></div>
-        </div>
-      </div>
-
-      <!-- RECENT ENTRIES (collapsible, split night/nap) -->
-      <div class="card card-info col-full" id="sleepLogCard">
-        <div class="card-header" data-collapse-target="sleepLogBody" data-collapse-chevron="sleepLogChevron">
-          <div class="card-title"><div class="icon icon-indigo"><svg class="zi"><use href="#zi-list"/></svg></div> Sleep Logs</div>
-          <div class="d-flex items-center gap-8">
-            <span class="t-sub" id="sleepLogCount"></span>
-            <span class="collapse-chevron" id="sleepLogChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
-          </div>
-        </div>
-        <div id="sleepLogPreview" class="mt-8"></div>
-        <div id="sleepLogBody" class="collapse-body" style="display:none;">
-          <div style="display:flex;gap:var(--sp-8);margin:8px 0;">
-            <button class="sq-btn active-sq" id="sleepLogFilter-all" data-sleep-filter="all">All</button>
-            <button class="sq-btn" id="sleepLogFilter-night" data-sleep-filter="night"><svg class="zi" aria-hidden="true"><use href="#zi-moon"/></svg> Night</button>
-            <button class="sq-btn" id="sleepLogFilter-nap" data-sleep-filter="nap"><svg class="zi" aria-hidden="true"><use href="#zi-zzz"/></svg> Naps</button>
-          </div>
-          <div id="sleepLogList" class="fx-col g8 scroll-list"></div>
         </div>
       </div>
 

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -17416,6 +17416,7 @@ function init() {
     else if (action === 'startSleepNap') startSleepNow('nap');
     else if (action === 'addNapEntry') addNapEntry();
     else if (action === 'sleepLogMode') setSleepLogMode(arg);
+    else if (action === 'openSleepLog') openSleepLogForm(arg);
     else if (action === 'cancelPoopEdit') cancelPoopEdit();
     else if (action === 'addPoopEntry') addPoopEntry();
     else if (action === 'homeFabAction') homeFabAction();
@@ -41704,7 +41705,7 @@ function renderSleepStats() {
       <div class="hsp-val">${lastNightStr}</div>
       <div class="hsp-label">Last night</div>
     </div>
-    <div class="home-stat-pill ${napColor}" data-scroll-to="sleepLogFormCard" data-scroll-block="start">
+    <div class="home-stat-pill ${napColor}" data-action="openSleepLog" data-arg="nap">
       <div class="hsp-icon"><svg class="zi"><use href="#zi-sleep"/></svg></div>
       <div class="hsp-val">${todayNaps.length > 0 ? napH + 'h ' + napM + 'm' : '—'}</div>
       <div class="hsp-label">${todayNaps.length} nap${todayNaps.length !== 1 ? 's' : ''} today</div>

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -4223,6 +4223,13 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
   font-size:var(--fs-base); font-weight:600; cursor:pointer; transition:all var(--ease-fast);
 }
 .sq-btn.active-sq { background:#5a6498; color:white; border-color:#5a6498; }
+.sleep-log-seg {
+  display:flex; gap:var(--sp-8);
+  margin:var(--sp-8) 0 var(--sp-16);
+}
+.sleep-log-seg .sq-btn {
+  flex:1; display:flex; align-items:center; justify-content:center; gap:var(--sp-6);
+}
 .sleep-stat-hero {
   font-family:'Fraunces',serif; font-size:var(--fs-3xl); font-weight:600;
   color:var(--tc-indigo); line-height:var(--lh-tight);
@@ -10922,92 +10929,116 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
       <div class="card col-full card-hero hero-sleep" id="sleepDomainHero" style="display:none;"></div>
 
       <!-- ─── TIER 1: STATS ─── -->
-      <!-- stat card wrapper removed -->
-        <div class="col-full stat-pills-grid" id="sleepStats"></div>
-
-      <!-- ─── TIER 2: ACTIONS ─── -->
-      <div class="home-section-label sec-t1 col-full">Log Sleep</div>
+      <div class="col-full stat-pills-grid" id="sleepStats"></div>
 
       <!-- In-progress sleep/nap banner -->
       <div class="col-full" id="sleepInProgressBanner" style="display:none;"></div>
 
-      <!-- SLEEP LOG FORM -->
-      <div class="card card-action col-full overflow-visible" id="sleepNightCard">
-        <div class="card-header">
-          <div class="card-title"><div class="icon icon-indigo"><svg class="zi"><use href="#zi-moon"/></svg></div> Log Night Sleep</div>
+      <!-- ─── TIER 2: LOG — collapsed by default, Night/Nap segmented ─── -->
+      <div class="card card-action col-full overflow-visible" id="sleepLogFormCard">
+        <div class="card-header" data-collapse-target="sleepLogFormBody" data-collapse-chevron="sleepLogFormChevron">
+          <div class="card-title"><div class="icon icon-indigo"><svg class="zi"><use href="#zi-moon"/></svg></div> Log Sleep</div>
+          <span class="collapse-chevron" id="sleepLogFormChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
         </div>
-        <div class="help-tip d-none" id="help-sleep">Track Ziva's bedtime and wake time. At 6–8 months, babies typically need 11–12 hours of night sleep plus 2–3 naps totalling 2–3 hours. Logging sleep helps spot patterns and ensure she's getting enough rest.</div>
-        <div class="fx-col g12 mt-8">
-          <div>
-            <label class="micro-label">Date</label>
-            <div class="d-flex items-center gap-8">
-              <input type="date" id="sleepDate" oninput="updateSleepDayLabel('sleepDate','sleepDayLabel')" class="form-input input-ctx-indigo flex-1">
-              <span id="sleepDayLabel" class="day-label day-label-indigo"></span>
+        <div id="sleepLogFormBody" class="collapse-body" style="display:none;">
+          <div class="sleep-log-seg">
+            <button class="sq-btn active-sq" id="sleepSeg-night" data-action="sleepLogMode" data-arg="night"><svg class="zi" aria-hidden="true"><use href="#zi-moon"/></svg> Night sleep</button>
+            <button class="sq-btn" id="sleepSeg-nap" data-action="sleepLogMode" data-arg="nap"><svg class="zi" aria-hidden="true"><use href="#zi-zzz"/></svg> Nap</button>
+          </div>
+
+          <!-- NIGHT FORM -->
+          <div id="sleepNightCard">
+            <div class="help-tip d-none" id="help-sleep">Track Ziva's bedtime and wake time. At 6–8 months, babies typically need 11–12 hours of night sleep plus 2–3 naps totalling 2–3 hours. Logging sleep helps spot patterns and ensure she's getting enough rest.</div>
+            <div class="fx-col g12">
+              <div>
+                <label class="micro-label">Date</label>
+                <div class="d-flex items-center gap-8">
+                  <input type="date" id="sleepDate" oninput="updateSleepDayLabel('sleepDate','sleepDayLabel')" class="form-input input-ctx-indigo flex-1">
+                  <span id="sleepDayLabel" class="day-label day-label-indigo"></span>
+                </div>
+              </div>
+              <div class="d-flex gap-12">
+                <div class="flex-1">
+                  <label class="micro-label">Bedtime</label>
+                  <input type="time" id="sleepBedtime" class="form-input input-ctx-indigo">
+                </div>
+                <div class="flex-1">
+                  <label class="micro-label">Wake time</label>
+                  <input type="time" id="sleepWakeTime" class="form-input input-ctx-indigo">
+                </div>
+              </div>
+              <div>
+                <label class="micro-label">Wake-ups</label>
+                <div class="d-flex items-center gap-8 mt-4">
+                  <button data-action="wakeDown" class="stepper-btn stepper-ctx-indigo">−</button>
+                  <span id="wakeCountVal" class="stepper-val stepper-ctx-indigo">0</span>
+                  <button data-action="wakeUp" class="stepper-btn stepper-ctx-indigo">+</button>
+                  <span class="t-sub" style="margin-left:4px;" id="wakeCountLabel">No wake-ups</span>
+                </div>
+              </div>
+              <div>
+                <label class="micro-label">Notes (optional)</label>
+                <input type="text" id="sleepNotes" placeholder="e.g. teething, restless..." class="form-input input-ctx-indigo">
+              </div>
+              <div class="d-flex gap-8 justify-end">
+                <button class="btn btn-ghost d-none" id="sleepCancelBtn" data-action="cancelSleepNight">Cancel</button>
+                <button class="btn btn-ghost" data-action="startSleepNight" id="sleepStartBtn" title="Uses entered time, or current time if empty"><svg class="zi"><use href="#zi-play"/></svg> Start</button>
+                <button class="btn-primary bp-indigo" data-action="addSleepEntry" id="sleepSaveBtn">Save Sleep Log</button>
+              </div>
             </div>
           </div>
-          <div class="d-flex gap-12">
-            <div class="flex-1">
-              <label class="micro-label">Bedtime</label>
-              <input type="time" id="sleepBedtime" class="form-input input-ctx-indigo">
+
+          <!-- NAP FORM -->
+          <div id="sleepNapCard" style="display:none;">
+            <div class="fx-col g12">
+              <div>
+                <label class="micro-label">Date</label>
+                <div class="d-flex items-center gap-8">
+                  <input type="date" id="napDate" oninput="updateSleepDayLabel('napDate','napDayLabel')" class="form-input input-ctx-indigo flex-1">
+                  <span id="napDayLabel" class="day-label day-label-indigo"></span>
+                </div>
+              </div>
+              <div class="d-flex gap-12">
+                <div class="flex-1">
+                  <label class="micro-label">Start</label>
+                  <input type="time" id="napStart" class="form-input input-ctx-indigo">
+                </div>
+                <div class="flex-1">
+                  <label class="micro-label">End</label>
+                  <input type="time" id="napEnd" class="form-input input-ctx-indigo">
+                </div>
+              </div>
+              <div>
+                <label class="micro-label">Notes (optional)</label>
+                <input type="text" id="napNotes" placeholder="e.g. contact nap, stroller, car seat..." class="form-input input-ctx-indigo">
+              </div>
+              <div class="d-flex gap-8 justify-end">
+                <button class="btn btn-ghost d-none" id="napCancelBtn" data-action="cancelSleepNap">Cancel</button>
+                <button class="btn btn-ghost" data-action="startSleepNap" id="napStartBtn" title="Uses entered time, or current time if empty"><svg class="zi"><use href="#zi-play"/></svg> Start</button>
+                <button class="btn-primary bp-indigo" data-action="addNapEntry" id="napSaveBtn">Save Nap</button>
+              </div>
             </div>
-            <div class="flex-1">
-              <label class="micro-label">Wake time</label>
-              <input type="time" id="sleepWakeTime" class="form-input input-ctx-indigo">
-            </div>
-          </div>
-          <div>
-            <label class="micro-label">Wake-ups</label>
-            <div class="d-flex items-center gap-8 mt-4">
-              <button data-action="wakeDown" class="stepper-btn stepper-ctx-indigo">−</button>
-              <span id="wakeCountVal" class="stepper-val stepper-ctx-indigo">0</span>
-              <button data-action="wakeUp" class="stepper-btn stepper-ctx-indigo">+</button>
-              <span class="t-sub" style="margin-left:4px;" id="wakeCountLabel">No wake-ups</span>
-            </div>
-          </div>
-          <div>
-            <label class="micro-label">Notes (optional)</label>
-            <input type="text" id="sleepNotes" placeholder="e.g. teething, restless..." class="form-input input-ctx-indigo">
-          </div>
-          <div class="d-flex gap-8 justify-end">
-            <button class="btn btn-ghost d-none" id="sleepCancelBtn" data-action="cancelSleepNight">Cancel</button>
-            <button class="btn btn-ghost" data-action="startSleepNight" id="sleepStartBtn" title="Uses entered time, or current time if empty"><svg class="zi"><use href="#zi-play"/></svg> Start</button>
-            <button class="btn-primary bp-indigo" data-action="addSleepEntry" id="sleepSaveBtn">Save Sleep Log</button>
           </div>
         </div>
       </div>
 
-      <!-- NAP LOG -->
-      <div class="card card-action col-full overflow-visible" id="sleepNapCard">
-        <div class="card-header">
-          <div class="card-title"><div class="icon icon-indigo"><svg class="zi"><use href="#zi-sleep"/></svg></div> Log Nap</div>
+      <!-- ─── TIER 2b: RECENT ENTRIES (promoted so the baby's data leads) ─── -->
+      <div class="card card-info col-full" id="sleepLogCard">
+        <div class="card-header" data-collapse-target="sleepLogBody" data-collapse-chevron="sleepLogChevron">
+          <div class="card-title"><div class="icon icon-indigo"><svg class="zi"><use href="#zi-list"/></svg></div> Sleep Logs</div>
+          <div class="d-flex items-center gap-8">
+            <span class="t-sub" id="sleepLogCount"></span>
+            <span class="collapse-chevron" id="sleepLogChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
+          </div>
         </div>
-        <div class="fx-col g12 mt-8">
-          <div>
-            <label class="micro-label">Date</label>
-            <div class="d-flex items-center gap-8">
-              <input type="date" id="napDate" oninput="updateSleepDayLabel('napDate','napDayLabel')" class="form-input input-ctx-indigo flex-1">
-              <span id="napDayLabel" class="day-label day-label-indigo"></span>
-            </div>
+        <div id="sleepLogPreview" class="mt-8"></div>
+        <div id="sleepLogBody" class="collapse-body" style="display:none;">
+          <div style="display:flex;gap:var(--sp-8);margin:8px 0;">
+            <button class="sq-btn active-sq" id="sleepLogFilter-all" data-sleep-filter="all">All</button>
+            <button class="sq-btn" id="sleepLogFilter-night" data-sleep-filter="night"><svg class="zi" aria-hidden="true"><use href="#zi-moon"/></svg> Night</button>
+            <button class="sq-btn" id="sleepLogFilter-nap" data-sleep-filter="nap"><svg class="zi" aria-hidden="true"><use href="#zi-zzz"/></svg> Naps</button>
           </div>
-          <div class="d-flex gap-12">
-            <div class="flex-1">
-              <label class="micro-label">Start</label>
-              <input type="time" id="napStart" class="form-input input-ctx-indigo">
-            </div>
-            <div class="flex-1">
-              <label class="micro-label">End</label>
-              <input type="time" id="napEnd" class="form-input input-ctx-indigo">
-            </div>
-          </div>
-          <div>
-            <label class="micro-label">Notes (optional)</label>
-            <input type="text" id="napNotes" placeholder="e.g. contact nap, stroller, car seat..." class="form-input input-ctx-indigo">
-          </div>
-          <div class="d-flex gap-8 justify-end">
-            <button class="btn btn-ghost d-none" id="napCancelBtn" data-action="cancelSleepNap">Cancel</button>
-            <button class="btn btn-ghost" data-action="startSleepNap" id="napStartBtn" title="Uses entered time, or current time if empty"><svg class="zi"><use href="#zi-play"/></svg> Start</button>
-            <button class="btn-primary bp-indigo" data-action="addNapEntry" id="napSaveBtn">Save Nap</button>
-          </div>
+          <div id="sleepLogList" class="fx-col g8 scroll-list"></div>
         </div>
       </div>
 
@@ -11033,26 +11064,6 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
         </div>
         <div id="sleepTipsBody" class="collapse-body" style="display:none;">
           <div id="sleepTips" class="fx-col g8 mt-8"></div>
-        </div>
-      </div>
-
-      <!-- RECENT ENTRIES (collapsible, split night/nap) -->
-      <div class="card card-info col-full" id="sleepLogCard">
-        <div class="card-header" data-collapse-target="sleepLogBody" data-collapse-chevron="sleepLogChevron">
-          <div class="card-title"><div class="icon icon-indigo"><svg class="zi"><use href="#zi-list"/></svg></div> Sleep Logs</div>
-          <div class="d-flex items-center gap-8">
-            <span class="t-sub" id="sleepLogCount"></span>
-            <span class="collapse-chevron" id="sleepLogChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
-          </div>
-        </div>
-        <div id="sleepLogPreview" class="mt-8"></div>
-        <div id="sleepLogBody" class="collapse-body" style="display:none;">
-          <div style="display:flex;gap:var(--sp-8);margin:8px 0;">
-            <button class="sq-btn active-sq" id="sleepLogFilter-all" data-sleep-filter="all">All</button>
-            <button class="sq-btn" id="sleepLogFilter-night" data-sleep-filter="night"><svg class="zi" aria-hidden="true"><use href="#zi-moon"/></svg> Night</button>
-            <button class="sq-btn" id="sleepLogFilter-nap" data-sleep-filter="nap"><svg class="zi" aria-hidden="true"><use href="#zi-zzz"/></svg> Naps</button>
-          </div>
-          <div id="sleepLogList" class="fx-col g8 scroll-list"></div>
         </div>
       </div>
 
@@ -17404,6 +17415,7 @@ function init() {
     else if (action === 'cancelSleepNap') cancelSleepEdit('nap');
     else if (action === 'startSleepNap') startSleepNow('nap');
     else if (action === 'addNapEntry') addNapEntry();
+    else if (action === 'sleepLogMode') setSleepLogMode(arg);
     else if (action === 'cancelPoopEdit') cancelPoopEdit();
     else if (action === 'addPoopEntry') addPoopEntry();
     else if (action === 'homeFabAction') homeFabAction();
@@ -41512,7 +41524,7 @@ function editSleepEntry(idx) {
     const btn = document.getElementById('sleepSaveBtn');
     btn.innerHTML = zi('check') + ' Update Sleep Log';
     document.getElementById('sleepCancelBtn').style.display = '';
-    document.getElementById('sleepNightCard').scrollIntoView({ behavior:'smooth', block:'start' });
+    openSleepLogForm('night');
   } else {
     document.getElementById('napDate').value = entry.date;
     document.getElementById('napStart').value = entry.bedtime;
@@ -41521,7 +41533,7 @@ function editSleepEntry(idx) {
     const btn = document.getElementById('napSaveBtn');
     btn.textContent = 'Update Nap';
     document.getElementById('napCancelBtn').style.display = '';
-    document.getElementById('sleepNapCard').scrollIntoView({ behavior:'smooth', block:'start' });
+    openSleepLogForm('nap');
   }
 }
 
@@ -41609,6 +41621,32 @@ function renderSleep() {
   renderSleepTips();
 }
 
+// ── Sleep log form: collapsed-by-default card, Night/Nap segmented ──
+let _sleepLogMode = 'night';
+
+function setSleepLogMode(mode) {
+  _sleepLogMode = mode === 'nap' ? 'nap' : 'night';
+  const nightForm = document.getElementById('sleepNightCard');
+  const napForm = document.getElementById('sleepNapCard');
+  if (nightForm) nightForm.style.display = _sleepLogMode === 'night' ? '' : 'none';
+  if (napForm) napForm.style.display = _sleepLogMode === 'nap' ? '' : 'none';
+  const segNight = document.getElementById('sleepSeg-night');
+  const segNap = document.getElementById('sleepSeg-nap');
+  if (segNight) segNight.classList.toggle('active-sq', _sleepLogMode === 'night');
+  if (segNap) segNap.classList.toggle('active-sq', _sleepLogMode === 'nap');
+}
+
+// Expand the collapsed Log card (if needed), pick a segment, scroll to it.
+function openSleepLogForm(mode) {
+  const body = document.getElementById('sleepLogFormBody');
+  if (body && !body.classList.contains('open')) {
+    toggleHistoryCard('sleepLogFormBody', 'sleepLogFormChevron');
+  }
+  setSleepLogMode(mode);
+  const card = document.getElementById('sleepLogFormCard');
+  if (card) setTimeout(() => card.scrollIntoView({ behavior: 'smooth', block: 'start' }), 80);
+}
+
 function renderSleepStats() {
   const el = document.getElementById('sleepStats');
   if (!el) return;
@@ -41666,7 +41704,7 @@ function renderSleepStats() {
       <div class="hsp-val">${lastNightStr}</div>
       <div class="hsp-label">Last night</div>
     </div>
-    <div class="home-stat-pill ${napColor}" data-scroll-to="sleepNapCard" data-scroll-block="start">
+    <div class="home-stat-pill ${napColor}" data-scroll-to="sleepLogFormCard" data-scroll-block="start">
       <div class="hsp-icon"><svg class="zi"><use href="#zi-sleep"/></svg></div>
       <div class="hsp-val">${todayNaps.length > 0 ? napH + 'h ' + napM + 'm' : '—'}</div>
       <div class="hsp-label">${todayNaps.length} nap${todayNaps.length !== 1 ? 's' : ''} today</div>


### PR DESCRIPTION
## Summary

The **Track → Sleep** sub-tab opened with two always-expanded log forms
(Night + Nap) stacked one after another, pushing the baby's actual sleep
data (recent logs, trend) far down the page.

- Replace the two separate form cards with a single **collapsed-by-default
  "Log Sleep" card** carrying a **Night sleep / Nap segmented toggle** —
  the form expands inline only when tapped.
- Promote the **Sleep Logs** card up directly below the hero/stats so the
  data leads; logging is one compact tap away rather than a wall of inputs.
- `editSleepEntry` now expands the Log card and selects the matching
  segment (night/nap) before scrolling to it; the "naps today" stat pill
  scrolls to the new Log card.

No data model or storage changes — only layout and the form's
expand/collapse behaviour.

## Test plan

- [x] Sleep tab loads with the Log card collapsed
- [x] Tapping the header expands it → Night segment + night form shown
- [x] Tapping **Nap** swaps to the nap form; segment active state updates
- [x] `editSleepEntry` expands the card, selects the right segment, fills fields
- [x] Build passes all 4 audit gates (emoji / icon-text / resolve-shield / viz-smoke)
- [x] e2e suite: 118 passed (6 pre-existing `#statusStrip` failures unrelated to Sleep)

https://claude.ai/code/session_0181kMWhpPkM6thUreXdHxsx

---
_Generated by [Claude Code](https://claude.ai/code/session_0181kMWhpPkM6thUreXdHxsx)_