### PR TITLE
HR-2/HR-3 compliance cleanup of the Diet panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -676,6 +676,17 @@ svg.zi { width:16px; height:16px; vertical-align:-2px; flex-shrink:0; }
   background:var(--sky-light); color:var(--text); outline:none;
 }
 .add-food input:focus { border-color:var(--sky); }
+/* "Can I Give This?" combo card — HR-2 token-driven classes */
+.combo-desc {
+  font-size:var(--fs-base); color:var(--mid);
+  line-height:var(--lh-relaxed); margin-bottom:var(--sp-10);
+}
+.combo-input { flex:1; min-width:180px; }
+.combo-quick-chips {
+  display:flex; flex-wrap:wrap; gap:var(--sp-8);
+  align-items:center; margin-bottom:var(--sp-10);
+}
+.combo-history { margin-top:var(--sp-12); }
 .food-slot-select {
   padding:var(--sp-8) var(--sp-12); border-radius:var(--r-lg);
   border:1.5px solid var(--sky-light);
@@ -10516,7 +10527,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
           <div class="card-title"><div class="icon icon-peach"><svg class="zi"><use href="#zi-bowl"/></svg></div> Today's Meals <button class="help-btn" aria-label="Help" data-help="help-meals"><span class="t-sm">ⓘ</span></button></div>
           <div class="date-nav">
             <button data-action="datePrev" aria-label="Previous day">‹</button>
-            <input type="date" id="feedingDate" onchange="loadFeedingDay()">
+            <input type="date" id="feedingDate">
             <button data-action="dateNext" aria-label="Next day">›</button>
             <button class="btn-primary bp-peach" id="saveFeedBtn" data-action="saveFeedingDay">Save</button>
           </div>
@@ -10530,7 +10541,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
             <div class="meal-label"><svg class="zi" aria-hidden="true"><use href="#zi-sun"/></svg> Breakfast <span class="meal-skip-btn" id="skip-breakfast" data-skip-meal="breakfast" style="display:none;">skip</span><input type="time" class="meal-time-input" id="mealtime-breakfast" title="Meal time (optional)" placeholder="--:--"></div>
             <div class="dqp-zone" id="dqp-breakfast"></div>
             <div class="meal-input-wrap">
-              <input type="text" id="meal-breakfast" class="meal-input" placeholder="Type to search foods..." oninput="onMealInput('breakfast')" onfocus="onMealFocus('breakfast')" autocomplete="off">
+              <input type="text" id="meal-breakfast" class="meal-input" placeholder="Type to search foods..." autocomplete="off">
               <div class="meal-dropdown" id="md-breakfast"></div>
             </div>
             <div class="meal-insight" id="insight-breakfast" style="display:none;"><span class="meal-insight-icon icon-amber"><svg class="zi" aria-hidden="true"><use href="#zi-sparkle"/></svg></span><span id="insight-breakfast-text"></span></div>
@@ -10539,7 +10550,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
             <div class="meal-label"><svg class="zi" aria-hidden="true"><use href="#zi-sun"/></svg> Lunch <span class="meal-skip-btn" id="skip-lunch" data-skip-meal="lunch" style="display:none;">skip</span><input type="time" class="meal-time-input" id="mealtime-lunch" title="Meal time (optional)" placeholder="--:--"></div>
             <div class="dqp-zone" id="dqp-lunch"></div>
             <div class="meal-input-wrap">
-              <input type="text" id="meal-lunch" class="meal-input" placeholder="Type to search foods..." oninput="onMealInput('lunch')" onfocus="onMealFocus('lunch')" autocomplete="off">
+              <input type="text" id="meal-lunch" class="meal-input" placeholder="Type to search foods..." autocomplete="off">
               <div class="meal-dropdown" id="md-lunch"></div>
             </div>
             <div class="meal-insight" id="insight-lunch" style="display:none;"><span class="meal-insight-icon icon-amber"><svg class="zi" aria-hidden="true"><use href="#zi-sparkle"/></svg></span><span id="insight-lunch-text"></span></div>
@@ -10548,7 +10559,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
             <div class="meal-label"><svg class="zi" aria-hidden="true"><use href="#zi-moon"/></svg> Dinner <span class="meal-skip-btn" id="skip-dinner" data-skip-meal="dinner" style="display:none;">skip</span><input type="time" class="meal-time-input" id="mealtime-dinner" title="Meal time (optional)" placeholder="--:--"></div>
             <div class="dqp-zone" id="dqp-dinner"></div>
             <div class="meal-input-wrap">
-              <input type="text" id="meal-dinner" class="meal-input" placeholder="Type to search foods..." oninput="onMealInput('dinner')" onfocus="onMealFocus('dinner')" autocomplete="off">
+              <input type="text" id="meal-dinner" class="meal-input" placeholder="Type to search foods..." autocomplete="off">
               <div class="meal-dropdown" id="md-dinner"></div>
             </div>
             <div class="meal-insight" id="insight-dinner" style="display:none;"><span class="meal-insight-icon icon-amber"><svg class="zi" aria-hidden="true"><use href="#zi-sparkle"/></svg></span><span id="insight-dinner-text"></span></div>
@@ -10557,7 +10568,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
             <div class="meal-label"><svg class="zi" aria-hidden="true"><use href="#zi-spoon"/></svg> Snack <span class="meal-skip-btn" id="skip-snack" data-skip-meal="snack" style="display:none;">skip</span><input type="time" class="meal-time-input" id="mealtime-snack" title="Meal time (optional)" placeholder="--:--"></div>
             <div class="dqp-zone" id="dqp-snack"></div>
             <div class="meal-input-wrap">
-              <input type="text" id="meal-snack" class="meal-input" placeholder="Type to search foods..." oninput="onMealInput('snack')" onfocus="onMealFocus('snack')" autocomplete="off">
+              <input type="text" id="meal-snack" class="meal-input" placeholder="Type to search foods..." autocomplete="off">
               <div class="meal-dropdown" id="md-snack"></div>
             </div>
             <div class="meal-insight" id="insight-snack" style="display:none;"><span class="meal-insight-icon icon-amber"><svg class="zi" aria-hidden="true"><use href="#zi-sparkle"/></svg></span><span id="insight-snack-text"></span></div>
@@ -10570,14 +10581,14 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
         <div class="card-header">
           <div class="card-title"><div class="icon icon-sage"><svg class="zi"><use href="#zi-chef"/></svg></div> Can I Give This?</div>
         </div>
-        <div style="font-size:var(--fs-base);color:var(--mid);margin-bottom:10px;line-height:var(--lh-relaxed);">Ask about any food or combination — get safety info, a recipe, and dos & don'ts for Ziva's age.</div>
+        <div class="combo-desc">Ask about any food or combination — get safety info, a recipe, and dos & don'ts for Ziva's age.</div>
         <div class="flex-gap8-wrap-mb">
-          <input type="text" id="comboInput" placeholder="e.g. moringa + ragi, egg yolk, paneer with rice..." style="flex:1;min-width:180px;padding:10px 14px;border-radius:var(--r-lg);border:1.5px solid var(--sage-light);font-family:'Nunito',sans-serif;font-size:var(--fs-base);background:var(--sage-light);color:var(--text);outline:none;" onkeydown="if(event.key==='Enter')checkFoodCombo()" oninput="activateBtn('comboCheckBtn',this.value.trim())">
+          <input type="text" id="comboInput" class="form-input input-ctx-sage combo-input" placeholder="e.g. moringa + ragi, egg yolk, paneer with rice...">
           <button class="btn btn-sage disabled-state btn-min80" data-action="checkFoodCombo" id="comboCheckBtn" >Check <svg class="zi" aria-hidden="true"><use href="#zi-sparkle"/></svg></button>
         </div>
-        <div id="comboQuickChips" style="display:flex;flex-wrap:wrap;gap:var(--sp-8);align-items:center;margin-bottom:10px;"></div>
+        <div id="comboQuickChips" class="combo-quick-chips"></div>
         <div id="comboResult"></div>
-        <div id="comboHistory" style="margin-top:12px;"></div>
+        <div id="comboHistory" class="combo-history"></div>
       </div>
 
       <!-- ─── TIER 3: REFERENCE ─── -->
@@ -10593,7 +10604,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
         <div id="foodsGrid"></div>
         <div class="add-food">
           <input type="text" id="foodInput" oninput="activateBtn('foodAddBtn',this.value.trim())" placeholder="Add a food..." onkeydown="if(event.key==='Enter')addFood()">
-          <input type="date" id="foodDate" style="padding:7px 10px;border-radius:var(--r-lg);border:1.5px solid var(--sky-light);font-family:'Nunito',sans-serif;font-size:var(--fs-base);background:var(--sky-light);color:var(--text);outline:none;">
+          <input type="date" id="foodDate">
           <select id="foodSlot" class="food-slot-select" aria-label="Meal slot">
             <option value="">Any meal</option>
             <option value="breakfast">Breakfast</option>
@@ -17243,6 +17254,8 @@ function init() {
   document.querySelectorAll('.meal-skip-btn[data-skip-meal]').forEach(btn => {
     btn.addEventListener('click', (e) => { e.stopPropagation(); skipSingleMeal(btn.dataset.skipMeal); });
   });
+  // Diet panel static inputs (HR-3 — no inline handlers)
+  wireDietPanelEvents();
   // Milestone categories
   document.querySelectorAll('.rtog[data-mcat]').forEach(btn => {
     btn.addEventListener('click', () => setMilestoneCat(btn.dataset.mcat));
@@ -26087,6 +26100,33 @@ function onMealInput(meal) {
     showMealDropdown(meal, token);
   } else {
     closeMealDropdown(meal);
+  }
+}
+
+// Wire the Diet panel's static inputs (HR-3 — no inline handlers). These
+// elements ship in template.html, so a single addEventListener pass at init
+// suffices; called from init() in core.js.
+function wireDietPanelEvents() {
+  const feedingDate = document.getElementById('feedingDate');
+  if (feedingDate) feedingDate.addEventListener('change', loadFeedingDay);
+
+  ['breakfast', 'lunch', 'dinner', 'snack'].forEach(meal => {
+    const inp = document.getElementById('meal-' + meal);
+    if (!inp) return;
+    inp.addEventListener('input', () => onMealInput(meal));
+    inp.addEventListener('focus', () => onMealFocus(meal));
+  });
+
+  const combo = document.getElementById('comboInput');
+  if (combo) {
+    combo.addEventListener('input', () => activateBtn('comboCheckBtn', combo.value.trim()));
+    combo.addEventListener('keydown', (e) => { if (e.key === 'Enter') checkFoodCombo(); });
+  }
+
+  const food = document.getElementById('foodInput');
+  if (food) {
+    food.addEventListener('input', () => activateBtn('foodAddBtn', food.value.trim()));
+    food.addEventListener('keydown', (e) => { if (e.key === 'Enter') addFood(); });
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -10603,7 +10603,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
         <div class="help-tip" id="help-foods">Track every new food Ziva tries. The 3-day rule: introduce one new food at a time and wait 3 days before the next to spot any reactions. Mark foods as "Watch" if you notice rash, loose stools, or fussiness. The "X of Y" count shows how much variety she has in each food group.</div>
         <div id="foodsGrid"></div>
         <div class="add-food">
-          <input type="text" id="foodInput" oninput="activateBtn('foodAddBtn',this.value.trim())" placeholder="Add a food..." onkeydown="if(event.key==='Enter')addFood()">
+          <input type="text" id="foodInput" placeholder="Add a food...">
           <input type="date" id="foodDate">
           <select id="foodSlot" class="food-slot-select" aria-label="Meal slot">
             <option value="">Any meal</option>

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.22-8",
+  "version": "2026.05.22-9",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.22-9",
+  "version": "2026.05.22-10",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -214,6 +214,8 @@ function init() {
   document.querySelectorAll('.meal-skip-btn[data-skip-meal]').forEach(btn => {
     btn.addEventListener('click', (e) => { e.stopPropagation(); skipSingleMeal(btn.dataset.skipMeal); });
   });
+  // Diet panel static inputs (HR-3 — no inline handlers)
+  wireDietPanelEvents();
   // Milestone categories
   document.querySelectorAll('.rtog[data-mcat]').forEach(btn => {
     btn.addEventListener('click', () => setMilestoneCat(btn.dataset.mcat));

--- a/split/home.js
+++ b/split/home.js
@@ -3577,6 +3577,33 @@ function onMealInput(meal) {
   }
 }
 
+// Wire the Diet panel's static inputs (HR-3 — no inline handlers). These
+// elements ship in template.html, so a single addEventListener pass at init
+// suffices; called from init() in core.js.
+function wireDietPanelEvents() {
+  const feedingDate = document.getElementById('feedingDate');
+  if (feedingDate) feedingDate.addEventListener('change', loadFeedingDay);
+
+  ['breakfast', 'lunch', 'dinner', 'snack'].forEach(meal => {
+    const inp = document.getElementById('meal-' + meal);
+    if (!inp) return;
+    inp.addEventListener('input', () => onMealInput(meal));
+    inp.addEventListener('focus', () => onMealFocus(meal));
+  });
+
+  const combo = document.getElementById('comboInput');
+  if (combo) {
+    combo.addEventListener('input', () => activateBtn('comboCheckBtn', combo.value.trim()));
+    combo.addEventListener('keydown', (e) => { if (e.key === 'Enter') checkFoodCombo(); });
+  }
+
+  const food = document.getElementById('foodInput');
+  if (food) {
+    food.addEventListener('input', () => activateBtn('foodAddBtn', food.value.trim()));
+    food.addEventListener('keydown', (e) => { if (e.key === 'Enter') addFood(); });
+  }
+}
+
 function updateFeedingSaveBtn() {
   const b = document.getElementById('meal-breakfast')?.value.trim();
   const l = document.getElementById('meal-lunch')?.value.trim();

--- a/split/styles.css
+++ b/split/styles.css
@@ -669,6 +669,17 @@ svg.zi { width:16px; height:16px; vertical-align:-2px; flex-shrink:0; }
   background:var(--sky-light); color:var(--text); outline:none;
 }
 .add-food input:focus { border-color:var(--sky); }
+/* "Can I Give This?" combo card — HR-2 token-driven classes */
+.combo-desc {
+  font-size:var(--fs-base); color:var(--mid);
+  line-height:var(--lh-relaxed); margin-bottom:var(--sp-10);
+}
+.combo-input { flex:1; min-width:180px; }
+.combo-quick-chips {
+  display:flex; flex-wrap:wrap; gap:var(--sp-8);
+  align-items:center; margin-bottom:var(--sp-10);
+}
+.combo-history { margin-top:var(--sp-12); }
 .food-slot-select {
   padding:var(--sp-8) var(--sp-12); border-radius:var(--r-lg);
   border:1.5px solid var(--sky-light);

--- a/split/template.html
+++ b/split/template.html
@@ -873,7 +873,7 @@
         <div class="help-tip" id="help-foods">Track every new food Ziva tries. The 3-day rule: introduce one new food at a time and wait 3 days before the next to spot any reactions. Mark foods as "Watch" if you notice rash, loose stools, or fussiness. The "X of Y" count shows how much variety she has in each food group.</div>
         <div id="foodsGrid"></div>
         <div class="add-food">
-          <input type="text" id="foodInput" oninput="activateBtn('foodAddBtn',this.value.trim())" placeholder="Add a food..." onkeydown="if(event.key==='Enter')addFood()">
+          <input type="text" id="foodInput" placeholder="Add a food...">
           <input type="date" id="foodDate">
           <select id="foodSlot" class="food-slot-select" aria-label="Meal slot">
             <option value="">Any meal</option>

--- a/split/template.html
+++ b/split/template.html
@@ -797,7 +797,7 @@
           <div class="card-title"><div class="icon icon-peach"><svg class="zi"><use href="#zi-bowl"/></svg></div> Today's Meals <button class="help-btn" aria-label="Help" data-help="help-meals"><span class="t-sm">ⓘ</span></button></div>
           <div class="date-nav">
             <button data-action="datePrev" aria-label="Previous day">‹</button>
-            <input type="date" id="feedingDate" onchange="loadFeedingDay()">
+            <input type="date" id="feedingDate">
             <button data-action="dateNext" aria-label="Next day">›</button>
             <button class="btn-primary bp-peach" id="saveFeedBtn" data-action="saveFeedingDay">Save</button>
           </div>
@@ -811,7 +811,7 @@
             <div class="meal-label"><svg class="zi" aria-hidden="true"><use href="#zi-sun"/></svg> Breakfast <span class="meal-skip-btn" id="skip-breakfast" data-skip-meal="breakfast" style="display:none;">skip</span><input type="time" class="meal-time-input" id="mealtime-breakfast" title="Meal time (optional)" placeholder="--:--"></div>
             <div class="dqp-zone" id="dqp-breakfast"></div>
             <div class="meal-input-wrap">
-              <input type="text" id="meal-breakfast" class="meal-input" placeholder="Type to search foods..." oninput="onMealInput('breakfast')" onfocus="onMealFocus('breakfast')" autocomplete="off">
+              <input type="text" id="meal-breakfast" class="meal-input" placeholder="Type to search foods..." autocomplete="off">
               <div class="meal-dropdown" id="md-breakfast"></div>
             </div>
             <div class="meal-insight" id="insight-breakfast" style="display:none;"><span class="meal-insight-icon icon-amber"><svg class="zi" aria-hidden="true"><use href="#zi-sparkle"/></svg></span><span id="insight-breakfast-text"></span></div>
@@ -820,7 +820,7 @@
             <div class="meal-label"><svg class="zi" aria-hidden="true"><use href="#zi-sun"/></svg> Lunch <span class="meal-skip-btn" id="skip-lunch" data-skip-meal="lunch" style="display:none;">skip</span><input type="time" class="meal-time-input" id="mealtime-lunch" title="Meal time (optional)" placeholder="--:--"></div>
             <div class="dqp-zone" id="dqp-lunch"></div>
             <div class="meal-input-wrap">
-              <input type="text" id="meal-lunch" class="meal-input" placeholder="Type to search foods..." oninput="onMealInput('lunch')" onfocus="onMealFocus('lunch')" autocomplete="off">
+              <input type="text" id="meal-lunch" class="meal-input" placeholder="Type to search foods..." autocomplete="off">
               <div class="meal-dropdown" id="md-lunch"></div>
             </div>
             <div class="meal-insight" id="insight-lunch" style="display:none;"><span class="meal-insight-icon icon-amber"><svg class="zi" aria-hidden="true"><use href="#zi-sparkle"/></svg></span><span id="insight-lunch-text"></span></div>
@@ -829,7 +829,7 @@
             <div class="meal-label"><svg class="zi" aria-hidden="true"><use href="#zi-moon"/></svg> Dinner <span class="meal-skip-btn" id="skip-dinner" data-skip-meal="dinner" style="display:none;">skip</span><input type="time" class="meal-time-input" id="mealtime-dinner" title="Meal time (optional)" placeholder="--:--"></div>
             <div class="dqp-zone" id="dqp-dinner"></div>
             <div class="meal-input-wrap">
-              <input type="text" id="meal-dinner" class="meal-input" placeholder="Type to search foods..." oninput="onMealInput('dinner')" onfocus="onMealFocus('dinner')" autocomplete="off">
+              <input type="text" id="meal-dinner" class="meal-input" placeholder="Type to search foods..." autocomplete="off">
               <div class="meal-dropdown" id="md-dinner"></div>
             </div>
             <div class="meal-insight" id="insight-dinner" style="display:none;"><span class="meal-insight-icon icon-amber"><svg class="zi" aria-hidden="true"><use href="#zi-sparkle"/></svg></span><span id="insight-dinner-text"></span></div>
@@ -838,7 +838,7 @@
             <div class="meal-label"><svg class="zi" aria-hidden="true"><use href="#zi-spoon"/></svg> Snack <span class="meal-skip-btn" id="skip-snack" data-skip-meal="snack" style="display:none;">skip</span><input type="time" class="meal-time-input" id="mealtime-snack" title="Meal time (optional)" placeholder="--:--"></div>
             <div class="dqp-zone" id="dqp-snack"></div>
             <div class="meal-input-wrap">
-              <input type="text" id="meal-snack" class="meal-input" placeholder="Type to search foods..." oninput="onMealInput('snack')" onfocus="onMealFocus('snack')" autocomplete="off">
+              <input type="text" id="meal-snack" class="meal-input" placeholder="Type to search foods..." autocomplete="off">
               <div class="meal-dropdown" id="md-snack"></div>
             </div>
             <div class="meal-insight" id="insight-snack" style="display:none;"><span class="meal-insight-icon icon-amber"><svg class="zi" aria-hidden="true"><use href="#zi-sparkle"/></svg></span><span id="insight-snack-text"></span></div>
@@ -851,14 +851,14 @@
         <div class="card-header">
           <div class="card-title"><div class="icon icon-sage"><svg class="zi"><use href="#zi-chef"/></svg></div> Can I Give This?</div>
         </div>
-        <div style="font-size:var(--fs-base);color:var(--mid);margin-bottom:10px;line-height:var(--lh-relaxed);">Ask about any food or combination — get safety info, a recipe, and dos & don'ts for Ziva's age.</div>
+        <div class="combo-desc">Ask about any food or combination — get safety info, a recipe, and dos & don'ts for Ziva's age.</div>
         <div class="flex-gap8-wrap-mb">
-          <input type="text" id="comboInput" placeholder="e.g. moringa + ragi, egg yolk, paneer with rice..." style="flex:1;min-width:180px;padding:10px 14px;border-radius:var(--r-lg);border:1.5px solid var(--sage-light);font-family:'Nunito',sans-serif;font-size:var(--fs-base);background:var(--sage-light);color:var(--text);outline:none;" onkeydown="if(event.key==='Enter')checkFoodCombo()" oninput="activateBtn('comboCheckBtn',this.value.trim())">
+          <input type="text" id="comboInput" class="form-input input-ctx-sage combo-input" placeholder="e.g. moringa + ragi, egg yolk, paneer with rice...">
           <button class="btn btn-sage disabled-state btn-min80" data-action="checkFoodCombo" id="comboCheckBtn" >Check <svg class="zi" aria-hidden="true"><use href="#zi-sparkle"/></svg></button>
         </div>
-        <div id="comboQuickChips" style="display:flex;flex-wrap:wrap;gap:var(--sp-8);align-items:center;margin-bottom:10px;"></div>
+        <div id="comboQuickChips" class="combo-quick-chips"></div>
         <div id="comboResult"></div>
-        <div id="comboHistory" style="margin-top:12px;"></div>
+        <div id="comboHistory" class="combo-history"></div>
       </div>
 
       <!-- ─── TIER 3: REFERENCE ─── -->
@@ -874,7 +874,7 @@
         <div id="foodsGrid"></div>
         <div class="add-food">
           <input type="text" id="foodInput" oninput="activateBtn('foodAddBtn',this.value.trim())" placeholder="Add a food..." onkeydown="if(event.key==='Enter')addFood()">
-          <input type="date" id="foodDate" style="padding:7px 10px;border-radius:var(--r-lg);border:1.5px solid var(--sky-light);font-family:'Nunito',sans-serif;font-size:var(--fs-base);background:var(--sky-light);color:var(--text);outline:none;">
+          <input type="date" id="foodDate">
           <select id="foodSlot" class="food-slot-select" aria-label="Meal slot">
             <option value="">Any meal</option>
             <option value="breakfast">Breakfast</option>

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -676,6 +676,17 @@ svg.zi { width:16px; height:16px; vertical-align:-2px; flex-shrink:0; }
   background:var(--sky-light); color:var(--text); outline:none;
 }
 .add-food input:focus { border-color:var(--sky); }
+/* "Can I Give This?" combo card — HR-2 token-driven classes */
+.combo-desc {
+  font-size:var(--fs-base); color:var(--mid);
+  line-height:var(--lh-relaxed); margin-bottom:var(--sp-10);
+}
+.combo-input { flex:1; min-width:180px; }
+.combo-quick-chips {
+  display:flex; flex-wrap:wrap; gap:var(--sp-8);
+  align-items:center; margin-bottom:var(--sp-10);
+}
+.combo-history { margin-top:var(--sp-12); }
 .food-slot-select {
   padding:var(--sp-8) var(--sp-12); border-radius:var(--r-lg);
   border:1.5px solid var(--sky-light);
@@ -10516,7 +10527,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
           <div class="card-title"><div class="icon icon-peach"><svg class="zi"><use href="#zi-bowl"/></svg></div> Today's Meals <button class="help-btn" aria-label="Help" data-help="help-meals"><span class="t-sm">ⓘ</span></button></div>
           <div class="date-nav">
             <button data-action="datePrev" aria-label="Previous day">‹</button>
-            <input type="date" id="feedingDate" onchange="loadFeedingDay()">
+            <input type="date" id="feedingDate">
             <button data-action="dateNext" aria-label="Next day">›</button>
             <button class="btn-primary bp-peach" id="saveFeedBtn" data-action="saveFeedingDay">Save</button>
           </div>
@@ -10530,7 +10541,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
             <div class="meal-label"><svg class="zi" aria-hidden="true"><use href="#zi-sun"/></svg> Breakfast <span class="meal-skip-btn" id="skip-breakfast" data-skip-meal="breakfast" style="display:none;">skip</span><input type="time" class="meal-time-input" id="mealtime-breakfast" title="Meal time (optional)" placeholder="--:--"></div>
             <div class="dqp-zone" id="dqp-breakfast"></div>
             <div class="meal-input-wrap">
-              <input type="text" id="meal-breakfast" class="meal-input" placeholder="Type to search foods..." oninput="onMealInput('breakfast')" onfocus="onMealFocus('breakfast')" autocomplete="off">
+              <input type="text" id="meal-breakfast" class="meal-input" placeholder="Type to search foods..." autocomplete="off">
               <div class="meal-dropdown" id="md-breakfast"></div>
             </div>
             <div class="meal-insight" id="insight-breakfast" style="display:none;"><span class="meal-insight-icon icon-amber"><svg class="zi" aria-hidden="true"><use href="#zi-sparkle"/></svg></span><span id="insight-breakfast-text"></span></div>
@@ -10539,7 +10550,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
             <div class="meal-label"><svg class="zi" aria-hidden="true"><use href="#zi-sun"/></svg> Lunch <span class="meal-skip-btn" id="skip-lunch" data-skip-meal="lunch" style="display:none;">skip</span><input type="time" class="meal-time-input" id="mealtime-lunch" title="Meal time (optional)" placeholder="--:--"></div>
             <div class="dqp-zone" id="dqp-lunch"></div>
             <div class="meal-input-wrap">
-              <input type="text" id="meal-lunch" class="meal-input" placeholder="Type to search foods..." oninput="onMealInput('lunch')" onfocus="onMealFocus('lunch')" autocomplete="off">
+              <input type="text" id="meal-lunch" class="meal-input" placeholder="Type to search foods..." autocomplete="off">
               <div class="meal-dropdown" id="md-lunch"></div>
             </div>
             <div class="meal-insight" id="insight-lunch" style="display:none;"><span class="meal-insight-icon icon-amber"><svg class="zi" aria-hidden="true"><use href="#zi-sparkle"/></svg></span><span id="insight-lunch-text"></span></div>
@@ -10548,7 +10559,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
             <div class="meal-label"><svg class="zi" aria-hidden="true"><use href="#zi-moon"/></svg> Dinner <span class="meal-skip-btn" id="skip-dinner" data-skip-meal="dinner" style="display:none;">skip</span><input type="time" class="meal-time-input" id="mealtime-dinner" title="Meal time (optional)" placeholder="--:--"></div>
             <div class="dqp-zone" id="dqp-dinner"></div>
             <div class="meal-input-wrap">
-              <input type="text" id="meal-dinner" class="meal-input" placeholder="Type to search foods..." oninput="onMealInput('dinner')" onfocus="onMealFocus('dinner')" autocomplete="off">
+              <input type="text" id="meal-dinner" class="meal-input" placeholder="Type to search foods..." autocomplete="off">
               <div class="meal-dropdown" id="md-dinner"></div>
             </div>
             <div class="meal-insight" id="insight-dinner" style="display:none;"><span class="meal-insight-icon icon-amber"><svg class="zi" aria-hidden="true"><use href="#zi-sparkle"/></svg></span><span id="insight-dinner-text"></span></div>
@@ -10557,7 +10568,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
             <div class="meal-label"><svg class="zi" aria-hidden="true"><use href="#zi-spoon"/></svg> Snack <span class="meal-skip-btn" id="skip-snack" data-skip-meal="snack" style="display:none;">skip</span><input type="time" class="meal-time-input" id="mealtime-snack" title="Meal time (optional)" placeholder="--:--"></div>
             <div class="dqp-zone" id="dqp-snack"></div>
             <div class="meal-input-wrap">
-              <input type="text" id="meal-snack" class="meal-input" placeholder="Type to search foods..." oninput="onMealInput('snack')" onfocus="onMealFocus('snack')" autocomplete="off">
+              <input type="text" id="meal-snack" class="meal-input" placeholder="Type to search foods..." autocomplete="off">
               <div class="meal-dropdown" id="md-snack"></div>
             </div>
             <div class="meal-insight" id="insight-snack" style="display:none;"><span class="meal-insight-icon icon-amber"><svg class="zi" aria-hidden="true"><use href="#zi-sparkle"/></svg></span><span id="insight-snack-text"></span></div>
@@ -10570,14 +10581,14 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
         <div class="card-header">
           <div class="card-title"><div class="icon icon-sage"><svg class="zi"><use href="#zi-chef"/></svg></div> Can I Give This?</div>
         </div>
-        <div style="font-size:var(--fs-base);color:var(--mid);margin-bottom:10px;line-height:var(--lh-relaxed);">Ask about any food or combination — get safety info, a recipe, and dos & don'ts for Ziva's age.</div>
+        <div class="combo-desc">Ask about any food or combination — get safety info, a recipe, and dos & don'ts for Ziva's age.</div>
         <div class="flex-gap8-wrap-mb">
-          <input type="text" id="comboInput" placeholder="e.g. moringa + ragi, egg yolk, paneer with rice..." style="flex:1;min-width:180px;padding:10px 14px;border-radius:var(--r-lg);border:1.5px solid var(--sage-light);font-family:'Nunito',sans-serif;font-size:var(--fs-base);background:var(--sage-light);color:var(--text);outline:none;" onkeydown="if(event.key==='Enter')checkFoodCombo()" oninput="activateBtn('comboCheckBtn',this.value.trim())">
+          <input type="text" id="comboInput" class="form-input input-ctx-sage combo-input" placeholder="e.g. moringa + ragi, egg yolk, paneer with rice...">
           <button class="btn btn-sage disabled-state btn-min80" data-action="checkFoodCombo" id="comboCheckBtn" >Check <svg class="zi" aria-hidden="true"><use href="#zi-sparkle"/></svg></button>
         </div>
-        <div id="comboQuickChips" style="display:flex;flex-wrap:wrap;gap:var(--sp-8);align-items:center;margin-bottom:10px;"></div>
+        <div id="comboQuickChips" class="combo-quick-chips"></div>
         <div id="comboResult"></div>
-        <div id="comboHistory" style="margin-top:12px;"></div>
+        <div id="comboHistory" class="combo-history"></div>
       </div>
 
       <!-- ─── TIER 3: REFERENCE ─── -->
@@ -10593,7 +10604,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
         <div id="foodsGrid"></div>
         <div class="add-food">
           <input type="text" id="foodInput" oninput="activateBtn('foodAddBtn',this.value.trim())" placeholder="Add a food..." onkeydown="if(event.key==='Enter')addFood()">
-          <input type="date" id="foodDate" style="padding:7px 10px;border-radius:var(--r-lg);border:1.5px solid var(--sky-light);font-family:'Nunito',sans-serif;font-size:var(--fs-base);background:var(--sky-light);color:var(--text);outline:none;">
+          <input type="date" id="foodDate">
           <select id="foodSlot" class="food-slot-select" aria-label="Meal slot">
             <option value="">Any meal</option>
             <option value="breakfast">Breakfast</option>
@@ -17243,6 +17254,8 @@ function init() {
   document.querySelectorAll('.meal-skip-btn[data-skip-meal]').forEach(btn => {
     btn.addEventListener('click', (e) => { e.stopPropagation(); skipSingleMeal(btn.dataset.skipMeal); });
   });
+  // Diet panel static inputs (HR-3 — no inline handlers)
+  wireDietPanelEvents();
   // Milestone categories
   document.querySelectorAll('.rtog[data-mcat]').forEach(btn => {
     btn.addEventListener('click', () => setMilestoneCat(btn.dataset.mcat));
@@ -26087,6 +26100,33 @@ function onMealInput(meal) {
     showMealDropdown(meal, token);
   } else {
     closeMealDropdown(meal);
+  }
+}
+
+// Wire the Diet panel's static inputs (HR-3 — no inline handlers). These
+// elements ship in template.html, so a single addEventListener pass at init
+// suffices; called from init() in core.js.
+function wireDietPanelEvents() {
+  const feedingDate = document.getElementById('feedingDate');
+  if (feedingDate) feedingDate.addEventListener('change', loadFeedingDay);
+
+  ['breakfast', 'lunch', 'dinner', 'snack'].forEach(meal => {
+    const inp = document.getElementById('meal-' + meal);
+    if (!inp) return;
+    inp.addEventListener('input', () => onMealInput(meal));
+    inp.addEventListener('focus', () => onMealFocus(meal));
+  });
+
+  const combo = document.getElementById('comboInput');
+  if (combo) {
+    combo.addEventListener('input', () => activateBtn('comboCheckBtn', combo.value.trim()));
+    combo.addEventListener('keydown', (e) => { if (e.key === 'Enter') checkFoodCombo(); });
+  }
+
+  const food = document.getElementById('foodInput');
+  if (food) {
+    food.addEventListener('input', () => activateBtn('foodAddBtn', food.value.trim()));
+    food.addEventListener('keydown', (e) => { if (e.key === 'Enter') addFood(); });
   }
 }
 

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -10603,7 +10603,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
         <div class="help-tip" id="help-foods">Track every new food Ziva tries. The 3-day rule: introduce one new food at a time and wait 3 days before the next to spot any reactions. Mark foods as "Watch" if you notice rash, loose stools, or fussiness. The "X of Y" count shows how much variety she has in each food group.</div>
         <div id="foodsGrid"></div>
         <div class="add-food">
-          <input type="text" id="foodInput" oninput="activateBtn('foodAddBtn',this.value.trim())" placeholder="Add a food..." onkeydown="if(event.key==='Enter')addFood()">
+          <input type="text" id="foodInput" placeholder="Add a food...">
           <input type="date" id="foodDate">
           <select id="foodSlot" class="food-slot-select" aria-label="Meal slot">
             <option value="">Any meal</option>


### PR DESCRIPTION
## Summary

HR-2/HR-3 compliance cleanup of the **Track → Diet** panel — converting its inline event handlers and inline styles to the codebase's compliant patterns. No behavior or visual change.

**HR-3 — inline handlers removed (13).** `onchange`/`oninput`/`onfocus`/`onkeydown` on `#feedingDate`, the four meal inputs, `#comboInput` and `#foodInput`. A new `wireDietPanelEvents()` in `home.js` binds them via `addEventListener` at init (these elements are static in `template.html`, so a single pass suffices — the same pattern already used for the meal-skip buttons).

**HR-2 — property-bearing inline styles removed (5).** The "Can I Give This?" card's inline styles become token-driven classes — `.combo-desc`, `.combo-input`, `.combo-quick-chips`, `.combo-history`. `#comboInput` now uses the standard `form-input` + `input-ctx-sage` system. `#foodDate`'s inline style was fully redundant with the existing `.add-food input` rule, so it is simply dropped.

**Deliberately out of scope.** Two residual debts in the Diet panel are *not* touched by this PR — both pre-existing, neither a regression here:
- The nine JS-toggled `style="display:none"` states (domain hero, meal-skip buttons, meal insights) — that visibility idiom is codebase-wide; converting it would mean touching show/hide logic across `home.js` and `intelligence-quicklog.js` for zero visual gain.
- The combo quick-chips and combo-history items rendered by `diet.js` still carry `onclick=` inline handlers. This PR cleans the *static* `template.html` inputs only; the `diet.js`-rendered handlers are a separate HR-3 follow-up.

## QA chain — canon-cc-008

Cleared the mandatory pre-merge gate (`docs/QA_GATE_SPEC.md` Gate 2.5):
- **Build & self-check** — `build.sh` clean, 4/4 audit gates pass, 125/125 e2e green.
- **Maren** (Governor of Care) — `clear`, no findings; HR-2/HR-3 cleanup complete in `home.js`, no Care-safety regression.
- **Kael** (Governor of Intelligence) — `clear-with-notes`: `core.js` init-order chain sound. Notes — an optional defensive guard (declined at synthesis: it would guard an impossible state) and the `diet.js` scope clarification, folded into "out of scope" above. No regression.
- **Lyra** synthesis — no code amendments required.
- **Cipher** Edict V final-pass — `LGTM`, no findings.

## Test plan

- [x] Build passes all 4 audit gates
- [x] Browser check — meal typeahead, combo Check activation + Enter, add-food activation, date-change all fire correctly; no JS errors
- [x] Full e2e suite → 125/125 pass

https://claude.ai/code/session_0181kMWhpPkM6thUreXdHxsx