### PR TITLE
chore: QA-chain pre-merge gate + Vercel config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 **Scope:** Cross-tool agent instructions (Claude Code, OpenAI Codex CLI, Gemini CLI)
 **Author:** Rishabh Jain
-**Updated:** 15 April 2026
+**Updated:** 22 May 2026
 
 ---
 
@@ -25,6 +25,7 @@ Three PWA projects sharing a common architectural pattern: split-file HTML conca
 6. **git --no-pager** for all git commands (Termux terminal width constraint).
 7. **Spec before build.** Complex features use the 8-pass SPEC_ITERATION_PROCESS. The spec is build-ready when the builder never makes an undocumented decision.
 8. **QA until cosmetic.** Post-build multi-round QA. Continue until only cosmetic bugs remain.
+9. **SproutLab — Governor audit chain before merge (canon-cc-008).** Every Capital change (edit under `split/`) clears the Governor→synthesis→Cipher chain before its PR leaves draft or merges: Maren audits Care files, Kael audits Intelligence files, both review shared modules, Lyra synthesizes, Cipher runs the Edict V pass. The `/code-review` skill does NOT discharge it. See CLAUDE.md §QA Chain and docs/QA_GATE_SPEC.md Gate 2.5.
 
 ## Build Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,34 @@ Cipher's Province mirror is a byte-identical deploy of the Codex canon (`Codex/d
 
 **Subagent vs skill split (canon-cc-022 artifact test):** subagent output is a separable, attributable interaction-artifact entering the cc-018 lifecycle (Lyra's Mode 1 spec authoring, Maren and Kael's Mode 1 jurisdictional audits, any Mode 2 committee-delegate positions). Skill output is an in-transcript register-flip — pattern-read, smell-check, Governor scout — with no signature, no gate, no Edict V chain entry. If the caller wants a signed audit or a spec-bearing record, summon the subagent. If the caller wants the voice mid-build without breaking flow, fire the skill.
 
-**QA-chain order (canon-cc-008):** Builder builds → Governors audit in parallel (Maren on Care, Kael on Intelligence, both on shared modules) → Lyra synthesizes → Cipher runs Edict V cross-cutting pass. Do not short-circuit.
+## QA Chain — Mandatory Pre-Merge Gate (canon-cc-008)
+
+**NON-NEGOTIABLE. This is a release gate, not a guideline.** Every SproutLab
+Capital change — any edit under `split/` headed for a PR — MUST clear the
+canon-cc-008 chain *before* the PR is taken out of draft or merged:
+
+1. **Build & self-check.** `build.sh` clean, all audit gates pass, e2e green.
+2. **Governor audit — Mode-1 subagents, summoned in parallel:**
+   - Diff touches `home.js`, `diet.js`, or `medical.js` → summon **Maren** (Care).
+   - Diff touches any `intelligence-*.js`, `core.js`, `data.js`, `sync.js`, `config.js`, or `start.js` → summon **Kael** (Intelligence).
+   - Diff touches `styles.css` or `template.html` → summon **both** (shared-module dual review).
+   - Diff is test-only / docs-only → the Governor audit may be waived; state the waiver explicitly.
+3. **Lyra synthesizes** the Governor reports and folds in the fixes.
+4. **Cipher** runs the Edict V cross-cutting final-pass.
+5. *Only now* — mark the PR ready / merge.
+
+**The `/code-review` skill is NOT a Governor audit and does NOT discharge
+this gate.** Per the canon-cc-022 artifact test, a skill run is an
+in-transcript smell-check — no signature, no Edict V chain entry. It may
+*supplement* the chain; it never *replaces* it.
+
+A draft PR may be opened before the chain runs — but it stays draft until
+the chain completes. Marking a PR ready, merging, or skipping a Governor
+whose jurisdiction the diff touched is a canon-cc-008 short-circuit.
+
+An Architect waiver ("skip the chain" / "merge it directly") is valid only
+when **explicitly given** — surface the chain, get the explicit waiver, note
+it. Silence is not a waiver. Full procedure: `docs/QA_GATE_SPEC.md` Gate 2.5.
 
 ## What SproutLab Is
 

--- a/Memory.md
+++ b/Memory.md
@@ -1,7 +1,7 @@
 # Memory.md
 **Scope:** Persistent institutional knowledge across all repos
 **Owner:** The Consul (cross-repo overseer)
-**Updated:** 15 April 2026
+**Updated:** 22 May 2026
 
 ---
 
@@ -61,6 +61,7 @@ CA by background. Business Manager at Soma Electro Products (zinc electroplating
 - **Split-file architecture** adopted after SproutLab monolith hit ~2MB. Migration M1–M3 pain documented; all new repos start split.
 - **Aurelius snippet format** is the canonical content import mechanism. Core principle: minimal manual input.
 - **QA multi-round** continues until only cosmetic bugs remain. Caught 8 critical bugs pre-build in CareTickets spec alone.
+- **QA chain is a pre-merge gate (canon-cc-008), enforced from 22 May 2026.** A SproutLab session built and merged PRs #99 and #100 — and staged #101 — running only the `/code-review` *skill*, with the Maren/Kael Governor audits and Cipher's Edict V pass skipped. The skill is an in-transcript smell-check (canon-cc-022 artifact test), not a Governor audit, and does not discharge the chain. Correction codified in CLAUDE.md §QA Chain and QA_GATE_SPEC.md Gate 2.5: no SproutLab Capital change leaves draft or merges until the Governor→synthesis→Cipher chain has run. Silence from the Architect is not a waiver — waivers must be explicit.
 
 ## Companion Registry (Quick Reference)
 

--- a/docs/QA_GATE_SPEC.md
+++ b/docs/QA_GATE_SPEC.md
@@ -1,5 +1,6 @@
 # SproutLab — Build QA Gate Spec
 **Created:** 9 April 2026
+**Updated:** 22 May 2026 — added Gate 2.5 (canon-cc-008 Governor audit chain)
 **Applies to:** Every SproutLab build session
 **Philosophy:** The user never asks for a QA audit. Code is not presented until it passes.
 
@@ -157,6 +158,40 @@ CHECKS:
 
 ---
 
+### Gate 2.5 — Governor Audit Chain (canon-cc-008)
+
+**When:** After Gate 2 passes, before a PR is taken out of draft or merged.
+**Owner:** Lyra (routing) → Governors (audit) → Cipher (Edict V final-pass).
+**Added:** 22 May 2026, after PRs #99–#101 were merged/staged without it.
+
+Gate 2 is the *builder's* self-check. Gate 2.5 is the *institutional* audit —
+the 30K-Rule QA chain. It is mandatory for every Capital change (any edit
+under `split/`). A draft PR may be opened first, but it stays draft until
+this gate clears.
+
+| Step | Who | Trigger |
+|------|-----|---------|
+| Care audit | **Maren** (Mode-1 subagent) | diff touches `home.js` / `diet.js` / `medical.js` |
+| Intelligence audit | **Kael** (Mode-1 subagent) | diff touches `intelligence-*.js` / `core.js` / `data.js` / `sync.js` / `config.js` / `start.js` |
+| Shared-module review | **both** Governors | diff touches `styles.css` / `template.html` |
+| Synthesis | **Lyra** | always — fold Governor findings into fixes |
+| Edict V final-pass | **Cipher** | always — cross-cutting sign-off |
+
+**Gate 2.5 passes when:** every touched-jurisdiction Governor has audited,
+Lyra has synthesized the findings, and Cipher has returned an `LGTM` or
+`amended` verdict.
+
+**The `/code-review` skill does NOT satisfy Gate 2.5.** A skill run is an
+in-transcript smell-check (canon-cc-022 artifact test) — no signature, no
+Edict V chain entry. Summon the Governor *subagents*; the skill may only
+supplement them.
+
+A test-only or docs-only change may waive the Governor audit — state the
+waiver explicitly. An Architect waiver ("merge it directly") is valid only
+when explicitly given; silence is not a waiver.
+
+---
+
 ### Gate 3 — Post-Deploy
 
 **When:** After user deploys and shares a screenshot or confirms it's running.
@@ -285,6 +320,7 @@ grep 'font-family' $CSS | grep -v 'Nunito\|Fraunces' || echo "  ✓ PASS"
 |------|------|------------------------|-------------------|
 | Gate 1 | Before code | All deps verified or waived | User sees the ask |
 | Gate 2 | Before delivery | Layers 1-3 all pass | **Builder only** — user never sees |
+| Gate 2.5 | Before PR ready/merge | Governors audited, Lyra synthesized, Cipher `LGTM`/`amended` | Lyra routes; chain entry recorded |
 | Gate 3 | After deploy | ≤2 cosmetic items as debt | User reviews visuals |
 
 **A session is complete when Gate 3 passes.**

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "buildCommand": "echo 'SproutLab ships a pre-built index.html (split/build.sh runs locally) — no Vercel build step.'",
+  "installCommand": "echo 'Static deploy — no dependencies to install.'",
+  "outputDirectory": ".",
+  "headers": [
+    {
+      "source": "/sw.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/(index.html)?",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/sproutlab.html",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/manifest.json",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, must-revalidate" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Process + infra changes that came out of a QA-chain post-mortem. **Two
commits, no `split/` source touched** — docs and config only.

### 1. Codify the canon-cc-008 QA chain as a mandatory pre-merge gate

PRs #99–#101 were built and merged (or staged) running only the
`/code-review` *skill* — the Maren/Kael Governor audits and Cipher's
Edict V pass were skipped. The chain *was* documented, but only as
descriptive prose with no operational gate.

- **`CLAUDE.md`** — new top-level section **§QA Chain — Mandatory
  Pre-Merge Gate**: a numbered release gate with a jurisdiction→Governor
  routing table, and the explicit rule that `/code-review` is a skill,
  not a Governor audit, and does not discharge the gate.
- **`docs/QA_GATE_SPEC.md`** — new **Gate 2.5 — Governor Audit Chain**
  between the builder's pre-delivery Gate 2 and post-deploy Gate 3.
- **`AGENTS.md`** — new rule 9 cross-referencing the gate.
- **`Memory.md`** — methodology-decision entry recording the lapse and
  the correction so future sessions inherit it.

### 2. Add `vercel.json`

Enables Vercel per-PR preview deploys (makes QA_GATE_SPEC Gate 3 runnable
before merge). No-ops Vercel's build/install — `index.html` is pre-built
and committed — and sets `Cache-Control` so `sw.js` and the HTML shell
stay fresh (HTTP-layer echo of canon-0034).

## QA chain

Per the gate this PR itself defines: **docs + config only, no `split/`
change → Governor audit waived** (the documented test/docs/config
carve-out). Stated explicitly here as the rule requires.

## Test plan

- [x] No code paths changed; `index.html` / `sproutlab.html` untouched, no rebuild needed
- [x] `vercel.json` recon: SproutLab uses all-relative paths (`sw.js`, `./index.html`) — serves correctly from a Vercel domain root
- [ ] Vercel dashboard connect (Architect) — then confirm a preview URL renders

https://claude.ai/code/session_0181kMWhpPkM6thUreXdHxsx

---
_Generated by [Claude Code](https://claude.ai/code/session_0181kMWhpPkM6thUreXdHxsx)_