### PR TITLE
fix(escape): escHtml escapes &quot; — close F-35-1 doctrine corner (#107)

### DIFF
--- a/index.html
+++ b/index.html
@@ -19674,7 +19674,10 @@ function migrateScrapbookIds() {
 
 function escHtml(s) {
   if (typeof s !== 'string') s = s == null ? '' : String(s);
-  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/\n/g,'<br>');
+  // Escapes & < > " \n — covers HTML body context and double-quoted attribute
+  // context. The " → &quot; closes the F-35-1 data-arg corner per issue #107
+  // (a literal " in user content would otherwise break out of data-arg="…").
+  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/\n/g,'<br>');
 }
 // V-K-10 (PR #75 carry-forward) — iconText(name, text) returns raw HTML:
 // `zi(name) + ' ' + escHtml(text)`. The text component is escaped at the

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.22-12",
+  "version": "2026.05.23-1",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -2634,7 +2634,10 @@ function migrateScrapbookIds() {
 
 function escHtml(s) {
   if (typeof s !== 'string') s = s == null ? '' : String(s);
-  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/\n/g,'<br>');
+  // Escapes & < > " \n — covers HTML body context and double-quoted attribute
+  // context. The " → &quot; closes the F-35-1 data-arg corner per issue #107
+  // (a literal " in user content would otherwise break out of data-arg="…").
+  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/\n/g,'<br>');
 }
 // V-K-10 (PR #75 carry-forward) — iconText(name, text) returns raw HTML:
 // `zi(name) + ' ' + escHtml(text)`. The text component is escaped at the

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -19674,7 +19674,10 @@ function migrateScrapbookIds() {
 
 function escHtml(s) {
   if (typeof s !== 'string') s = s == null ? '' : String(s);
-  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/\n/g,'<br>');
+  // Escapes & < > " \n — covers HTML body context and double-quoted attribute
+  // context. The " → &quot; closes the F-35-1 data-arg corner per issue #107
+  // (a literal " in user content would otherwise break out of data-arg="…").
+  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/\n/g,'<br>');
 }
 // V-K-10 (PR #75 carry-forward) — iconText(name, text) returns raw HTML:
 // `zi(name) + ' ' + escHtml(text)`. The text component is escaped at the

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -3158,17 +3158,51 @@ test.describe('Polish-10b — HR-3 onclick batch (Care + Home; ~24 sites)', () =
     // user-content data-arg / data-arg2 positions; apostrophe in double-
     // quoted HTML attribute is parser-safe; escHtml leaves apostrophe
     // literal; dataset.arg returns clean string.
-    const homeRes = await request.get('/split/home.js');
+    //
+    // #107 extension: also scan diet.js — PR #106 moved user-content
+    // data-arg escaping into the combo-card render sites (c.text, h.q,
+    // p.partner, queryFoods), so the doctrine guard now reaches both
+    // files Maren governs the render boundaries of.
+    const [homeRes, dietRes] = await Promise.all([
+      request.get('/split/home.js'),
+      request.get('/split/diet.js'),
+    ]);
     const home = await homeRes.text();
+    const diet = await dietRes.text();
 
     // Affected fields: m.name (medication), nextMilestone.text (milestone),
     // val (food meal value), f.name (food name), comboStr (combo string),
     // s.partner (synergy partner food name).
-    const buggyPattern = /data-arg2?="\$\{escAttr\((m\.name|nextMilestone\.text|comboStr|s\.partner|f\.name|val)\b/g;
-    const violations = home.match(buggyPattern) || [];
-    expect(violations,
-      `Polish-10b r2: zero escAttr in user-content data-arg positions (Maren F-35-1 fix). Found: ${violations.join(' | ')}`)
+    const buggyPatternHome = /data-arg2?="\$\{escAttr\((m\.name|nextMilestone\.text|comboStr|s\.partner|f\.name|val)\b/g;
+    // diet.js user-content fields: c.text (combo quick-chip), h.q (combo
+    // history query), p.partner (synergy partner), queryFoods (parsed combo).
+    const buggyPatternDiet = /data-arg2?="\$\{escAttr\((c\.text|h\.q|p\.partner|queryFoods)\b/g;
+    const homeViolations = home.match(buggyPatternHome) || [];
+    const dietViolations = diet.match(buggyPatternDiet) || [];
+    expect(homeViolations,
+      `home.js: zero escAttr in user-content data-arg positions (Maren F-35-1 fix). Found: ${homeViolations.join(' | ')}`)
       .toEqual([]);
+    expect(dietViolations,
+      `diet.js: zero escAttr in user-content data-arg positions (#107 coverage extension). Found: ${dietViolations.join(' | ')}`)
+      .toEqual([]);
+  });
+
+  test('regression-guard (#107 V-K-14) — escHtml escapes " for double-quoted attribute safety', async ({ request }) => {
+    // Issue #107 V-K-14 fix: escHtml now escapes " → &quot; so that
+    // data-arg="..." attributes carrying user-content are safe against
+    // attribute-breakout. Without this, a literal " in user content
+    // (e.g. a combo-history query like `sweet "tangy" sauce`) would
+    // terminate the attribute early; dataset.arg would arrive truncated
+    // and comboHistory.find(x => x.q === arg) would silently miss.
+    // The F-35-1 doctrine continues to mandate escHtml-not-escAttr for
+    // user-content data-arg; this guard locks in the " coverage that
+    // escHtml previously lacked.
+    const core = await (await request.get('/split/core.js')).text();
+    const escHtmlBody = core.match(/function escHtml\(s\)\s*\{[\s\S]*?\n\}/);
+    expect(escHtmlBody, 'escHtml definition found in core.js').not.toBeNull();
+    expect(escHtmlBody![0].includes(`replace(/"/g,'&quot;')`),
+      `escHtml must escape " → &quot; (issue #107 V-K-14). Body was:\n${escHtmlBody?.[0]}`)
+      .toBeTruthy();
   });
 });
 

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -3200,8 +3200,12 @@ test.describe('Polish-10b — HR-3 onclick batch (Care + Home; ~24 sites)', () =
     const core = await (await request.get('/split/core.js')).text();
     const escHtmlBody = core.match(/function escHtml\(s\)\s*\{[\s\S]*?\n\}/);
     expect(escHtmlBody, 'escHtml definition found in core.js').not.toBeNull();
-    expect(escHtmlBody![0].includes(`replace(/"/g,'&quot;')`),
-      `escHtml must escape " → &quot; (issue #107 V-K-14). Body was:\n${escHtmlBody?.[0]}`)
+    // Tolerant of whitespace and quote-delimiter variation (Kael V-K-17):
+    // a future reformat like `replace(/"/g, "&quot;")` or extra spaces must
+    // still satisfy the guard so long as the semantic `"` → `&quot;` survives.
+    const quotEscapePattern = /\.replace\(\s*\/"\/g\s*,\s*['"]&quot;['"]\s*\)/;
+    expect(quotEscapePattern.test(escHtmlBody![0]),
+      `escHtml must escape " → &quot; (issue #107 V-K-14). Body was:\n${escHtmlBody![0]}`)
       .toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

Closes **#107** — the F-35-1 doctrine corner Kael surfaced in PR #106's audit.

### The fix — `escHtml` now escapes `"`

One line added to `escHtml` in `core.js`:

```js
.replace(/"/g, '&quot;')
```

User-content `data-arg="..."` sites carrying a literal `"` (e.g. a combo-history query like `sweet "tangy" sauce`) previously terminated the attribute early; `dataset.arg` arrived truncated, and downstream consumers like `comboHistory.find(x => x.q === arg)` silently missed. This closes the F-35-1 data-arg corner across **every** `data-arg` site in the codebase.

**Safe everywhere:** `&quot;` is a no-op in HTML body context (renders as `"`) and is required in double-quoted attribute context. Cipher's cross-cutting trace confirmed: every escHtml call site lands in body / quoted-attribute / dataset round-trip — all decode `&quot;` back to `"` before any consumer sees it. The patch incidentally also closes latent `"`-attribute-breakouts at three `title="${escHtml(...)}"` callers and at the pre-existing inline `onclick=` sites at `diet.js:4003` / `intelligence-quicklog.js:2838`.

### Regression-guard coverage (Maren's #107 ask)

`tests/e2e/smoke.spec.ts`:
- **Extends** the F-35-1 r2 guard to also scan `diet.js` (PR #106 moved user-content `data-arg` escaping there).
- **Adds** a new `#107 V-K-14` regression guard with a whitespace/quote-tolerant regex (folds Kael's V-K-17 at synthesis) asserting `escHtml`'s source contains the `"`-escape.

## QA chain — canon-cc-008

Cleared the mandatory pre-merge gate:
- **Build & self-check** — `build.sh` clean, 4/4 audit gates pass, 125/125 e2e green.
- **Maren** (Governor of Care) — `clear-with-notes`; the `escHtml` ripple across `home.js`/`diet.js`/`medical.js` is benign at every render boundary she traced. Notes routed to follow-up (see below).
- **Kael** (Governor of Intelligence) — `clear-with-notes`; the `core.js` change is regex-order-correct, codebase-wide ripple safe. V-K-17 (test-guard whitespace) folded at synthesis; other notes routed to follow-up.
- **Lyra** synthesis — folded V-K-17 (commit `3609d49`).
- **Cipher** Edict V final-pass — `LGTM`, no blocking findings.

## Follow-ups opened from the audit

Pre-existing latent issues the chain surfaced; **not** regressions introduced by this PR:
- **#109** — `diet.js:4003` ql-freq-pill HR-3 inline-onclick (Maren V-M-19; same shape as PR #106 chips).
- **#110** — CareTicket title HR-4 boundary violations: `_ctSystemNotify` plain-text body double-escape + Today So Far label double-escape (Kael V-K-15 + V-K-16).
- **#111** — Extend F-35-1 guard to `medical.js` after converting several `escAttr` sites to `escHtml` (Maren V-M-20).

Closes #107

https://claude.ai/code/session_0181kMWhpPkM6thUreXdHxsx