### PR TITLE
spec(isl): ISL Upgrade v1 (Arc B, standalone) — Arc A diet-rework parked as superseded

### DIFF
--- a/docs/handoffs/diet-rework-journal.md
+++ b/docs/handoffs/diet-rework-journal.md
@@ -1,0 +1,94 @@
+# Diet Tab Rework — Session-Arc Journal
+
+**Arc name:** Diet Tab Rework v1
+**Start date:** 2026-05-23
+**Builder:** Lyra (The Weaver) — main session + Mode-1 subagent
+**Scope:** Two parallel arcs. **Arc A:** Information-architecture rework of the Diet sub-tab. Touches `split/diet.js`, `split/template.html`, `split/styles.css`; possibly `split/core.js` for sticky-state helper. **Arc B:** Intelligence Layer Upgrade. Touches the seven `split/intelligence-*.js` files, `split/data.js` (food-DB consumers), possibly `split/core.js`.
+**Branch convention:** `claude/sproutlab-diet-rework-pN` (N = 0..6)
+**Specs:** `docs/specs/diet-rework-v1.md` (Arc A, pending Wave 1.5 synthesis) · `docs/specs/isl-upgrade-v1.md` (Arc B, pending Wave 1.5 synthesis)
+**Authority chain:** CLAUDE.md §QA Chain · canon-cc-008 · canon-cc-018 (spec lifecycle) · canon-cc-022 (artifact test)
+
+---
+
+## Phase tracker
+
+| Phase | Name | Branch | PR # | Status | Build | Maren | Kael | Cipher | Aurelius | Notes |
+|-------|------|--------|------|--------|-------|-------|------|--------|----------|-------|
+| 0 | Spec authoring | claude/sproutlab-diet-rework-p0 | — | pending | — | — | — | — | — | Lyra Mode-1 in progress |
+| 1 | Segment shell | claude/sproutlab-diet-rework-p1 | — | not started | — | — | — | — | — | Zero-loss refactor |
+| 2 | Today segment | claude/sproutlab-diet-rework-p2 | — | not started | — | — | — | — | — | Meal-card compression, skip icon-toggle |
+| 3 | Score segment | claude/sproutlab-diet-rework-p3 | — | not started | — | — | — | — | — | Dead-data inventory pending |
+| 4 | Insights segment | claude/sproutlab-diet-rework-p4 | — | not started | — | — | — | — | — | Expand-by-default accordions |
+| 5 | Library segment | claude/sproutlab-diet-rework-p5 | — | not started | — | — | — | — | — | Foods Introduced compaction + quick-add integrate |
+| 6 | Polish + regressions | claude/sproutlab-diet-rework-p6 | — | not started | — | — | — | — | — | Sticky-state persistence, a11y, motion |
+
+### Arc B — Intelligence Layer Upgrade (parallel)
+
+| Phase | Name | Branch | PR # | Status | Build | Kael | Cipher | Aurelius | Notes |
+|-------|------|--------|------|--------|-------|------|--------|----------|-------|
+| B0 | Spec — ISL state-of-union + upgrade roadmap | claude/sproutlab-isl-upgrade-p0 | — | pending | — | — | — | — | Lyra Mode-1 synthesis pending scribe-scout #2 return |
+| B1+ | TBD — sized by spec | — | — | not started | — | — | — | — | Phase 3 of Arc A consumes Arc B early outputs |
+
+**Cross-arc dependency:** Phase 3 of Arc A ([Score] segment with trend strip + new-field analytics) depends on Arc B early phases plumbing the new food-DB fields through ISL. Other Arc A phases (1, 2, 4, 5, 6) are independent and can ship without Arc B landing first.
+
+QA-chain status legend per phase: `—` not started, `✓` pass, `✗` fail, `~` in progress, `waived` (state reason).
+
+---
+
+## V-tag registry — this arc only
+
+**Starting high-water marks** (from scribe-record sweep, 2026-05-23):
+- V-K high-water at arc start: **48**
+- V-M high-water at arc start: **46**
+
+First new V-K issued in this arc: V-K-49
+First new V-M issued in this arc: V-M-47
+
+| V-tag | Phase / Source | Finding (1 line) | State | Notes |
+|-------|----------------|------------------|-------|-------|
+| (none yet) | | | | |
+
+State legend: `open` (unresolved), `folded` (resolved at synthesis), `issue` (filed as GitHub issue, link), `merged` (PR resolving it landed).
+
+---
+
+## Decision log
+
+| Date | Decision | Source | Notes |
+|------|----------|--------|-------|
+| 2026-05-23 | IA pattern A chosen (sub-segment pills `[Today] [Score] [Insights] [Library]`) | Architect via AskUserQuestion | Hybrid B (pull-up sheets) and other variants rejected |
+| 2026-05-23 | Default landing: last-used (sticky in localStorage); cold-start = `[Today]` | Architect | Optimizes for logging-first first visit, intent-respecting thereafter |
+| 2026-05-23 | Branch convention: `claude/sproutlab-diet-rework-pN` | Architect | Per handoff `claude/sproutlab-<topic>` convention |
+| 2026-05-23 | Phase 3 dead-data inventory deferred to separate Architect submission | Architect | Spec marks Phase 3 sizing TBD |
+| 2026-05-23 | Full Companion roster + Scribe Worker Tier engaged for this arc | Architect | "Show of coordination" — Wave 1 fan-out: Lyra Mode-1 + scribe-scout + scribe-record |
+| 2026-05-23 | Phase 3 dead-data identity: new fields on 146 foods in food DB; surface via intelligence layer | Architect | Resolves the `TBD pending Architect inventory` placeholder in Lyra Mode-1 spec |
+| 2026-05-23 | Arc B opened: Intelligence Layer Upgrade, parallel to Diet rework | Architect | "Speaking of, go through our intelligence layer..." — ISL flagged as still pre-alpha |
+| 2026-05-23 | Two-spec strategy: `diet-rework-v1.md` (Arc A) + `isl-upgrade-v1.md` (Arc B), cross-referenced | Lyra (main-session synthesis) | Allows Arc A phases 1/2/4/5/6 to ship independent of Arc B; Phase 3 depends on Arc B early phases |
+
+---
+
+## Companion deployment log
+
+| Timestamp | Companion | Mode | Purpose | Returned artifact |
+|-----------|-----------|------|---------|-------------------|
+| 2026-05-23 (Wave 1) | Lyra | subagent, Mode-1 | Phase 0 spec authoring | `docs/specs/diet-rework-v1.md` (pending) |
+| 2026-05-23 (Wave 1) | scribe-scout | subagent | Code-surface reconnaissance | In-transcript findings brief |
+| 2026-05-23 (Wave 1) | scribe-record | subagent | Journal + V-tag registry setup | This file + sweep report |
+| 2026-05-23 (Wave 1.5) | scribe-scout #1 | subagent under Lyra | Food DB schema survey + dead-field analytics potential | In-transcript findings brief |
+| 2026-05-23 (Wave 1.5) | scribe-scout #2 | subagent under Lyra | Intelligence layer capability map + upgrade-surface inventory | In-transcript findings brief |
+| 2026-05-23 (Wave 1.5) | scribe-record | subagent under Lyra | Journal update — Arc B opening | This file (this edit) |
+
+---
+
+## References
+
+- `docs/specs/diet-rework-v1.md` — the spec (Wave 1 deliverable, Lyra Mode-1)
+- `docs/SESSION_HANDOFF.md` — prior session record
+- `CLAUDE.md` — policy floor, HRs, QA chain
+- `invocation.md` — Companion invocation procedure
+- `PERSONA_REGISTRY.md` — roster, jurisdictions, the 30K Rule
+- `docs/specs/isl-upgrade-v1.md` — Arc B spec (Intelligence Layer Upgrade roadmap, pending Wave 1.5 synthesis)
+
+---
+
+*Journal opened by scribe-record under Lyra, 2026-05-23. Future entries append below.*

--- a/docs/handoffs/diet-rework-journal.md
+++ b/docs/handoffs/diet-rework-journal.md
@@ -5,7 +5,8 @@
 **Builder:** Lyra (The Weaver) — main session + Mode-1 subagent
 **Scope:** Two parallel arcs. **Arc A:** Information-architecture rework of the Diet sub-tab. Touches `split/diet.js`, `split/template.html`, `split/styles.css`; possibly `split/core.js` for sticky-state helper. **Arc B:** Intelligence Layer Upgrade. Touches the seven `split/intelligence-*.js` files, `split/data.js` (food-DB consumers), possibly `split/core.js`.
 **Branch convention:** `claude/sproutlab-diet-rework-pN` (N = 0..6)
-**Specs:** `docs/specs/diet-rework-v1.md` (Arc A, pending Wave 1.5 synthesis) · `docs/specs/isl-upgrade-v1.md` (Arc B, pending Wave 1.5 synthesis)
+**Specs:** `docs/specs/diet-rework-v1.md` (Arc A) · `docs/specs/isl-upgrade-v1.md` (Arc B) — both pending_review (cc-018); Wave 2 audits complete; awaiting Architect ratification.
+**PR:** [#113](https://github.com/Rishabh1804/sproutlab/pull/113) (draft, Phase 0 docs-only, arc-pair)
 **Authority chain:** CLAUDE.md §QA Chain · canon-cc-008 · canon-cc-018 (spec lifecycle) · canon-cc-022 (artifact test)
 
 ---
@@ -14,7 +15,7 @@
 
 | Phase | Name | Branch | PR # | Status | Build | Maren | Kael | Cipher | Aurelius | Notes |
 |-------|------|--------|------|--------|-------|-------|------|--------|----------|-------|
-| 0 | Spec authoring | claude/sproutlab-diet-rework-p0 | — | pending | — | — | — | — | — | Lyra Mode-1 in progress |
+| 0 | Spec authoring | claude/sproutlab-diet-rework-p0 | #113 | Wave 2 complete | waived (docs-only) | ✓ V-M-47..54 | ✓ V-K-49..57 | ✓ pass-w/fixes | ✓ chronicling-ready | Awaiting Architect ratification |
 | 1 | Segment shell | claude/sproutlab-diet-rework-p1 | — | not started | — | — | — | — | — | Zero-loss refactor |
 | 2 | Today segment | claude/sproutlab-diet-rework-p2 | — | not started | — | — | — | — | — | Meal-card compression, skip icon-toggle |
 | 3 | Score segment | claude/sproutlab-diet-rework-p3 | — | not started | — | — | — | — | — | Dead-data inventory pending |
@@ -26,8 +27,11 @@
 
 | Phase | Name | Branch | PR # | Status | Build | Kael | Cipher | Aurelius | Notes |
 |-------|------|--------|------|--------|-------|------|--------|----------|-------|
-| B0 | Spec — ISL state-of-union + upgrade roadmap | claude/sproutlab-isl-upgrade-p0 | — | pending | — | — | — | — | Lyra Mode-1 synthesis pending scribe-scout #2 return |
-| B1+ | TBD — sized by spec | — | — | not started | — | — | — | — | Phase 3 of Arc A consumes Arc B early outputs |
+| B0 | Spec — ISL state-of-union + upgrade roadmap | claude/sproutlab-diet-rework-p0 (shared, PR #113) | #113 | Wave 2 complete | waived (docs-only) | ✓ V-K-49..57 (primary) | ✓ pass-w/fixes | ✓ chronicling-ready | Co-ratified with Arc A |
+| B1 | Keystone trio (chemRollup + meal_combo_check + qaAnswerMealCombo + computeMealCombos) | claude/sproutlab-isl-upgrade-p1 | — | pending B-0 ratify | — | — | — | — | ~150–200 LOC across 4 files (isl + qa + qa-handlers + cards) |
+| B2 | Chem-variety cards + UIB antiNutrient warnings | claude/sproutlab-isl-upgrade-p2 | — | not started | — | — | — | — | Maren cross-consult on phrasing |
+| B3 | Temporal parser ext + silent-catch console.error | claude/sproutlab-isl-upgrade-p3 | — | not started | — | — | — | — | Scope collapsed from original B-3 per V-K-49 |
+| B4 | Filing-cabinet relocations (~172 LOC moved + ~30 LOC moved) | claude/sproutlab-isl-upgrade-p4 | — | not started | — | — | — | — | Includes QA_SUGGEST_POOL per V-K-51 |
 
 **Cross-arc dependency:** Phase 3 of Arc A ([Score] segment with trend strip + new-field analytics) depends on Arc B early phases plumbing the new food-DB fields through ISL. Other Arc A phases (1, 2, 4, 5, 6) are independent and can ship without Arc B landing first.
 
@@ -44,11 +48,39 @@ QA-chain status legend per phase: `—` not started, `✓` pass, `✗` fail, `~`
 First new V-K issued in this arc: V-K-49
 First new V-M issued in this arc: V-M-47
 
-| V-tag | Phase / Source | Finding (1 line) | State | Notes |
-|-------|----------------|------------------|-------|-------|
-| (none yet) | | | | |
+**Issuance procedure:** Wave 2 audits issue V-tags sequentially by Governor; collisions resolved at Lyra synthesis. The chronicler renumbers to the next free registry slot on intake.
 
-State legend: `open` (unresolved), `folded` (resolved at synthesis), `issue` (filed as GitHub issue, link), `merged` (PR resolving it landed).
+### Wave 2 V-tag intake (Phase 0 audits — 2026-05-23)
+
+| V-tag | Source | Finding (1 line) | State |
+|-------|--------|------------------|-------|
+| V-K-49 | Kael Mode-1 | scout #2's "two undefined handlers" claim is FALSE — both wired in `intelligence-quicklog.js:1290, :1322` | **folded (blocker)** — Arc B B-3 collapsed |
+| V-K-50 | Kael Mode-1 | `calcZivaScore()` is NOT cached (`core.js:1926-1979`) | folded — non-coupling rule in dispatcher contract |
+| V-K-51 | Kael Mode-1 | B-4 must include `QA_SUGGEST_POOL` (78 LOC) | folded — B-4 LOC ~172 |
+| V-K-52 | Kael Mode-1 | Add `console.error` to silent catch | folded — new B-3 row 13 (Cipher + Kael + Maren convergence) |
+| V-K-53 | Kael Mode-1 | `COMBO_RULES` rule #6 not nutrient-keyed; handler must tri-resolve | folded — tri-resolution in B-1.3 architecture |
+| V-K-54 | Kael Mode-1 | Canonical lookup is `_baseFoodName` (`core.js:2729`, 4-layer) | folded — B-1.1 updated |
+| V-K-55 | Kael Mode-1 | Roadmap row 11 redundant — `_islMarkDirty('diet')` covers | folded — row dropped |
+| V-K-56 | Kael Mode-1 | **Region LOC at 30,725 — 30K Rule trigger ALREADY BREACHED pre-arcs** | **open (watch-item)** — `intelligence-cards.js` natural sub-split target |
+| V-K-57 | Kael Mode-1 | CLAUDE.md "22 intents" wrong (actual 30); registry location misattributed | folded — separate tiny PR post-ratify endorsed |
+| V-M-47 | Maren Mode-1 | Safety-override over-broad (`renderDietIntelBanner` also carries positive synergy) | folded — `hasSafetySignal()` predicate OR banner split |
+| V-M-48 | Maren Mode-1 | "Anti-Nutrient Watch" would alarm on every iron-rich Indian staple | folded — renamed "Variety nudge"; Maren-drafted copy + AND-gate + icon-ban |
+| V-M-49 | Maren Mode-1 | `qaAnswerMealCombo` schema mismatch with `qaRenderAnswer` contract | folded — schema corrected (sections+signal); data-fn separated; 6-rule copy locked |
+| V-M-50 | Maren Mode-1 | "Introduce with care" chip — current meal-input has ZERO proactive safety signal | folded — lifted Phase 3 → Phase 2 |
+| V-M-51 | Maren Mode-1 | `dqp-zone` compression is Care-safe (no-op affirming) | resolved — no action |
+| V-M-52 | Maren Mode-1 | Chip-count "≈13" → "up to 10" | folded — mechanical |
+| V-M-53 | Maren Mode-1 | HR-1 latent at `diet.js:2742` is false positive | resolved — concurs with Cipher; voluntary rename only |
+| V-M-54 | Maren Mode-1 | "Zero `if(true)return;`" claim scope correction (9 across codebase, not 0) | folded — scoped to intel files |
+
+State legend: `open` (unresolved), `folded` (resolved at synthesis), `resolved` (no-op or false-positive), `issue` (filed as GitHub issue, link), `merged` (PR resolving it landed).
+
+### Phase 0 Findings (Wave 1.5 + Wave 2 discoveries, chronicled discrete)
+
+1. **CLAUDE.md ISL drift** — "22 intents with dedicated handlers" misattributes location (registry is in `intelligence-qa.js` not ISL) AND count (actual 30). Separate tiny PR post-ratify.
+2. **Food-DB count discrepancy** — `NUTRITION` has 148 raw entries / 130 unique keys (18 duplicate keys across `// ── EXPANDED:` blocks silently overwrite earlier declarations). Architect's "146" predates EXPANDED dupes or is mid-flight. Confirm before consumers cite the count.
+3. **Scout #2 methodology gap (V-K-49)** — Wave 1.5 scout swept `qa-handlers.js` only for `qaAnswer*` symbols; missed `intelligence-quicklog.js` where 2 of the 29 handlers live. Future scout briefs must instruct grep across the full file-set under audit, not the file where a symbol is "expected".
+4. **30K Region breach (V-K-56)** — Kael jurisdiction at 30,725 LOC pre-arcs. `intelligence-cards.js` is the natural sub-split target if pressure escalates. Lyra/Cipher watch-item.
+5. **HR-6 latent in `_qaUpdateSuggestions:180-192`** — pre-existing `addEventListener` usage. B-4 relocation surfaces it but does not fix it. **File as follow-up issue**, sibling shape to #109/#111 from prior session.
 
 ---
 
@@ -76,18 +108,25 @@ State legend: `open` (unresolved), `folded` (resolved at synthesis), `issue` (fi
 | 2026-05-23 (Wave 1) | scribe-record | subagent | Journal + V-tag registry setup | This file + sweep report |
 | 2026-05-23 (Wave 1.5) | scribe-scout #1 | subagent under Lyra | Food DB schema survey + dead-field analytics potential | In-transcript findings brief |
 | 2026-05-23 (Wave 1.5) | scribe-scout #2 | subagent under Lyra | Intelligence layer capability map + upgrade-surface inventory | In-transcript findings brief |
-| 2026-05-23 (Wave 1.5) | scribe-record | subagent under Lyra | Journal update — Arc B opening | This file (this edit) |
+| 2026-05-23 (Wave 1.5) | scribe-record | subagent under Lyra | Journal update — Arc B opening | This file (Arc B section added; decision log + companion deployment log appended) |
+| 2026-05-23 (Wave 1.5 synth) | Lyra | main session | Wave 1.5 fold-in synthesis (scout #1 + #2 amendments) | Two specs amended: `docs/specs/diet-rework-v1.md` + NEW `docs/specs/isl-upgrade-v1.md` — committed in `022c8ed` |
+| 2026-05-23 (Wave 2) | Maren | subagent, Mode-1 | Care lens audit of both arc-pair specs | Mode-1 audit report; verdict yes-with-fixes; **V-M-47..54 issued** |
+| 2026-05-23 (Wave 2) | Kael | subagent, Mode-1 | Intelligence lens audit (primary on Arc B) | Mode-1 audit report; verdict yes-with-fixes; **V-K-49..57 issued**; V-K-49 reshaped Arc B Phase B-3 |
+| 2026-05-23 (Wave 2) | Cipher | subagent, Mode-1 | Edict V pre-pass on architectural shape | Verdict **pass-with-fixes**; arc-pair shape **certified**; 3 required + 6 recommended; 11 regression-guard names provided |
+| 2026-05-23 (Wave 2) | Aurelius | subagent | Cross-cluster chronicling + PR #113 review | Verdict **chronicling-ready**; 4 marginal amendments; 3 Codex Memory.md candidates noted post-ratify per Chronicler discretion |
+| 2026-05-23 (Wave 2 synth) | Lyra | main session | Wave 2 fold-in synthesis | Both specs re-written with all required + recommended fixes folded; this journal updated; PR #113 amended |
 
 ---
 
 ## References
 
-- `docs/specs/diet-rework-v1.md` — the spec (Wave 1 deliverable, Lyra Mode-1)
+- `docs/specs/diet-rework-v1.md` — Arc A spec (Lyra Mode-1 + Wave 1.5 + Wave 2 synthesis)
+- `docs/specs/isl-upgrade-v1.md` — Arc B spec (Lyra Wave 1.5 main-session + Wave 2 synthesis)
+- **PR #113** — https://github.com/Rishabh1804/sproutlab/pull/113 (draft, Phase 0 docs-only; Wave 2 complete; awaiting Architect ratification)
 - `docs/SESSION_HANDOFF.md` — prior session record
-- `CLAUDE.md` — policy floor, HRs, QA chain
+- `CLAUDE.md` — policy floor, HRs, QA chain (note: ISL Key Subsystems line is stale — separate tiny PR planned post-ratify per V-K-57)
 - `invocation.md` — Companion invocation procedure
 - `PERSONA_REGISTRY.md` — roster, jurisdictions, the 30K Rule
-- `docs/specs/isl-upgrade-v1.md` — Arc B spec (Intelligence Layer Upgrade roadmap, pending Wave 1.5 synthesis)
 
 ---
 

--- a/docs/specs/diet-rework-v1.md
+++ b/docs/specs/diet-rework-v1.md
@@ -1,0 +1,253 @@
+# Spec: Diet Tab Rework v1
+
+**Version:** v1.0 draft (Mode-1 + Wave 1.5 main-session synthesis)
+**Date:** 2026-05-23
+**Authors:**
+- Lyra (Mode-1 subagent) — primary spec body (Wave 1)
+- Lyra (main-session synthesis) — Wave 1.5 amendments folding `scribe-scout` #1 (food DB) + #2 (ISL capability map) findings
+
+**Authority chain:** `CLAUDE.md` §QA Chain · canon-cc-008 · canon-cc-022 · cc-018 `pending_review`
+**Against commit:** `b2670f7`
+**Cross-references:** `docs/specs/isl-upgrade-v1.md` (Arc B — Phase 3 of this spec depends on Arc B's keystone trio)
+
+## Status
+
+`pending_review` (cc-018). Prerequisites for `ratified`:
+
+- Architect ratification of IA pattern A, the Wave-1.5 fold-in, and the two-spec arc-pair strategy.
+- Maren Mode-1 audit (Care jurisdiction — `home.js` / `diet.js` / `medical.js` touch surface; shared `template.html` / `styles.css`).
+- Kael Mode-1 audit (Intelligence jurisdiction — `core.js` segment-routing touch; `intelligence-isl.js` / `intelligence-qa.js` / `intelligence-qa-handlers.js` / `intelligence-cards.js` Phase-3 touch surfaces specified in Arc B).
+- Cipher Mode-1 Edict V pre-pass on the spec itself.
+- Aurelius chronicling on ratification (Codex Memory.md cross-cluster note: ISL drift + arc-pair strategy).
+
+## Why
+
+The Diet sub-tab under TRACK does four jobs in one vertical scroll, and the IA pattern is monolithic-single-scroll where it should be sub-tabbed.
+
+- **Job 1 — analytics.** Hero score `renderDomainHero('diet')` defined at `diet.js:2702–2764`, invoked from `home.js:2650`; 5 stat tiles via `renderDietStats` at `home.js:2595–2649`; 2×2 sub-score grid emitted as `.dsh-comp-pill` row inside `renderDomainHero` at `diet.js:2746–2760`.
+- **Job 2 — logging.** Today's Meals card, `template.html:795–846`, four meal sub-cards with autocomplete inputs and `dqp-zone` history-chip walls.
+- **Job 3 — decision-support.** Can I Give This? `template.html:850–862`; Recent Checks `renderComboHistory` `diet.js:890–903`; Insights & Tips `renderTips` `diet.js:905–1014` rendering 15 active Avoid / Good-to-Know / Add-to-Diet items behind three collapsed accordions.
+- **Job 4 — reference.** Foods Introduced grid + quick-add form, `template.html:868–890`.
+
+Three pathologies follow from the monolith: (a) triple analytics stack at top competes for primacy before the parent can act — the logging-first user lands on a 73 score when they came to log breakfast; (b) each meal card carries a `dqp-zone` stacking up to ~13 chips in 2–4 rows under each meal × 4 meals = a wall of food names; (c) the highest-value analytical surface — Insights & Tips, 15 active items — is buried at the bottom behind three collapsed accordions. The failure mode is **job-mixing in a single scroll** — fix it by routing by job.
+
+**Wave 1.5 substrate finding.** The food DB (`NUTRITION` at `data.js:2228–2402`) has new fields — the `chem` sub-object (`fibre`, `antiNutrients`, `bioactives`) — and a full `COMBO_RULES` table (`data.js:2463–2476`) that have **zero outside-`data.js` references**. They are specced but unsurfaced. The intelligence layer is the only place they can be surfaced — and ISL's diet accessor (`_islDietData` at `intelligence-isl.js:446–499`) does not yet expose them. **Phase 3 of this spec depends on Arc B (ISL Upgrade) landing the substrate first.**
+
+## Scope
+
+**In scope.** Sub-segment IA inside the Diet sub-tab of TRACK; per-segment content specs; meal-card history-chip compression; segment router contract; sticky-state contract; Phase 0–6 PR sequence; HR pre-check; Governor-readiness asks. Phase 3 consumes Arc B outputs (specified by cross-reference).
+
+**Out of scope.** No new data sources beyond the food-DB fields already present. No Care-Region semantic changes — meal-data schema, food DB, reaction tracking, CareTicket linkage all untouched. No new sync surfaces. No changes to the TRACK top-level sub-bar (`renderTrackSubBar` at `core.js:3161–3186`) — the Diet pill there continues to behave as today; new segments live one level below.
+
+**Hard boundary.** This spec changes presentation and information architecture, not safety logic. Allergen / reaction / Can I Give This? semantics remain identical; only their placement and surfacing change. The new `meal_combo_check` ISL intent (specced in Arc B, consumed by `[Today]` in Phase 3 here) introduces NEW decision-support — it does not modify existing safety logic.
+
+## IA pattern declaration
+
+Pattern A: a sub-segment pill row directly under the Diet header inside `#tab-diet` (`template.html:782`), rendering one of four segments below it.
+
+```
+[Today]   [Score]   [Insights]   [Library]
+```
+
+**Segment content boundaries (locked):**
+
+- **[Today]** — logging-only. Date picker (`#feedingDate`), Diet Intel Banner (`#dietIntelBanner`), four meal cards (`.meal-card.{breakfast|lunch|dinner|snack}`), per-meal compressed `dqp-zone` (see §Meal-card compression), Save. **Phase 3 fold-in:** post-log `meal_combo_check` chip stack consuming Arc B's new ISL intent + `COMBO_RULES` + `chem.antiNutrients` (e.g., logging ragi + paneer fires "spacing tip: serve calcium 2h apart"). Plus a proactive "introduce with care" chip next to the meal input when the typed/selected food crosses `AGE_RULES.minMonth` or `ALLERGENS` (Group D from scout #1 — data already read, but not yet proactively surfaced).
+- **[Score]** — analytics. Hero score card (`renderDomainHero('diet')`), 2×2 sub-score grid, 5 stat tiles (`#dietStats` via `renderDietStats`), trend strip. **Phase 3 fold-in:** "Fibre Variety" tile + "Bioactive Diversity" tile derived from `chemRollup` (the new field on `_islDietData` specced in Arc B). New tiles render via NEW `renderInfoChemVariety` in `intelligence-cards.js` — `chem.*` analytics' natural home, alongside existing `computeNutrientHeatmap` / `computeFoodCombos` / `computeMealBreakdown`.
+- **[Insights]** — decision-support. Can I Give This? + Recent Checks (`renderComboHistory`) + Insights & Tips (`renderTips`) with the three category accordions **rendered inline, expanded by default**. The 15-active-item surface lands on segment open, not behind chevrons.
+- **[Library]** — reference. Foods Introduced grid (`#foodsGrid` via `renderFoods` at `home.js:2947+`), group-drill view, per-food detail overlay. **Phase 3 fold-in:** per-food detail overlay gains a "Chemistry" sub-tab exposing `chem.fibre` / `chem.antiNutrients` / `chem.bioactives` (Group A from scout #1) — direct surfacing on a discrete tap, not pushed into every food-row tile. Quick-add form integrated.
+
+**Segment router contract:**
+
+- Data-action-driven per HR-3. Pill click fires `data-action="switchDietSegment"` with `data-arg` ∈ `{today, score, insights, library}`. Dispatcher branch in `core.js`'s existing action delegator (sister to `switchTrackSub` at `core.js:3136`).
+- Segment state stored in `localStorage` under key **`ziva_diet_segment`** — matching the house convention `ziva_*` (sister to `ziva_track_sub` at `core.js:3139`, `ziva_active_tab` at `core.js:1053/3077`). **No `sl.*` keys exist anywhere in the codebase**; the spec follows the established prefix.
+- Segment change re-renders the **segment body only**, not the whole Diet tab.
+
+**Critical structural finding (scout #2).** **There is no `renderDiet()` orchestrator today.** `switchTrackSub('diet')` at `core.js:3153` calls only `renderDietStats()`. Per-segment lazy rendering requires inventing a `renderDietSegment(segmentKey)` dispatcher in Phase 1. This is structural, not veneer — and is the load-bearing change in Phase 1.
+
+**Sticky-state contract:**
+
+- Write `ziva_diet_segment` on every segment change.
+- Read on Diet sub-tab mount (inside `switchTrackSub(sub)` when `sub === 'diet'`).
+- Fallback to `today` if absent, malformed, or not in the enum. Logging-first cold-start is non-negotiable.
+- **Safety override (Maren-flagged).** If `renderDietIntelBanner` (`home.js:3831`) produces non-empty content (active fever/diarrhoea episode with diet implications), force-route to `[Today]` regardless of sticky-state. The banner is the highest-signal surface; if it has something to say, the parent must see it.
+
+**Segment-pill component contract:**
+
+- Reuse the existing `.track-sub-btn` styling pattern (`styles.css:4930–4947`) at a derived class `.diet-seg-btn` — visual continuity with the parent TRACK sub-bar, marked as sub-level (no `tsb-score` numeric slot, denser).
+- **Sticky positioning decision (open question, Lyra recommends inline-only).** The parent `.track-sub-bar` is `position: sticky; top: 0` (`styles.css:4932`). Three options: (a) **inline-only** — scrolls with content, no double-sticky overhead; (b) also-sticky stacked under the TRACK bar — heavier but always visible; (c) both-sticky with z-index management. **Recommendation: inline-only** to keep phone viewport breathing room.
+- Token-driven; no new color domain. Spacing from `--sp-*`; radii from `--r-full`; type from `--fs-sm` / `--fs-xs`.
+
+## Per-segment specs
+
+### `[Today]` — logging segment
+
+**Purpose.** Log today's meals fast, one-handed, with minimum chrome.
+
+**Content.** Date nav (`‹` / date input / `›` / Save), Diet Intel Banner (`renderDietIntelBanner` at `home.js:3831`), four meal cards (breakfast / lunch / dinner / snack), each with compressed `dqp-zone` (see §Meal-card compression), `meal-input` autocomplete dropdown, per-meal insight strip (`#insight-{meal}`).
+
+**Phase 3 fold-in.**
+- **`meal_combo_check` chip stack** — appears under the meal-card group when the newly-saved food triggers a combo from `COMBO_RULES` against today's already-logged foods. Shape: dismissable chip with `data-action="dismissComboTip"` / `data-arg="{ruleId}"`. The ISL intent + handler are specced in Arc B (`isl-upgrade-v1.md` §Sequencing keystone). NOTE: `COMBO_RULES` is keyed by *nutrient* (`foods:['iron','calcium']`), not food name; the handler must tag-resolve via `NUTRITION[food].nutrients`.
+- **Proactive "introduce with care" chip** — appears next to the meal-input dropdown when the typed/selected food crosses `AGE_RULES.minMonth` against Ziva's current age, or appears in `ALLERGENS`. Group D from scout #1. The data is already *read* at log-time (`diet.js:465`, `diet.js:475`); this fold-in just promotes it to a *proactive* surface.
+
+**Major changes (Phases 1+2).** (1) Analytics removed from this segment's view — hero / sub-score grid / stat tiles all live in `[Score]`. (2) `dqp-zone` compressed from up-to-four-stacked rows to one expandable "Recent" row. (3) `meal-skip-btn` text-link replaced with icon-toggle.
+
+**Data sources / state reads.** `feedingData` (current entry by date), `foods` array (autocomplete), ISL `dqp` pulls already plumbed in `renderDietQuickPicker`, Diet Intel Banner reads fever-episode state from `intelligence-illness.js`. Phase-3 additions: ISL `meal_combo_check` intent (Arc B); `AGE_RULES` / `ALLERGENS` already in scope.
+
+**Open questions.** Should the date nav promote into the Diet segment header (next to the segment pills) or stay at the top of `[Today]`? Should Tomorrow Prep (`renderTomorrowPrep` at `diet.js:2157`) surface here or in `[Insights]`?
+
+### `[Score]` — analytics segment
+
+**Purpose.** Show how Ziva's diet is tracking — score, sub-scores, tiles, trend, chemistry-variety.
+
+**Content.** `renderDomainHero('diet')` → 2×2 sub-score grid → `#dietStats` 5-tile grid → trend strip.
+
+**Phase 3 fold-in.**
+- **"Fibre Variety" tile.** Counts distinct `chem.fibre` categories Ziva consumed in the last 7 days. Direct answer to "is the fibre mix varied?" (parent question scout #1 surfaced). Source: `chemRollup.fibreDaysHigh` from Arc B.
+- **"Bioactive Diversity" tile.** Distinct `chem.bioactives` count over 7 days — variety matters more than mg-totals at this developmental stage. Source: `chemRollup.bioactiveCount` from Arc B.
+- **Optional "Anti-Nutrient Watch" inline note.** If `chemRollup.antiNutrientFlags` flags multi-day oxalate/phytate load, surface a calm advisory (not alarm) chip. Maren consult required on phrasing.
+
+**Renderer routing.** New tiles render via NEW functions in `intelligence-cards.js` (the natural home for `chem.*` analytics per scout #2 — `renderInfo*` master + sibling compute fns already there). Proposed: `renderInfoChemVariety` + `renderInfoBioactiveDiversity`, both consuming `chemRollup` via `getDomainData('diet', ...)`.
+
+**Major changes.** (1) Score is no longer the first thing seen on a logging visit. (2) Trend strip is new; sized by the Phase-3 chem-variety tiles. (3) Existing stat-tiles (`ds-sage` classes) and the new chem-variety tiles must NOT duplicate — Phase 3 resolves whether the new tiles ADD to the stat-tile row or REPLACE one of the existing tiles. Recommend ADD with explicit re-flow.
+
+**Data sources / state reads.** Existing: `calcZivaScore()` cache, `getZivaScoreTrend7d()`, food/iron/variety derivations in `renderDietStats`. New (Arc B): `chemRollup` via `_islDietData`.
+
+**Open questions.** Sparkline density. Whether the 2×2 sub-score grid here matches the popup's `_spRenderOverview` layout exactly or a denser inline variant. Stat-tile duplication resolution (ADD vs REPLACE).
+
+### `[Insights]` — decision-support segment
+
+**Purpose.** Answer "Can I give this?" and surface what the data is saying.
+
+**Content.** Can I Give This? input + result + chips + Recent Checks (`renderComboHistory`) + Insights & Tips (`renderTips`) with three sections **rendered inline, expanded by default** — Avoid / Good to Know / Add to Diet. The accordion-collapsed pattern is removed for this segment.
+
+**Major changes.** (1) The 15-active-item Insights & Tips surface lands on segment open. (2) Three category accordions → inline sections with section headers, no default chevron-collapse. (3) Recent Checks promoted next to Can I Give This?, not buried under it.
+
+**Data sources / state reads.** `comboHistory` (localStorage key `ziva_combo_history`, `COMBO_HISTORY_KEY` per `diet.js:378,380,614`), tip-generation pipeline from `renderTips` / `generateDos` / `generateDonts`.
+
+**Open questions.** Does Tomorrow Prep belong here as a fourth inline section? Should the Insights & Tips count badge (`#tipsCount`) move into the segment-pill itself as a numeric badge on `[Insights]`?
+
+### `[Library]` — reference segment
+
+**Purpose.** What has Ziva tried, by group; per-food chemistry; quick-add a new food.
+
+**Content.** Foods Introduced 6-card grid (`#foodsGrid`, by food group), drill-into-group expanded view, **per-food detail overlay** (new — Phase 3 fold-in), quick-add form (`#foodInput` + `#foodDate` + `#foodSlot` + reaction toggle + Add button).
+
+**Phase 3 fold-in — per-food "Chemistry" sub-tab on detail overlay.**
+- Tap any food tile → detail overlay opens.
+- Two sub-tabs: "Overview" (existing nutrients/tags display) + "Chemistry" (NEW).
+- "Chemistry" sub-tab shows `chem.fibre` (with brief explanation of what each category means), `chem.antiNutrients` as info chips (with soak/cook hints from a small inline lookup or a future `chem.advisories` derivation), `chem.bioactives` with one-line lay descriptions.
+- HR-4 hard: every `chem.*` value passed through `escHtml` at the render boundary.
+
+**Major changes.** (1) Quick-add form remains here (final placement TBD per Open Questions). (2) Group-drill view defaults to compact summary; tap-group expands. (3) Per-food detail overlay is NEW (current tap doesn't open one).
+
+**Data sources / state reads.** `foods` array, `feedingData` (for "X of Y" group counts and frequency), `NUTRITION[name]` for chemistry sub-tab.
+
+**Open questions.** Delete the quick-add form entirely in favour of per-meal autocomplete + reaction-marking inline, or keep both? Should the food-group card layout shift from 6 fixed cards to a denser pill-grid?
+
+## Meal-card compression sub-spec
+
+The `dqp-zone` currently emits, per meal: up to three "same-as previous day" pills (Yd / 2d ago / 3d ago — `DAY_LABELS` at `home.js:3767`), plus up to three "other-meal-today" pills, plus up to four "top frequent for this slot" pills, plus up to three general top-foods fallbacks. **Maximum density: ≈13 pills in 2–4 stacked rows under every meal input. Wall-of-food-names against four meal cards.**
+
+**Compression target.** One **"Recent"** row of up to 6 chips, with an expand-to-see-all affordance. Priority order (top of row first): (1) same-meal same-day-last-week if exists; (2) Yd / 2d / 3d same-meal-as pills (most recent first); (3) top-frequent for this meal slot. Expand → reveals the full pill set under the row.
+
+**Markup shape.** `<div class="dqp-zone"><div class="dqp-recent">{6 chips}<button class="dqp-expand" data-action="dqpExpand" data-arg="{meal}">More</button></div><div class="dqp-all" hidden>{full set}</div></div>`. Expand toggles `[hidden]` on `.dqp-all` and updates the button label. Note: `dqp-same` chip uses JS-level substring truncation (`home.js:3790, 3802`), NOT CSS `text-overflow: ellipsis` — preserved for HR-10.
+
+**Skip toggle.** The `meal-skip-btn` text-link (`template.html:811,820,829,838`, styled at `styles.css:489–491`) — currently the literal text "skip" — becomes an icon toggle. Symbol name: **`zi-skip`** (simpler than `zi-bowl-skip`; matches existing sprite convention). Avoids semantic collision with `zi-skip-forward` (`template.html:107`, which means "advance to next" in media context). New symbol added to template — count goes 109 → 110.
+
+## Region boundary declarations
+
+| File | Governor jurisdiction | Phase(s) | Expected change size | Notes |
+|------|----------------------|----------|----------------------|-------|
+| `split/diet.js` | Maren | 1, 2, 4 (Insights expand), 5 | medium | `renderDietSegment(key)` dispatcher (NEW, Phase 1), per-segment render fns, compressed `dqp` branch, `renderTips` expand-by-default mode, per-food detail overlay (Phase 5 — Phase 3 chem sub-tab consumed here). |
+| `split/template.html` | Maren + Kael (shared) | 1, 2, 5 | small–medium | `#tab-diet` restructure: segment pill row + four segment containers wrapping existing content nodes. Per-food detail overlay scaffold. New `zi-skip` symbol (#110). |
+| `split/styles.css` | Maren + Kael (shared) | 1, 2 | small | `.diet-seg-bar` / `.diet-seg-btn` rules (token-driven, derived from `.track-sub-bar`), `.dqp-recent` / `.dqp-all` density rules, `meal-skip-btn` icon-state. |
+| `split/core.js` | Kael | 1 | small | Dispatcher branch for `switchDietSegment`; `ziva_diet_segment` read in `switchTrackSub` mount path. Inline; no `slStickyState` helper introduced. |
+| `split/home.js` | Maren | 2 | small | `renderDietQuickPicker` (`:3752–3829`) compression to single Recent + expand. Stat-tile re-flow for new Score-segment tiles (Phase 3). |
+| `split/intelligence-isl.js` | Kael | 3 (Arc-B-led) | **see Arc B** | `_islDietData` `chemRollup` extension. Specified in Arc B; consumed here. |
+| `split/intelligence-qa.js` | Kael | 3 (Arc-B-led) | **see Arc B** | `meal_combo_check` intent registration + dispatch. Specified in Arc B; consumed here. |
+| `split/intelligence-qa-handlers.js` | Kael | 3 (Arc-B-led) | **see Arc B** | `qaAnswerMealCombo` handler. Specified in Arc B; consumed here. |
+| `split/intelligence-cards.js` | Kael | 3 | medium | `renderInfoChemVariety` + `renderInfoBioactiveDiversity` cards (NEW). Consumes Arc B's `chemRollup`. |
+| `split/data.js` | shared | none (consumers only) | — | Out of scope this spec; `NUTRITION` and `COMBO_RULES` already specced. |
+
+**Out of scope this spec.** `split/sync.js`, `split/intelligence-illness.js`, `split/intelligence-quicklog.js`, `split/intelligence-caretickets.js`, `split/medical.js`. Phase 3's intelligence-layer dependency is fully spelled out in `docs/specs/isl-upgrade-v1.md`.
+
+## HR pre-check
+
+| HR | Predicted risk | Why | Mitigation in this spec |
+|----|----------------|-----|-------------------------|
+| HR-1 (no emojis) | low (this spec) / **pre-existing flag** | The spec adds `zi-skip` and uses only `zi(*)` for all icons. **However, scout #2 noted a pre-existing latent issue:** `renderDomainHero` at `diet.js:2742` pushes `lbl.emoji` directly into HTML. If `getScoreLabel().emoji` returns Unicode emoji rather than a `zi()` SVG, that's an HR-1 violation that pre-dates this rework. **Flag for Maren** as a separate follow-up issue, NOT folded into this spec. |
+| HR-2 (no inline styles) | elevated | Existing diet-tab markup carries inline `style="display:none;"` (e.g., `#dietDomainHero`). New segment containers must default-hide via class, not inline style. | `.diet-seg-panel.active` toggle parallels existing `.track-sub-panel.active`. Phase 1 audit watches for any new inline-style introductions. |
+| HR-3 (no inline handlers) | elevated | New actions: `switchDietSegment`, `dqpExpand`, `dismissComboTip`, per-food detail overlay open/close, chemistry sub-tab switch. | All declared with `data-action` / `data-arg`; dispatcher branches added at `core.js:340–520`. Per the V-M-45 precedent in `diet.js` from the prior session. |
+| HR-4 (escHtml at render boundaries) | medium | Meal-card compression renders food-name chips; food names are user input. Existing `dqp-zone` already uses `escHtml(val)` (`home.js:3792`). Phase 3 chemistry-sub-tab renders `chem.*` values — also need `escHtml`. | Every new render boundary calls `escHtml` — food strings, chip text, chem values, tip text. Phase 1/5 audit. |
+| HR-5 (tokens-only spacing) | low–medium | `.diet-seg-bar` derives from `--sp-*` like `.track-sub-bar`. | Token list referenced (`--sp-4/6/8/10/12`, `--r-full`). No raw px. |
+| HR-6 (data-action delegation universal) | elevated | Same surface as HR-3. | Confirmed in segment-router contract. |
+| HR-7 (zi via innerHTML) | low | `zi-skip` rendered via `zi('skip')` → SVG via innerHTML. | Standard pattern. |
+| HR-8 (Coming-soon stubs) | n/a | No stub features in this spec. | — |
+| HR-9 (post-build multi-round QA) | structural | Every phase runs canon-cc-008 chain. | PR sequence table names Governors per phase. |
+| HR-10 (no text-overflow ellipsis) | medium | Compressed "Recent" row must preserve JS substring truncation, not introduce CSS ellipsis. | Phase 2 pre-check note. |
+| HR-11 (Math.floor currency) | n/a | No currency. | — |
+| HR-12 (timezone-safe dates) | low | Existing `toDateStr` / `setDate(getDate()-i)` in `renderDietQuickPicker`. Preserved. | No new date construction. |
+
+## Governor-readiness note
+
+**For Maren (Care).**
+1. Does compressing `dqp-zone` from up-to-four stacked rows to a single "Recent" row (6 chips + expand) lose care-context a parent depends on at moment-of-logging? Specifically: if yesterday's lunch caused a reaction note, does the parent need to see that lunch's contents in the breakfast-log glance, or is "yesterday's lunch" the wrong place to surface a reaction signal regardless?
+2. Sticky-state landing the parent on `[Library]` (last-used) could hide a critical safety surface they'd otherwise see — confirm the proposed safety-override (force-route to `[Today]` when `renderDietIntelBanner` non-empty).
+3. Phase 3 fold-in: proactive "introduce with care" chip in `[Today]` based on `AGE_RULES.minMonth` and `ALLERGENS` — phrasing, dismissibility, and whether dismissing should persist across sessions (probably no).
+4. Phase 3 fold-in: "Anti-Nutrient Watch" tile in `[Score]` — phrasing must be calm-advisory not alarm. Maren to draft / approve copy.
+5. **Pre-existing HR-1 latent** at `diet.js:2742` (`lbl.emoji` push) — confirm whether `getScoreLabel().emoji` ever returns a Unicode codepoint. If so, follow-up issue.
+
+**For Kael (Intelligence).**
+1. Does the segment router add any score-derivation recompute cost? `calcZivaScore()` is cached; segment-change should not re-trigger it.
+2. Does `ziva_diet_segment` read on Diet-tab mount interact with ISL day-summary generation? The day-summary path runs through `intelligence-quicklog.js` and `intelligence-isl.js`; the segment-state read is presentational, but flag if any ISL pull is segment-gated.
+3. Confirm `ziva_diet_segment` namespace does not collide with any existing localStorage key.
+4. Phase 1 invents `renderDietSegment(segmentKey)` dispatcher in `diet.js`. Where exactly does it sit relative to `_dietActiveSegment` state, and should this state mirror the `_activeTrackSub` pattern at `core.js`?
+5. Phase 3 dependency on Arc B's keystone trio — review the cross-spec contract in `isl-upgrade-v1.md` and flag any plumbing risks.
+
+## PR sequence (Phases 0–6)
+
+| Phase | Name | Scope | Branch | Jurisdiction | Diff size | QA chain |
+|-------|------|-------|--------|--------------|-----------|----------|
+| **0** | **Spec (this PR)** | This document + `docs/specs/isl-upgrade-v1.md` + journal updates. | `claude/sproutlab-diet-rework-p0` | docs-only | small (~3 files) | Governor audit waived per docs-only carve-out; Architect ratification + Cipher Mode-1 pre-pass on shape + Aurelius chronicling. |
+| 1 | Segment shell | `renderDietSegment(key)` dispatcher (NEW); segment-pill row + 4 segment containers; `ziva_diet_segment` sticky-state with safety override; zero-loss visual refactor (everything still visible, just behind right pill). | `claude/sproutlab-diet-rework-p1` | shared (template + styles + diet.js + core.js segment branch) | medium | Maren + Kael parallel → Lyra synth → Cipher Edict V. |
+| 2 | Meal-card compression | Compress `dqp-zone` to single "Recent" row + expand. Skip text-link → `zi-skip` icon toggle. Symbol #110 added. | `claude/sproutlab-diet-rework-p2` | Maren primary (home.js `dqp`); shared-module touch on template/styles | medium | Maren primary + Kael shared-module → synth → Cipher. |
+| **3** | **[Score] + dead-data surface** | NEW `renderInfoChemVariety` + `renderInfoBioactiveDiversity` cards in `intelligence-cards.js`; trend-strip in `[Score]`; proactive "introduce with care" chip in `[Today]`; `meal_combo_check` chip consumption (handler specced in Arc B); per-food chemistry sub-tab in `[Library]`. **Depends on Arc B Phase B1 (keystone trio) being merged.** | `claude/sproutlab-diet-rework-p3` | Maren (diet.js, template) + Kael (intelligence-cards.js, ISL consumption) | medium–large | Maren + Kael (full parallel) → synth → Cipher. |
+| 4 | `[Insights]` expand-by-default | `renderTips` inline-by-default; `renderComboHistory` promoted; accordion chevrons defaulted-open or removed. **Dormant-code disposition** for `renderInsightsD3 / renderVarietyCard / renderNutrientRadar` at `diet.js:3450/3499/3595` — Lyra recommends DELETE (prior iteration superseded). | `claude/sproutlab-diet-rework-p4` | Maren (diet.js) | small–medium | Maren → synth → Cipher. |
+| 5 | `[Library]` integration | Group-drill view; per-food detail overlay with Overview + Chemistry sub-tabs; quick-add form audit (delete-or-keep per Open Question 4). | `claude/sproutlab-diet-rework-p5` | shared (template + diet.js + styles) | small–medium | Maren + Kael shared-module → synth → Cipher. |
+| 6 | Polish | Sticky-state localStorage final; a11y on segment pills (aria-selected, keyboard nav, focus ring); motion review on segment-swap; regression-guard tests for segment-router behaviour; smoke tests for sticky-state + safety override. | `claude/sproutlab-diet-rework-p6` | shared | small | Maren + Kael → synth → Cipher. |
+
+## Open questions
+
+1. **Food DB count discrepancy.** Architect said 146 foods; scout #1 found 148 raw entries / 130 unique keys in `NUTRITION` (18 duplicate keys across `// ── EXPANDED:` blocks silently overwriting earlier declarations). Confirm: is the spec count 130 (deduped), 148 (raw), or in-flight to 146?
+2. **Sticky positioning of `.diet-seg-bar`.** Inline-only (Lyra recommends) vs also-sticky stacked under `.track-sub-bar`. Phone-viewport call.
+3. **Dormant code at `diet.js:3450, 3499, 3595`** (`renderInsightsD3 / renderVarietyCard / renderNutrientRadar`). Delete (Lyra recommends — prior iteration superseded by current `renderTips`) vs revive vs leave. Resolved in Phase 4.
+4. **Quick-add form vs per-meal autocomplete redundancy.** Delete the form, integrate reaction-marking inline in per-meal flow, or keep both?
+5. **Stat-tile duplication in Phase 3.** New "Fibre Variety" / "Bioactive Diversity" tiles — ADD to the existing 5-tile row (re-flow to 7?) or REPLACE one of the existing tiles?
+6. **Tomorrow Prep placement.** `renderTomorrowPrep` (`diet.js:2157`) currently renders into `#tomorrowPrepCard` outside the Diet sub-tab body. Move into `[Today]`, `[Insights]`, or leave outside the segment system?
+7. **`zi-skip` symbol design.** Lyra proposes a simple slash-through bowl or a "no-entry" glyph. Architect call on visual.
+
+## Synthesis amendments (Wave 1.5 fold-in)
+
+This v1.0 draft folds the following amendments to the Lyra Mode-1 (Wave 1) spec body, all surfaced by Wave 1.5 scouts:
+
+**Mechanical corrections (scout-validated):**
+- Sticky-state key: `sl.diet.segment` → `ziva_diet_segment` (house convention).
+- Combo history key: `sl.combo.history.v1` → `ziva_combo_history` (`COMBO_HISTORY_KEY`).
+- Skip-toggle symbol: `zi-bowl-skip` → `zi-skip` (matches sprite convention).
+- The 73/59/95/79/75 pill row was misidentified in Wave 1 as a precedent inside Diet; it is the parent `.track-sub-bar` with `tsb-score` chips. The visual idiom we clone lives one level *up*; `.diet-seg-bar` is a *sub-level* derivation.
+
+**Structural additions (scout-surfaced):**
+- No `renderDiet()` orchestrator exists today — Phase 1 invents `renderDietSegment(key)`. Load-bearing change.
+- Sticky positioning of `.diet-seg-bar` flagged as an open question (Lyra recommends inline-only).
+- Phase 3 dead-data identity: `chem.*` sub-object + `COMBO_RULES` from `data.js`. Surface routing decided: `chem.*` analytics' natural home is `intelligence-cards.js`; combo intelligence is a new ISL intent (`meal_combo_check`) specced in Arc B.
+
+**Risk flags (scout-flagged for Governor attention):**
+- Pre-existing HR-1 latent at `diet.js:2742` (`lbl.emoji` direct HTML push). Flag for Maren as follow-up issue.
+- Stat-tile duplication risk in Phase 3 — explicit ADD vs REPLACE decision needed.
+- COMBO_RULES is keyed by *nutrient* not food name — handler must tag-resolve.
+
+**Arc-pair strategy.** This spec (Arc A — Diet IA) and `docs/specs/isl-upgrade-v1.md` (Arc B — ISL Upgrade) are ratified together because Phase 3 of Arc A depends on Arc B's keystone trio. Phases 1, 2, 4, 5, 6 of Arc A are independent and can ship without Arc B landing first.
+
+---
+
+— Lyra (Mode-1 subagent + main-session Wave 1.5 synthesis), 2026-05-23, against `b2670f7`. cc-018 status: `pending_review`.

--- a/docs/specs/diet-rework-v1.md
+++ b/docs/specs/diet-rework-v1.md
@@ -1,10 +1,11 @@
 # Spec: Diet Tab Rework v1
 
-**Version:** v1.0 draft (Mode-1 + Wave 1.5 main-session synthesis)
+**Version:** v1.0 draft (Mode-1 + Wave 1.5 + Wave 2 main-session synthesis)
 **Date:** 2026-05-23
 **Authors:**
 - Lyra (Mode-1 subagent) — primary spec body (Wave 1)
-- Lyra (main-session synthesis) — Wave 1.5 amendments folding `scribe-scout` #1 (food DB) + #2 (ISL capability map) findings
+- Lyra (main-session synthesis) — Wave 1.5 amendments folding scribe-scout #1 (food DB) + #2 (ISL capability map) findings
+- Lyra (main-session synthesis) — Wave 2 amendments folding Maren / Kael / Cipher / Aurelius Mode-1 audits
 
 **Authority chain:** `CLAUDE.md` §QA Chain · canon-cc-008 · canon-cc-022 · cc-018 `pending_review`
 **Against commit:** `b2670f7`
@@ -14,11 +15,13 @@
 
 `pending_review` (cc-018). Prerequisites for `ratified`:
 
-- Architect ratification of IA pattern A, the Wave-1.5 fold-in, and the two-spec arc-pair strategy.
-- Maren Mode-1 audit (Care jurisdiction — `home.js` / `diet.js` / `medical.js` touch surface; shared `template.html` / `styles.css`).
-- Kael Mode-1 audit (Intelligence jurisdiction — `core.js` segment-routing touch; `intelligence-isl.js` / `intelligence-qa.js` / `intelligence-qa-handlers.js` / `intelligence-cards.js` Phase-3 touch surfaces specified in Arc B).
-- Cipher Mode-1 Edict V pre-pass on the spec itself.
-- Aurelius chronicling on ratification (Codex Memory.md cross-cluster note: ISL drift + arc-pair strategy).
+- Architect ratification of IA pattern A, the Wave-1.5 fold-in, the Wave-2 amendments, and the two-spec arc-pair strategy.
+- Maren Mode-1 audit — **complete** (V-M-47 through V-M-54 issued; verdict: yes-with-fixes; fixes folded below).
+- Kael Mode-1 audit — **complete** (V-K-49 through V-K-57 issued; verdict: yes-with-fixes; fixes folded below).
+- Cipher Mode-1 Edict V pre-pass — **complete** (verdict: pass-with-fixes; fixes folded below).
+- Aurelius cross-cluster chronicling — **complete** (verdict: chronicling-ready; amendments folded; Codex Memory.md candidates per Chronicler's discretion post-ratify).
+
+**Companion-set deploy delta — paired ratification.** This spec and `isl-upgrade-v1.md` form a single arc-pair artifact under cc-018. Ratifying one without the other constitutes a canon-cc-008 short-circuit unless the Architect explicitly defers one — in which case Arc A Phase 3 must be deferred until Arc B Phase B-1 ratifies separately.
 
 ## Why
 
@@ -29,13 +32,15 @@ The Diet sub-tab under TRACK does four jobs in one vertical scroll, and the IA p
 - **Job 3 — decision-support.** Can I Give This? `template.html:850–862`; Recent Checks `renderComboHistory` `diet.js:890–903`; Insights & Tips `renderTips` `diet.js:905–1014` rendering 15 active Avoid / Good-to-Know / Add-to-Diet items behind three collapsed accordions.
 - **Job 4 — reference.** Foods Introduced grid + quick-add form, `template.html:868–890`.
 
-Three pathologies follow from the monolith: (a) triple analytics stack at top competes for primacy before the parent can act — the logging-first user lands on a 73 score when they came to log breakfast; (b) each meal card carries a `dqp-zone` stacking up to ~13 chips in 2–4 rows under each meal × 4 meals = a wall of food names; (c) the highest-value analytical surface — Insights & Tips, 15 active items — is buried at the bottom behind three collapsed accordions. The failure mode is **job-mixing in a single scroll** — fix it by routing by job.
+Three pathologies follow from the monolith: (a) triple analytics stack at top competes for primacy before the parent can act — the logging-first user lands on a 73 score when they came to log breakfast; (b) each meal card carries a `dqp-zone` stacking up to **10 chips** in 2–4 rows under each meal × 4 meals = a wall of food names; (c) the highest-value analytical surface — Insights & Tips, 15 active items — is buried at the bottom behind three collapsed accordions. The failure mode is **job-mixing in a single scroll** — fix it by routing by job.
 
-**Wave 1.5 substrate finding.** The food DB (`NUTRITION` at `data.js:2228–2402`) has new fields — the `chem` sub-object (`fibre`, `antiNutrients`, `bioactives`) — and a full `COMBO_RULES` table (`data.js:2463–2476`) that have **zero outside-`data.js` references**. They are specced but unsurfaced. The intelligence layer is the only place they can be surfaced — and ISL's diet accessor (`_islDietData` at `intelligence-isl.js:446–499`) does not yet expose them. **Phase 3 of this spec depends on Arc B (ISL Upgrade) landing the substrate first.**
+**Wave 1.5 substrate finding.** The food DB (`NUTRITION` at `data.js:2228–2402`) has new fields — the `chem` sub-object (`fibre`, `antiNutrients`, `bioactives`) — and a full `COMBO_RULES` table (`data.js:2463–2476`) that have **zero outside-`data.js` references**. They are present but unsurfaced. The intelligence layer is the only place they can be surfaced — and ISL's diet accessor (`_islDietData` at `intelligence-isl.js:446–499`) does not yet expose them. **Phase 3 of this spec depends on Arc B (ISL Upgrade) landing the substrate first.**
+
+**Wave 2 Care-tier finding (V-M-50).** Tracing the current meal-input flow — `onMealInput` (`home.js:3568`) → `showMealDropdown` (`:3614`) → `updateMealInsight` (`:3387`) → `getMealInsight` (`:3282`) — **none of these paths consult `AGE_RULES` or `ALLERGENS`**. The dropdown surfaces raw `FOOD_SUGGESTIONS` with zero age/allergen filtering. The reads I originally cited in Phase 3 fold-in live inside `analyzeFoodSafety`, which fires ONLY for the explicit "Can I Give This?" query — NOT for the meal-input typing flow. This is a Care-tier gap that pre-dates this rework, and Phase 2 is the right place to close it (lifted from Phase 3 — see PR sequence).
 
 ## Scope
 
-**In scope.** Sub-segment IA inside the Diet sub-tab of TRACK; per-segment content specs; meal-card history-chip compression; segment router contract; sticky-state contract; Phase 0–6 PR sequence; HR pre-check; Governor-readiness asks. Phase 3 consumes Arc B outputs (specified by cross-reference).
+**In scope.** Sub-segment IA inside the Diet sub-tab of TRACK; per-segment content specs; meal-card history-chip compression; segment router contract; sticky-state contract with safety override; Phase 0–6 PR sequence; HR pre-check; Governor-readiness asks. Phase 3 consumes Arc B outputs (specified by cross-reference).
 
 **Out of scope.** No new data sources beyond the food-DB fields already present. No Care-Region semantic changes — meal-data schema, food DB, reaction tracking, CareTicket linkage all untouched. No new sync surfaces. No changes to the TRACK top-level sub-bar (`renderTrackSubBar` at `core.js:3161–3186`) — the Diet pill there continues to behave as today; new segments live one level below.
 
@@ -51,31 +56,31 @@ Pattern A: a sub-segment pill row directly under the Diet header inside `#tab-di
 
 **Segment content boundaries (locked):**
 
-- **[Today]** — logging-only. Date picker (`#feedingDate`), Diet Intel Banner (`#dietIntelBanner`), four meal cards (`.meal-card.{breakfast|lunch|dinner|snack}`), per-meal compressed `dqp-zone` (see §Meal-card compression), Save. **Phase 3 fold-in:** post-log `meal_combo_check` chip stack consuming Arc B's new ISL intent + `COMBO_RULES` + `chem.antiNutrients` (e.g., logging ragi + paneer fires "spacing tip: serve calcium 2h apart"). Plus a proactive "introduce with care" chip next to the meal input when the typed/selected food crosses `AGE_RULES.minMonth` or `ALLERGENS` (Group D from scout #1 — data already read, but not yet proactively surfaced).
-- **[Score]** — analytics. Hero score card (`renderDomainHero('diet')`), 2×2 sub-score grid, 5 stat tiles (`#dietStats` via `renderDietStats`), trend strip. **Phase 3 fold-in:** "Fibre Variety" tile + "Bioactive Diversity" tile derived from `chemRollup` (the new field on `_islDietData` specced in Arc B). New tiles render via NEW `renderInfoChemVariety` in `intelligence-cards.js` — `chem.*` analytics' natural home, alongside existing `computeNutrientHeatmap` / `computeFoodCombos` / `computeMealBreakdown`.
-- **[Insights]** — decision-support. Can I Give This? + Recent Checks (`renderComboHistory`) + Insights & Tips (`renderTips`) with the three category accordions **rendered inline, expanded by default**. The 15-active-item surface lands on segment open, not behind chevrons.
-- **[Library]** — reference. Foods Introduced grid (`#foodsGrid` via `renderFoods` at `home.js:2947+`), group-drill view, per-food detail overlay. **Phase 3 fold-in:** per-food detail overlay gains a "Chemistry" sub-tab exposing `chem.fibre` / `chem.antiNutrients` / `chem.bioactives` (Group A from scout #1) — direct surfacing on a discrete tap, not pushed into every food-row tile. Quick-add form integrated.
+- **[Today]** — logging-only. Date picker (`#feedingDate`), Diet Intel Banner (`#dietIntelBanner`), four meal cards (`.meal-card.{breakfast|lunch|dinner|snack}`), per-meal compressed `dqp-zone` (see §Meal-card compression), Save. **Phase 2 fold-in (lifted from Phase 3 per V-M-50):** proactive "introduce with care" chip next to the meal-input dropdown when the typed/selected food crosses `AGE_RULES.minMonth` against Ziva's current age, OR appears in `ALLERGENS`. **Phase 3 fold-in:** post-log combo-check chip stack consuming Arc B's `meal_combo_check` data (chip-stack data source: `computeMealCombos(date)` per V-M-49 separation).
+- **[Score]** — analytics. Hero score card (`renderDomainHero('diet')`), 2×2 sub-score grid, 5 stat tiles (`#dietStats` via `renderDietStats`), trend strip. **Phase 3 fold-in:** "Fibre Variety" tile + "Bioactive Diversity" tile derived from `chemRollup` (the new field on `_islDietData` specced in Arc B). New tiles render via NEW `renderInfoChemVariety` in `intelligence-cards.js`. Plus the "Variety nudge" tile (V-M-48 — see [Score] sub-spec).
+- **[Insights]** — decision-support. Can I Give This? + Recent Checks (`renderComboHistory`) + Insights & Tips (`renderTips`) with the three category accordions **rendered inline, expanded by default**. The 15-active-item surface lands on segment open, not behind chevrons. **Plus Tomorrow Prep (Open Q 6 resolved per Wave 2 — Cipher + Maren concur).** Decision-support belongs here.
+- **[Library]** — reference. Foods Introduced 6-card grid, group-drill view, per-food detail overlay (Phase 3 fold-in: "Chemistry" sub-tab exposing `chem.fibre` / `chem.antiNutrients` / `chem.bioactives`), quick-add form retained (Open Q 4 resolved per V-M from Maren — KEEP both surfaces until per-meal save grows a reaction-marking step).
 
 **Segment router contract:**
 
 - Data-action-driven per HR-3. Pill click fires `data-action="switchDietSegment"` with `data-arg` ∈ `{today, score, insights, library}`. Dispatcher branch in `core.js`'s existing action delegator (sister to `switchTrackSub` at `core.js:3136`).
-- Segment state stored in `localStorage` under key **`ziva_diet_segment`** — matching the house convention `ziva_*` (sister to `ziva_track_sub` at `core.js:3139`, `ziva_active_tab` at `core.js:1053/3077`). **No `sl.*` keys exist anywhere in the codebase**; the spec follows the established prefix.
-- Segment change re-renders the **segment body only**, not the whole Diet tab.
+- Segment state stored in `localStorage` under key **`ziva_diet_segment`** — matching the house convention `ziva_*` (sister to `ziva_track_sub` at `core.js:3139`, `ziva_active_tab` at `core.js:1053/3077`).
+- Segment change re-renders the **segment body only**. **Critical contract (V-K-50):** `renderDietSegment(key)` must NOT call `renderTrackSubBar` — `calcZivaScore()` is NOT cached (verified at `core.js:1926–1979`) and is recomputed on every `renderTrackSubBar` call; segment-switching is sub-Diet, not Track-level, and must not trigger the upstream re-compute. Phase 6 adds a regression-guard asserting this non-coupling.
 
-**Critical structural finding (scout #2).** **There is no `renderDiet()` orchestrator today.** `switchTrackSub('diet')` at `core.js:3153` calls only `renderDietStats()`. Per-segment lazy rendering requires inventing a `renderDietSegment(segmentKey)` dispatcher in Phase 1. This is structural, not veneer — and is the load-bearing change in Phase 1.
+**Critical structural finding (scout #2).** **There is no `renderDiet()` orchestrator today.** `switchTrackSub('diet')` at `core.js:3153` calls only `renderDietStats()`. Per-segment lazy rendering requires inventing a `renderDietSegment(segmentKey)` dispatcher in Phase 1. State field `_dietActiveSegment` mirrors the `_activeTrackSub` pattern (per Kael's Q4 confirmation).
 
 **Sticky-state contract:**
 
 - Write `ziva_diet_segment` on every segment change.
 - Read on Diet sub-tab mount (inside `switchTrackSub(sub)` when `sub === 'diet'`).
 - Fallback to `today` if absent, malformed, or not in the enum. Logging-first cold-start is non-negotiable.
-- **Safety override (Maren-flagged).** If `renderDietIntelBanner` (`home.js:3831`) produces non-empty content (active fever/diarrhoea episode with diet implications), force-route to `[Today]` regardless of sticky-state. The banner is the highest-signal surface; if it has something to say, the parent must see it.
+- **Safety override — REVISED per V-M-47.** `renderDietIntelBanner` (`home.js:3831–3962`) populates **both safety signals (illness episodes + 3-day reaction window) AND positive synergy suggestions** (`:3907–3958` — "Breakfast ideas from Ziva's favorites"). A naive `banner-non-empty` override force-routes on positive nudges too, which is wrong. **Override fires only on the safety subset.** Phase 1 refactors `renderDietIntelBanner` to expose a `hasSafetySignal()` predicate that returns true iff an active illness episode OR the 3-day reaction window has content (NOT when only synergy suggestions exist). The segment-router consults `hasSafetySignal()` for the override. Alternative shape: split rendering into `renderDietSafetyBanner` + `renderDietSynergyBanner` and key the override off the safety renderer's output.
 
 **Segment-pill component contract:**
 
-- Reuse the existing `.track-sub-btn` styling pattern (`styles.css:4930–4947`) at a derived class `.diet-seg-btn` — visual continuity with the parent TRACK sub-bar, marked as sub-level (no `tsb-score` numeric slot, denser).
-- **Sticky positioning decision (open question, Lyra recommends inline-only).** The parent `.track-sub-bar` is `position: sticky; top: 0` (`styles.css:4932`). Three options: (a) **inline-only** — scrolls with content, no double-sticky overhead; (b) also-sticky stacked under the TRACK bar — heavier but always visible; (c) both-sticky with z-index management. **Recommendation: inline-only** to keep phone viewport breathing room.
-- Token-driven; no new color domain. Spacing from `--sp-*`; radii from `--r-full`; type from `--fs-sm` / `--fs-xs`.
+- Reuse `.track-sub-btn` styling (`styles.css:4930–4947`) at a derived class `.diet-seg-btn`. Sub-level mark: no `tsb-score` numeric slot, denser.
+- **Sticky positioning:** inline-only (per Open Q 2 — no Care concern surfaced; phone-viewport reasoning holds).
+- Token-driven per HR-5. Spacing from `--sp-*`; radii from `--r-full`; type from `--fs-sm` / `--fs-xs`.
 
 ## Per-segment specs
 
@@ -83,171 +88,198 @@ Pattern A: a sub-segment pill row directly under the Diet header inside `#tab-di
 
 **Purpose.** Log today's meals fast, one-handed, with minimum chrome.
 
-**Content.** Date nav (`‹` / date input / `›` / Save), Diet Intel Banner (`renderDietIntelBanner` at `home.js:3831`), four meal cards (breakfast / lunch / dinner / snack), each with compressed `dqp-zone` (see §Meal-card compression), `meal-input` autocomplete dropdown, per-meal insight strip (`#insight-{meal}`).
+**Content.** Date nav, Diet Intel Banner (split per V-M-47), four meal cards with compressed `dqp-zone`, `meal-input` autocomplete dropdown with **proactive age/allergen chip (Phase 2 — V-M-50)**, per-meal insight strip, Save.
 
-**Phase 3 fold-in.**
-- **`meal_combo_check` chip stack** — appears under the meal-card group when the newly-saved food triggers a combo from `COMBO_RULES` against today's already-logged foods. Shape: dismissable chip with `data-action="dismissComboTip"` / `data-arg="{ruleId}"`. The ISL intent + handler are specced in Arc B (`isl-upgrade-v1.md` §Sequencing keystone). NOTE: `COMBO_RULES` is keyed by *nutrient* (`foods:['iron','calcium']`), not food name; the handler must tag-resolve via `NUTRITION[food].nutrients`.
-- **Proactive "introduce with care" chip** — appears next to the meal-input dropdown when the typed/selected food crosses `AGE_RULES.minMonth` against Ziva's current age, or appears in `ALLERGENS`. Group D from scout #1. The data is already *read* at log-time (`diet.js:465`, `diet.js:475`); this fold-in just promotes it to a *proactive* surface.
+**Phase 2 fold-in — "introduce with care" chip (lifted from Phase 3 per V-M-50).**
+- Trigger: typed/selected food in the meal-input crosses `AGE_RULES.minMonth` against Ziva's age OR appears in `ALLERGENS`.
+- Phrasing: **specific to the rule that fired**, NOT a generic "introduce with care."
+  - Example (age): `"Honey: wait until 12 months — risk of infant botulism."` Sourced from `AGE_RULES['honey']` message field if present, fallback constructed from `minMonth`.
+  - Example (allergen): `"Peanut: introduce in small amounts, watch 3 days for reaction."` Sourced from `ALLERGENS['peanut']` advisory field.
+- Dismissibility: per-food, per-session. **NOT persistent across sessions** — a dismissed honey warning that doesn't return tomorrow is the silent-failure shape Maren guards against (V-M-50).
+- HR-4 hard on every rule-message string at render.
+- HR-3: `data-action="dismissAgeAllergenChip"` with `data-arg="{food}"`.
 
-**Major changes (Phases 1+2).** (1) Analytics removed from this segment's view — hero / sub-score grid / stat tiles all live in `[Score]`. (2) `dqp-zone` compressed from up-to-four-stacked rows to one expandable "Recent" row. (3) `meal-skip-btn` text-link replaced with icon-toggle.
+**Phase 3 fold-in — `meal_combo_check` post-log chip stack.**
+- Chip-stack data source: `computeMealCombos(date)` (NEW pure-data function in `intelligence-cards.js`, per V-M-49 separation of data-fetch from answer-render). Both the chip-stack render in `[Today]` AND `qaAnswerMealCombo` UIB renderer consume this same data function.
+- Chip render: small-format pills under the meal-card group. Each chip carries a `data-action="dismissComboTip"` / `data-arg="{ruleId}"`.
 
-**Data sources / state reads.** `feedingData` (current entry by date), `foods` array (autocomplete), ISL `dqp` pulls already plumbed in `renderDietQuickPicker`, Diet Intel Banner reads fever-episode state from `intelligence-illness.js`. Phase-3 additions: ISL `meal_combo_check` intent (Arc B); `AGE_RULES` / `ALLERGENS` already in scope.
+**Major changes (Phases 1+2).** (1) Analytics removed from this segment's view. (2) `dqp-zone` compressed from up-to-four-stacked rows to one expandable "Recent" row. (3) `meal-skip-btn` text-link replaced with `zi-skip` icon-toggle. (4) Proactive age/allergen chip added (Phase 2).
 
-**Open questions.** Should the date nav promote into the Diet segment header (next to the segment pills) or stay at the top of `[Today]`? Should Tomorrow Prep (`renderTomorrowPrep` at `diet.js:2157`) surface here or in `[Insights]`?
+**Data sources / state reads.** `feedingData`, `foods`, ISL `dqp` pulls, `renderDietIntelBanner` (split), `AGE_RULES` + `ALLERGENS` (Phase 2 chip — already in `data.js`), `computeMealCombos(date)` (Phase 3 — Arc B).
 
 ### `[Score]` — analytics segment
 
 **Purpose.** Show how Ziva's diet is tracking — score, sub-scores, tiles, trend, chemistry-variety.
 
-**Content.** `renderDomainHero('diet')` → 2×2 sub-score grid → `#dietStats` 5-tile grid → trend strip.
+**Content.** `renderDomainHero('diet')` → 2×2 sub-score grid → `#dietStats` 5-tile grid (ADD — see Open Q 5 resolution) → trend strip.
 
 **Phase 3 fold-in.**
-- **"Fibre Variety" tile.** Counts distinct `chem.fibre` categories Ziva consumed in the last 7 days. Direct answer to "is the fibre mix varied?" (parent question scout #1 surfaced). Source: `chemRollup.fibreDaysHigh` from Arc B.
-- **"Bioactive Diversity" tile.** Distinct `chem.bioactives` count over 7 days — variety matters more than mg-totals at this developmental stage. Source: `chemRollup.bioactiveCount` from Arc B.
-- **Optional "Anti-Nutrient Watch" inline note.** If `chemRollup.antiNutrientFlags` flags multi-day oxalate/phytate load, surface a calm advisory (not alarm) chip. Maren consult required on phrasing.
+- **"Fibre Variety" tile.** Counts distinct `chem.fibre` categories Ziva consumed in last 7 days. Source: `chemRollup.fibreDaysHigh` (Arc B B-1).
+- **"Bioactive Diversity" tile.** Distinct `chem.bioactives` count over 7 days. Source: `chemRollup.bioactiveCount` (Arc B B-1).
+- **"Variety nudge" tile (V-M-48 — Maren-drafted, NOT "Anti-Nutrient Watch").**
+  - **Tile label:** `"Variety nudge"` (NOT alarm-shaped — "Anti-Nutrient Watch" was renamed at Maren's audit).
+  - **Trigger condition:** same `chem.antiNutrients` flag (e.g., phytates) appears ≥5 days in a 7-day window **AND** fibre variety is low (one or two `chem.fibre` categories only). Both gates must fire; either alone is normal Indian-staple eating.
+  - **Copy (Maren-approved):** *"This week's iron-rich meals lean heavily on phytate-rich grains and pulses. Soaking, sprouting, or fermenting overnight reduces phytates and improves iron absorption. A serving of vitamin-C fruit (orange, mango, tomato) alongside also helps."*
+  - **Icon constraint (HARD):** `zi('bulb')` or `zi('sparkle')` ONLY. **Never** `zi('warn')` or `zi('siren')` on this tile. The signal is variety-tip, not warning.
+  - Source: `chemRollup.antiNutrientFlags` + `chemRollup.fibreDistribution` (Arc B — `fibreDistribution` is one of the two fields deferred from B-1 to B-2 per V-K position; if not in B-2, fall back to `fibreDaysHigh` lookup).
 
-**Renderer routing.** New tiles render via NEW functions in `intelligence-cards.js` (the natural home for `chem.*` analytics per scout #2 — `renderInfo*` master + sibling compute fns already there). Proposed: `renderInfoChemVariety` + `renderInfoBioactiveDiversity`, both consuming `chemRollup` via `getDomainData('diet', ...)`.
+**Renderer routing.** New tiles render via NEW functions in `intelligence-cards.js` — `renderInfoChemVariety` (for Fibre Variety + Bioactive Diversity) and `renderInfoVarietyNudge` (for the Variety nudge). Both consume `chemRollup` via `getDomainData('diet', ...)`.
 
-**Major changes.** (1) Score is no longer the first thing seen on a logging visit. (2) Trend strip is new; sized by the Phase-3 chem-variety tiles. (3) Existing stat-tiles (`ds-sage` classes) and the new chem-variety tiles must NOT duplicate — Phase 3 resolves whether the new tiles ADD to the stat-tile row or REPLACE one of the existing tiles. Recommend ADD with explicit re-flow.
+**Open Q 5 resolution (Wave 2 — Kael + Maren concur):** stat-tile duplication → **ADD with re-flow** (5 → 7 tiles, plus the conditional Variety nudge). Don't displace tiles a parent has learned to read. The new tiles surface new data classes (`chem.*`), not duplicates.
 
-**Data sources / state reads.** Existing: `calcZivaScore()` cache, `getZivaScoreTrend7d()`, food/iron/variety derivations in `renderDietStats`. New (Arc B): `chemRollup` via `_islDietData`.
-
-**Open questions.** Sparkline density. Whether the 2×2 sub-score grid here matches the popup's `_spRenderOverview` layout exactly or a denser inline variant. Stat-tile duplication resolution (ADD vs REPLACE).
+**Data sources / state reads.** `calcZivaScore()` (NOT cached — recomputed per `renderTrackSubBar` per V-K-50), `getZivaScoreTrend7d()`, `renderDietStats` source data, `chemRollup` (Arc B).
 
 ### `[Insights]` — decision-support segment
 
 **Purpose.** Answer "Can I give this?" and surface what the data is saying.
 
-**Content.** Can I Give This? input + result + chips + Recent Checks (`renderComboHistory`) + Insights & Tips (`renderTips`) with three sections **rendered inline, expanded by default** — Avoid / Good to Know / Add to Diet. The accordion-collapsed pattern is removed for this segment.
+**Content.** Can I Give This? + Recent Checks (`renderComboHistory`, promoted next to Can I Give This?) + Insights & Tips (`renderTips` with three sections **rendered inline, expanded by default** — Avoid / Good to Know / Add to Diet) **+ Tomorrow Prep** (per Open Q 6 resolution — Cipher + Maren concur: Tomorrow Prep is decision-support, not logging; belongs here).
 
-**Major changes.** (1) The 15-active-item Insights & Tips surface lands on segment open. (2) Three category accordions → inline sections with section headers, no default chevron-collapse. (3) Recent Checks promoted next to Can I Give This?, not buried under it.
+**Major changes.** (1) The 15-active-item Insights & Tips surface lands on segment open. (2) Three category accordions → inline sections. (3) Recent Checks promoted next to Can I Give This?. (4) Tomorrow Prep lifted into this segment.
 
-**Data sources / state reads.** `comboHistory` (localStorage key `ziva_combo_history`, `COMBO_HISTORY_KEY` per `diet.js:378,380,614`), tip-generation pipeline from `renderTips` / `generateDos` / `generateDonts`.
-
-**Open questions.** Does Tomorrow Prep belong here as a fourth inline section? Should the Insights & Tips count badge (`#tipsCount`) move into the segment-pill itself as a numeric badge on `[Insights]`?
+**Data sources / state reads.** `comboHistory` (localStorage key `ziva_combo_history`, `COMBO_HISTORY_KEY` per `diet.js:378,380,614`), `renderTips` / `generateDos` / `generateDonts`, `renderTomorrowPrep` (`diet.js:2157`).
 
 ### `[Library]` — reference segment
 
 **Purpose.** What has Ziva tried, by group; per-food chemistry; quick-add a new food.
 
-**Content.** Foods Introduced 6-card grid (`#foodsGrid`, by food group), drill-into-group expanded view, **per-food detail overlay** (new — Phase 3 fold-in), quick-add form (`#foodInput` + `#foodDate` + `#foodSlot` + reaction toggle + Add button).
+**Content.** Foods Introduced 6-card grid (`#foodsGrid`, `renderFoods` at `home.js:2947+`), drill-into-group expanded view, **per-food detail overlay** (NEW — Phase 3 fold-in), **quick-add form retained** (Open Q 4 resolution — Maren ruling: KEEP both surfaces because the reaction `bad`/`mild`/`watch`/`ok` toggle is Care-Region data backbone; per-meal autocomplete doesn't yet expose this toggle).
 
 **Phase 3 fold-in — per-food "Chemistry" sub-tab on detail overlay.**
 - Tap any food tile → detail overlay opens.
-- Two sub-tabs: "Overview" (existing nutrients/tags display) + "Chemistry" (NEW).
-- "Chemistry" sub-tab shows `chem.fibre` (with brief explanation of what each category means), `chem.antiNutrients` as info chips (with soak/cook hints from a small inline lookup or a future `chem.advisories` derivation), `chem.bioactives` with one-line lay descriptions.
-- HR-4 hard: every `chem.*` value passed through `escHtml` at the render boundary.
+- Two sub-tabs: "Overview" (existing nutrients/tags) + "Chemistry" (NEW).
+- "Chemistry" sub-tab shows `chem.fibre` (with brief explanation), `chem.antiNutrients` as info chips, `chem.bioactives` with one-line lay descriptions.
+- HR-4 hard: every `chem.*` value through `escHtml` at the render boundary.
 
-**Major changes.** (1) Quick-add form remains here (final placement TBD per Open Questions). (2) Group-drill view defaults to compact summary; tap-group expands. (3) Per-food detail overlay is NEW (current tap doesn't open one).
-
-**Data sources / state reads.** `foods` array, `feedingData` (for "X of Y" group counts and frequency), `NUTRITION[name]` for chemistry sub-tab.
-
-**Open questions.** Delete the quick-add form entirely in favour of per-meal autocomplete + reaction-marking inline, or keep both? Should the food-group card layout shift from 6 fixed cards to a denser pill-grid?
+**Open Q 4 resolution (Maren V-M):** Quick-add form KEEPS its place for the reaction-marking toggle. If a future PR migrates reaction-marking into the per-meal save path with equal prominence, re-evaluate then. Today's surface is the data-tier's only entry point for the toggle; deleting it would orphan the backbone read in `qaAnswerFoodSafety`.
 
 ## Meal-card compression sub-spec
 
-The `dqp-zone` currently emits, per meal: up to three "same-as previous day" pills (Yd / 2d ago / 3d ago — `DAY_LABELS` at `home.js:3767`), plus up to three "other-meal-today" pills, plus up to four "top frequent for this slot" pills, plus up to three general top-foods fallbacks. **Maximum density: ≈13 pills in 2–4 stacked rows under every meal input. Wall-of-food-names against four meal cards.**
+The `dqp-zone` currently emits, per meal: up to three "same-as previous day" pills + up to three "other-meal-today" pills + up to four "top frequent for this slot" pills = **up to 10 chips max** (V-M-52 mechanical correction — prior framing said ≈13). 10 chips × 4 meals = a wall of food names.
 
-**Compression target.** One **"Recent"** row of up to 6 chips, with an expand-to-see-all affordance. Priority order (top of row first): (1) same-meal same-day-last-week if exists; (2) Yd / 2d / 3d same-meal-as pills (most recent first); (3) top-frequent for this meal slot. Expand → reveals the full pill set under the row.
+**Compression target.** One **"Recent"** row of up to 6 chips, with an expand-to-see-all affordance. Priority order: same-meal same-day-last-week → Yd/2d/3d same-meal-as → top-frequent for this meal slot. Expand → reveals the full pill set.
 
-**Markup shape.** `<div class="dqp-zone"><div class="dqp-recent">{6 chips}<button class="dqp-expand" data-action="dqpExpand" data-arg="{meal}">More</button></div><div class="dqp-all" hidden>{full set}</div></div>`. Expand toggles `[hidden]` on `.dqp-all` and updates the button label. Note: `dqp-same` chip uses JS-level substring truncation (`home.js:3790, 3802`), NOT CSS `text-overflow: ellipsis` — preserved for HR-10.
+**Markup shape.** `<div class="dqp-zone"><div class="dqp-recent">{6 chips}<button class="dqp-expand" data-action="dqpExpand" data-arg="{meal}">More</button></div><div class="dqp-all" hidden>{full set}</div></div>`. JS-substring truncation preserved per HR-10 (`home.js:3790, 3802`).
 
-**Skip toggle.** The `meal-skip-btn` text-link (`template.html:811,820,829,838`, styled at `styles.css:489–491`) — currently the literal text "skip" — becomes an icon toggle. Symbol name: **`zi-skip`** (simpler than `zi-bowl-skip`; matches existing sprite convention). Avoids semantic collision with `zi-skip-forward` (`template.html:107`, which means "advance to next" in media context). New symbol added to template — count goes 109 → 110.
+**Skip toggle.** `meal-skip-btn` text-link (`template.html:811,820,829,838`) → icon toggle using new `zi-skip` symbol (count 109 → 110). Avoids semantic collision with `zi-skip-forward` (media "advance").
+
+**Care-safe (V-M-51).** Reaction signal lives in `dietIntelBanner` 3-day window, not in `dqp` chips. Compression loses recall, not safety signal.
 
 ## Region boundary declarations
 
 | File | Governor jurisdiction | Phase(s) | Expected change size | Notes |
 |------|----------------------|----------|----------------------|-------|
-| `split/diet.js` | Maren | 1, 2, 4 (Insights expand), 5 | medium | `renderDietSegment(key)` dispatcher (NEW, Phase 1), per-segment render fns, compressed `dqp` branch, `renderTips` expand-by-default mode, per-food detail overlay (Phase 5 — Phase 3 chem sub-tab consumed here). |
-| `split/template.html` | Maren + Kael (shared) | 1, 2, 5 | small–medium | `#tab-diet` restructure: segment pill row + four segment containers wrapping existing content nodes. Per-food detail overlay scaffold. New `zi-skip` symbol (#110). |
-| `split/styles.css` | Maren + Kael (shared) | 1, 2 | small | `.diet-seg-bar` / `.diet-seg-btn` rules (token-driven, derived from `.track-sub-bar`), `.dqp-recent` / `.dqp-all` density rules, `meal-skip-btn` icon-state. |
-| `split/core.js` | Kael | 1 | small | Dispatcher branch for `switchDietSegment`; `ziva_diet_segment` read in `switchTrackSub` mount path. Inline; no `slStickyState` helper introduced. |
-| `split/home.js` | Maren | 2 | small | `renderDietQuickPicker` (`:3752–3829`) compression to single Recent + expand. Stat-tile re-flow for new Score-segment tiles (Phase 3). |
-| `split/intelligence-isl.js` | Kael | 3 (Arc-B-led) | **see Arc B** | `_islDietData` `chemRollup` extension. Specified in Arc B; consumed here. |
-| `split/intelligence-qa.js` | Kael | 3 (Arc-B-led) | **see Arc B** | `meal_combo_check` intent registration + dispatch. Specified in Arc B; consumed here. |
-| `split/intelligence-qa-handlers.js` | Kael | 3 (Arc-B-led) | **see Arc B** | `qaAnswerMealCombo` handler. Specified in Arc B; consumed here. |
-| `split/intelligence-cards.js` | Kael | 3 | medium | `renderInfoChemVariety` + `renderInfoBioactiveDiversity` cards (NEW). Consumes Arc B's `chemRollup`. |
-| `split/data.js` | shared | none (consumers only) | — | Out of scope this spec; `NUTRITION` and `COMBO_RULES` already specced. |
+| `split/diet.js` | Maren | 1, 2, 4, 5 | medium | `renderDietSegment(key)` dispatcher (NEW, Phase 1) with explicit non-coupling rule to `renderTrackSubBar`; per-segment render fns; compressed `dqp` branch; `renderTips` expand-by-default; per-food detail overlay (Phase 5); Tomorrow Prep relocation. |
+| `split/template.html` | shared-module dual review | 1, 2, 5 | small–medium | `#tab-diet` restructure; segment-pill row + 4 segment containers; per-food detail overlay scaffold; new `zi-skip` symbol (#110). |
+| `split/styles.css` | shared-module dual review | 1, 2 | small | `.diet-seg-bar`/`.diet-seg-btn` rules; `.dqp-recent`/`.dqp-all` density; `meal-skip-btn` icon-state. |
+| `split/core.js` | Kael | 1 | small | Dispatcher branch for `switchDietSegment`; `ziva_diet_segment` read in `switchTrackSub` mount path. |
+| `split/home.js` | Maren | 2 | medium | `renderDietQuickPicker` compression (`:3752–3829`); `renderDietIntelBanner` split into `renderDietSafetyBanner` + `renderDietSynergyBanner` (V-M-47); **NEW: proactive age/allergen chip wiring in meal-input flow** (V-M-50 — `onMealInput`/`showMealDropdown`/`updateMealInsight` paths); stat-tile re-flow for new Score tiles (Phase 3). |
+| `split/intelligence-isl.js` | Kael | 3 (Arc-B-led) | **see Arc B** | `_islDietData` `chemRollup` extension. |
+| `split/intelligence-qa.js` | Kael | 3 (Arc-B-led) | **see Arc B** | `meal_combo_check` intent registration + dispatch. |
+| `split/intelligence-qa-handlers.js` | Kael | 3 (Arc-B-led) | **see Arc B** | `qaAnswerMealCombo` handler. |
+| `split/intelligence-cards.js` | Kael | 3 | medium | `renderInfoChemVariety` + `renderInfoVarietyNudge` cards (NEW); `computeMealCombos(date)` data function (V-M-49 separation). |
+| `split/data.js` | shared | none (consumer only) | — | Out of scope. |
 
-**Out of scope this spec.** `split/sync.js`, `split/intelligence-illness.js`, `split/intelligence-quicklog.js`, `split/intelligence-caretickets.js`, `split/medical.js`. Phase 3's intelligence-layer dependency is fully spelled out in `docs/specs/isl-upgrade-v1.md`.
+**Phasing terminology — unified per C-REC-2:** every shared-module touch uses the phrase "shared-module dual review" consistently. Maren + Kael Mode-1 audits in parallel; Lyra synthesizes.
 
 ## HR pre-check
 
-| HR | Predicted risk | Why | Mitigation in this spec |
-|----|----------------|-----|-------------------------|
-| HR-1 (no emojis) | low (this spec) / **pre-existing flag** | The spec adds `zi-skip` and uses only `zi(*)` for all icons. **However, scout #2 noted a pre-existing latent issue:** `renderDomainHero` at `diet.js:2742` pushes `lbl.emoji` directly into HTML. If `getScoreLabel().emoji` returns Unicode emoji rather than a `zi()` SVG, that's an HR-1 violation that pre-dates this rework. **Flag for Maren** as a separate follow-up issue, NOT folded into this spec. |
-| HR-2 (no inline styles) | elevated | Existing diet-tab markup carries inline `style="display:none;"` (e.g., `#dietDomainHero`). New segment containers must default-hide via class, not inline style. | `.diet-seg-panel.active` toggle parallels existing `.track-sub-panel.active`. Phase 1 audit watches for any new inline-style introductions. |
-| HR-3 (no inline handlers) | elevated | New actions: `switchDietSegment`, `dqpExpand`, `dismissComboTip`, per-food detail overlay open/close, chemistry sub-tab switch. | All declared with `data-action` / `data-arg`; dispatcher branches added at `core.js:340–520`. Per the V-M-45 precedent in `diet.js` from the prior session. |
-| HR-4 (escHtml at render boundaries) | medium | Meal-card compression renders food-name chips; food names are user input. Existing `dqp-zone` already uses `escHtml(val)` (`home.js:3792`). Phase 3 chemistry-sub-tab renders `chem.*` values — also need `escHtml`. | Every new render boundary calls `escHtml` — food strings, chip text, chem values, tip text. Phase 1/5 audit. |
-| HR-5 (tokens-only spacing) | low–medium | `.diet-seg-bar` derives from `--sp-*` like `.track-sub-bar`. | Token list referenced (`--sp-4/6/8/10/12`, `--r-full`). No raw px. |
-| HR-6 (data-action delegation universal) | elevated | Same surface as HR-3. | Confirmed in segment-router contract. |
-| HR-7 (zi via innerHTML) | low | `zi-skip` rendered via `zi('skip')` → SVG via innerHTML. | Standard pattern. |
-| HR-8 (Coming-soon stubs) | n/a | No stub features in this spec. | — |
-| HR-9 (post-build multi-round QA) | structural | Every phase runs canon-cc-008 chain. | PR sequence table names Governors per phase. |
-| HR-10 (no text-overflow ellipsis) | medium | Compressed "Recent" row must preserve JS substring truncation, not introduce CSS ellipsis. | Phase 2 pre-check note. |
+| HR | Predicted risk | Why | Mitigation |
+|----|----------------|-----|------------|
+| HR-1 (no emojis) | low | Spec uses `zi(*)` only; `zi-skip` added (#110). **Pre-existing claim correction (V-M-53 + Cipher):** `getScoreLabel().emoji` at `core.js:1078–1083` returns `zi(*)` SVG strings, NOT Unicode codepoints. The field name is a naming-misnomer (legacy from when Unicode was used) but the substance is HR-1 compliant. **Resolved as no-op; voluntary rename `emoji` → `iconHtml` in a future hygiene PR, NOT a Maren follow-up issue.** |
+| HR-2 (no inline styles) | elevated | Existing `style="display:none;"` on Diet-tab nodes (`#dietDomainHero`). New segment containers default-hide via class. | `.diet-seg-panel.active` toggle parallels `.track-sub-panel.active`. Phase 1 audit. |
+| HR-3 (no inline handlers) | elevated | New actions: `switchDietSegment`, `dqpExpand`, `dismissComboTip`, `dismissAgeAllergenChip`, per-food detail open/close, chemistry sub-tab switch, Tomorrow Prep interactions. | All declared with `data-action` / `data-arg`; dispatcher branches at `core.js:340–520`. Per V-M-45 precedent. |
+| HR-4 (escHtml at render boundaries) | medium | New render boundaries — food-name chips, `chem.*` values in chemistry sub-tab + chem-variety tiles, age/allergen chip text, **Variety nudge advisory copy + antiNutrient-flag strings**, combo-chip text. | Every new `${...}` calls `escHtml`. Phase 1/2/3/5 audit. Specifically (C-REC-1): the Variety nudge tile renders `chemRollup.antiNutrientFlags` array strings + advisory copy — every component through `escHtml`. |
+| HR-5 (tokens-only spacing) | low–medium | `.diet-seg-bar` derives from `--sp-*`. | Tokens: `--sp-4/6/8/10/12`, `--r-full`. No raw px. |
+| HR-6 (data-action delegation universal) | elevated | Same surface as HR-3. | Dispatcher branches. |
+| HR-7 (zi via innerHTML) | low | `zi-skip` via `zi('skip')` → SVG via innerHTML. | Standard. |
+| HR-8 (Coming-soon stubs) | n/a | No stub features. | — |
+| HR-9 (post-build multi-round QA) | structural | Every phase runs canon-cc-008 chain. | PR sequence names Governors. |
+| HR-10 (no text-overflow ellipsis) | medium | Recent row preserves JS substring truncation. | Phase 2 pre-check. |
 | HR-11 (Math.floor currency) | n/a | No currency. | — |
-| HR-12 (timezone-safe dates) | low | Existing `toDateStr` / `setDate(getDate()-i)` in `renderDietQuickPicker`. Preserved. | No new date construction. |
+| HR-12 (timezone-safe dates) | low | Existing `toDateStr` / `setDate(getDate()-i)` preserved. | No new date construction. |
 
-## Governor-readiness note
+## Governor-readiness — Wave 2 audit results
 
-**For Maren (Care).**
-1. Does compressing `dqp-zone` from up-to-four stacked rows to a single "Recent" row (6 chips + expand) lose care-context a parent depends on at moment-of-logging? Specifically: if yesterday's lunch caused a reaction note, does the parent need to see that lunch's contents in the breakfast-log glance, or is "yesterday's lunch" the wrong place to surface a reaction signal regardless?
-2. Sticky-state landing the parent on `[Library]` (last-used) could hide a critical safety surface they'd otherwise see — confirm the proposed safety-override (force-route to `[Today]` when `renderDietIntelBanner` non-empty).
-3. Phase 3 fold-in: proactive "introduce with care" chip in `[Today]` based on `AGE_RULES.minMonth` and `ALLERGENS` — phrasing, dismissibility, and whether dismissing should persist across sessions (probably no).
-4. Phase 3 fold-in: "Anti-Nutrient Watch" tile in `[Score]` — phrasing must be calm-advisory not alarm. Maren to draft / approve copy.
-5. **Pre-existing HR-1 latent** at `diet.js:2742` (`lbl.emoji` push) — confirm whether `getScoreLabel().emoji` ever returns a Unicode codepoint. If so, follow-up issue.
+**Maren (Care) — V-M-47 through V-M-54 issued, verdict: yes-with-fixes.**
+1. Safety-override `renderDietIntelBanner` non-empty: **OVER-BROAD (V-M-47)** — tighten to `hasSafetySignal()` predicate or split renderer.
+2. `dqp-zone` compression Care-safety: **safe (V-M-51)** — reaction signal not in chips; explicit no-op finding.
+3. Proactive "introduce with care" chip: **lift Phase 3 → Phase 2 (V-M-50)** — current meal-input flow has zero proactive safety signal; this is a pre-existing Care gap, not a Phase 3 fold-in. Specific per-rule phrasing; per-session dismissibility (NOT persistent).
+4. Variety nudge tile copy (was "Anti-Nutrient Watch"): **drafted (V-M-48)** — label rename, ≥5/7-day gate + low-fibre-variety AND-gate, Maren-approved copy, icon-ban on `zi('warn')`/`zi('siren')`.
+5. HR-1 latent at `diet.js:2742`: **false positive (V-M-53)** — concurs with Cipher. No follow-up issue.
 
-**For Kael (Intelligence).**
-1. Does the segment router add any score-derivation recompute cost? `calcZivaScore()` is cached; segment-change should not re-trigger it.
-2. Does `ziva_diet_segment` read on Diet-tab mount interact with ISL day-summary generation? The day-summary path runs through `intelligence-quicklog.js` and `intelligence-isl.js`; the segment-state read is presentational, but flag if any ISL pull is segment-gated.
-3. Confirm `ziva_diet_segment` namespace does not collide with any existing localStorage key.
-4. Phase 1 invents `renderDietSegment(segmentKey)` dispatcher in `diet.js`. Where exactly does it sit relative to `_dietActiveSegment` state, and should this state mirror the `_activeTrackSub` pattern at `core.js`?
-5. Phase 3 dependency on Arc B's keystone trio — review the cross-spec contract in `isl-upgrade-v1.md` and flag any plumbing risks.
+**Kael (Intelligence) — V-K-49 through V-K-57 issued, verdict: yes-with-fixes.**
+1. `calcZivaScore()` cache contract: **NOT cached (V-K-50)** — corrected; non-coupling rule added to dispatcher contract.
+2. `ziva_diet_segment` ISL interaction: **none** (presentational read; no ISL pull is segment-gated).
+3. `ziva_diet_segment` namespace collision: **none** (sweep complete; nearest neighbor is `ziva_diet_pref`, unrelated).
+4. `_dietActiveSegment` state field placement: **top of `diet.js` segment-router section**; mirrors `_activeTrackSub` pattern.
+5. Phase 3 → Arc B B-1 cross-spec contract: clean once V-K-49 / V-K-53 corrections land in Arc B.
+
+**Cipher (Censor) — Edict V pass-with-fixes; 3 required, 6 recommended; 11 regression-guard names provided for Phase 6 / B-4 test planning. Arc-pair shape certified.**
+
+**Aurelius (Chronicler) — chronicling-ready with 4 marginal amendments; Codex Memory.md candidates per Chronicler's discretion post-ratify.**
 
 ## PR sequence (Phases 0–6)
 
 | Phase | Name | Scope | Branch | Jurisdiction | Diff size | QA chain |
 |-------|------|-------|--------|--------------|-----------|----------|
-| **0** | **Spec (this PR)** | This document + `docs/specs/isl-upgrade-v1.md` + journal updates. | `claude/sproutlab-diet-rework-p0` | docs-only | small (~3 files) | Governor audit waived per docs-only carve-out; Architect ratification + Cipher Mode-1 pre-pass on shape + Aurelius chronicling. |
-| 1 | Segment shell | `renderDietSegment(key)` dispatcher (NEW); segment-pill row + 4 segment containers; `ziva_diet_segment` sticky-state with safety override; zero-loss visual refactor (everything still visible, just behind right pill). | `claude/sproutlab-diet-rework-p1` | shared (template + styles + diet.js + core.js segment branch) | medium | Maren + Kael parallel → Lyra synth → Cipher Edict V. |
-| 2 | Meal-card compression | Compress `dqp-zone` to single "Recent" row + expand. Skip text-link → `zi-skip` icon toggle. Symbol #110 added. | `claude/sproutlab-diet-rework-p2` | Maren primary (home.js `dqp`); shared-module touch on template/styles | medium | Maren primary + Kael shared-module → synth → Cipher. |
-| **3** | **[Score] + dead-data surface** | NEW `renderInfoChemVariety` + `renderInfoBioactiveDiversity` cards in `intelligence-cards.js`; trend-strip in `[Score]`; proactive "introduce with care" chip in `[Today]`; `meal_combo_check` chip consumption (handler specced in Arc B); per-food chemistry sub-tab in `[Library]`. **Depends on Arc B Phase B1 (keystone trio) being merged.** | `claude/sproutlab-diet-rework-p3` | Maren (diet.js, template) + Kael (intelligence-cards.js, ISL consumption) | medium–large | Maren + Kael (full parallel) → synth → Cipher. |
-| 4 | `[Insights]` expand-by-default | `renderTips` inline-by-default; `renderComboHistory` promoted; accordion chevrons defaulted-open or removed. **Dormant-code disposition** for `renderInsightsD3 / renderVarietyCard / renderNutrientRadar` at `diet.js:3450/3499/3595` — Lyra recommends DELETE (prior iteration superseded). | `claude/sproutlab-diet-rework-p4` | Maren (diet.js) | small–medium | Maren → synth → Cipher. |
-| 5 | `[Library]` integration | Group-drill view; per-food detail overlay with Overview + Chemistry sub-tabs; quick-add form audit (delete-or-keep per Open Question 4). | `claude/sproutlab-diet-rework-p5` | shared (template + diet.js + styles) | small–medium | Maren + Kael shared-module → synth → Cipher. |
-| 6 | Polish | Sticky-state localStorage final; a11y on segment pills (aria-selected, keyboard nav, focus ring); motion review on segment-swap; regression-guard tests for segment-router behaviour; smoke tests for sticky-state + safety override. | `claude/sproutlab-diet-rework-p6` | shared | small | Maren + Kael → synth → Cipher. |
+| **0** | **Spec (this PR)** | Both arc-pair specs + journal. | `claude/sproutlab-diet-rework-p0` | docs-only | small | Wave 2 complete. Architect ratification pending. |
+| 1 | Segment shell | `renderDietSegment(key)` dispatcher with non-coupling rule to `renderTrackSubBar`; segment pill row + 4 containers; `ziva_diet_segment` sticky-state with `hasSafetySignal()`-gated safety override; `renderDietIntelBanner` split into safety + synergy halves. | `claude/sproutlab-diet-rework-p1` | shared-module dual review (template + styles + diet.js + core.js + home.js banner-split) | medium | shared-module dual review → Lyra synth → Cipher Edict V. |
+| 2 | Meal-card compression + age/allergen chip | Compress `dqp-zone` to single "Recent" row + expand. Skip text-link → `zi-skip` icon (#110). **NEW (lifted from Phase 3 per V-M-50): proactive age/allergen chip in meal-input flow** consuming `AGE_RULES.minMonth` + `ALLERGENS`. | `claude/sproutlab-diet-rework-p2` | Maren primary (home.js dqp + chip wiring); shared-module touch | medium | Maren primary + shared-module dual review → synth → Cipher. |
+| **3** | **[Score] + chem cards + combo chips** | NEW `renderInfoChemVariety` + `renderInfoVarietyNudge` cards in `intelligence-cards.js`; trend strip in `[Score]`; `meal_combo_check` chip stack consumption in `[Today]` via `computeMealCombos(date)` (Arc B); per-food chemistry sub-tab in `[Library]`. **Depends on Arc B Phase B-1.** | `claude/sproutlab-diet-rework-p3` | Maren (diet.js, template) + Kael (intelligence-cards.js, ISL consumption) | medium–large | shared-module dual review → synth → Cipher. |
+| 4 | `[Insights]` expand-by-default + dormant-code deletion | `renderTips` inline-by-default; `renderComboHistory` promoted; Tomorrow Prep relocated into `[Insights]`. **Delete** `renderInsightsD3 / renderVarietyCard / renderNutrientRadar` at `diet.js:3450/3499/3595` (Open Q 3 resolved — Lyra + Maren approve DELETE; supersession by current `renderTips` confirmed). | `claude/sproutlab-diet-rework-p4` | Maren | small–medium | Maren → synth → Cipher. |
+| 5 | `[Library]` integration | Group-drill view; per-food detail overlay with Overview + Chemistry sub-tabs; quick-add form retained (Open Q 4 — KEEP both per Maren ruling). | `claude/sproutlab-diet-rework-p5` | shared-module dual review | small–medium | dual review → synth → Cipher. |
+| 6 | Polish + regression-guards | Sticky-state localStorage final; a11y on segment pills (aria-selected, keyboard nav, focus ring — required, not optional per Maren); motion review; **regression-guard suite per C-REC-5 naming convention `regression-guard-{phase}-{concern}`**. | `claude/sproutlab-diet-rework-p6` | shared-module dual review | small | dual review → synth → Cipher. |
 
-## Open questions
+**Regression-guard names per phase (from Cipher Edict V, locked in Phase 6 / B-4 planning):**
+- A-1: `regression-guard-segment-pill-data-action`, `regression-guard-sticky-state-contract`, `regression-guard-segment-no-tracksubbar-recompute` (V-K-50)
+- A-2: `regression-guard-dqp-truncation-js-not-css`, `regression-guard-zi-skip-symbol-present`, `regression-guard-age-allergen-chip-fires` (V-M-50)
+- A-3: `regression-guard-chem-escape-doctrine`, `regression-guard-combo-tag-resolution` (V-K-53 tri-resolution), `regression-guard-variety-nudge-icon-ban` (V-M-48)
+- A-4: `regression-guard-tips-expanded-by-default`, `regression-guard-dormant-code-deleted`
+- A-5: `regression-guard-food-detail-overlay-action`
+- A-6: `regression-guard-seg-pill-a11y`
 
-1. **Food DB count discrepancy.** Architect said 146 foods; scout #1 found 148 raw entries / 130 unique keys in `NUTRITION` (18 duplicate keys across `// ── EXPANDED:` blocks silently overwriting earlier declarations). Confirm: is the spec count 130 (deduped), 148 (raw), or in-flight to 146?
-2. **Sticky positioning of `.diet-seg-bar`.** Inline-only (Lyra recommends) vs also-sticky stacked under `.track-sub-bar`. Phone-viewport call.
-3. **Dormant code at `diet.js:3450, 3499, 3595`** (`renderInsightsD3 / renderVarietyCard / renderNutrientRadar`). Delete (Lyra recommends — prior iteration superseded by current `renderTips`) vs revive vs leave. Resolved in Phase 4.
-4. **Quick-add form vs per-meal autocomplete redundancy.** Delete the form, integrate reaction-marking inline in per-meal flow, or keep both?
-5. **Stat-tile duplication in Phase 3.** New "Fibre Variety" / "Bioactive Diversity" tiles — ADD to the existing 5-tile row (re-flow to 7?) or REPLACE one of the existing tiles?
-6. **Tomorrow Prep placement.** `renderTomorrowPrep` (`diet.js:2157`) currently renders into `#tomorrowPrepCard` outside the Diet sub-tab body. Move into `[Today]`, `[Insights]`, or leave outside the segment system?
-7. **`zi-skip` symbol design.** Lyra proposes a simple slash-through bowl or a "no-entry" glyph. Architect call on visual.
+## Open questions — Wave 2 resolutions
 
-## Synthesis amendments (Wave 1.5 fold-in)
+1. **Food DB count (146/148/130).** Architect call; no Care/Intel concern bound on count itself. Recommendation: confirm before implementations that consume the count cite the deduped (130) figure.
+2. **Sticky positioning of `.diet-seg-bar`.** Resolved — **inline-only**. No Care concern; phone-viewport reasoning.
+3. **Dormant code at `diet.js:3450/3499/3595`.** Resolved — **DELETE** in Phase 4 (Lyra + Maren approve; superseded by current `renderTips`).
+4. **Quick-add form vs per-meal autocomplete.** Resolved — **KEEP BOTH** (Maren ruling) until per-meal save grows a reaction-marking step.
+5. **Stat-tile duplication ADD vs REPLACE.** Resolved — **ADD with re-flow** (5 → 7 tiles + conditional Variety nudge). Kael + Maren concur.
+6. **Tomorrow Prep placement.** Resolved — **`[Insights]`**. Cipher + Maren concur; decision-support not logging.
+7. **`zi-skip` symbol design.** Architect call on visual — slash-through bowl or no-entry glyph. Implementation in Phase 2.
 
-This v1.0 draft folds the following amendments to the Lyra Mode-1 (Wave 1) spec body, all surfaced by Wave 1.5 scouts:
+## Synthesis amendments
 
-**Mechanical corrections (scout-validated):**
-- Sticky-state key: `sl.diet.segment` → `ziva_diet_segment` (house convention).
-- Combo history key: `sl.combo.history.v1` → `ziva_combo_history` (`COMBO_HISTORY_KEY`).
-- Skip-toggle symbol: `zi-bowl-skip` → `zi-skip` (matches sprite convention).
-- The 73/59/95/79/75 pill row was misidentified in Wave 1 as a precedent inside Diet; it is the parent `.track-sub-bar` with `tsb-score` chips. The visual idiom we clone lives one level *up*; `.diet-seg-bar` is a *sub-level* derivation.
+### Wave 1.5 fold-in (scribe-scout #1 + #2 + scribe-record)
+- Sticky-state key `sl.diet.segment` → `ziva_diet_segment` (house convention).
+- Combo history key `sl.combo.history.v1` → `ziva_combo_history` (`COMBO_HISTORY_KEY`).
+- Skip-toggle symbol `zi-bowl-skip` → `zi-skip`.
+- Phase 1 invents `renderDietSegment(key)` dispatcher — load-bearing.
+- Phase 3 dead-data identity: `chem.*` sub-object + `COMBO_RULES`. Routing: `chem.*` analytics' natural home is `intelligence-cards.js`; combo intelligence is new ISL intent in Arc B.
 
-**Structural additions (scout-surfaced):**
-- No `renderDiet()` orchestrator exists today — Phase 1 invents `renderDietSegment(key)`. Load-bearing change.
-- Sticky positioning of `.diet-seg-bar` flagged as an open question (Lyra recommends inline-only).
-- Phase 3 dead-data identity: `chem.*` sub-object + `COMBO_RULES` from `data.js`. Surface routing decided: `chem.*` analytics' natural home is `intelligence-cards.js`; combo intelligence is a new ISL intent (`meal_combo_check`) specced in Arc B.
+### Wave 2 fold-in (Maren / Kael / Cipher / Aurelius Mode-1)
 
-**Risk flags (scout-flagged for Governor attention):**
-- Pre-existing HR-1 latent at `diet.js:2742` (`lbl.emoji` direct HTML push). Flag for Maren as follow-up issue.
-- Stat-tile duplication risk in Phase 3 — explicit ADD vs REPLACE decision needed.
-- COMBO_RULES is keyed by *nutrient* not food name — handler must tag-resolve.
+**Mechanical corrections:**
+- HR-1 latent at `diet.js:2742` reframed as naming-misnomer (V-M-53 + Cipher concur); strike "Maren follow-up issue" wording.
+- `dqp-zone` chip count "≈13" → "up to 10" (V-M-52).
+- `calcZivaScore()` "cached" claim struck (V-K-50).
+- Anti-Nutrient Watch → Variety nudge rename (V-M-48).
 
-**Arc-pair strategy.** This spec (Arc A — Diet IA) and `docs/specs/isl-upgrade-v1.md` (Arc B — ISL Upgrade) are ratified together because Phase 3 of Arc A depends on Arc B's keystone trio. Phases 1, 2, 4, 5, 6 of Arc A are independent and can ship without Arc B landing first.
+**Phase re-scopes:**
+- "Introduce with care" chip lifts Phase 3 → Phase 2 (V-M-50).
+- Phase 1 `renderDietIntelBanner` splits into safety + synergy halves (V-M-47).
+- Phase 6 adopts regression-guard naming convention `regression-guard-{phase}-{concern}` (C-REC-5).
+
+**Schema corrections (Arc-B-led, consumed here):**
+- `qaAnswerMealCombo` return shape fixed to `qaRenderAnswer` contract (V-M-49 — see Arc B for full schema).
+- Chip-stack data source separated from UIB answer-render (`computeMealCombos(date)` in `intelligence-cards.js`).
+
+**Open Question resolutions** — see §Open questions above for the 7-question table.
+
+### Wave 2 amendments declined (with rationale)
+None. All Wave 2 required and recommended fixes folded above.
 
 ---
 
-— Lyra (Mode-1 subagent + main-session Wave 1.5 synthesis), 2026-05-23, against `b2670f7`. cc-018 status: `pending_review`.
+— Lyra (Mode-1 subagent + Wave 1.5 + Wave 2 main-session synthesis), 2026-05-23, against `b2670f7`. cc-018 status: `pending_review` (Wave 2 complete; awaiting Architect ratification).

--- a/docs/specs/diet-rework-v1.md
+++ b/docs/specs/diet-rework-v1.md
@@ -1,6 +1,6 @@
-# Spec: Diet Tab Rework v1
+# Spec: Diet Tab Rework v1 — SUPERSEDED
 
-**Version:** v1.0 draft (Mode-1 + Wave 1.5 + Wave 2 main-session synthesis)
+**Version:** v1.0 draft (Mode-1 + Wave 1.5 + Wave 2 main-session synthesis) — **superseded 2026-05-28**
 **Date:** 2026-05-23
 **Authors:**
 - Lyra (Mode-1 subagent) — primary spec body (Wave 1)
@@ -11,17 +11,19 @@
 **Against commit:** `b2670f7`
 **Cross-references:** `docs/specs/isl-upgrade-v1.md` (Arc B — Phase 3 of this spec depends on Arc B's keystone trio)
 
-## Status
+## Status — SUPERSEDED (2026-05-28)
 
-`pending_review` (cc-018). Prerequisites for `ratified`:
+**`superseded` (cc-018). Retained for provenance. Do not implement from this body.**
 
-- Architect ratification of IA pattern A, the Wave-1.5 fold-in, the Wave-2 amendments, and the two-spec arc-pair strategy.
-- Maren Mode-1 audit — **complete** (V-M-47 through V-M-54 issued; verdict: yes-with-fixes; fixes folded below).
-- Kael Mode-1 audit — **complete** (V-K-49 through V-K-57 issued; verdict: yes-with-fixes; fixes folded below).
-- Cipher Mode-1 Edict V pre-pass — **complete** (verdict: pass-with-fixes; fixes folded below).
-- Aurelius cross-cluster chronicling — **complete** (verdict: chronicling-ready; amendments folded; Codex Memory.md candidates per Chronicler's discretion post-ratify).
+> Arc A here redesigned the Diet tab into `[Today] [Score] [Insights] [Library]` segments. Between authoring (2026-05-23) and now, **`food-sub-tab-v1` was ratified and shipped** (PRs #166 / #168, spec amendments #167 / #169), restructuring the *same* surface (`#tab-diet`) into a different, now-merged IA — **`[Log] [Library] [Patterns]`** (`switchDietSub` / `.diet-sub-panel` on `main`). Two competing IA visions for one surface; the merged one wins.
 
-**Companion-set deploy delta — paired ratification.** This spec and `isl-upgrade-v1.md` form a single arc-pair artifact under cc-018. Ratifying one without the other constitutes a canon-cc-008 short-circuit unless the Architect explicitly defers one — in which case Arc A Phase 3 must be deferred until Arc B Phase B-1 ratifies separately.
+**Disposition (Architect, 2026-05-28 post-F-2 board triage):**
+
+- **Arc A IA rework — PARKED.** Phases 1, 2, 4, 5, 6 (the whole-tab restructure: segment router `switchDietSegment`, `renderDietSegment` dispatcher, `ziva_diet_segment` sticky-state, meal-card `dqp` compression, expand-by-default Insights, Library overlay) are obsolete — `main` already carries diet sub-tab nav + structured F-1/F-2 entry. Implementing them as-written would rip out merged scaffolding.
+- **Surviving content → migrated to Arc B.** The Phase-3 chemistry/combo surfacing (Fibre Variety / Bioactive Diversity / Variety-nudge tiles, per-food Chemistry detail, `meal_combo_check` chip-stack) was the genuinely valuable half. It is **re-homed into `isl-upgrade-v1.md` (Arc B, §Surfacing re-home)**, re-targeted from Arc A's segments to the merged `[Patterns]` (analytics tiles + combo surfacing) and `[Library]` (per-food chemistry) sub-tabs.
+- **Surviving Care-gap → carried forward.** V-M-50 (the meal-input flow surfaces no proactive age/allergen signal) is a real pre-existing Care gap, independent of IA. Re-evaluate against the F-2 FOB Feed-sheet entry flow; not actioned here.
+
+The Wave-1/1.5/2 audit record below (Maren V-M-47–54, Kael V-K-49–57, Cipher Edict V, Aurelius) is preserved unchanged as the provenance trail.
 
 ## Why
 

--- a/docs/specs/isl-upgrade-v1.md
+++ b/docs/specs/isl-upgrade-v1.md
@@ -1,8 +1,11 @@
 # Spec: ISL Upgrade v1
 
-**Version:** v1.0 draft (main-session synthesis from scribe-scout #2 capability map)
+**Version:** v1.0 draft (main-session Wave 1.5 + Wave 2 synthesis from scribe + Mode-1 audits)
 **Date:** 2026-05-23
-**Author:** Lyra (main-session synthesis) — ingest from `scribe-scout` Wave 1.5 ISL capability map
+**Authors:**
+- Lyra (main-session synthesis) — primary spec body, ingest from scribe-scout #2 capability map (Wave 1.5)
+- Lyra (main-session synthesis) — Wave 2 amendments folding Maren / Kael / Cipher / Aurelius Mode-1 audits
+
 **Authority chain:** `CLAUDE.md` §QA Chain · canon-cc-008 · canon-cc-022 · cc-018 `pending_review`
 **Against commit:** `b2670f7`
 **Cross-references:** `docs/specs/diet-rework-v1.md` (Arc A — Phase 3 depends on Arc B's keystone trio)
@@ -11,64 +14,76 @@
 
 `pending_review` (cc-018). Prerequisites for `ratified`:
 
-- Architect ratification of the upgrade roadmap and the Arc-A/Arc-B sequencing.
-- **Kael Mode-1 audit** (primary — this is his jurisdiction: `intelligence-*.js`, `core.js`, `data.js`, `sync.js`, `config.js`).
-- Maren Mode-1 cross-consult (Phase B-3 fold-in for the `qaAnswerMealCombo` handler — Care-side semantic check on the answer-card shape and copy).
-- Cipher Mode-1 Edict V pre-pass on the upgrade roadmap.
-- Aurelius chronicling on ratification (Codex Memory.md cross-cluster: ISL drift findings + the unwired-intents behavioral bug).
+- Architect ratification of the upgrade roadmap, the Wave-2 amendments, and the Arc-A/Arc-B sequencing.
+- Kael Mode-1 audit — **complete** (V-K-49 through V-K-57 issued; verdict: yes-with-fixes; fixes folded below).
+- Maren Mode-1 cross-consult — **complete** (V-M-47 through V-M-54 issued; copy + schema + safety-override findings folded below).
+- Cipher Mode-1 Edict V pre-pass — **complete** (verdict: pass-with-fixes; fixes folded below).
+- Aurelius cross-cluster chronicling — **complete** (verdict: chronicling-ready; Codex Memory.md candidates per Chronicler's discretion post-ratify).
+
+**Companion-set deploy delta — paired ratification.** This spec and `diet-rework-v1.md` form a single arc-pair artifact under cc-018. Ratifying one without the other constitutes a canon-cc-008 short-circuit unless the Architect explicitly defers one — in which case Arc A Phase 3 must be deferred until Arc B Phase B-1 ratifies separately.
 
 ## Why
 
-The SproutLab intelligence layer is 7 files, ~18,400 LOC distributed (post-PR-G split): `intelligence-isl.js` (1,029) + `intelligence-qa.js` (2,234) + `intelligence-qa-handlers.js` (3,614) + `intelligence-illness.js` (2,541) + `intelligence-quicklog.js` (4,355) + `intelligence-cards.js` (2,403) + `intelligence-caretickets.js` (2,224). The Architect framed it as "still pre-alpha." The Wave 1.5 capability map found this framing **partially accurate**:
+The SproutLab intelligence layer is 7 files, ~18,400 LOC distributed (post-PR-G split): `intelligence-isl.js` (1,029) + `intelligence-qa.js` (2,234) + `intelligence-qa-handlers.js` (3,614) + `intelligence-illness.js` (2,541) + `intelligence-quicklog.js` (4,355) + `intelligence-cards.js` (**2,643** per V-K-56 re-baseline — was 2,403 at spec-write) + `intelligence-caretickets.js` (2,224). The Architect framed it as "still pre-alpha." The Wave 1.5 capability map found this framing **partially accurate** — but Wave 2 corrected a load-bearing scout error:
 
-- **Leaner than the framing suggests.** Across all 18,400 LOC there are zero `if(true)return;` early-exit stubs, zero `if(false)` gates, zero `TODO` / `FIXME` / `XXX` comments. The dormant surface is concentrated in **7 material findings**, not pervasive drift.
-- **But two behavioral bugs are lurking.** Two registered QA intents — `prediction_accuracy` and `favorite_foods` — dispatch to **undefined handlers**. The dispatch is wrapped in `try { … } catch(e) { answer = null }` (`intelligence-qa.js:1670–1672`), so the user sees "no match" instead of the answer they expected. Two silent `ReferenceError`s lying in wait.
-- **Plus one CLAUDE.md drift.** CLAUDE.md says "ISL: 22 intents with dedicated handlers." The canonical intent registry is `QA_INTENTS` in `intelligence-qa.js:1–175`, not in ISL, and the count is now **30**. The doc misattributes the location AND the count.
-- **And data-layer surfaces are waiting for ISL consumers.** `NUTRITION[*].chem` (3 sub-fields) and `COMBO_RULES` (6 rules) are present in `data.js` with zero outside-`data.js` consumers — the data is specced but the intelligence layer doesn't yet pipe it.
+- **Leaner than the framing suggests.** Across the seven `intelligence-*.js` files (V-M-54 scope correction — claim is to the file set under audit, not the whole codebase) there are zero `if(true)return;` early-exit stubs, zero `if(false)` gates, zero `TODO` / `FIXME` / `XXX` comments. The dormant surface is concentrated in a handful of findings.
+- **No silent ReferenceErrors — scout #2 missed `intelligence-quicklog.js` (V-K-49).** Wave 1.5 claimed two registered QA intents (`prediction_accuracy`, `favorite_foods`) dispatched to undefined handlers. **Kael Mode-1 verified the opposite:** both handlers exist and ship:
+  - `qaAnswerPredictionAccuracy` at `intelligence-quicklog.js:1290–1320` — reads `KEYS.qlPredictions`, computes Top-1/Top-N accuracy over the last 30 days, gracefully degrades to "Need more data" when n < 5.
+  - `qaAnswerFavoriteFoods` at `intelligence-quicklog.js:1322–1341` — reads `foods.filter(f => f.favorite === true)`, computes per-food frequency.
+  - The total `qaAnswer*` count across both `qa-handlers.js` AND `quicklog.js` is 29 (= 30 intents − the `ct_create` special-case picker branch).
+  - The scout swept `qa-handlers.js` only. **Wave 1.5 methodology lesson:** capability-map scouts must grep across the full file-set under audit, not the file where a symbol is "expected" to live.
+- **One CLAUDE.md drift.** CLAUDE.md says "ISL: 22 intents with dedicated handlers." The canonical intent registry `QA_INTENTS` is in `intelligence-qa.js:1–175`, not in ISL, and the count is now **30** (independently verified by Kael). The doc misattributes BOTH location AND count.
+- **Data-layer surfaces waiting for ISL consumers.** `NUTRITION[*].chem` (3 sub-fields) and `COMBO_RULES` (6 rules) are present in `data.js` with zero outside-`data.js` consumers — the data is specced but the intelligence layer doesn't yet pipe it. **`COMBO_RULES` is not uniformly nutrient-keyed (V-K-53):** rule #6 is `{foods:['banana','constipation']}` — food-name + symptom. The handler must tri-resolve, not single-resolve.
+- **Region LOC over the 30K trigger (V-K-56).** Live count: 30,725 LOC for the full Kael jurisdiction (`intelligence-*.js` + `core.js` + `data.js` + `sync.js` + `config.js` + `start.js`). Threshold is 30,000. **The Region is currently over budget, pre-arcs**, and `intelligence-cards.js` is +240 LOC since the Wave-1.5 capability map. Arcs B-1 (+~150 LOC) and B-2 (+~80 LOC) will push further. Surfaced as architectural watch-item — not a B-0 blocker, but Lyra/Cipher should plan for an `intelligence-cards.js` sub-split or similar before Region pressure becomes acute.
 
-The Arc A (Diet Tab Rework v1) Phase 3 is blocked on this layer. Hence this Arc B — surgically targeted upgrades, sized to unblock Arc A Phase 3, retire the two silent ReferenceErrors, and resolve the boundary smells the capability map surfaced.
+Arc A Phase 3 is blocked on this layer. Hence this Arc B — surgically targeted upgrades, sized to unblock Arc A Phase 3 and resolve the boundary smells the capability map (corrected) surfaced.
 
 ## Scope
 
 **In scope.**
 - The Phase-3 keystone trio (see §Sequencing).
-- The two unwired intents — wire-or-de-register decision and implementation.
-- Filing-cabinet boundary cleanups (`_qaUpdateSuggestions`, `_qaDetectDomain`, `renderInfoAdoption` relocations).
-- CLAUDE.md drift fix (split into a tiny follow-up PR to keep this scope tight; flagged here, fix elsewhere).
-- 2–3 user-visible upgrade candidates from the ranked list (selection at Architect's discretion after ratification).
+- Temporal parser extension (`last Tuesday`, `N weeks ago`).
+- Filing-cabinet boundary cleanups (`_qaUpdateSuggestions` + `QA_SUGGEST_POOL` + `_qaDetectDomain`, `renderInfoAdoption` relocations).
+- Silent-catch `console.error` addition (per Wave 2 cross-companion convergence).
+- CLAUDE.md drift fix flagged here, executed as a separate tiny PR (Open Q 6 — Lyra recommends separate).
 
 **Out of scope.**
 - No new domains added to ISL (sleep/poop/medical/milestones accessors stay as specced).
-- No CareTicket state-machine changes (`intelligence-caretickets.js` two "Coming soon" stubs at `:1868–1873` are HR-8-compliant placeholders, not in this scope).
-- No Smart Q&A intent additions beyond `meal_combo_check` + the two ReferenceError fixes.
+- No CareTicket state-machine changes (`intelligence-caretickets.js` two "Coming soon" stubs at `:1868–1873` are HR-8-compliant placeholders).
 - No `sync.js` / Firebase boundary changes.
 - No `intelligence-quicklog.js` Activity Log / Today So Far refactors (mixed-concerns sleep+activity split is a known smell; deferred to a dedicated future arc).
+- **No "wire pre-alpha handlers" work (V-K-49 retirement).** Both `prediction_accuracy` and `favorite_foods` are already wired and shipping; nothing to wire or de-register.
+- **Diet-side surfaces (`diet.js`, `home.js`, `core.js` segment routing) — see Arc A (C-REQ-3 boundary).**
 
 **Hard boundary.** Arc B does not modify ISL semantics — it extends ISL surface. Existing intents, handlers, and accessors keep their contracts. New surfaces are additive.
 
-## State of the union (scout #2 capability sketch)
+## State of the union (scout #2 + Wave 2 corrections)
 
 | File | LOC | Main entry | Top symbols | Notes |
 |------|-----|------------|-------------|-------|
-| `intelligence-isl.js` | 1,029 | `getDomainData(domain, start, end)` (`:380`) | `resolveTimeQuery`, `generateDaySummary`, `generateRangeSummary`, `_islGetCached`, `_islMarkDirty`, `ISL_THRESHOLDS` | Pure data provider. Six domain accessors. **Scope leaks:** `_qaUpdateSuggestions` (`:115–198`) + `_qaDetectDomain` (`:890–899`) belong to QA. |
-| `intelligence-qa.js` | 2,234 | `qaExecuteQuery` (`:1579`); dispatch ladder `:1631–1668` | `QA_INTENTS` (`:1–175`, **30 entries**), `qaClassifyInput` (`:220`), `qaMatchIntent` (`:1272`), `_qaHandleTemporal` (`:1899`), UIB plumbing `_iqRenderPicker` (`:351`) / `_iqMineMealCombos` (`:493`) / `_iqBuildNewCombos` (`:686`) / `_iqGetWarnings` (`:822`) | The file Lyra edits to register new intents. |
-| `intelligence-qa-handlers.js` | 3,614 | `qaAnswer*` family (27 functions) | Diet-relevant: `qaAnswerNutrientGap` (`:1892`), `qaAnswerFoodVariety` (`:2154`), `qaAnswerFoodSafety` (`:2225`), `qaAnswerTexture` (`:2300`); plus `_qaHandleLookback`/`Pattern`/`Planning`. **Scope leak:** `renderInfoAdoption` (`:3409`). |
-| `intelligence-illness.js` | 2,541 | `startFeverEpisode` / `logFeverReading` / `resolveFeverEpisode` (`:37/61/96`); `renderHomeFeverBanner` (`:563`) | Four illness state machines (fever, diarrhoea, vomiting, cold). Self-contained; tight. |
-| `intelligence-quicklog.js` | 4,355 | `saveActivity` (`:239`); `openActivityLogPrefilled` (`:232`); `renderActivityChips` (`:195`) | Activity Log + Sleep Info-tab analytics cluster (`renderInfoSleepBedtimeDrift` `:3110` → `renderInfoSleepRegression` `:4355`). Mixed concerns — deferred refactor. |
-| `intelligence-cards.js` | 2,403 | `renderInfo()` master (`:1025`) | Cross-domain analytics. Diet-relevant: `computeNutrientHeatmap` (`:1283`), `computeFoodCombos` (`:1446`), `computeMealBreakdown` (`:1755`), `renderInfoFoodIntro` (`:1075`), `renderInfoComboFreq` (`:1610`). **Natural home for chem.* analytics.** |
-| `intelligence-caretickets.js` | 2,224 | `CT_TEMPLATES` (`:27`); `ctCreate`; `ctNextDueTime` (`:210`) | CareTicket lifecycle. Two "Coming soon" placeholders at `:1868–1873` — out of scope. |
+| `intelligence-isl.js` | 1,029 | `getDomainData(domain, start, end)` (`:380`) | `resolveTimeQuery`, `generateDaySummary`, `generateRangeSummary`, `_islGetCached`, `_islMarkDirty`, `ISL_THRESHOLDS` | Pure data provider. Six domain accessors. **Scope leaks:** `_qaUpdateSuggestions` (`:115–198`) + `QA_SUGGEST_POOL` (`:36–113`, 78 LOC sole-consumer-of `_qaUpdateSuggestions` per V-K-51) + `_qaDetectDomain` (`:890–899`) belong to QA. |
+| `intelligence-qa.js` | 2,234 | `qaExecuteQuery` (`:1579`); dispatch ladder `:1631–1668` | `QA_INTENTS` (`:1–175`, **30 entries**), `qaClassifyInput` (`:220`), `qaMatchIntent` (`:1272`), `_qaHandleTemporal` (`:1899`), UIB plumbing `_iqRenderPicker` (`:351`) / `_iqMineMealCombos` (`:493`) / `_iqBuildNewCombos` (`:686`) / `_iqGetWarnings` (`:822`) | File for new intent registration. |
+| `intelligence-qa-handlers.js` | 3,614 | `qaAnswer*` family (27 functions HERE; 2 more in `quicklog.js` per V-K-49) | Diet-relevant: `qaAnswerNutrientGap` (`:1892`), `qaAnswerFoodVariety` (`:2154`), `qaAnswerFoodSafety` (`:2225`), `qaAnswerTexture` (`:2300–:2395`). **Scope leak:** `renderInfoAdoption` (`:3409`). |
+| `intelligence-illness.js` | 2,541 | `startFeverEpisode` / `logFeverReading` / `resolveFeverEpisode` (`:37/61/96`); `renderHomeFeverBanner` (`:563`) | Four illness state machines. Self-contained. |
+| `intelligence-quicklog.js` | 4,355 | `saveActivity` (`:239`); `openActivityLogPrefilled` (`:232`); `renderActivityChips` (`:195`); **`qaAnswerPredictionAccuracy` (`:1290`) + `qaAnswerFavoriteFoods` (`:1322`) — both shipping, V-K-49** | Activity Log + sleep-analytics cluster (`renderInfoSleepBedtimeDrift` `:3110`–). Mixed concerns; deferred refactor. |
+| `intelligence-cards.js` | **2,643** (re-baseline V-K-56; +240 from spec-write) | `renderInfo()` master (`:1025`) | Cross-domain analytics. Diet-relevant: `computeNutrientHeatmap` (`:1283`), `computeFoodCombos` (`:1446`), `computeMealBreakdown` (`:1755`), `renderInfoFoodIntro` (`:1075`), `renderInfoComboFreq` (`:1610`), `renderInfoMealBreakdown` (`:1885`–~2020). **Natural home for chem.* cards AND the new `computeMealCombos(date)` data fn per V-M-49 separation.** |
+| `intelligence-caretickets.js` | 2,224 | `CT_TEMPLATES` (`:27`); `ctCreate`; `ctNextDueTime` (`:210`) | CareTicket lifecycle. Two "Coming soon" placeholders at `:1868–1873` — HR-8-compliant, out of scope. |
 
-**Dormant inventory (top 7):**
+**Dormant inventory — Wave 2 corrected:**
 
 | File | Symbol | Line | Status | LOC | Action |
 |------|--------|------|-------|-----|--------|
-| `intelligence-qa.js` | `QA_INTENTS[id='prediction_accuracy']` | 158–161 | **stub — handler undefined** | 4 | Decide: wire or de-register |
-| `intelligence-qa.js` | `QA_INTENTS[id='favorite_foods']` | 163–166 | **stub — handler undefined** | 4 | Decide: wire or de-register |
-| `intelligence-caretickets.js` | `ctViewAll` action | 1868–1870 | "Coming soon" placeholder | 3 | Out of scope — HR-8 compliant |
-| `intelligence-caretickets.js` | `ctViewOverdue` action | 1871–1873 | "Coming soon" placeholder | 3 | Out of scope — HR-8 compliant |
-| `intelligence-isl.js` | `_qaUpdateSuggestions` | 115–198 | misplaced (belongs in QA) | 84 | Phase B-4 — relocate |
-| `intelligence-isl.js` | `_qaDetectDomain` | 890–899 | misplaced (belongs in QA) | 10 | Phase B-4 — relocate |
-| `intelligence-qa-handlers.js` | `renderInfoAdoption` | 3409 | misplaced (belongs in cards) | ~30 | Phase B-4 — relocate |
+| ~~`intelligence-qa.js`~~ | ~~`QA_INTENTS[id='prediction_accuracy']`~~ | ~~158–161~~ | **WIRED — handler at quicklog.js:1290 (V-K-49)** | — | No action. |
+| ~~`intelligence-qa.js`~~ | ~~`QA_INTENTS[id='favorite_foods']`~~ | ~~163–166~~ | **WIRED — handler at quicklog.js:1322 (V-K-49)** | — | No action. |
+| `intelligence-caretickets.js` | `ctViewAll` action | 1868–1870 | "Coming soon" placeholder | 3 | Out of scope — HR-8 compliant. |
+| `intelligence-caretickets.js` | `ctViewOverdue` action | 1871–1873 | "Coming soon" placeholder | 3 | Out of scope — HR-8 compliant. |
+| `intelligence-isl.js` | `_qaUpdateSuggestions` + `QA_SUGGEST_POOL` (V-K-51) | 115–198, 36–113 | misplaced (belongs in QA) | 84 + 78 = **162** | Phase B-4 — relocate as unit. |
+| `intelligence-isl.js` | `_qaDetectDomain` | 890–899 | misplaced (belongs in QA) | 10 | Phase B-4 — relocate. |
+| `intelligence-qa-handlers.js` | `renderInfoAdoption` | 3409 | misplaced (belongs in cards) | ~30 | Phase B-4 — relocate. |
+
+**Behavioral concerns flagged separately:**
+- **Silent catch at `intelligence-qa.js:1670–1672`** swallows all `qaAnswer*` throws into `null`/`qaRenderNoMatch`. With V-K-49 retired, this is no longer hiding undefined-handler ReferenceErrors — but it still defeats observability for genuine handler bugs. **Decision (Cipher + Kael + Maren convergence):** add `console.error('qaExecuteQuery dispatch failed:', e)` in B-3. No external observability hook (over-engineering for a no-backend PWA).
+- **Pre-existing HR-6 latent in `_qaUpdateSuggestions` event handler at `:180–192`** uses `addEventListener` (V-K relocation finding). NOT in B-4 scope; **file as follow-up issue** sibling to #109/#111 from prior session.
 
 ## Coupling — load-bearing vs stranded
 
@@ -77,12 +92,11 @@ The Arc A (Diet Tab Rework v1) Phase 3 is blocked on this layer. Hence this Arc 
 2. **`intelligence-qa.js`** — `QA_INTENTS` + `renderQABar` is the UIB entry; home.js mounts it.
 3. **`intelligence-illness.js`** — wired into medical.js, home.js, core.js, sync.js. Fever banner on the Home hero.
 4. **`intelligence-cards.js`** — `renderInfo()` is the entire Info tab; heatmap consumed by home + diet.
-5. **`intelligence-quicklog.js`** — Activity Log save path universal.
+5. **`intelligence-quicklog.js`** — Activity Log save path universal; also hosts `qaAnswerPredictionAccuracy` + `qaAnswerFavoriteFoods` (V-K-49).
 
 **Stranded / experimental** (0–1 outside callers):
-1. Two unwired intents (`prediction_accuracy`, `favorite_foods`) — pre-alpha promises.
-2. `_qaHandlePlanning` + `_qaTomorrowPlan` + `_qaDoctorPrep` + `_qaShareToday` in `intelligence-qa-handlers.js` — lightly used planning surface.
-3. `intelligence-caretickets.js`'s ISL-side surface is thin (one intent, `ct_create`).
+- `_qaHandlePlanning` + `_qaTomorrowPlan` + `_qaDoctorPrep` + `_qaShareToday` in `intelligence-qa-handlers.js` — lightly used planning surface.
+- `intelligence-caretickets.js`'s ISL-side surface is thin (one intent, `ct_create`).
 
 ## Sequencing — the keystone trio (Phase B-1)
 
@@ -90,26 +104,30 @@ The Arc A (Diet Tab Rework v1) Phase 3 is blocked on this layer. Hence this Arc 
 
 ### B-1.1 — Extend `_islDietData` with `chemRollup` (`intelligence-isl.js:446–499`)
 
-Add a `chemRollup` field to the object returned by `_islDietData`, computed by joining `allFoods` against `NUTRITION[base].chem`. Shape:
+Add a `chemRollup` field to the object returned by `_islDietData`, computed by joining `allFoods` against `NUTRITION[base].chem`. **Ship 3 fields in B-1 per V-K reduction**; defer 2 fields to B-2:
 
 ```js
+// B-1 ship:
 chemRollup: {
   fibreDaysHigh: <int>,       // distinct chem.fibre categories consumed in window
-  fibreDistribution: { ... }, // category → days-count map
   antiNutrientFlags: [ ... ], // ordered list of {nutrient, daysSeen, foodCount}
-  bioactiveCount: <int>,      // distinct chem.bioactives across window
-  bioactiveTopFive: [ ... ]   // most-frequent bioactives
+  bioactiveCount: <int>       // distinct chem.bioactives across window
 }
+
+// Defer to B-2 (YAGNI — chem cards may not need these maps):
+//   fibreDistribution: { ... }
+//   bioactiveTopFive: [ ... ]
 ```
 
-- Joins `allFoods` (already computed in `_islDietData`) to `NUTRITION` via the canonical food-base lookup (`_FOOD_ALIASES`-aware).
-- Skips foods absent from `NUTRITION` silently (does not throw).
-- HR-12: respects the existing window's `start`/`end` date construction; no new date logic.
-- Cache: covered by existing `_islGetCached` keyed on `domain+start+end`. No new cache invalidation path needed (read-only join over already-cached data).
+- Joins `allFoods` (already computed in `_islDietData`) to `NUTRITION` via **`_baseFoodName(food)` at `core.js:2729–2748`** (V-K-54) — handles alias / parenthetical / form-word / plural normalization (4-layer lookup, not the prior single-layer "_FOOD_ALIASES-aware" framing).
+- Skips foods absent from `NUTRITION` silently; logs a one-time `console.warn` on first-encounter unaliased synonym (V-K-54 + V-K position on Open Q 4).
+- HR-12: window math via existing `resolveTimeQuery` — no new date construction in B-1.
+- Cache: covered by existing `_islGetCached` keyed on `domain+start+end`. `_islMarkDirty('diet')` (`:218–227`) already clears any `diet:*`-keyed cache; **roadmap row 11 dropped per V-K-55 — `NUTRITION` is const-bound; no separate hook needed today**.
+- **Naming locked: `chemRollup`** (rationale: "Rollup" matches aggregation-over-window semantic; "Summary" would collide with `generateDaySummary`/`generateRangeSummary` lexicon; "nutritionDeep" reads vague).
 
 ### B-1.2 — Register `meal_combo_check` intent (`intelligence-qa.js`)
 
-Add at `:69` (between `food_texture` and the POOP block):
+Add at `:69` (between `food_texture` and POOP block):
 
 ```js
 {
@@ -121,7 +139,7 @@ Add at `:69` (between `food_texture` and the POOP block):
 }
 ```
 
-Add dispatch at `:1642` (between `answerTexture` and `answerPoopGeneral`):
+Add dispatch at **`:1643`** (V-K spec-line correction — `:1642` is the `answerTexture` row; insert AFTER it):
 
 ```js
 else if (handler === 'answerMealCombo') answer = qaAnswerMealCombo(intent.id);
@@ -129,119 +147,193 @@ else if (handler === 'answerMealCombo') answer = qaAnswerMealCombo(intent.id);
 
 ### B-1.3 — Implement `qaAnswerMealCombo` (`intelligence-qa-handlers.js`)
 
-Insert between `qaAnswerTexture` (`:2300–~2395`) and `qaAnswerPoopFood` (`:2396`). Model on `qaAnswerFoodSafety` (`:2225`) for shape.
+Insert between `:2395` (end of `qaAnswerTexture`) and `:2396` (start of `qaAnswerPoopFood`).
+
+**Architecture (V-M-49 separation):** the handler does NOT compute combo data — it consumes a NEW pure-data function `computeMealCombos(date)` in `intelligence-cards.js` (lives alongside `computeFoodCombos`/`computeNutrientHeatmap`/`computeMealBreakdown` sibling set). Both `qaAnswerMealCombo` (UIB answer-card surface) AND the `[Today]` chip-stack render in Arc A consume `computeMealCombos(date)`. Single source of truth.
+
+**`computeMealCombos(date)` shape:**
 
 ```js
-function qaAnswerMealCombo(intentId) {
-  // 1. Pull recent feeding window via getDomainData('diet', start, end) — last 1 day for meal-window scope.
-  // 2. For each pair of foods in the window, tag-resolve via NUTRITION[food].nutrients.
-  // 3. Match the resolved nutrient pair against COMBO_RULES entries (data.js:2463–2476).
-  // 4. For each matched rule, build an answer-card item: { title, body, severity, advice }.
-  // 5. Also consult chem.antiNutrients for foods in the window; flag multi-flag oxalate/phytate loads.
-  // 6. Return: { title: 'Today's combos', headline, domain: 'sage', icon: 'food', items, actions: [] }.
-  // HR-4: escHtml every food string, every rule body. HR-1: zi() for any icon.
+function computeMealCombos(date) {
+  // 1. Pull recent feeding window via getDomainData('diet', start, end) — last 1 day (meal-window scope).
+  // 2. For each food in the window, resolve to base name via _baseFoodName().
+  // 3. For each pair of foods, evaluate against COMBO_RULES (data.js:2463–2476):
+  //    - Tri-resolution per V-K-53 (COMBO_RULES is NOT uniformly nutrient-keyed):
+  //      a. Tag-match: rule.foods[i] matches a nutrient in NUTRITION[food].nutrients
+  //      b. Name-match: rule.foods[i] === _baseFoodName(food) (catches rule #6: banana)
+  //      c. State-match: rule.foods[i] in {constipation, fever, diarrhoea, ...} -> consult
+  //         intelligence-illness.js active episodes + recent poop consistency
+  //         (catches rule #6: constipation). Cross-Region read.
+  // 4. For each matched rule, emit { ruleId, foods:[a,b], signal, copy }
+  //    where signal ∈ {good, warn, action, info, neutral} per Maren-approved per-rule
+  //    assignment (see §Maren-approved per-rule copy below).
+  // 5. Also consult chem.antiNutrients for foods in the window; emit "Variety nudge"-class
+  //    entries when ≥5/7-day same-flag concentration appears (gates align with V-M-48 tile).
+  // 6. Return { combos: [{ruleId, foods, signal, copy}, ...] }.
 }
 ```
 
-**Critical handler detail.** `COMBO_RULES` keys are nutrient names (`foods:['iron','calcium']`), NOT food names. The handler must tag-resolve via `NUTRITION[food].nutrients` arrays, not name-match the food strings.
+**`qaAnswerMealCombo` shape (V-M-49 — corrected to match `qaRenderAnswer` contract at `intelligence-qa.js:1684–1742`):**
 
-**That trio is the minimum.** Three files touched, ~150 LOC added, retires Group A/B/C from scout #1's dead-data inventory.
+```js
+function qaAnswerMealCombo(intentId) {
+  const data = computeMealCombos(today());
+  if (!data.combos.length) return { /* no-match shape */ dataGap: true };
+  return {
+    icon: 'food', domain: 'sage',
+    title: "Today's combos",
+    headline: `${data.combos.length} pairing tip${data.combos.length>1?'s':''} for today`,
+    sections: [{
+      label: 'Pairings', icon: 'food',
+      items: data.combos.map(c => ({
+        signal: c.signal,        // 'good' | 'warn' | 'action' | 'info' | 'neutral'
+        icon: signalIcon(c.signal),
+        text: escHtml(c.copy)    // HR-4
+      }))
+    }],
+    actions: [],
+    confidence: 'high'
+  };
+}
+```
 
-## Upgrade roadmap — full ranked list
+**HR-4 hard:** every food string + every rule body + every `chem.*` value through `escHtml` at the render boundary. Model on `qaAnswerFoodSafety` (`:2225–~2295`) for shape parity.
+
+**Maren-approved per-rule copy (V-M-49 — locked in this spec):**
+
+| Rule ID | Foods (rule.foods) | Signal | Copy |
+|---------|-------------------|--------|------|
+| 1 | iron + calcium | `info` | "Space these by 2 hours when you can — calcium can reduce iron absorption." |
+| 2 | iron + vitamin c | `good` | "Great pairing — Vit C boosts iron absorption up to 3×." |
+| 3 | iron + tea | `action` | "Tea blocks iron — never serve tea to babies." |
+| 4 | fat + vitamin a | `good` | "Ghee or coconut oil helps absorb Vit A from carrot/sweet potato/pumpkin." |
+| 5 | probiotic + prebiotic | `good` | "Curd with banana or oats feeds healthy gut bacteria." |
+| 6 | banana + constipation | `info` | "If Ziva is constipated, swap banana for pear, papaya, or prune today." |
+
+**No rule may carry `warn` signal** — too-broad escalation. Use `info` for spacing-tips, `good` for boosts, `action` only for the never-serve-tea case.
+
+**That trio is the minimum.** Three files touched (isl + qa + qa-handlers) + the `computeMealCombos` data fn in cards = ~150–200 LOC added (re-baseline; V-K-56 watch-item applies). Retires Group A/B/C from scout #1's dead-data inventory.
+
+## Upgrade roadmap — full ranked list (Wave 2 corrected)
 
 | # | Name | Scope | Why | Effort | Preconditions | Phase-3 relation | Spec phase |
 |---|------|-------|-----|--------|---------------|------------------|------------|
-| 1 | Extend `_islDietData` with `chemRollup` | `intelligence-isl.js:446–499` | Keystone — one accessor surfaces `chem.*` to every downstream | M | none | **yes** | **B-1** |
-| 2 | Add `meal_combo_check` intent | `intelligence-qa.js:69, :1642` | Combo intelligence surface for `[Today]` | M | #1 | **yes** | **B-1** |
-| 3 | Implement `qaAnswerMealCombo` handler | `intelligence-qa-handlers.js` between `:2395`/`:2396` | Required for #2 | M | #1, #2 | **yes** | **B-1** |
-| 4 | Add `renderInfoChemVariety` + `renderInfoBioactiveDiversity` cards | `intelligence-cards.js` after `:1885` | Surfaces `chem.fibre` + `chem.bioactives` rollup to Diet `[Score]` segment + Info tab | M | #1 | **yes** | **B-2** |
+| 1 | Extend `_islDietData` with `chemRollup` (3 fields) | `intelligence-isl.js:446–499` | Keystone — one accessor surfaces `chem.*` to every downstream | M | none | **yes** | **B-1** |
+| 2 | Add `meal_combo_check` intent | `intelligence-qa.js:69, :1643` | Combo intelligence surface | M | #1 | **yes** | **B-1** |
+| 3 | Implement `qaAnswerMealCombo` + `computeMealCombos` data fn | `intelligence-qa-handlers.js` between `:2395`/`:2396`; `intelligence-cards.js` (data fn after `:2020`) | Required for #2; data-fn separation enables Arc A chip-stack reuse | M | #1, #2 | **yes** | **B-1** |
+| 4 | Add `renderInfoChemVariety` + `renderInfoVarietyNudge` cards | `intelligence-cards.js` after `:2020` (V-K — corrects "after `:1885`" to "after the function ends") | Surfaces `chem.fibre`+`chem.bioactives` rollup + the Variety nudge tile (V-M-48 — Maren-drafted copy locked) | M | #1; `fibreDistribution` field ship in B-2 | **yes** | **B-2** |
 | 5 | Promote `chem.antiNutrients` to UIB warnings | `intelligence-qa.js:822` `_iqGetWarnings` | UIB already builds warnings; antiNutrients is a free signal | S | #1 | **yes** | **B-2** |
-| 6 | Wire `qaAnswerFavoriteFoods` handler | `intelligence-qa-handlers.js` (new) + register call at `:1659` | Pre-alpha intent silently no-matches — user-visible gap | S | none | no | **B-3** |
-| 7 | Wire `qaAnswerPredictionAccuracy` handler — or de-register intent | `intelligence-qa-handlers.js` (new) or `intelligence-qa.js:158–161` removal | Second pre-alpha intent. Depends on whether prediction infrastructure exists | S–M | none (de-register) / depends (wire) | no | **B-3** |
-| 8 | Extend `resolveTimeQuery` with `last/this Tuesday` + `N weeks ago` | `intelligence-isl.js:242–376` | Closes most-asked temporal gap; useful for richer chem time-slicing | M | none | partial | **B-3** |
-| 9 | Relocate `_qaUpdateSuggestions` + `_qaDetectDomain` → `intelligence-qa.js` | `intelligence-isl.js:115–198, :890–899` | Hygiene: 100+ LOC of QA plumbing out of the pure-data layer | S | none | no | **B-4** |
-| 10 | Relocate `renderInfoAdoption` → `intelligence-cards.js` | `intelligence-qa-handlers.js:3409` | Joins `renderInfo*` siblings | S | none | no | **B-4** |
-| 11 | Cache invalidation hook on chem-data mutation | `intelligence-isl.js:218` `_islMarkDirty` | Pre-emptive: if chem becomes mutable in a future UI, ISL cache needs a `diet`-domain dirty hook | M | #1 | partial | **B-3 or later** |
-| 12 | Cross-link `qaAnswerMealCombo` from `food_safe` + `food_nutrient` | `intelligence-qa-handlers.js` | Richer answers from existing intents by cross-referencing `COMBO_RULES` | L | #1, #2, #3 | **yes** | **B-3 or later** |
+| ~~6~~ | ~~Wire `qaAnswerFavoriteFoods` handler~~ | — | **RETIRED V-K-49 — already wired at `intelligence-quicklog.js:1322`** | — | — | — | — |
+| ~~7~~ | ~~Wire `qaAnswerPredictionAccuracy` handler — or de-register intent~~ | — | **RETIRED V-K-49 — already wired at `intelligence-quicklog.js:1290`** | — | — | — | — |
+| 8 | Extend `resolveTimeQuery` with `last/this Tuesday` + `N weeks ago` | `intelligence-isl.js:242–376` | Closes most-asked temporal gap | M | none | partial | **B-3** |
+| 9 | Relocate `_qaUpdateSuggestions` + `QA_SUGGEST_POOL` + `_qaDetectDomain` → `intelligence-qa.js` (~172 LOC, V-K-51) | `intelligence-isl.js:36–113, 115–198, 890–899` | Hygiene: QA plumbing out of pure-data layer | S | none | no | **B-4** |
+| 10 | Relocate `renderInfoAdoption` → `intelligence-cards.js` (~30 LOC) | `intelligence-qa-handlers.js:3409` | Joins `renderInfo*` siblings | S | none | no | **B-4** |
+| ~~11~~ | ~~Cache invalidation hook on chem-data mutation~~ | — | **DROPPED V-K-55 — `_islMarkDirty('diet')` already covers `chemRollup`; `NUTRITION` is const-bound** | — | — | — | — |
+| 12 | Cross-link `qaAnswerMealCombo` from `food_safe` + `food_nutrient` | `intelligence-qa-handlers.js` | Richer answers via cross-referenced `COMBO_RULES` | L | #1, #2, #3 | **yes** | Later (post-B-4) |
+| 13 | **NEW: Silent-catch `console.error` (Wave 2 convergence)** | `intelligence-qa.js:1670–1672` | Future-regression visibility for genuine handler bugs | XS | none | no | **B-3** |
 
 ## Region boundary declarations
 
 | File | Governor jurisdiction | Phase(s) | Expected change size |
 |------|----------------------|----------|----------------------|
-| `split/intelligence-isl.js` | Kael | B-1 (chemRollup), B-3 (temporal parser ext), B-4 (relocations) | medium total |
-| `split/intelligence-qa.js` | Kael | B-1 (intent reg), B-2 (UIB warnings), B-3 (handlers wire), B-4 (recv relocations) | medium total |
-| `split/intelligence-qa-handlers.js` | Kael | B-1 (handler impl), B-3 (favorite_foods / prediction_accuracy handlers), B-4 (send `renderInfoAdoption`) | medium |
-| `split/intelligence-cards.js` | Kael | B-2 (chem cards), B-4 (recv `renderInfoAdoption`) | small–medium |
+| `split/intelligence-isl.js` | Kael | B-1 (chemRollup), B-3 (temporal parser ext), B-4 (relocations out) | medium total |
+| `split/intelligence-qa.js` | Kael | B-1 (intent reg + dispatch), B-2 (UIB warnings), B-3 (console.error), B-4 (recv relocations) | medium total |
+| `split/intelligence-qa-handlers.js` | Kael | B-1 (handler impl), B-4 (send `renderInfoAdoption`) | medium |
+| `split/intelligence-cards.js` | Kael | B-1 (`computeMealCombos` data fn), B-2 (chem cards), B-4 (recv `renderInfoAdoption`) | medium |
+| `split/intelligence-illness.js` + `split/medical.js` | shared (Maren+Kael) | B-1 cross-Region read | small (read-only consumption via tri-resolution state-match path) |
 | `split/data.js` | shared | none (consumer only) | — |
 | `split/core.js` | Kael | none expected | — |
-| `split/template.html` | Maren + Kael (shared) | none expected | — |
-| `split/styles.css` | Maren + Kael (shared) | possibly B-2 (new chem-card tokens if needed) | small |
 
-**Cross-Region consult.** Phase B-1's `qaAnswerMealCombo` handler produces an answer card consumed in Care-jurisdiction surfaces (Diet `[Today]` chips). Maren cross-consult on answer-card schema and copy.
+**Cross-Region consult.** Phase B-1's `qaAnswerMealCombo` / `computeMealCombos` produces output consumed in Care-jurisdiction surfaces (Diet `[Today]` chips). Maren cross-consult complete in Wave 2 — answer-card schema corrected (V-M-49), per-rule copy locked, tri-resolution state-match path specced for rule #6.
 
-## HR pre-check
+## HR pre-check (Wave 2 corrected)
 
 | HR | Predicted risk | Mitigation |
 |----|----------------|-----------|
-| HR-1 (no emojis) | low | Handler uses `zi(*)` only. |
+| HR-1 (no emojis) | low | Handler uses `zi(*)` only. Variety nudge tile icon-banned `zi('warn')`/`zi('siren')` per V-M-48. |
 | HR-2 (no inline styles) | low | Cards use existing token system. |
 | HR-3 (no inline handlers) | low | Chip dismissal via `data-action`. |
-| HR-4 (escHtml at render boundaries) | medium | Handler renders `chem.*` values (data.js strings) and combo-rule bodies (data.js strings). HR-4 audit on every `${...}` in handler render output. |
+| HR-4 (escHtml at render boundaries) | medium | Handler renders `chem.*` strings + food strings + COMBO_RULES bodies. **Variety nudge tile renders `chemRollup.antiNutrientFlags` strings + advisory copy — all through escHtml (C-REC-1).** |
 | HR-5 (tokens-only) | low | — |
-| HR-6 (data-action) | low | — |
+| HR-6 (data-action) | low | — but pre-existing HR-6 latent flagged at `_qaUpdateSuggestions:180–192` (uses `addEventListener`); file as follow-up issue. |
 | HR-7 (zi via innerHTML) | low | — |
-| HR-8 (Coming-soon stubs) | n/a | Two CareTicket stubs at `:1868–1873` are pre-existing and HR-8 compliant. |
+| HR-8 (Coming-soon stubs) | n/a | CareTickets stubs at `:1868–1873` pre-existing HR-8 compliant. |
 | HR-9 (post-build QA) | structural | Per-phase canon-cc-008 chain. |
 | HR-10 (no text-overflow ellipsis) | low | — |
 | HR-11 (Math.floor currency) | n/a | — |
-| HR-12 (timezone-safe dates) | medium | `chemRollup` aggregates over a window. The window's `start`/`end` come from `resolveTimeQuery` — already HR-12 compliant. No new date construction inside chemRollup. |
+| **HR-12 (timezone-safe dates) — split per C-REQ-2** | **B-1: low / B-3: medium** | **B-1:** window math via existing `resolveTimeQuery`; no new date construction. **B-3:** `last Tuesday` + `N weeks ago` parser is **net-new date construction** in `intelligence-isl.js`. Every `new Date()` and date-arithmetic boundary must go through `toDateStr` / equivalent timezone-safe pattern; regression-guard `regression-guard-b3-temporal-tuesday-timezone-safe`. |
 
-## Governor-readiness note
+## Governor-readiness — Wave 2 audit results
 
-**For Kael (primary).**
-1. `chemRollup` shape — does the proposed object layout (`fibreDaysHigh`, `fibreDistribution`, `antiNutrientFlags`, `bioactiveCount`, `bioactiveTopFive`) capture the right derivations, or are we surfacing too much / too little? Naming: `chemRollup` vs `chemSummary` vs nest into `nutritionDeep`? Kael call.
-2. Should the `_FOOD_ALIASES` join in `chemRollup` raise warnings for unaliased synonym pairs (scout #1: almond/almonds, fig/anjeer, etc.) or silently dedupe? Affects variety analytics correctness.
-3. Two pre-alpha intents — wire `favorite_foods` (Lyra recommends — high user value, data already present) and **de-register** `prediction_accuracy` (no prediction infrastructure exists yet, the intent promises something we cannot deliver). Confirm.
-4. Filing-cabinet relocations — `_qaUpdateSuggestions` (84 LOC) + `_qaDetectDomain` (10 LOC) from ISL → QA; `renderInfoAdoption` (~30 LOC) from qa-handlers → cards. Single PR or split? Lyra leans single PR for hygiene; each move is small.
-5. The two undefined-handler ReferenceErrors are swallowed by `try/catch` at `intelligence-qa.js:1670–1672`. Should the catch ALSO log to console / sentry for observability, or stay silent (current behavior)? Behavioral change implications.
-6. Phase B-1 keystone trio — review the contract for `qaAnswerMealCombo`'s answer-card shape and how `COMBO_RULES` (nutrient-keyed) gets tag-resolved via `NUTRITION[food].nutrients`. Any edge cases (e.g., food with no entry in NUTRITION)?
+**Kael (Intelligence) — primary audit, V-K-49 through V-K-57 issued, verdict: yes-with-fixes.**
+- V-K-49 (BLOCKER): pre-alpha intents are wired — **retired roadmap rows 6–7 above**.
+- V-K-50: `calcZivaScore` cache claim corrected in Arc A.
+- V-K-51: B-4 scope includes `QA_SUGGEST_POOL` — **~172 LOC moved as unit**.
+- V-K-52: console.error addition — **NEW roadmap row 13 in B-3**.
+- V-K-53: `COMBO_RULES` tri-resolution **specced in B-1.3 architecture above**.
+- V-K-54: `_baseFoodName` named explicitly in B-1.1.
+- V-K-55: roadmap row 11 dropped.
+- V-K-56: 30K Region breach surfaced — watch-item; `intelligence-cards.js` is the natural sub-split target if pressure escalates.
+- V-K-57: CLAUDE.md drift fix endorsed for separate tiny PR.
 
-**For Maren (cross-Region consult).**
-1. The `qaAnswerMealCombo` answer-card copy and severity scoring — Maren-approved phrasing for combo guidance ("spacing tip", "absorption boost", "double oxalate load"). Drafting needed.
-2. Phase B-2 `renderInfoChemVariety` card — copy and visualization choices. The "Anti-Nutrient Watch" element in particular needs calm-advisory phrasing not alarm.
+**Maren (Care) — cross-consult, V-M-47 through V-M-54 relevant findings folded:**
+- V-M-48: Variety nudge label + copy + condition + icon-ban locked in §B-1.1 ship + Arc A `[Score]` per-segment.
+- V-M-49: `qaAnswerMealCombo` schema corrected (sections[] + signal); `computeMealCombos(date)` data-fn separation introduced; per-rule copy locked (6 rows above).
+- V-M-54: "zero `if(true)return;`" claim scoped to the 7 intelligence-* files (Maren swept and found 9 across codebase total: 1 in core.js, 3 in diet.js Phase 4 deletes, 5 in home.js).
+
+**Cipher (Censor) — pass-with-fixes; arc-pair shape certified.** 3 required fixes folded; 6 recommended fixes folded. 11 regression-guard names provided.
+
+**Aurelius (Chronicler) — chronicling-ready; 4 marginal amendments folded.** Codex Memory.md candidates noted post-ratify per Chronicler discretion: (1) Province briefings carry implicit as-of timestamps (CLAUDE.md drift canon); (2) cross-arc dependency triggers arc-pair ratification (procedural canon); (3) presentation-data-infra cascade work-shape (lore).
 
 ## PR sequence (Phases B-0 → B-4)
 
 | Phase | Name | Scope | Branch | Jurisdiction | Diff size | QA chain |
 |-------|------|-------|--------|--------------|-----------|----------|
-| **B-0** | **Spec (this PR)** | This document + Arc-A spec + journal updates. | `claude/sproutlab-diet-rework-p0` (shared with Arc A) | docs-only | small | Governor audit waived (docs-only); Architect ratification + Kael Mode-1 pre-pass + Cipher Mode-1 + Aurelius chronicling. |
-| B-1 | Keystone trio | `chemRollup` field + `meal_combo_check` intent + `qaAnswerMealCombo` handler | `claude/sproutlab-isl-upgrade-p1` | Kael (all 3 files) | medium | Kael Mode-1 → Lyra synth → Cipher. Maren cross-consult on card copy/schema. |
-| B-2 | Chem-variety cards + UIB antiNutrient warnings | `renderInfoChemVariety` + `renderInfoBioactiveDiversity` cards; `_iqGetWarnings` antiNutrients integration | `claude/sproutlab-isl-upgrade-p2` | Kael; Maren cross-consult on phrasing | small–medium | Kael Mode-1 + Maren cross-consult → synth → Cipher. |
-| B-3 | Pre-alpha intent resolution + temporal parser ext | Wire `qaAnswerFavoriteFoods`; de-register or wire `qaAnswerPredictionAccuracy`; `resolveTimeQuery` += `last Tuesday` + `N weeks ago` | `claude/sproutlab-isl-upgrade-p3` | Kael | small | Kael Mode-1 → synth → Cipher. |
-| B-4 | Boundary cleanup (hygiene) | Relocate `_qaUpdateSuggestions` + `_qaDetectDomain` → qa; `renderInfoAdoption` → cards | `claude/sproutlab-isl-upgrade-p4` | Kael | small (~125 LOC moved) | Kael Mode-1 → synth → Cipher. |
+| **B-0** | **Spec (this PR)** | This document + Arc A spec + journal. | `claude/sproutlab-diet-rework-p0` (shared with Arc A) | docs-only | small | Wave 2 complete. Architect ratification pending. |
+| B-1 | Keystone trio | `chemRollup` (3 fields) + `meal_combo_check` intent + `qaAnswerMealCombo` handler + `computeMealCombos` data fn | `claude/sproutlab-isl-upgrade-p1` | Kael (4 files); Maren cross-consult on copy/schema (locked above) | medium (~150–200 LOC) | Kael Mode-1 → Lyra synth → Cipher. |
+| B-2 | Chem-variety cards + UIB antiNutrient warnings | `renderInfoChemVariety` + `renderInfoVarietyNudge` cards (after `intelligence-cards.js:~2020`); `_iqGetWarnings` antiNutrients; defer-fields `fibreDistribution` + `bioactiveTopFive` added to `chemRollup` if needed | `claude/sproutlab-isl-upgrade-p2` | Kael; Maren cross-consult on phrasing | small–medium | Kael Mode-1 + Maren cross-consult → synth → Cipher. |
+| B-3 | Temporal parser ext + silent-catch console.error | `resolveTimeQuery` += `last Tuesday` + `N weeks ago` (HR-12 medium); `console.error` in `intelligence-qa.js:1670–1672` | `claude/sproutlab-isl-upgrade-p3` | Kael | small | Kael Mode-1 → synth → Cipher. **(Scope-collapsed from original B-3 per V-K-49 — pre-alpha intent rows retired.)** |
+| B-4 | Boundary cleanup (hygiene) | Relocate `_qaUpdateSuggestions` + `QA_SUGGEST_POOL` + `_qaDetectDomain` → qa (~172 LOC); `renderInfoAdoption` → cards (~30 LOC). | `claude/sproutlab-isl-upgrade-p4` | Kael | small (~200 LOC moved, concat-order safe) | Kael Mode-1 → synth → Cipher. |
 
-**Dependency on Arc A.** Arc A Phase 3 depends on Arc B Phase B-1 (keystone trio) being merged. Arc A Phases 1, 2, 4, 5, 6 are independent of Arc B.
+**Dependency on Arc A.** Arc A Phase 3 depends on Arc B Phase B-1. Arc A Phases 1, 2, 4, 5, 6 are independent.
 
-**CLAUDE.md drift fix** is a separate tiny docs-only follow-up PR (not in any of B-1 through B-4). Single-line correction: "ISL: 22 intents with dedicated handlers" → "Smart Q&A: 30 intents (registry in `intelligence-qa.js`); ISL: temporal query parser + 6 domain-data accessors + day/range summary generators."
+**Regression-guard names (from Cipher Edict V + Wave 2 additions, locked):**
+- B-1: `regression-guard-chemrollup-contract`, `regression-guard-meal-combo-intent-registered`, `regression-guard-combo-tri-resolution` (V-K-53 — confirms tri-resolution catches rule #6).
+- B-2: `regression-guard-chem-card-tokens`, `regression-guard-variety-nudge-icon-ban` (V-M-48 — confirms no warn/siren icons).
+- B-3: `regression-guard-temporal-tuesday-timezone-safe` (HR-12), `regression-guard-qa-dispatch-console-error` (V-K-52 — confirms catch logs to console).
+- B-4: `regression-guard-concat-order-stable` (all relocated symbols resolve under post-move concat order).
 
-## Open questions
+**CLAUDE.md drift fix** — separate tiny docs-only PR. Single-line correction: "ISL: 22 intents with dedicated handlers" → "Smart Q&A: 30 intents (registry in `intelligence-qa.js`); ISL: temporal query parser + 6 domain-data accessors + day/range summary generators."
 
-1. **`chemRollup` naming and shape.** `chemRollup` vs `chemSummary` vs `nutritionDeep`. Field set granularity. (Kael call after B-1 review.)
-2. **`prediction_accuracy` intent.** Wire (and to what — current prediction infrastructure?) or de-register? Lyra recommends **de-register** (the intent promises something the codebase cannot deliver today).
-3. **Silent catch behavior** at `intelligence-qa.js:1670–1672` — keep silent (current), add console.error, or add observability hook? Affects bug-detection for future undefined-handler regressions.
-4. **`_FOOD_ALIASES` discipline in `chemRollup`** — warn on unaliased synonyms (almond/almonds etc., scout #1 flag) or silent dedupe?
-5. **Filing-cabinet relocations** — single PR (B-4) or three micro-PRs? Lyra recommends single.
-6. **CLAUDE.md drift fix scope** — fold into B-0 (this PR) or separate tiny PR? Doctrine allows docs-only waiver either way. Lyra recommends **separate** to keep this PR tight.
+## Open questions — Wave 2 resolutions
 
-## Synthesis amendments — Wave 1.5 source attribution
+1. **`chemRollup` naming and shape.** Resolved — **`chemRollup`** name; ship 3 fields in B-1 (`fibreDaysHigh`, `bioactiveCount`, `antiNutrientFlags`); defer 2 (`fibreDistribution`, `bioactiveTopFive`) to B-2 per YAGNI.
+2. **`prediction_accuracy` intent.** **RETIRED — V-K-49.** Already wired and shipping.
+3. **Silent catch behavior.** Resolved — **add `console.error`** in B-3 (Cipher + Kael + Maren convergence). No external observability hook.
+4. **`_FOOD_ALIASES` discipline in `chemRollup`.** Resolved — silent dedupe + first-encounter `console.warn` for unaliased synonym pairs. The almond/almonds, fig/anjeer etc. flags from scout #1 are `data.js` hygiene findings, fixed there separately.
+5. **Filing-cabinet relocations PR shape.** Resolved — **single B-4 PR** (Kael endorse). Three mechanical moves; `renderInfoAdoption` at ~30 LOC could split if needed.
+6. **CLAUDE.md drift fix scope.** Resolved — **separate tiny PR** post-ratify (Cipher endorse).
 
-This spec is authored in main-session synthesis, ingesting findings from:
-- **scribe-scout #2** (Wave 1.5 re-fire) — capability map, dormant inventory, coupling graph, ranked upgrade candidates, sequencing recommendation.
-- **scribe-scout #1** (Wave 1.5 first wave) — food-DB schema survey (`NUTRITION.chem`, `COMBO_RULES` dead-data identification, food-DB count discrepancy, latent data-quality oddities).
-- **scribe-record** (Wave 1.5) — journal infrastructure; the pattern observation that "Arc B isn't tangential — it's the substrate Arc A's Phase 3 will stand on."
+## Synthesis amendments
 
-The Lyra Mode-1 Wave 1 spec (Diet rework v1) did not yet exist as a separate Arc B; this spec was authored fresh in main-session after Wave 1.5 surfaced the substrate gap.
+### Wave 1.5 sources
+- scribe-scout #2 — capability map, ranked candidates, sequencing recommendation (with the methodology error V-K-49 corrected).
+- scribe-scout #1 — food-DB schema survey (`NUTRITION.chem`, `COMBO_RULES` dead-data, food-DB count discrepancy, latent oddities).
+- scribe-record — journal infrastructure + the pattern observation that Arc B is the substrate Arc A's Phase 3 stands on.
+
+### Wave 2 amendments
+**Blocker fixes folded (V-K-49):** roadmap rows 6 & 7 retired; dormant-inventory rows 1 & 2 corrected; B-3 scope collapsed.
+**Schema corrections folded (V-M-49):** `qaAnswerMealCombo` shape aligned to `qaRenderAnswer` contract; `computeMealCombos(date)` data-fn separation introduced; 6-rule Maren-approved copy table locked.
+**Tri-resolution folded (V-K-53):** `COMBO_RULES` handler dispatches on nutrient-tag OR `_baseFoodName` OR active-episode state. Rule #6 (`banana` + `constipation`) covered.
+**Scope corrections folded (C-REQ-3, V-K-51):** Out-of-scope explicit on Diet-side surfaces; B-4 LOC re-stated to include `QA_SUGGEST_POOL`.
+**HR-12 row split (C-REQ-2):** B-1 low / B-3 medium.
+**Roadmap pruned (V-K-55):** row 11 dropped; row 13 added (console.error).
+**LOC re-baseline (V-K-56):** `intelligence-cards.js` 2,403 → 2,643; Region at 30,725 surfaced as watch-item.
+**`_baseFoodName` named explicitly (V-K-54).**
+**B-1 dispatch line corrected (`:1642` → `:1643`).**
+**B-2 insert point clarified ("after `:1885`" → "after the function ends ~`:2020`").**
+**"Zero `if(true)return;`" claim scoped to intelligence-* (V-M-54).**
 
 ---
 
-— Lyra (main-session synthesis from scribe-scout #2 capability map), 2026-05-23, against `b2670f7`. cc-018 status: `pending_review`.
+— Lyra (main-session Wave 1.5 + Wave 2 synthesis from scribe-scout #2 + Maren/Kael/Cipher/Aurelius Mode-1 audits), 2026-05-23, against `b2670f7`. cc-018 status: `pending_review` (Wave 2 complete; awaiting Architect ratification).

--- a/docs/specs/isl-upgrade-v1.md
+++ b/docs/specs/isl-upgrade-v1.md
@@ -22,6 +22,8 @@
 
 **Arc-pair dissolved — Arc B now stands alone (2026-05-28).** Arc A (`diet-rework-v1.md`) is superseded by the ratified-and-merged `food-sub-tab-v1` IA; its surfacing targets are re-homed here (see §Surfacing re-home). Arc B is self-contained on the intelligence layer and **ratifies standalone** — there is no longer a paired Arc A to gate against. The engine work (B-1, B-3, B-4) is surface-agnostic; only the B-2 card surfacing re-points to the merged `[Patterns]` / `[Library]` sub-tabs.
 
+**Reconciliation update (2026-05-29).** The re-homed surfacing is now **folded into the `food-sub-tab-v1` arc itself** (PR #173), not merely re-pointed: B-2's chem-variety / variety-nudge cards land in **food-sub-tab F-4** `[Patterns]`, and the per-food Chemistry detail lands in **food-sub-tab F-3** `[Library]`. Arc B therefore narrows to its **engine + hygiene core — B-1 (the keystone-trio engine), B-3, and B-4**; the diet-tab card mounts belong to the food-sub-tab phases that consume the B-1 engine. Re-verified against `main` @ `65d5bda` (post F-1/F-2): `NUTRITION.chem` + `COMBO_RULES` remain zero-consumer dead data (F-2 wired neither — its `CURATED_COMBOS` is a separate autofill structure). See §Surfacing re-home for the updated mapping.
+
 ## Why
 
 The SproutLab intelligence layer is 7 files, ~18,400 LOC distributed (post-PR-G split): `intelligence-isl.js` (1,029) + `intelligence-qa.js` (2,234) + `intelligence-qa-handlers.js` (3,614) + `intelligence-illness.js` (2,541) + `intelligence-quicklog.js` (4,355) + `intelligence-cards.js` (**2,643** per V-K-56 re-baseline — was 2,403 at spec-write) + `intelligence-caretickets.js` (2,224). The Architect framed it as "still pre-alpha." The Wave 1.5 capability map found this framing **partially accurate** — but Wave 2 corrected a load-bearing scout error:
@@ -34,9 +36,9 @@ The SproutLab intelligence layer is 7 files, ~18,400 LOC distributed (post-PR-G 
   - The scout swept `qa-handlers.js` only. **Wave 1.5 methodology lesson:** capability-map scouts must grep across the full file-set under audit, not the file where a symbol is "expected" to live.
 - **One CLAUDE.md drift.** CLAUDE.md says "ISL: 22 intents with dedicated handlers." The canonical intent registry `QA_INTENTS` is in `intelligence-qa.js:1–175`, not in ISL, and the count is now **30** (independently verified by Kael). The doc misattributes BOTH location AND count.
 - **Data-layer surfaces waiting for ISL consumers.** `NUTRITION[*].chem` (3 sub-fields) and `COMBO_RULES` (6 rules) are present in `data.js` with zero outside-`data.js` consumers — the data is specced but the intelligence layer doesn't yet pipe it. **`COMBO_RULES` is not uniformly nutrient-keyed (V-K-53):** rule #6 is `{foods:['banana','constipation']}` — food-name + symptom. The handler must tri-resolve, not single-resolve.
-- **Region LOC over the 30K trigger (V-K-56).** Live count: 30,725 LOC for the full Kael jurisdiction (`intelligence-*.js` + `core.js` + `data.js` + `sync.js` + `config.js` + `start.js`). Threshold is 30,000. **The Region is currently over budget, pre-arcs**, and `intelligence-cards.js` is +240 LOC since the Wave-1.5 capability map. Arcs B-1 (+~150 LOC) and B-2 (+~80 LOC) will push further. Surfaced as architectural watch-item — not a B-0 blocker, but Lyra/Cipher should plan for an `intelligence-cards.js` sub-split or similar before Region pressure becomes acute.
+- **Region LOC over the 30K trigger (V-K-56; re-baselined 2026-05-29).** Spec-write count was 30,725; **current `main` @ `65d5bda` is 34,907 LOC** for the full Kael jurisdiction (`intelligence-*.js` + `core.js` + `data.js` + `sync.js` + `config.js` + `start.js`) — F-1/F-2 + milestones work added ~4.2K. Threshold is 30,000. **The Region is ~16% over budget before Arc B adds anything.** B-1 (~150–200 LOC) pushes further. The `intelligence-cards.js` sub-split is no longer a soft watch-item — Lyra/Cipher should treat it as a near-term precondition or pair a split with the first Arc B impl PR.
 
-Arc A Phase 3 is blocked on this layer. Hence this Arc B — surgically targeted upgrades, sized to unblock Arc A Phase 3 and resolve the boundary smells the capability map (corrected) surfaced.
+This dead-data substrate is what the diet surfacing needs. Hence this Arc B — surgically targeted intelligence-layer upgrades that pipe `chem.*` / `COMBO_RULES` to consumers (now the `food-sub-tab-v1` `[Patterns]`/`[Library]` phases, post-reconciliation) and resolve the boundary smells the capability map (corrected) surfaced. (The original "unblock Arc A Phase 3" framing is retired — Arc A is superseded; the consuming surface is the food-sub-tab arc.)
 
 ## Scope
 
@@ -57,18 +59,20 @@ Arc A Phase 3 is blocked on this layer. Hence this Arc B — surgically targeted
 
 **Hard boundary.** Arc B does not modify ISL semantics — it extends ISL surface. Existing intents, handlers, and accessors keep their contracts. New surfaces are additive.
 
-## Surfacing re-home (2026-05-28 — Arc A superseded)
+## Surfacing re-home → folded into food-sub-tab arc (2026-05-28; folded 2026-05-29)
 
-Arc B's engine outputs were originally surfaced by Arc A's `[Today]` / `[Score]` / `[Library]` segments. With Arc A parked (its IA superseded by the merged `food-sub-tab-v1`), the **B-2 surfacing re-targets the merged `food-sub-tab-v1` sub-tabs** on `main` (`switchDietSub` / `.diet-sub-panel`):
+Arc B's engine outputs were originally surfaced by Arc A's `[Today]` / `[Score]` / `[Library]` segments. Arc A is superseded by the merged `food-sub-tab-v1` IA, so the surfacing is **folded into the food-sub-tab arc** (PR #173 amends `food-sub-tab-v1.md` F-3/F-4) rather than carried as Arc B phases. Targets on `main` use `switchDietSub` / `.diet-sub-panel`:
 
-| Engine output (Arc B) | Original Arc A home | Re-homed target (merged IA) |
-|-----------------------|---------------------|------------------------------|
-| `renderInfoChemVariety` (Fibre Variety + Bioactive Diversity tiles) | `[Score]` segment | **`[Patterns]`** sub-tab (analytics surface) |
-| `renderInfoVarietyNudge` (Variety-nudge tile, V-M-48 copy locked) | `[Score]` segment | **`[Patterns]`** sub-tab |
-| Per-food Chemistry detail (`chem.fibre`/`antiNutrients`/`bioactives`) | `[Library]` per-food overlay | **`[Library]`** sub-tab per-food view |
-| `meal_combo_check` chip-stack (`computeMealCombos`) | `[Today]` post-log chips | logging/review surface — **F-3 Log review surface or `[Patterns]`** (exact placement confirmed against the F-2/F-3 surface contracts at B-2 implementation time, not pinned here) |
+| Engine output (Arc B B-1) | Consumer (food-sub-tab arc) |
+|---|---|
+| `renderInfoChemVariety` (Fibre Variety + Bioactive Diversity tiles) | **F-4** `[Patterns]` sub-tab |
+| `renderInfoVarietyNudge` (Variety-nudge tile, V-M-48 copy locked) | **F-4** `[Patterns]` sub-tab |
+| Per-food Chemistry detail (`chem.fibre`/`antiNutrients`/`bioactives`) | **F-3** `[Library]` per-food view |
+| `meal_combo_check` chip-stack (`computeMealCombos`) | **F-4** `[Patterns]` or the F-3 Log review surface (placement confirmed against F-3/F-4 surface contracts at impl time) |
 
-**The B-1 keystone trio (`chemRollup` + `meal_combo_check` intent + `qaAnswerMealCombo` + `computeMealCombos`) is surface-agnostic and unchanged** — it ships regardless of where the cards ultimately land. Only B-2 (the card renderers) carries the re-home; its `intelligence-cards.js` insert points are unaffected (engine-side), only the diet-tab mount call-sites change from Arc A segments to the merged sub-tab panels.
+**Arc B retains only the engine.** The B-1 keystone trio (`chemRollup` + `meal_combo_check` intent + `qaAnswerMealCombo` + `computeMealCombos`) ships as Arc B, surface-agnostic. The card renderers above are **food-sub-tab F-3/F-4 deliverables** that consume that engine — listed here to document the contract, not as Arc B phases. (The old B-2 roadmap/PR-sequence rows are correspondingly re-homed; Arc B's own PR sequence is **B-1 → B-3 → B-4**.)
+
+**Design note (feeding read path).** `chemRollup` and `computeMealCombos` must read feeding data via the canonical reader `_fdReadDayMeal(dayObj, mealKey)` (`data.js:3160` on `main`), NOT the raw `entry[meal]` legacy string. The F-2 writer co-writes a legacy comma-string at `entry[meal]` (so a naive read works today), but the structured `items[]` sidecar carries the precise `nutritionRef` resolved at write-time — using it avoids a second-best `_baseFoodName` re-derivation AND stays correct when F-5's `parseFeeding` eventually drops the legacy co-write. (Same note folded into `food-sub-tab-v1.md` §Arc B reconciliation.)
 
 ## State of the union (scout #2 + Wave 2 corrections)
 
@@ -113,7 +117,7 @@ Arc B's engine outputs were originally surfaced by Arc A's `[Today]` / `[Score]`
 
 ## Sequencing — the keystone trio (Phase B-1)
 
-**Minimum spec-bearing change to unblock Arc A Phase 3.** Three surgical edits:
+**Minimum spec-bearing change — the engine the food-sub-tab `[Patterns]`/`[Library]` phases consume (post-reconciliation; was framed "unblock Arc A Phase 3").** Three surgical edits:
 
 ### B-1.1 — Extend `_islDietData` with `chemRollup` (`intelligence-isl.js:446–499`)
 
@@ -234,8 +238,8 @@ function qaAnswerMealCombo(intentId) {
 | 1 | Extend `_islDietData` with `chemRollup` (3 fields) | `intelligence-isl.js:446–499` | Keystone — one accessor surfaces `chem.*` to every downstream | M | none | **yes** | **B-1** |
 | 2 | Add `meal_combo_check` intent | `intelligence-qa.js:69, :1643` | Combo intelligence surface | M | #1 | **yes** | **B-1** |
 | 3 | Implement `qaAnswerMealCombo` + `computeMealCombos` data fn | `intelligence-qa-handlers.js` between `:2395`/`:2396`; `intelligence-cards.js` (data fn after `:2020`) | Required for #2; data-fn separation enables Arc A chip-stack reuse | M | #1, #2 | **yes** | **B-1** |
-| 4 | Add `renderInfoChemVariety` + `renderInfoVarietyNudge` cards | `intelligence-cards.js` after `:2020` (V-K — corrects "after `:1885`" to "after the function ends") | Surfaces `chem.fibre`+`chem.bioactives` rollup + the Variety nudge tile (V-M-48 — Maren-drafted copy locked) | M | #1; `fibreDistribution` field ship in B-2 | **yes** | **B-2** |
-| 5 | Promote `chem.antiNutrients` to UIB warnings | `intelligence-qa.js:822` `_iqGetWarnings` | UIB already builds warnings; antiNutrients is a free signal | S | #1 | **yes** | **B-2** |
+| 4 | Add `renderInfoChemVariety` + `renderInfoVarietyNudge` cards | `intelligence-cards.js` after `:2020` (V-K — corrects "after `:1885`" to "after the function ends") | Surfaces `chem.fibre`+`chem.bioactives` rollup + the Variety nudge tile (V-M-48 — Maren-drafted copy locked) | M | #1 (defer-fields `fibreDistribution`/`bioactiveTopFive` ship with the cards) | **yes** | **→ food-sub-tab F-4 (re-homed; was B-2)** |
+| 5 | Promote `chem.antiNutrients` to UIB warnings | `intelligence-qa.js:822` `_iqGetWarnings` | UIB already builds warnings; antiNutrients is a free signal | S | #1 | **yes** | **B-1+ engine (was B-2; UIB extension, not a diet-tab card)** |
 | ~~6~~ | ~~Wire `qaAnswerFavoriteFoods` handler~~ | — | **RETIRED V-K-49 — already wired at `intelligence-quicklog.js:1322`** | — | — | — | — |
 | ~~7~~ | ~~Wire `qaAnswerPredictionAccuracy` handler — or de-register intent~~ | — | **RETIRED V-K-49 — already wired at `intelligence-quicklog.js:1290`** | — | — | — | — |
 | 8 | Extend `resolveTimeQuery` with `last/this Tuesday` + `N weeks ago` | `intelligence-isl.js:242–376` | Closes most-asked temporal gap | M | none | partial | **B-3** |
@@ -304,11 +308,11 @@ function qaAnswerMealCombo(intentId) {
 |-------|------|-------|--------|--------------|-----------|----------|
 | **B-0** | **Spec (this PR)** | This document + Arc A spec + journal. | `claude/sproutlab-diet-rework-p0` (shared with Arc A) | docs-only | small | Wave 2 complete. Architect ratification pending. |
 | B-1 | Keystone trio | `chemRollup` (3 fields) + `meal_combo_check` intent + `qaAnswerMealCombo` handler + `computeMealCombos` data fn | `claude/sproutlab-isl-upgrade-p1` | Kael (4 files); Maren cross-consult on copy/schema (locked above) | medium (~150–200 LOC) | Kael Mode-1 → Lyra synth → Cipher. |
-| B-2 | Chem-variety cards + UIB antiNutrient warnings | `renderInfoChemVariety` + `renderInfoVarietyNudge` cards (after `intelligence-cards.js:~2020`); `_iqGetWarnings` antiNutrients; defer-fields `fibreDistribution` + `bioactiveTopFive` added to `chemRollup` if needed | `claude/sproutlab-isl-upgrade-p2` | Kael; Maren cross-consult on phrasing | small–medium | Kael Mode-1 + Maren cross-consult → synth → Cipher. |
+| ~~B-2~~ | **Dissolved 2026-05-29** | Chem-variety/variety-nudge **cards → food-sub-tab F-4** (PR #173); `_iqGetWarnings` antiNutrient promotion → folds into **B-1** engine track; `chemRollup` defer-fields ship with the F-4 cards if needed. | — | — | — | — |
 | B-3 | Temporal parser ext + silent-catch console.error | `resolveTimeQuery` += `last Tuesday` + `N weeks ago` (HR-12 medium); `console.error` in `intelligence-qa.js:1670–1672` | `claude/sproutlab-isl-upgrade-p3` | Kael | small | Kael Mode-1 → synth → Cipher. **(Scope-collapsed from original B-3 per V-K-49 — pre-alpha intent rows retired.)** |
 | B-4 | Boundary cleanup (hygiene) | Relocate `_qaUpdateSuggestions` + `QA_SUGGEST_POOL` + `_qaDetectDomain` → qa (~172 LOC); `renderInfoAdoption` → cards (~30 LOC). | `claude/sproutlab-isl-upgrade-p4` | Kael | small (~200 LOC moved, concat-order safe) | Kael Mode-1 → synth → Cipher. |
 
-**Arc A dependency — dissolved.** Arc A is superseded (parked 2026-05-28); Arc B no longer gates or is gated by it. B-2 surfacing re-homes to the merged `food-sub-tab-v1` sub-tabs (see §Surfacing re-home). B-1/B-3/B-4 are surface-agnostic and unaffected.
+**Arc A dependency dissolved; Arc B PR sequence is B-1 → B-3 → B-4 (2026-05-29).** Arc A is superseded (parked 2026-05-28); Arc B no longer gates or is gated by it. The former B-2 is dissolved: its chem-variety/variety-nudge **cards fold into food-sub-tab F-4** (PR #173, see §Surfacing re-home), and its `_iqGetWarnings` antiNutrient promotion folds into the **B-1** engine track. B-1/B-3/B-4 are surface-agnostic.
 
 **Regression-guard names (from Cipher Edict V + Wave 2 additions, locked):**
 - B-1: `regression-guard-chemrollup-contract`, `regression-guard-meal-combo-intent-registered`, `regression-guard-combo-tri-resolution` (V-K-53 — confirms tri-resolution catches rule #6).
@@ -316,7 +320,7 @@ function qaAnswerMealCombo(intentId) {
 - B-3: `regression-guard-temporal-tuesday-timezone-safe` (HR-12), `regression-guard-qa-dispatch-console-error` (V-K-52 — confirms catch logs to console).
 - B-4: `regression-guard-concat-order-stable` (all relocated symbols resolve under post-move concat order).
 
-**CLAUDE.md drift fix** — separate tiny docs-only PR. Single-line correction: "ISL: 22 intents with dedicated handlers" → "Smart Q&A: 30 intents (registry in `intelligence-qa.js`); ISL: temporal query parser + 6 domain-data accessors + day/range summary generators."
+**CLAUDE.md drift fix — ALREADY RESOLVED on `main` (retire this item).** The canon-gen-001 CLAUDE.md refresh already reads "Smart Q&A: 30 intents (registry in `intelligence-qa.js`)" plus the corrected ISL line ("temporal query parser + 6 domain-data accessors + day/range summary generators"). The originally-flagged separate-PR correction (was: "ISL: 22 intents with dedicated handlers") is no longer needed.
 
 ## Open questions — Wave 2 resolutions
 

--- a/docs/specs/isl-upgrade-v1.md
+++ b/docs/specs/isl-upgrade-v1.md
@@ -8,19 +8,19 @@
 
 **Authority chain:** `CLAUDE.md` §QA Chain · canon-cc-008 · canon-cc-022 · cc-018 `pending_review`
 **Against commit:** `b2670f7`
-**Cross-references:** `docs/specs/diet-rework-v1.md` (Arc A — Phase 3 depends on Arc B's keystone trio)
+**Cross-references:** `docs/specs/diet-rework-v1.md` (Arc A — **SUPERSEDED 2026-05-28**; its IA rework is parked, its chem/combo surfacing re-homed here into the merged `food-sub-tab-v1` sub-tabs — see §Surfacing re-home)
 
 ## Status
 
 `pending_review` (cc-018). Prerequisites for `ratified`:
 
-- Architect ratification of the upgrade roadmap, the Wave-2 amendments, and the Arc-A/Arc-B sequencing.
+- Architect ratification of the upgrade roadmap and the Wave-2 amendments. (Arc-A/Arc-B sequencing is moot — Arc A superseded 2026-05-28; Arc B ratifies standalone.)
 - Kael Mode-1 audit — **complete** (V-K-49 through V-K-57 issued; verdict: yes-with-fixes; fixes folded below).
 - Maren Mode-1 cross-consult — **complete** (V-M-47 through V-M-54 issued; copy + schema + safety-override findings folded below).
 - Cipher Mode-1 Edict V pre-pass — **complete** (verdict: pass-with-fixes; fixes folded below).
 - Aurelius cross-cluster chronicling — **complete** (verdict: chronicling-ready; Codex Memory.md candidates per Chronicler's discretion post-ratify).
 
-**Companion-set deploy delta — paired ratification.** This spec and `diet-rework-v1.md` form a single arc-pair artifact under cc-018. Ratifying one without the other constitutes a canon-cc-008 short-circuit unless the Architect explicitly defers one — in which case Arc A Phase 3 must be deferred until Arc B Phase B-1 ratifies separately.
+**Arc-pair dissolved — Arc B now stands alone (2026-05-28).** Arc A (`diet-rework-v1.md`) is superseded by the ratified-and-merged `food-sub-tab-v1` IA; its surfacing targets are re-homed here (see §Surfacing re-home). Arc B is self-contained on the intelligence layer and **ratifies standalone** — there is no longer a paired Arc A to gate against. The engine work (B-1, B-3, B-4) is surface-agnostic; only the B-2 card surfacing re-points to the merged `[Patterns]` / `[Library]` sub-tabs.
 
 ## Why
 
@@ -56,6 +56,19 @@ Arc A Phase 3 is blocked on this layer. Hence this Arc B — surgically targeted
 - **Diet-side surfaces (`diet.js`, `home.js`, `core.js` segment routing) — see Arc A (C-REQ-3 boundary).**
 
 **Hard boundary.** Arc B does not modify ISL semantics — it extends ISL surface. Existing intents, handlers, and accessors keep their contracts. New surfaces are additive.
+
+## Surfacing re-home (2026-05-28 — Arc A superseded)
+
+Arc B's engine outputs were originally surfaced by Arc A's `[Today]` / `[Score]` / `[Library]` segments. With Arc A parked (its IA superseded by the merged `food-sub-tab-v1`), the **B-2 surfacing re-targets the merged `food-sub-tab-v1` sub-tabs** on `main` (`switchDietSub` / `.diet-sub-panel`):
+
+| Engine output (Arc B) | Original Arc A home | Re-homed target (merged IA) |
+|-----------------------|---------------------|------------------------------|
+| `renderInfoChemVariety` (Fibre Variety + Bioactive Diversity tiles) | `[Score]` segment | **`[Patterns]`** sub-tab (analytics surface) |
+| `renderInfoVarietyNudge` (Variety-nudge tile, V-M-48 copy locked) | `[Score]` segment | **`[Patterns]`** sub-tab |
+| Per-food Chemistry detail (`chem.fibre`/`antiNutrients`/`bioactives`) | `[Library]` per-food overlay | **`[Library]`** sub-tab per-food view |
+| `meal_combo_check` chip-stack (`computeMealCombos`) | `[Today]` post-log chips | logging/review surface — **F-3 Log review surface or `[Patterns]`** (exact placement confirmed against the F-2/F-3 surface contracts at B-2 implementation time, not pinned here) |
+
+**The B-1 keystone trio (`chemRollup` + `meal_combo_check` intent + `qaAnswerMealCombo` + `computeMealCombos`) is surface-agnostic and unchanged** — it ships regardless of where the cards ultimately land. Only B-2 (the card renderers) carries the re-home; its `intelligence-cards.js` insert points are unaffected (engine-side), only the diet-tab mount call-sites change from Arc A segments to the merged sub-tab panels.
 
 ## State of the union (scout #2 + Wave 2 corrections)
 
@@ -295,7 +308,7 @@ function qaAnswerMealCombo(intentId) {
 | B-3 | Temporal parser ext + silent-catch console.error | `resolveTimeQuery` += `last Tuesday` + `N weeks ago` (HR-12 medium); `console.error` in `intelligence-qa.js:1670–1672` | `claude/sproutlab-isl-upgrade-p3` | Kael | small | Kael Mode-1 → synth → Cipher. **(Scope-collapsed from original B-3 per V-K-49 — pre-alpha intent rows retired.)** |
 | B-4 | Boundary cleanup (hygiene) | Relocate `_qaUpdateSuggestions` + `QA_SUGGEST_POOL` + `_qaDetectDomain` → qa (~172 LOC); `renderInfoAdoption` → cards (~30 LOC). | `claude/sproutlab-isl-upgrade-p4` | Kael | small (~200 LOC moved, concat-order safe) | Kael Mode-1 → synth → Cipher. |
 
-**Dependency on Arc A.** Arc A Phase 3 depends on Arc B Phase B-1. Arc A Phases 1, 2, 4, 5, 6 are independent.
+**Arc A dependency — dissolved.** Arc A is superseded (parked 2026-05-28); Arc B no longer gates or is gated by it. B-2 surfacing re-homes to the merged `food-sub-tab-v1` sub-tabs (see §Surfacing re-home). B-1/B-3/B-4 are surface-agnostic and unaffected.
 
 **Regression-guard names (from Cipher Edict V + Wave 2 additions, locked):**
 - B-1: `regression-guard-chemrollup-contract`, `regression-guard-meal-combo-intent-registered`, `regression-guard-combo-tri-resolution` (V-K-53 — confirms tri-resolution catches rule #6).

--- a/docs/specs/isl-upgrade-v1.md
+++ b/docs/specs/isl-upgrade-v1.md
@@ -1,0 +1,247 @@
+# Spec: ISL Upgrade v1
+
+**Version:** v1.0 draft (main-session synthesis from scribe-scout #2 capability map)
+**Date:** 2026-05-23
+**Author:** Lyra (main-session synthesis) — ingest from `scribe-scout` Wave 1.5 ISL capability map
+**Authority chain:** `CLAUDE.md` §QA Chain · canon-cc-008 · canon-cc-022 · cc-018 `pending_review`
+**Against commit:** `b2670f7`
+**Cross-references:** `docs/specs/diet-rework-v1.md` (Arc A — Phase 3 depends on Arc B's keystone trio)
+
+## Status
+
+`pending_review` (cc-018). Prerequisites for `ratified`:
+
+- Architect ratification of the upgrade roadmap and the Arc-A/Arc-B sequencing.
+- **Kael Mode-1 audit** (primary — this is his jurisdiction: `intelligence-*.js`, `core.js`, `data.js`, `sync.js`, `config.js`).
+- Maren Mode-1 cross-consult (Phase B-3 fold-in for the `qaAnswerMealCombo` handler — Care-side semantic check on the answer-card shape and copy).
+- Cipher Mode-1 Edict V pre-pass on the upgrade roadmap.
+- Aurelius chronicling on ratification (Codex Memory.md cross-cluster: ISL drift findings + the unwired-intents behavioral bug).
+
+## Why
+
+The SproutLab intelligence layer is 7 files, ~18,400 LOC distributed (post-PR-G split): `intelligence-isl.js` (1,029) + `intelligence-qa.js` (2,234) + `intelligence-qa-handlers.js` (3,614) + `intelligence-illness.js` (2,541) + `intelligence-quicklog.js` (4,355) + `intelligence-cards.js` (2,403) + `intelligence-caretickets.js` (2,224). The Architect framed it as "still pre-alpha." The Wave 1.5 capability map found this framing **partially accurate**:
+
+- **Leaner than the framing suggests.** Across all 18,400 LOC there are zero `if(true)return;` early-exit stubs, zero `if(false)` gates, zero `TODO` / `FIXME` / `XXX` comments. The dormant surface is concentrated in **7 material findings**, not pervasive drift.
+- **But two behavioral bugs are lurking.** Two registered QA intents — `prediction_accuracy` and `favorite_foods` — dispatch to **undefined handlers**. The dispatch is wrapped in `try { … } catch(e) { answer = null }` (`intelligence-qa.js:1670–1672`), so the user sees "no match" instead of the answer they expected. Two silent `ReferenceError`s lying in wait.
+- **Plus one CLAUDE.md drift.** CLAUDE.md says "ISL: 22 intents with dedicated handlers." The canonical intent registry is `QA_INTENTS` in `intelligence-qa.js:1–175`, not in ISL, and the count is now **30**. The doc misattributes the location AND the count.
+- **And data-layer surfaces are waiting for ISL consumers.** `NUTRITION[*].chem` (3 sub-fields) and `COMBO_RULES` (6 rules) are present in `data.js` with zero outside-`data.js` consumers — the data is specced but the intelligence layer doesn't yet pipe it.
+
+The Arc A (Diet Tab Rework v1) Phase 3 is blocked on this layer. Hence this Arc B — surgically targeted upgrades, sized to unblock Arc A Phase 3, retire the two silent ReferenceErrors, and resolve the boundary smells the capability map surfaced.
+
+## Scope
+
+**In scope.**
+- The Phase-3 keystone trio (see §Sequencing).
+- The two unwired intents — wire-or-de-register decision and implementation.
+- Filing-cabinet boundary cleanups (`_qaUpdateSuggestions`, `_qaDetectDomain`, `renderInfoAdoption` relocations).
+- CLAUDE.md drift fix (split into a tiny follow-up PR to keep this scope tight; flagged here, fix elsewhere).
+- 2–3 user-visible upgrade candidates from the ranked list (selection at Architect's discretion after ratification).
+
+**Out of scope.**
+- No new domains added to ISL (sleep/poop/medical/milestones accessors stay as specced).
+- No CareTicket state-machine changes (`intelligence-caretickets.js` two "Coming soon" stubs at `:1868–1873` are HR-8-compliant placeholders, not in this scope).
+- No Smart Q&A intent additions beyond `meal_combo_check` + the two ReferenceError fixes.
+- No `sync.js` / Firebase boundary changes.
+- No `intelligence-quicklog.js` Activity Log / Today So Far refactors (mixed-concerns sleep+activity split is a known smell; deferred to a dedicated future arc).
+
+**Hard boundary.** Arc B does not modify ISL semantics — it extends ISL surface. Existing intents, handlers, and accessors keep their contracts. New surfaces are additive.
+
+## State of the union (scout #2 capability sketch)
+
+| File | LOC | Main entry | Top symbols | Notes |
+|------|-----|------------|-------------|-------|
+| `intelligence-isl.js` | 1,029 | `getDomainData(domain, start, end)` (`:380`) | `resolveTimeQuery`, `generateDaySummary`, `generateRangeSummary`, `_islGetCached`, `_islMarkDirty`, `ISL_THRESHOLDS` | Pure data provider. Six domain accessors. **Scope leaks:** `_qaUpdateSuggestions` (`:115–198`) + `_qaDetectDomain` (`:890–899`) belong to QA. |
+| `intelligence-qa.js` | 2,234 | `qaExecuteQuery` (`:1579`); dispatch ladder `:1631–1668` | `QA_INTENTS` (`:1–175`, **30 entries**), `qaClassifyInput` (`:220`), `qaMatchIntent` (`:1272`), `_qaHandleTemporal` (`:1899`), UIB plumbing `_iqRenderPicker` (`:351`) / `_iqMineMealCombos` (`:493`) / `_iqBuildNewCombos` (`:686`) / `_iqGetWarnings` (`:822`) | The file Lyra edits to register new intents. |
+| `intelligence-qa-handlers.js` | 3,614 | `qaAnswer*` family (27 functions) | Diet-relevant: `qaAnswerNutrientGap` (`:1892`), `qaAnswerFoodVariety` (`:2154`), `qaAnswerFoodSafety` (`:2225`), `qaAnswerTexture` (`:2300`); plus `_qaHandleLookback`/`Pattern`/`Planning`. **Scope leak:** `renderInfoAdoption` (`:3409`). |
+| `intelligence-illness.js` | 2,541 | `startFeverEpisode` / `logFeverReading` / `resolveFeverEpisode` (`:37/61/96`); `renderHomeFeverBanner` (`:563`) | Four illness state machines (fever, diarrhoea, vomiting, cold). Self-contained; tight. |
+| `intelligence-quicklog.js` | 4,355 | `saveActivity` (`:239`); `openActivityLogPrefilled` (`:232`); `renderActivityChips` (`:195`) | Activity Log + Sleep Info-tab analytics cluster (`renderInfoSleepBedtimeDrift` `:3110` → `renderInfoSleepRegression` `:4355`). Mixed concerns — deferred refactor. |
+| `intelligence-cards.js` | 2,403 | `renderInfo()` master (`:1025`) | Cross-domain analytics. Diet-relevant: `computeNutrientHeatmap` (`:1283`), `computeFoodCombos` (`:1446`), `computeMealBreakdown` (`:1755`), `renderInfoFoodIntro` (`:1075`), `renderInfoComboFreq` (`:1610`). **Natural home for chem.* analytics.** |
+| `intelligence-caretickets.js` | 2,224 | `CT_TEMPLATES` (`:27`); `ctCreate`; `ctNextDueTime` (`:210`) | CareTicket lifecycle. Two "Coming soon" placeholders at `:1868–1873` — out of scope. |
+
+**Dormant inventory (top 7):**
+
+| File | Symbol | Line | Status | LOC | Action |
+|------|--------|------|-------|-----|--------|
+| `intelligence-qa.js` | `QA_INTENTS[id='prediction_accuracy']` | 158–161 | **stub — handler undefined** | 4 | Decide: wire or de-register |
+| `intelligence-qa.js` | `QA_INTENTS[id='favorite_foods']` | 163–166 | **stub — handler undefined** | 4 | Decide: wire or de-register |
+| `intelligence-caretickets.js` | `ctViewAll` action | 1868–1870 | "Coming soon" placeholder | 3 | Out of scope — HR-8 compliant |
+| `intelligence-caretickets.js` | `ctViewOverdue` action | 1871–1873 | "Coming soon" placeholder | 3 | Out of scope — HR-8 compliant |
+| `intelligence-isl.js` | `_qaUpdateSuggestions` | 115–198 | misplaced (belongs in QA) | 84 | Phase B-4 — relocate |
+| `intelligence-isl.js` | `_qaDetectDomain` | 890–899 | misplaced (belongs in QA) | 10 | Phase B-4 — relocate |
+| `intelligence-qa-handlers.js` | `renderInfoAdoption` | 3409 | misplaced (belongs in cards) | ~30 | Phase B-4 — relocate |
+
+## Coupling — load-bearing vs stranded
+
+**Load-bearing** (heavy outside-Region usage):
+1. **`intelligence-isl.js`** — every QA path + medical analytics traverse it. ~20 outside-file call sites. Pure provider.
+2. **`intelligence-qa.js`** — `QA_INTENTS` + `renderQABar` is the UIB entry; home.js mounts it.
+3. **`intelligence-illness.js`** — wired into medical.js, home.js, core.js, sync.js. Fever banner on the Home hero.
+4. **`intelligence-cards.js`** — `renderInfo()` is the entire Info tab; heatmap consumed by home + diet.
+5. **`intelligence-quicklog.js`** — Activity Log save path universal.
+
+**Stranded / experimental** (0–1 outside callers):
+1. Two unwired intents (`prediction_accuracy`, `favorite_foods`) — pre-alpha promises.
+2. `_qaHandlePlanning` + `_qaTomorrowPlan` + `_qaDoctorPrep` + `_qaShareToday` in `intelligence-qa-handlers.js` — lightly used planning surface.
+3. `intelligence-caretickets.js`'s ISL-side surface is thin (one intent, `ct_create`).
+
+## Sequencing — the keystone trio (Phase B-1)
+
+**Minimum spec-bearing change to unblock Arc A Phase 3.** Three surgical edits:
+
+### B-1.1 — Extend `_islDietData` with `chemRollup` (`intelligence-isl.js:446–499`)
+
+Add a `chemRollup` field to the object returned by `_islDietData`, computed by joining `allFoods` against `NUTRITION[base].chem`. Shape:
+
+```js
+chemRollup: {
+  fibreDaysHigh: <int>,       // distinct chem.fibre categories consumed in window
+  fibreDistribution: { ... }, // category → days-count map
+  antiNutrientFlags: [ ... ], // ordered list of {nutrient, daysSeen, foodCount}
+  bioactiveCount: <int>,      // distinct chem.bioactives across window
+  bioactiveTopFive: [ ... ]   // most-frequent bioactives
+}
+```
+
+- Joins `allFoods` (already computed in `_islDietData`) to `NUTRITION` via the canonical food-base lookup (`_FOOD_ALIASES`-aware).
+- Skips foods absent from `NUTRITION` silently (does not throw).
+- HR-12: respects the existing window's `start`/`end` date construction; no new date logic.
+- Cache: covered by existing `_islGetCached` keyed on `domain+start+end`. No new cache invalidation path needed (read-only join over already-cached data).
+
+### B-1.2 — Register `meal_combo_check` intent (`intelligence-qa.js`)
+
+Add at `:69` (between `food_texture` and the POOP block):
+
+```js
+{
+  id: 'meal_combo_check',
+  triggers: ['combo', 'pairing', 'pair with', 'eat together', 'with this', 'spacing'],
+  boosts: ['food', 'iron', 'calcium', 'absorb'],
+  exclude: [/* domain disambiguators if needed */],
+  handler: 'answerMealCombo'
+}
+```
+
+Add dispatch at `:1642` (between `answerTexture` and `answerPoopGeneral`):
+
+```js
+else if (handler === 'answerMealCombo') answer = qaAnswerMealCombo(intent.id);
+```
+
+### B-1.3 — Implement `qaAnswerMealCombo` (`intelligence-qa-handlers.js`)
+
+Insert between `qaAnswerTexture` (`:2300–~2395`) and `qaAnswerPoopFood` (`:2396`). Model on `qaAnswerFoodSafety` (`:2225`) for shape.
+
+```js
+function qaAnswerMealCombo(intentId) {
+  // 1. Pull recent feeding window via getDomainData('diet', start, end) — last 1 day for meal-window scope.
+  // 2. For each pair of foods in the window, tag-resolve via NUTRITION[food].nutrients.
+  // 3. Match the resolved nutrient pair against COMBO_RULES entries (data.js:2463–2476).
+  // 4. For each matched rule, build an answer-card item: { title, body, severity, advice }.
+  // 5. Also consult chem.antiNutrients for foods in the window; flag multi-flag oxalate/phytate loads.
+  // 6. Return: { title: 'Today's combos', headline, domain: 'sage', icon: 'food', items, actions: [] }.
+  // HR-4: escHtml every food string, every rule body. HR-1: zi() for any icon.
+}
+```
+
+**Critical handler detail.** `COMBO_RULES` keys are nutrient names (`foods:['iron','calcium']`), NOT food names. The handler must tag-resolve via `NUTRITION[food].nutrients` arrays, not name-match the food strings.
+
+**That trio is the minimum.** Three files touched, ~150 LOC added, retires Group A/B/C from scout #1's dead-data inventory.
+
+## Upgrade roadmap — full ranked list
+
+| # | Name | Scope | Why | Effort | Preconditions | Phase-3 relation | Spec phase |
+|---|------|-------|-----|--------|---------------|------------------|------------|
+| 1 | Extend `_islDietData` with `chemRollup` | `intelligence-isl.js:446–499` | Keystone — one accessor surfaces `chem.*` to every downstream | M | none | **yes** | **B-1** |
+| 2 | Add `meal_combo_check` intent | `intelligence-qa.js:69, :1642` | Combo intelligence surface for `[Today]` | M | #1 | **yes** | **B-1** |
+| 3 | Implement `qaAnswerMealCombo` handler | `intelligence-qa-handlers.js` between `:2395`/`:2396` | Required for #2 | M | #1, #2 | **yes** | **B-1** |
+| 4 | Add `renderInfoChemVariety` + `renderInfoBioactiveDiversity` cards | `intelligence-cards.js` after `:1885` | Surfaces `chem.fibre` + `chem.bioactives` rollup to Diet `[Score]` segment + Info tab | M | #1 | **yes** | **B-2** |
+| 5 | Promote `chem.antiNutrients` to UIB warnings | `intelligence-qa.js:822` `_iqGetWarnings` | UIB already builds warnings; antiNutrients is a free signal | S | #1 | **yes** | **B-2** |
+| 6 | Wire `qaAnswerFavoriteFoods` handler | `intelligence-qa-handlers.js` (new) + register call at `:1659` | Pre-alpha intent silently no-matches — user-visible gap | S | none | no | **B-3** |
+| 7 | Wire `qaAnswerPredictionAccuracy` handler — or de-register intent | `intelligence-qa-handlers.js` (new) or `intelligence-qa.js:158–161` removal | Second pre-alpha intent. Depends on whether prediction infrastructure exists | S–M | none (de-register) / depends (wire) | no | **B-3** |
+| 8 | Extend `resolveTimeQuery` with `last/this Tuesday` + `N weeks ago` | `intelligence-isl.js:242–376` | Closes most-asked temporal gap; useful for richer chem time-slicing | M | none | partial | **B-3** |
+| 9 | Relocate `_qaUpdateSuggestions` + `_qaDetectDomain` → `intelligence-qa.js` | `intelligence-isl.js:115–198, :890–899` | Hygiene: 100+ LOC of QA plumbing out of the pure-data layer | S | none | no | **B-4** |
+| 10 | Relocate `renderInfoAdoption` → `intelligence-cards.js` | `intelligence-qa-handlers.js:3409` | Joins `renderInfo*` siblings | S | none | no | **B-4** |
+| 11 | Cache invalidation hook on chem-data mutation | `intelligence-isl.js:218` `_islMarkDirty` | Pre-emptive: if chem becomes mutable in a future UI, ISL cache needs a `diet`-domain dirty hook | M | #1 | partial | **B-3 or later** |
+| 12 | Cross-link `qaAnswerMealCombo` from `food_safe` + `food_nutrient` | `intelligence-qa-handlers.js` | Richer answers from existing intents by cross-referencing `COMBO_RULES` | L | #1, #2, #3 | **yes** | **B-3 or later** |
+
+## Region boundary declarations
+
+| File | Governor jurisdiction | Phase(s) | Expected change size |
+|------|----------------------|----------|----------------------|
+| `split/intelligence-isl.js` | Kael | B-1 (chemRollup), B-3 (temporal parser ext), B-4 (relocations) | medium total |
+| `split/intelligence-qa.js` | Kael | B-1 (intent reg), B-2 (UIB warnings), B-3 (handlers wire), B-4 (recv relocations) | medium total |
+| `split/intelligence-qa-handlers.js` | Kael | B-1 (handler impl), B-3 (favorite_foods / prediction_accuracy handlers), B-4 (send `renderInfoAdoption`) | medium |
+| `split/intelligence-cards.js` | Kael | B-2 (chem cards), B-4 (recv `renderInfoAdoption`) | small–medium |
+| `split/data.js` | shared | none (consumer only) | — |
+| `split/core.js` | Kael | none expected | — |
+| `split/template.html` | Maren + Kael (shared) | none expected | — |
+| `split/styles.css` | Maren + Kael (shared) | possibly B-2 (new chem-card tokens if needed) | small |
+
+**Cross-Region consult.** Phase B-1's `qaAnswerMealCombo` handler produces an answer card consumed in Care-jurisdiction surfaces (Diet `[Today]` chips). Maren cross-consult on answer-card schema and copy.
+
+## HR pre-check
+
+| HR | Predicted risk | Mitigation |
+|----|----------------|-----------|
+| HR-1 (no emojis) | low | Handler uses `zi(*)` only. |
+| HR-2 (no inline styles) | low | Cards use existing token system. |
+| HR-3 (no inline handlers) | low | Chip dismissal via `data-action`. |
+| HR-4 (escHtml at render boundaries) | medium | Handler renders `chem.*` values (data.js strings) and combo-rule bodies (data.js strings). HR-4 audit on every `${...}` in handler render output. |
+| HR-5 (tokens-only) | low | — |
+| HR-6 (data-action) | low | — |
+| HR-7 (zi via innerHTML) | low | — |
+| HR-8 (Coming-soon stubs) | n/a | Two CareTicket stubs at `:1868–1873` are pre-existing and HR-8 compliant. |
+| HR-9 (post-build QA) | structural | Per-phase canon-cc-008 chain. |
+| HR-10 (no text-overflow ellipsis) | low | — |
+| HR-11 (Math.floor currency) | n/a | — |
+| HR-12 (timezone-safe dates) | medium | `chemRollup` aggregates over a window. The window's `start`/`end` come from `resolveTimeQuery` — already HR-12 compliant. No new date construction inside chemRollup. |
+
+## Governor-readiness note
+
+**For Kael (primary).**
+1. `chemRollup` shape — does the proposed object layout (`fibreDaysHigh`, `fibreDistribution`, `antiNutrientFlags`, `bioactiveCount`, `bioactiveTopFive`) capture the right derivations, or are we surfacing too much / too little? Naming: `chemRollup` vs `chemSummary` vs nest into `nutritionDeep`? Kael call.
+2. Should the `_FOOD_ALIASES` join in `chemRollup` raise warnings for unaliased synonym pairs (scout #1: almond/almonds, fig/anjeer, etc.) or silently dedupe? Affects variety analytics correctness.
+3. Two pre-alpha intents — wire `favorite_foods` (Lyra recommends — high user value, data already present) and **de-register** `prediction_accuracy` (no prediction infrastructure exists yet, the intent promises something we cannot deliver). Confirm.
+4. Filing-cabinet relocations — `_qaUpdateSuggestions` (84 LOC) + `_qaDetectDomain` (10 LOC) from ISL → QA; `renderInfoAdoption` (~30 LOC) from qa-handlers → cards. Single PR or split? Lyra leans single PR for hygiene; each move is small.
+5. The two undefined-handler ReferenceErrors are swallowed by `try/catch` at `intelligence-qa.js:1670–1672`. Should the catch ALSO log to console / sentry for observability, or stay silent (current behavior)? Behavioral change implications.
+6. Phase B-1 keystone trio — review the contract for `qaAnswerMealCombo`'s answer-card shape and how `COMBO_RULES` (nutrient-keyed) gets tag-resolved via `NUTRITION[food].nutrients`. Any edge cases (e.g., food with no entry in NUTRITION)?
+
+**For Maren (cross-Region consult).**
+1. The `qaAnswerMealCombo` answer-card copy and severity scoring — Maren-approved phrasing for combo guidance ("spacing tip", "absorption boost", "double oxalate load"). Drafting needed.
+2. Phase B-2 `renderInfoChemVariety` card — copy and visualization choices. The "Anti-Nutrient Watch" element in particular needs calm-advisory phrasing not alarm.
+
+## PR sequence (Phases B-0 → B-4)
+
+| Phase | Name | Scope | Branch | Jurisdiction | Diff size | QA chain |
+|-------|------|-------|--------|--------------|-----------|----------|
+| **B-0** | **Spec (this PR)** | This document + Arc-A spec + journal updates. | `claude/sproutlab-diet-rework-p0` (shared with Arc A) | docs-only | small | Governor audit waived (docs-only); Architect ratification + Kael Mode-1 pre-pass + Cipher Mode-1 + Aurelius chronicling. |
+| B-1 | Keystone trio | `chemRollup` field + `meal_combo_check` intent + `qaAnswerMealCombo` handler | `claude/sproutlab-isl-upgrade-p1` | Kael (all 3 files) | medium | Kael Mode-1 → Lyra synth → Cipher. Maren cross-consult on card copy/schema. |
+| B-2 | Chem-variety cards + UIB antiNutrient warnings | `renderInfoChemVariety` + `renderInfoBioactiveDiversity` cards; `_iqGetWarnings` antiNutrients integration | `claude/sproutlab-isl-upgrade-p2` | Kael; Maren cross-consult on phrasing | small–medium | Kael Mode-1 + Maren cross-consult → synth → Cipher. |
+| B-3 | Pre-alpha intent resolution + temporal parser ext | Wire `qaAnswerFavoriteFoods`; de-register or wire `qaAnswerPredictionAccuracy`; `resolveTimeQuery` += `last Tuesday` + `N weeks ago` | `claude/sproutlab-isl-upgrade-p3` | Kael | small | Kael Mode-1 → synth → Cipher. |
+| B-4 | Boundary cleanup (hygiene) | Relocate `_qaUpdateSuggestions` + `_qaDetectDomain` → qa; `renderInfoAdoption` → cards | `claude/sproutlab-isl-upgrade-p4` | Kael | small (~125 LOC moved) | Kael Mode-1 → synth → Cipher. |
+
+**Dependency on Arc A.** Arc A Phase 3 depends on Arc B Phase B-1 (keystone trio) being merged. Arc A Phases 1, 2, 4, 5, 6 are independent of Arc B.
+
+**CLAUDE.md drift fix** is a separate tiny docs-only follow-up PR (not in any of B-1 through B-4). Single-line correction: "ISL: 22 intents with dedicated handlers" → "Smart Q&A: 30 intents (registry in `intelligence-qa.js`); ISL: temporal query parser + 6 domain-data accessors + day/range summary generators."
+
+## Open questions
+
+1. **`chemRollup` naming and shape.** `chemRollup` vs `chemSummary` vs `nutritionDeep`. Field set granularity. (Kael call after B-1 review.)
+2. **`prediction_accuracy` intent.** Wire (and to what — current prediction infrastructure?) or de-register? Lyra recommends **de-register** (the intent promises something the codebase cannot deliver today).
+3. **Silent catch behavior** at `intelligence-qa.js:1670–1672` — keep silent (current), add console.error, or add observability hook? Affects bug-detection for future undefined-handler regressions.
+4. **`_FOOD_ALIASES` discipline in `chemRollup`** — warn on unaliased synonyms (almond/almonds etc., scout #1 flag) or silent dedupe?
+5. **Filing-cabinet relocations** — single PR (B-4) or three micro-PRs? Lyra recommends single.
+6. **CLAUDE.md drift fix scope** — fold into B-0 (this PR) or separate tiny PR? Doctrine allows docs-only waiver either way. Lyra recommends **separate** to keep this PR tight.
+
+## Synthesis amendments — Wave 1.5 source attribution
+
+This spec is authored in main-session synthesis, ingesting findings from:
+- **scribe-scout #2** (Wave 1.5 re-fire) — capability map, dormant inventory, coupling graph, ranked upgrade candidates, sequencing recommendation.
+- **scribe-scout #1** (Wave 1.5 first wave) — food-DB schema survey (`NUTRITION.chem`, `COMBO_RULES` dead-data identification, food-DB count discrepancy, latent data-quality oddities).
+- **scribe-record** (Wave 1.5) — journal infrastructure; the pattern observation that "Arc B isn't tangential — it's the substrate Arc A's Phase 3 will stand on."
+
+The Lyra Mode-1 Wave 1 spec (Diet rework v1) did not yet exist as a separate Arc B; this spec was authored fresh in main-session after Wave 1.5 surfaced the substrate gap.
+
+---
+
+— Lyra (main-session synthesis from scribe-scout #2 capability map), 2026-05-23, against `b2670f7`. cc-018 status: `pending_review`.


### PR DESCRIPTION
Arc B (ISL Upgrade v1) standalone spec — surgically-targeted intelligence-layer upgrades that surface the dead `NUTRITION.chem` + `COMBO_RULES` data. Originally half of a coupled arc-pair; Arc A (diet-rework) was superseded by the merged `food-sub-tab-v1` IA, so this is narrowed to Arc B.

## 2026-05-29 reconciliation (latest commit)
Paired with **#173**. Re-verified against `main` @ `65d5bda` (only F-1/F-2 shipped; F-3/F-4/F-5 still planned). `NUTRITION.chem` + `COMBO_RULES` remain **zero-consumer dead data** (F-2 wired neither — its `CURATED_COMBOS` is a separate autofill structure), so Arc B's premise holds.

The diet **surfacing folds into the food-sub-tab arc** (PR #173 amends `food-sub-tab-v1.md`):
- **B-2 chem-variety / variety-nudge cards → food-sub-tab F-4** `[Patterns]`
- **Per-food Chemistry detail → food-sub-tab F-3** `[Library]`
- **Former B-2 dissolved**; its `_iqGetWarnings` antiNutrient promotion (an engine extension, not a diet-tab card) folds into the **B-1** engine track.

**Arc B now narrows to engine + hygiene: PR sequence B-1 → B-3 → B-4.**
- **B-1** — keystone trio: `chemRollup` (`_islDietData`) + `meal_combo_check` intent + `qaAnswerMealCombo` + `computeMealCombos` data fn. The engine F-4/the combo surface consume.
- **B-3** — temporal parser ext (`last Tuesday`, `N weeks ago`) + silent-catch `console.error`.
- **B-4** — filing-cabinet relocations (`_qaUpdateSuggestions`/`QA_SUGGEST_POOL`/`_qaDetectDomain` → qa; `renderInfoAdoption` → cards).

Other amendments this commit: design note that `chemRollup`/`computeMealCombos` must read feeding via `_fdReadDayMeal` (precise `nutritionRef` + F-5 forward-compat), not raw `entry[meal]`; Region LOC re-baselined 30,725 → **34,907** (~16% over 30K pre-arc — `intelligence-cards.js` sub-split elevated to near-term precondition); residual "unblock Arc A Phase 3" prose scrubbed; CLAUDE.md drift item marked already-resolved on `main`.

## QA gate
Docs-only diff → canon-cc-008 Governor audit **waived**. Still draft pending Architect ratification of Arc B standalone. Note (carried from spec): **Arc B B-1 implementation should get a fresh canon-cc-008 pass** since its consuming surface changed.

> ⚠️ This branch is based on the older `b2670f7`; it predates the canon-gen-001 / QA-gate refreshes now on `main`. Recommend rebasing onto current `main` before (or at) ratification so the eventual merge is clean.

https://claude.ai/code/session_01QMQk72WmE7ezu3mVB5BHwU