### PR TITLE
Vit D3 tracking v1: half-hearted to meaningful (truth + context + pattern)

### DIFF
--- a/docs/CARETICKET_STATE_MACHINE.html
+++ b/docs/CARETICKET_STATE_MACHINE.html
@@ -91,7 +91,7 @@ code { font-family: var(--mono); font-size: 12px; color: var(--ink); }
 </head>
 <body>
 <h1>CareTicket State Machine</h1>
-<p class="subtitle">SproutLab — 6-transition lifecycle, spec vs implementation. Generated <code>2026-05-23</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on transition-layout snapshots</strong>; <code>CARETICKETS_SPEC_v5.md</code> wins on transition rationale; CLAUDE.md wins on rules, HRs, build commands, persona.</p>
+<p class="subtitle">SproutLab — 6-transition lifecycle, spec vs implementation. Generated <code>2026-05-24</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on transition-layout snapshots</strong>; <code>CARETICKETS_SPEC_v5.md</code> wins on transition rationale; CLAUDE.md wins on rules, HRs, build commands, persona.</p>
 
 <div class="diagram-wrap">
 <svg viewBox="0 0 520 420" width="520" height="420">

--- a/docs/POOP_COLOR_REFERENCE.html
+++ b/docs/POOP_COLOR_REFERENCE.html
@@ -108,7 +108,7 @@ code { font-family: var(--mono); font-size: 12px; color: var(--ink-soft); }
 </head>
 <body>
 <h1>Poop-Color Reference</h1>
-<p class="subtitle">SproutLab — token + render + contrast + lexicon snapshot. Generated <code>2026-05-23</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on token-value snapshots</strong>; CLAUDE.md wins on usage rules.</p>
+<p class="subtitle">SproutLab — token + render + contrast + lexicon snapshot. Generated <code>2026-05-24</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on token-value snapshots</strong>; CLAUDE.md wins on usage rules.</p>
 
 <div class="meta-bar">
   <span>light <code>--warm</code> <code>#fef6f0</code></span>

--- a/docs/specs/vit-d3-tracking-v1.md
+++ b/docs/specs/vit-d3-tracking-v1.md
@@ -1,0 +1,217 @@
+# Vit D3 Tracking v1 — half-hearted to meaningful
+
+**Spec version:** v1
+**Date:** 2026-05-23
+**Branch:** `claude/sproutlab-vit-d3-tracking-v1`
+**Author:** Lyra (main-session)
+**Jurisdiction:** **Maren PRIMARY** (write-path + reminder + Today So Far + medical-tab detail card all live in home.js / medical.js / diet.js — care surface; "what if this data is wrong and a parent acts on it?" applies). Kael SECONDARY (core.js schema helpers + intelligence-isl.js read accessor + intelligence-qa-handlers.js intent improvement). Vela WAIVED first-pass (no `intelligence-cards.js` or `intelligence-quicklog.js` touch); if styles.css gets new tokens beyond reuse-of-existing, Vela folds in as shared-module reviewer.
+**Authority:** Architect-directed during the food-DB cleanup arc closeout. Trigger: Architect flagged the current Vit D3 implementation as "half-hearted" — `medChecks[date][medName] = 'done:HH:MM'` where HH:MM is the moment the parent tapped "Done", not the moment the dose was actually administered. Only intelligence is a simple % adherence number with no time-of-day, with-fat, or pattern analysis.
+
+---
+
+## What the upgrade ships
+
+A real Vit D3 tracking + analysis surface. Three concurrent shifts:
+
+1. **Truth at write time** — capture the actual administration time, not the tap-time.
+2. **Context at write time** — auto-detect whether the dose was given with a fat-containing food (Vit D3 is fat-soluble; absorption is meaningfully better with co-ingested fat like ghee, curd, paneer, almonds, etc.). No parent input required — observed from the feeding log.
+3. **Meaning at read time** — surface the truth and context so the parent can see patterns, not just a Done/Pending boolean.
+
+## What the current implementation does (and doesn't)
+
+**Reconnaissance baseline (verified at `b73ebcc`):**
+
+- **Storage:** `localStorage['ziva_med_checks']` → `medChecks[date][medName] = 'done:HH:MM' | 'done:late' | 'skipped'`. The HH:MM is tap-time (line `home.js:875`).
+- **Write paths:** `markMedDone(name, idx)` at `home.js:872`, `markMedSkipped` at `:891`, `resolveMissedMed` at `:907` (retroactive late-mark).
+- **Reads:** unified reminders card at `home.js:706-717` (pending vs done); Today So Far chip at `:8672-8676` (`'Done today'` / `'Pending'`); Medical tab list at `medical.js:4293-4327` (registered med metadata only — no adherence); ISL accessor `_islMedicalData()` at `intelligence-isl.js:542-604` (extracts `d3Times[]` for the date range); Smart Q&A handler at `intelligence-qa-handlers.js:320, 549` (% adherence + raw counts).
+- **Intelligence:** one threshold (`D3_ADHERENCE_GOOD_PCT = 90` at `intelligence-isl.js:690`). That's the entire analysis.
+- **Uncoupled:** `diet.js:765` knows ghee + fat-soluble vitamins absorb together but has zero link to D3 logging.
+
+**What's missing:** actual administration time, meal context, time-of-day pattern detection, with-fat rate, gap detection, optimal-time-of-day guidance, illness-malabsorption flag, dose-form metadata, brand-swap tracking. Every claim in the spec below addresses one of these.
+
+## Schema migration (non-destructive, backwards-compatible)
+
+`medChecks[date][medName]` accepts **either shape** going forward:
+
+```js
+// Legacy (existing data — never rewritten):
+'done:08:42'           // string starting with 'done:'
+'done:late'            // late retroactive mark
+'skipped'              // skip
+
+// New (all writes from this PR forward):
+{
+  status:    'done' | 'late' | 'skipped',
+  givenAt:   'HH:MM',          // ACTUAL administration time (parent-stated or now-default)
+  loggedAt:  'HH:MM',          // tap-time (audit trail)
+  withFat:   true | false,     // auto-detected — was a fat-bearing food logged near givenAt?
+  fatFood:   'ghee chapati' | null,  // the matched food string, if any
+  fatDelta:  -25 | 42 | null,  // minutes between givenAt and the matched meal (signed; negative = food first)
+}
+```
+
+**Migration policy:** no destructive rewrite. Old strings stay as strings; the read helpers normalise both shapes to a canonical object at read time. A new write always emits the object shape. Over time, the storage transitions naturally as parents log fresh doses; legacy strings remain readable and analyzable (tap-time becomes `givenAt`, `withFat` is `null` / unknown).
+
+**Helper functions** (added to `core.js`):
+
+- `parseMedCheck(val)` → `{ status, givenAt, loggedAt, withFat, fatFood, fatDelta }` (normalises both shapes; returns `null` if not done/skipped)
+- `medCheckIsDone(val)` → boolean (replaces the `.startsWith('done:')` calls scattered across home.js / isl)
+- `medCheckGivenAt(val)` → time string or null
+- `medCheckSkipped(val)` → boolean
+
+Every existing reader of `medChecks[date][name]` migrates to these helpers (4 sites: `home.js:875` write, `home.js:5163` _obCheckVitD3, `home.js:8675` Today So Far chip, `intelligence-isl.js:555-561` extraction).
+
+## With-fat detection
+
+Vit D3 is fat-soluble — co-ingestion with dietary fat materially improves absorption. The diet log already knows what Ziva ate at each meal-time. Cross-reference at log time.
+
+**Fat-bearing food set:** derived programmatically from `NUTRITION` (post-C-1.5):
+
+```js
+function _getFatBearingFoodNames() {
+  // Memoised. Derived from NUTRITION entries with 'healthy-fats' tag OR
+  // 'healthy fats' / 'omega-3' / 'MCTs' in nutrients[].
+  // Hand-augmented with 'paratha' (carries ghee in Indian-prep default).
+}
+```
+
+Computed-not-hardcoded so the food-DB factuality work flows through automatically — no second source of truth to maintain.
+
+**Detection algorithm** (`_detectFatContextNearTime(timeStr, dateStr)` in `core.js`):
+
+1. Read `feedingData[dateStr]` (day's meal log: `{breakfast, breakfast_time, lunch, lunch_time, ...}`).
+2. For each meal, if `meal_time` and `meal` content present, compute delta in minutes vs `timeStr`.
+3. Window: ±60 minutes default (Vit D3 absorption window for fat co-ingestion is broad).
+4. Token-match the meal content against the fat-bearing set. If any matches AND meal is in window, capture `{withFat: true, fatFood: '<matched name>', fatDelta: <signed minutes>}`.
+5. Pick closest-in-time match if multiple meals qualify.
+6. If no qualifying match, return `{withFat: false, fatFood: null, fatDelta: null}`.
+
+**Care-tier note:** auto-detection is **observed truth, not asked truth**. The parent never sees a question. If the system mis-detects (e.g., parent gave D3 separately from a feed but a fat-meal coincided in time), the data is wrong in a low-stakes direction (the analysis surface shows `with ghee chapati` when really it was separate). This is acceptable for v1 — the analysis surfaces the observation honestly ("logged near …") rather than claiming the parent affirmed the pairing. Maren consult on the framing language for the surfaces.
+
+## Write-path UX (per Architect choice — "two explicit buttons + reachable adjust")
+
+**Reminder card — pending state:**
+
+```
+[icon] Reminder — Vitamin D3 Drops
+       0.5 ml · 800 IU · Once daily
+       [Done now]   [Done at...]   [Skip]
+```
+
+- **Done now** → one tap → `markMedDone(name, idx)` with `givenAt = now`, `loggedAt = now`, with-fat auto-detection runs.
+- **Done at...** → expands card inline (no modal) to:
+
+```
+[icon] Reminder — Vitamin D3 Drops
+       0.5 ml · 800 IU · Once daily
+       Given at: [07:30]   [Save]   [Cancel]
+```
+
+Inline `<input type="time">` defaulting to current time. Matches the existing pattern at `intelligence-illness.js:212` (fever-log inline time-edit). Save → `markMedDone(name, idx, pickedTime)` with `givenAt = pickedTime`, `loggedAt = now`.
+
+- **Skip** → unchanged.
+
+**Reminder card — done state (NEW resolved surface):**
+
+```
+[check] Done at 8:42 AM · with ghee chapati                      [Adjust]
+```
+
+- The done state renders the captured truth: `givenAt` + with-fat context if detected.
+- **Adjust** → expands to the same inline time-edit, pre-populated with current `givenAt`. Save → `adjustMedTime(name, dateStr, newTime)` with full schema-aware update + re-run with-fat detection on the new time.
+
+**Half-awake test:** "Done now" is one tap, same as today. The new affordances are opt-in; the 2-AM-panic floor is preserved.
+
+## Read-path / surface upgrades
+
+**1. Today So Far chip (`home.js:8672-8676`):**
+
+```
+Before: "Done today"      / "Pending"
+After:  "Done at 8:42 AM" / "Pending · 22h since last"
+        [with ghee chapati badge if withFat detected]
+```
+
+Compact, parsable in 0.5s, still room for the next-meal-fat-pairing hint when pending.
+
+**2. Medical tab — Vit D3 detail card (NEW):**
+
+A new card inserted in the medical-tab medication section. 14-day rolling window:
+
+- **Title row:** "Vitamin D3 · 14-day pattern"
+- **Adherence:** % + streak ("Current streak: 9 days")
+- **Time-of-day micro-plot:** 14 dots on a 24-hour axis, one per dose, coloured by `withFat` (sage if with-fat, amber if without, indigo if unknown/legacy)
+- **With-fat rate:** "12 of 14 doses given with a fat-containing food (86%)"
+- **Common pairing:** the most-frequent fat food across the window ("usually with ghee chapati or curd")
+- **Empty/gap callout:** if any day in the last 14 has no entry, list those dates compactly
+
+Uses existing sage / amber / indigo domain tokens. Reuses the dot-plot pattern from `intelligence-cards.js` where available; otherwise minimal SVG.
+
+**3. Smart Q&A handler upgrade (`intelligence-qa-handlers.js`):**
+
+The existing "Vit D3 / supplement" intent (registry at `intelligence-qa.js:2079`) currently answers with adherence %. Upgrade to handle the richer surface:
+
+- "When did Ziva get D3 today?" → `givenAt` + with-fat status
+- "What's her D3 pattern?" → typical-time-of-day cluster + with-fat rate + streak
+- "Is she getting D3 with fat?" → with-fat rate over the queried window + recent counter-examples if rate < 70%
+
+Adds one new sub-intent (`vit-d3-pattern`) or extends the existing handler — Lyra's call at implementation.
+
+## Non-goals (deferred to v2 or later)
+
+Explicitly NOT in v1 scope:
+
+- Reminder / notification scheduling (touches sync + notification engine — a separate effort).
+- Skip-reason capture ("ran out / forgot / refused" categorisation).
+- Dose override UI (Ziva's 0.5ml regimen is stable; brand swap is a metadata edit on the med definition, not a per-dose event).
+- Diarrhoea-malabsorption cross-reference (interesting — D3 absorption tanks during gut illness; cross-read against `intelligence-illness.js` episodes is a v2 candidate that the with-fat detection pattern can extend cleanly).
+- CareTicket auto-creation on multi-day gaps (a v2 — once the analysis surface is in place, the "3+ day gap" CareTicket trigger is a natural next).
+- Multi-tenant family-config (Ziva-first per Architect doctrine).
+- Vit D3 age-correlated dose escalation reminders (often 800 → 1000 IU at 12mo+; an AGE_RULES adjacent concern).
+
+## Regression guards
+
+`tests/e2e/vit-d3-tracking.spec.ts` — new file:
+
+1. **`regression-guard-d3-schema-backwards-compat`** — write a legacy `'done:08:42'` string into medChecks, verify `parseMedCheck()` returns canonical object with `givenAt:'08:42'` and `withFat:null`.
+2. **`regression-guard-d3-write-object-shape`** — call `markMedDone(name, idx)` (now-default), verify `medChecks[today]['Vitamin D3 Drops']` is an object with all 6 fields populated.
+3. **`regression-guard-d3-with-fat-auto-detect`** — log a fat-bearing food at 8:30 in feedingData, call `markMedDone()` with `givenAt = 08:42`, verify `withFat:true` + `fatFood` non-null + `fatDelta` within ±60min window.
+4. **`regression-guard-d3-with-fat-no-match`** — log a non-fat food in feedingData OR no food at all, call `markMedDone()`, verify `withFat:false`.
+5. **`regression-guard-d3-adjust-flow`** — mark done, then call `adjustMedTime()` with a new time, verify both `givenAt` updates AND with-fat re-detection runs on the new time.
+
+## QA chain (canon-cc-008)
+
+1. Build & self-check.
+2. **Maren Mode-1 (primary)** + **Kael Mode-1 (secondary)** in parallel.
+3. Lyra synth.
+4. Cipher Edict V final-pass.
+5. Draft → ready.
+
+## HR pre-check
+
+| HR | Risk | Mitigation |
+|----|------|------------|
+| HR-1 (no emojis) | n/a | All icons via zi() — `zi('sun')`, `zi('check')`, `zi('clock')`, etc. |
+| HR-2 (no inline styles) | low | One existing inline-style site in current home.js:884 (`el.style.transform = 'scale(0.97)'`); not introducing more. New micro-plot uses CSS classes + design tokens. |
+| HR-3 (no inline handlers) | n/a | data-action delegation for all new buttons ("Done now" / "Done at..." / "Save" / "Cancel" / "Adjust") |
+| HR-4 (escHtml at boundaries) | medium | The `fatFood` string is observed from `feedingData[date][meal]` parent input — must escHtml when rendered in Today So Far chip + reminder done-state + detail card |
+| HR-5 (tokens-only) | n/a | sage / amber / indigo / sky / peach domain tokens for all colour decisions |
+| HR-6 (data-action) | n/a | Universal |
+| HR-7 (zi via innerHTML) | n/a | Unchanged |
+| HR-8 (Coming-soon stubs) | n/a | No stubs |
+| HR-9 (post-build multi-round QA) | structural | canon-cc-008 chain runs |
+| HR-10 (no text-overflow ellipsis) | n/a | Done-state strings are short |
+| HR-11 (Math.floor currency) | n/a | No currency |
+| HR-12 (timezone-safe dates) | medium | `givenAt` is HH:MM only — no Date construction needed. `loggedAt` similar. Date keys via `today()` (existing helper). |
+
+## Doctrinal references
+
+- `docs/specs/food-db-cleanup-v1.md` §C-1.5 (NUTRITION factuality audit — `healthy-fats` tags now defensible; with-fat detection consumes this)
+- `CLAUDE.md` §Ziva Context ("Takes Vit D3 — track administration timing, not just taken/not-taken." — this spec is the implementation of that brief)
+- `intelligence-illness.js:212` (precedent for inline `<input type="time">` in a render card — UX pattern reuse)
+- canon-cc-008 (QA chain gate)
+- canon-cc-027 (spec amendment authority — for future v2 amendments)
+
+---
+
+— Lyra (main-session), 2026-05-23, against `b73ebcc` (food-DB cleanup tip; this branch's base). cc-018 status: `drafted — awaiting Maren Mode-1 primary audit on the live implementation commit, then Kael Mode-1 secondary, then Cipher Edict V before PR leaves draft`.

--- a/docs/specs/vit-d3-tracking-v2-backlog.md
+++ b/docs/specs/vit-d3-tracking-v2-backlog.md
@@ -1,0 +1,170 @@
+# Vit D3 Tracking v2 — backlog
+
+**Status:** drafted 2026-05-24. Carried forward from PR #116 v1 closeout.
+**Authority:** Architect-directed closeout — "v1 done per council recommendation."
+**Source:** second `/code-review` pass on commit range `b73ebcc..ff514f1` after the canon-cc-008 chain had already discharged twice (initial v1 + post-CR-fix re-discharge). The 15 findings below are what TWO Governor chains + Cipher + one prior `/code-review` did not catch.
+**v1 disposition:** ship at `ff514f1` with Cipher Edict V `LGTM` standing. These findings become v2.
+
+## Why v2 instead of a third synth
+
+The PR has been through:
+1. Initial Vit D3 v1 implementation (`ea9b7d5`)
+2. First Lyra synth — Maren V-M-59..67 + Kael V-K-66..72 + Vela V-V-01..09 (`90161e8`)
+3. Cipher Edict V #1 — LGTM with cosmetic cleanup (`4f6f945`)
+4. `/code-review` #1 — 15 findings (CR-1..CR-15)
+5. CR-fix synth (`e7c8945`)
+6. Second Governor chain — Maren V-M-68..76 + Kael V-K-73..77 + Vela V-V-10..17 (audits)
+7. Second Lyra synth (`ff514f1`)
+8. Cipher Edict V #2 — `LGTM`
+9. `/code-review` #2 — these 15 findings
+
+Each pass surfaced what the prior pass introduced. The `/code-review` #2 closing-note: "diminishing returns — each pass surfaces what the prior pass introduced." Architect ratified: stop the synth-loop, ship v1, capture the rest in v2.
+
+## v2 spec authority
+
+This file is the source-of-truth for the v2 design. When v2 work starts, Lyra promotes the relevant tier to a real spec at `docs/specs/vit-d3-tracking-v2.md` and the canon-cc-008 chain runs against that spec.
+
+---
+
+## Tier 1 — real bugs with concrete user impact
+
+These should land first in v2. Each has a verified failure scenario and a clear fix shape.
+
+### T1-1 — adjustMedTime erases positive withFat observation
+**File:** `split/home.js:1016`. **Severity:** HIGH.
+
+Contradicts the CR-14 doctrine ("never erase a real positive observation") that `_refreshTodayMedWithFat` carefully respects. User-initiated Adjust takes the destructive interpretation.
+
+**Trigger:** Parent logs D3 at 08:42 alongside paratha → `{withFat:true, fatFood:'paratha'}`. Parent later deletes paratha from feedingData. Parent taps Adjust for any reason. `_detectFatContextNearTime` returns `withFat:false` (no fat-bearing food visible now). adjustMedTime overwrites the positive observation silently.
+
+**Fix shape:** Preserve withFat:true when the new detection returns withFat:false. Only flip true→false when the parent explicitly clears it (a future "remove fat-pairing" affordance). The doctrine boundary "Adjust = correct just the time" vs "Adjust = refresh everything" should resolve to the former.
+
+### T1-2 — Pattern card stale on tab return + sync push
+**File:** `split/medical.js:4329`. **Severity:** HIGH.
+
+`renderMedD3PatternCard()` has exactly ONE invocation site (inside `renderMeds()`). Tab switches don't fire it; sync.js's medChecks renderer list lacks it. The headline new surface of this PR has zero live-update paths.
+
+**Trigger:** Parent renders pattern card on medical tab → switches to home, taps Done → switches back. Tab-switch dispatcher fires renderMedicalStats + others but NOT renderMeds. Pattern card body retains pre-Done HTML.
+
+**Fix shape:** Add `renderMedD3PatternCard` to (a) the tab-switch dispatcher for the medical tab, and (b) sync.js's `'track:medical'` renderer list. Cheap one-line wires at each site.
+
+### T1-3 — Skipped med events dropped from TSF event-list
+**File:** `split/intelligence-quicklog.js:1909-1913`. **Severity:** HIGH.
+
+`_tsfCollectEvents` filters: events.push only when timeMin !== null; noTimeEvents.push only when status !== 'skipped'. Skipped doses (timeMin null AND status === 'skipped') hit neither — the audit-trail loggedAt CR-10 explicitly added is invisible.
+
+**Trigger:** Parent taps Skip on D3 at 09:00. The skip is logged with loggedAt but does not appear on the Today So Far timeline.
+
+**Fix shape:** Remove the `parsed.status !== 'skipped'` gate on the noTimeEvents.push branch. Render the skip event with `displayTime` derived from `loggedAt` (formatted via `_formatTime12h`) so the TSF chip shows "Skipped at 9:00 AM".
+
+### T1-4 — `_refreshTodayMedWithFat` mutates without re-rendering
+**File:** `split/core.js:197`. **Severity:** HIGH.
+
+Vela's V-V-13 advisory predicted this. The helper mutates medChecks + dirties caches but never triggers `renderRemindersAndAlerts` / `renderHomeContextAlerts` / `renderMedD3PatternCard`. Visible badges stay stale until tab switch.
+
+**Trigger:** Parent logs D3 at 09:00 (no breakfast yet) → withFat:false stored. Diet tab → save breakfast 'paratha' at 09:30. Refresh helper flips storage to withFat:true but home reminder card still shows "no fat-meal logged nearby" until parent navigates back to home.
+
+**Fix shape:** Append render calls inside the helper's `if (mutated)` block. Or have the helper return `mutated:boolean` and let each caller decide which render to fire (cleaner — the helper stays render-agnostic).
+
+### T1-5 — ISL day-summary leaks raw 24h time
+**File:** `split/intelligence-isl.js:873`. **Severity:** MEDIUM.
+
+`_islRangeSummary` interpolates `md.d3Times[0]` verbatim — the CR-9 sweep applied `_formatTime12h` to 9 surfaces but missed this one. Cross-surface inconsistency.
+
+**Trigger:** Parent gives D3 at 14:30 → daily/range summary card renders "Vit D3 given at 14:30" while every other surface shows "2:30 PM".
+
+**Fix shape:** Wrap `_formatTime12h(md.d3Times[0])` at the interpolation site.
+
+### T1-6 — undoMedSkip destroys CR-10 audit trail
+**File:** `split/home.js:988`. **Severity:** MEDIUM.
+
+`delete medChecks[todayStr][name]` removes the entire record including the loggedAt audit timestamp CR-10 explicitly added. The diff's comment calls this "acceptable" but it contradicts CR-10's stated invariant.
+
+**Trigger:** Parent skips at 09:00, undoes at 09:05, eventually logs Done at 09:30. No record remains of the skip → undo → done sequence.
+
+**Fix shape:** Preserve audit via either (a) `{status:'cleared', priorStatus:'skipped', priorLoggedAt:'09:00', clearedAt:'09:05'}` sentinel or (b) a small `history[]` array on the record. Option (a) is the minimal change; option (b) is forward-compatible for future state transitions.
+
+---
+
+## Tier 2 — care-tier UX / surface-quality
+
+These fail the half-awake test but don't crash or corrupt data.
+
+### T2-7 — Pattern card adherence + unloggedDays count today as missed
+**File:** `split/medical.js:4406, 4419`. V-M-64 fixed the streak label asymmetry; adherence math + the warn-tier "N days not logged in this window" still punish a perfect-streak parent for the pre-dose morning gap. At 8 AM on day 14 of a perfect streak, card reads "Adherence: 13/14 days (93%)" + "1 day not logged in this window" alongside "Streak through yesterday: 13 days" — three lines that disagree.
+
+**Fix shape:** When `eligibleDays[length-1].parsed === null && eligibleDays[length-1].date === today`, exclude today from both the adherence denominator and the unloggedDays callout. The streak's V-M-64 logic already does this; the adherence/unlogged surfaces should follow suit.
+
+### T2-8 — Pattern card streak 0 on skipped-today, no through-yesterday fallback
+**File:** `split/medical.js:4399`. V-M-64 only handles the unlogged-today case. A parent who legitimately skips today loses all historical streak context — card shows "Current streak: 0 days" with no preserved through-yesterday framing.
+
+**Fix shape:** Extend the V-M-64 logic to treat status:'skipped' the same as todayResolved=false for streak walking purposes — start at length-2 and label "Streak through yesterday: N days."
+
+### T2-9 — markMedDone initial-write surfaces false-negative badge before meal logged
+**File:** `split/home.js:906`. Half-awake morning case: parent gives D3 at 7:55 AM before logging breakfast. markMedDone writes withFat:false → reminder card immediately shows "no fat-meal logged nearby" badge. The window from dose-log to meal-log is exactly where half-awake mornings live; v1 surfaces a false-negative there.
+
+**Fix shape:** When `_detectFatContextNearTime` finds no meal in the window AND `feedingData[today]` has no meals logged AT ALL, write `withFat:null` (unknown) instead of `withFat:false`. The refresh helper flips it on first meal save. Alternatively: defer the negative-badge render until at least one meal has been logged today.
+
+### T2-10 — adjustMedTime midnight rollover wedge
+**File:** `split/home.js:1005`. Parent opens Adjust at 23:58, taps Save at 00:01. today() returns the new date, the record is on the prior date's key, function silently no-ops without re-rendering. Editor wedged.
+
+**Fix shape:** Capture todayStr at openMedAdjust time and pass it through confirmMedAdjust → adjustMedTime. Or detect the midnight rollover and surface a toast "Date changed — please re-open Adjust on yesterday's record."
+
+### T2-11 — adjustMedTime + confirmMedDoneAt accept future times
+**File:** `split/home.js:1014, 944`. Parent mistypes the time as 23:00 (intended 11:00). adjustMedTime stamps the future time, re-runs detection → withFat flips true→false. C-1.5 with-fat denominator silently corrupts.
+
+**Fix shape:** Add `pickedMin <= _hhmmToMinutes(_currentHHMM())` check in both confirmMedDoneAt and confirmMedAdjust. On failure, toast "Time must be in the past" + keep editor open.
+
+### T2-12 — Outing-planner D3 suppressed by skip-as-resolved
+**File:** `split/home.js:5371` (callers at 5105, 5308). V-M-67/74's skip-as-resolved fix for the home overlay propagates into outing-planner packing list and medical block. A misclick skip at 7 AM silently suppresses D3 packing for an afternoon outing.
+
+**Fix shape:** Add an `_obCheckVitD3Needed` separate helper that takes `(intent: 'overlay' | 'outing-pack' | 'outing-give')` and routes the skip semantic per-intent. The home overlay treats skip as resolved; the outing-pack treats skip as "still pack" (parent might undo later); the outing-give treats skip as "still surface as a checkable item."
+
+---
+
+## Tier 3 — defensive / latent
+
+Fix opportunistically. None gate v2 readiness.
+
+### T3-13 — V-K-73 AM/PM branch missing range validation
+**File:** `split/core.js:105`. V-K-73 closed the 24h-branch range check; the AM/PM branch still passes 'done:13:42 PM' through as h=25, storing givenAt='25:42' unclamped. `_formatTime12h` falls back to returning the input verbatim → '25:42' rendered literally.
+
+**Fix shape:** Add `if (h < 0 || h > 23) givenAt = null;` after the AM/PM conversion. Or pre-validate the parsed h before constructing givenAt.
+
+### T3-14 — Pending filter raw truthy-check accepts corruption
+**File:** `split/home.js:6631` and `split/medical.js:2306`. Both use `!todayChecks[m.name]` instead of `medCheckIsDone`/`medCheckSkipped`. Corrupted partial-write objects (`{}` or `{status:null,...}`) silently treated as "not pending" → divergent from the home reminder card which uses parseMedCheck.
+
+**Fix shape:** Replace `!todayChecks[m.name]` with `!medCheckIsDone(todayChecks[m.name]) && !medCheckSkipped(todayChecks[m.name])` at both sites.
+
+### T3-15 — Fresh-install warm-start fails on length=0 case
+**File:** `split/medical.js:4409`. V-M-74's strict-equal `eligibleDays.length === 1` misses the future-medStart case where `eligibleDays.length === 0` → falls through to rose-tier "Adherence: 0/0 days (0%)".
+
+**Fix shape:** Change condition to `eligibleDays.length <= 1 && doneDays.length === 0 && skippedDays.length === 0`. Or add a separate `eligibleDays.length === 0` branch that renders "Med starts <formatDate(effectiveStart)>" instead of the warm-start string.
+
+---
+
+## Noise tier — closed without action
+
+Per `/code-review` #2's "diminishing returns" framing, these get filed as canon notes only — no v2 implementation work allocated:
+
+- **WR-2 dispatcher dead-code duplicates** — second-arm entries are unreachable but harmless. Cleanup-on-next-touch.
+- **B3 bare-'done' → status:'late'** — narrow legacy edge; no realistic data has bare 'done'.
+- **D-1 single-digit hour padding** — narrow mobile WebView edge.
+- **D-2 token-split missing `;` `/`** — Indian-parent typing edge; the existing `,` `and` `+` `&` cover most patterns.
+- **D-3 percentile math at N<11** — already partially gated by N≥5 + relabeled "Time range so far" for small N; the indexing math is documented imprecision.
+- **D-4 `_hhmmToMinutes` non-end-anchored regex** — defensive concern; no current writer produces non-canonical _time strings.
+- **D-5 Object.assign partial-schema propagation** — latent forward-compatibility concern; no current writer produces partial schemas.
+- **D-7 NaN windowMinutes** — defensive; no current caller passes a 3rd arg.
+- **C2 `_refreshTodayMedWithFat` asymmetric (never flips true→false)** — by design per CR-14; the trade-off is documented.
+- **C5 Q&A 'Skipped today' info vs warn signal** — minor signal-color inconsistency.
+- **C6/WR-4 `_obCheckVitD3` no medStart gate** — pre-existing behavior; not introduced by this PR.
+- **WR-6 `_getFatBearingFoodNames` cache never invalidated** — latent; NUTRITION is currently const.
+- **WR-7 Q&A handler silent on null-status corruption** — defensive; null-status is itself a corruption signal.
+
+---
+
+## Closing note
+
+The v1→v2 split honors the principle that "ship clean enough" beats "iterate to a fixed point." Each finding above is real; together they would justify a v2 effort of similar scope to v1. The Architect's call to declare v1 done unlocks the merge of #116 and shifts the remaining work to a properly-spec'd v2 with its own canon-cc-008 chain.
+
+— Lyra (main-session), 2026-05-24, post-Edict V #2 LGTM on `ff514f1`. cc-018 status: `v1 ratified for merge; v2 backlog drafted`.

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@ audit-emoji.sh [default (5 surfaced ranges)]: 0 HR-1 violations across split, in
 audit-icon-text: PASS (0 unannotated `(label|text|reason|detail): (zi|iconText)(` field-assignments)
 audit-resolve-shield: PASS (4 resolve-caller(s) carry the explicit `'Resolve'` btnText shield per V-M-41 doctrine)
 audit-viz-smoke: PASS (4 ids + 5 tokens) across template.html + styles.css
-[bump-version] 2026.05.23-7 → 2026.05.23-8
+[bump-version] 2026.05.23-8 → 2026.05.23-9
 [poop-reference] wrote /home/user/sproutlab/docs/POOP_COLOR_REFERENCE.html
 [careticket-sm] wrote /home/user/sproutlab/docs/CARETICKET_STATE_MACHINE.html — 6 transitions, 0 drift flags
 <!DOCTYPE html>
@@ -17253,7 +17253,7 @@ function _detectFatContextNearTime(timeStr, dateStr, windowMinutes) {
   meals.forEach(function(m) {
     var mTime = day[m + '_time'];
     var mFoods = day[m];
-    if (!mTime || !mFoods || mFoods === '—skipped—' || mFoods === '—skipped—') return;
+    if (!mTime || !mFoods || mFoods === '—skipped—') return;
     var mMin = _hhmmToMinutes(mTime);
     if (mMin < 0) return;
     var delta = mMin - targetMin; // signed: negative = meal before dose

--- a/index.html
+++ b/index.html
@@ -1,3 +1,10 @@
+audit-emoji.sh [default (5 surfaced ranges)]: 0 HR-1 violations across split, index.html, sproutlab.html
+audit-icon-text: PASS (0 unannotated `(label|text|reason|detail): (zi|iconText)(` field-assignments)
+audit-resolve-shield: PASS (4 resolve-caller(s) carry the explicit `'Resolve'` btnText shield per V-M-41 doctrine)
+audit-viz-smoke: PASS (4 ids + 5 tokens) across template.html + styles.css
+[bump-version] 2026.05.24-1 → 2026.05.24-2
+[poop-reference] wrote /home/user/sproutlab/docs/POOP_COLOR_REFERENCE.html
+[careticket-sm] wrote /home/user/sproutlab/docs/CARETICKET_STATE_MACHINE.html — 6 transitions, 0 drift flags
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -2328,10 +2335,13 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
 }
 .supp-alert-skipped .supp-alert-title { color:var(--tc-warn); }
 .supp-alert-skipped .supp-alert-detail { color:var(--tc-warn); }
-/* CR-7: openMedAdjust hint when no historical time was captured */
+/* CR-7: openMedAdjust hint when no historical time was captured.
+   V-V-10: explicit --mid colour so the italic reads as neutral observation rather than
+   inheriting --tc-sage from .supp-alert-done (which read as confirmatory not directive).
+   V-V-11: baked-in fs-sm so the class is self-contained if a future caller forgets t-sm. */
 .supp-adjust-hint {
   display:inline-block; margin-right:var(--sp-6);
-  font-style:italic;
+  font-style:italic; font-size:var(--fs-sm); color:var(--mid);
 }
 .med-d3-summary {
   padding:var(--sp-8) 0; line-height:var(--lh-relaxed);
@@ -17187,11 +17197,15 @@ function parseMedCheck(val) {
     // CR-2: accept BOTH 'HH:MM' (24h) AND 'HH:MM am|pm' / 'HH:MM AM|PM' (legacy en-IN 12h).
     // The pre-v1 markMedDone used en-IN locale which produced 12h+suffix strings;
     // those must round-trip through parseMedCheck without losing givenAt.
-    var isHHMM24 = /^\d{1,2}:\d{2}$/.test(t);
+    // V-K-73: tighten range validation — pre-fix, '24:00' / '25:99' passed the structural
+    // regex and stored as givenAt, then _hhmmToMinutes returned out-of-range minutes (1440+).
+    var hhmm24 = t.match(/^(\d{1,2}):(\d{2})$/);
     var ampmMatch = t.match(/^(\d{1,2}):(\d{2})\s*(am|pm)$/i);
     var givenAt = null;
-    if (isHHMM24) {
-      givenAt = t;
+    if (hhmm24) {
+      var h24 = parseInt(hhmm24[1], 10);
+      var m24 = parseInt(hhmm24[2], 10);
+      if (h24 >= 0 && h24 <= 23 && m24 >= 0 && m24 <= 59) givenAt = t;
     } else if (ampmMatch) {
       var h = parseInt(ampmMatch[1], 10);
       var mm = ampmMatch[2];
@@ -17295,7 +17309,10 @@ function _refreshTodayMedWithFat() {
 // CR-9: display formatter — 24h canonical 'HH:MM' → '8:42 AM' / '2:30 PM' for parent-facing surfaces.
 // The schema stores 24h (en-GB canonical) per V-M-60; this formatter renders the Indian-parent 12h convention.
 function _formatTime12h(hhmm) {
-  if (!hhmm || !/^\d{1,2}:\d{2}$/.test(hhmm)) return hhmm || '';
+  // V-M-72: string-only guard at entry so a future render site without an outer
+  // `if (givenAt)` check can't leak literal 'null' / 'undefined' to the parent.
+  if (typeof hhmm !== 'string' || !hhmm) return '';
+  if (!/^\d{1,2}:\d{2}$/.test(hhmm)) return hhmm;
   var parts = hhmm.split(':');
   var h = parseInt(parts[0], 10);
   var m = parts[1];
@@ -17660,6 +17677,7 @@ function init() {
     else if (action === 'cancelMedDoneAt' && typeof cancelMedDoneAt === 'function') cancelMedDoneAt(Number(arg2));
     else if (action === 'openMedAdjust' && typeof openMedAdjust === 'function') openMedAdjust(arg, Number(arg2));
     else if (action === 'confirmMedAdjust' && typeof confirmMedAdjust === 'function') confirmMedAdjust(arg, Number(arg2));
+    else if (action === 'undoMedSkip' && typeof undoMedSkip === 'function') undoMedSkip(arg, Number(arg2));
     else if (action === 'deleteFeedingEntry' && typeof deleteFeedingEntry === 'function') deleteFeedingEntry(arg);
     else if (action === 'switchFoodCatSub' && typeof switchFoodCatSub === 'function') switchFoodCatSub(arg, arg2);
     else if (action === 'expandMilestoneByIdx' && typeof expandMilestoneByIdx === 'function') expandMilestoneByIdx(Number(arg));
@@ -18001,6 +18019,7 @@ function init() {
     else if (action === 'cancelMedDoneAt') cancelMedDoneAt(parseInt(arg2));
     else if (action === 'openMedAdjust') openMedAdjust(arg, parseInt(arg2));
     else if (action === 'confirmMedAdjust') confirmMedAdjust(arg, parseInt(arg2));
+    else if (action === 'undoMedSkip') undoMedSkip(arg, parseInt(arg2));
     else if (action === 'overrideMilestoneStatus') { const args = arg.split(',').map(s=>s.trim().replace(/^'|'$/g,'')); overrideMilestoneStatus(...args); }
     else if (action === 'upcomingToMilestone') { const args = arg.split(',').map(s=>s.trim().replace(/^'|'$/g,'')); upcomingToMilestone(...args); }
     else if (action === 'deleteFoodAndRender') { deleteFood(arg); renderFoodCatSubContent(arg2); }
@@ -23580,20 +23599,22 @@ function renderRemindersAndAlerts() {
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${fatBadge}</div>
       </div>`;
     } else if (isSkipped) {
-      // CR-5: NEW skipped-state render. Pre-fix, the skipped branch produced no card at all
-      // and the 'All medications done for today' banner was removed — the parent got zero
-      // visual acknowledgement of their explicit skip, while _obCheckVitD3 kept flagging
-      // 'Vit D3 pending' on the home overlay, contradicting the just-recorded action.
+      // CR-5: skipped-state render with explicit acknowledgement + Undo affordance.
+      // V-M-68 + V-M-73 fix: Undo no longer calls markMedDone(name, idx) directly (which
+      // silently substituted tap-time as the administration time, exactly the CR-4 class
+      // of bug). Instead Undo clears the skip back to PENDING — the card re-renders with
+      // the standard [Done now] [Done at...] [Skip] buttons, forcing the parent to make
+      // an explicit choice. No fabricated time, no destroyed audit trail.
       html += `
       <div class="supp-alert supp-alert-skipped" id="supp-alert-${idx}">
         <div class="supp-alert-top">
           <div class="supp-alert-icon">${zi('skip-forward')}</div>
           <div class="supp-alert-title">Skipped today — ${escHtml(m.name)}</div>
           <div class="supp-alert-action">
-            <button class="supp-skip-btn supp-adjust-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Undo skip</button>
+            <button class="supp-skip-btn supp-adjust-btn" data-action="undoMedSkip" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Undo skip</button>
           </div>
         </div>
-        <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}Skip recorded — tap Undo to revert and log a dose.</div>
+        <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}Skip recorded — tap Undo to clear and log the dose.</div>
       </div>`;
     }
   });
@@ -23808,6 +23829,22 @@ function confirmMedDoneAt(name, idx) {
   markMedDone(name, idx, picked);
 }
 function cancelMedDoneAt(idx) {
+  renderRemindersAndAlerts();
+  renderHomeContextAlerts();
+}
+
+// V-M-68 + V-M-73: revert a skip back to PENDING (not to "Done at tap-time"). The skip's
+// loggedAt audit trail is dropped — acceptable because the parent's post-Undo intent is
+// "I want to log the dose properly now," not "preserve the misclick." Re-renders so the
+// parent sees the original [Done now] [Done at...] [Skip] choice without a fabricated time.
+function undoMedSkip(name, idx) {
+  const todayStr = today();
+  if (medChecks[todayStr] && medChecks[todayStr][name] !== undefined) {
+    delete medChecks[todayStr][name];
+    save(KEYS.medChecks, medChecks);
+    _tsfMarkDirty();
+    _islMarkDirty('medical');
+  }
   renderRemindersAndAlerts();
   renderHomeContextAlerts();
 }
@@ -29411,9 +29448,11 @@ function renderHistoryPreviews() {
     const ydChecks = medChecks[ydKey] || {};
     const activeMeds = meds.filter(m => m.active);
 
-    // Check yesterday for missed/skipped
-    const ydMissed = activeMeds.filter(m => !ydChecks[m.name]);
-    const ydSkipped = activeMeds.filter(m => ydChecks[m.name] === 'skipped');
+    // Check yesterday for missed/skipped — V-K-74: schema-aware via medCheckSkipped.
+    // Pre-fix `=== 'skipped'` missed the new object shape; parent who skipped yesterday
+    // saw the "Yesterday's meds not logged" danger strip instead of "Skipped yesterday".
+    const ydMissed = activeMeds.filter(m => !ydChecks[m.name] || (!medCheckIsDone(ydChecks[m.name]) && !medCheckSkipped(ydChecks[m.name])));
+    const ydSkipped = activeMeds.filter(m => medCheckSkipped(ydChecks[m.name]));
 
     if (ydMissed.length > 0) {
       medPrev.innerHTML = `<div class="info-strip is-danger">
@@ -35099,6 +35138,10 @@ function _miSetIntake(dateStr, meal, value) {
   feedingData[dateStr][meal + '_intake'] = value;
   save(KEYS.feeding, feedingData);
   _islMarkDirty('diet');
+  // V-M-70: intake adjustment alone doesn't change meal content (so withFat won't flip),
+  // but completes the contract that EVERY feedingData mutation re-evaluates today's
+  // negative-withFat doses. Defensive — harmless when nothing matches.
+  if (dateStr === today() && typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();
 }
 
 function _miLevelFor(value) {
@@ -41182,6 +41225,16 @@ function renderMedD3PatternCard() {
   for (let i = startIdx; i >= 0; i--) {
     if (eligibleDays[i] && eligibleDays[i].parsed && (eligibleDays[i].parsed.status === 'done' || eligibleDays[i].parsed.status === 'late')) streak++;
     else break;
+  }
+  // V-M-74: fresh-install warm-start — when the parent has just installed and hasn't
+  // logged a dose yet, don't slap them with a rose-tier "0/1 days (0%)". Render a
+  // softer "Just getting started" stripe with no aggressive percentile / streak / fat
+  // surfaces yet.
+  if (eligibleDays.length === 1 && doneDays.length === 0 && skippedDays.length === 0) {
+    body.innerHTML = '<div class="med-d3-summary"><div class="med-d3-summary-row">'
+      + zi('clock') + ' Just getting started — log today\'s dose to begin tracking.'
+      + '</div></div>';
+    return;
   }
   // Build summary lines
   const sigClass = adherence >= 90 ? 'tc-sage' : adherence >= 70 ? 'tc-warn' : 'tc-rose';
@@ -58770,7 +58823,11 @@ function _tsfCollectEvents() {
       timeStr = parsed.givenAt;
       displayTime = _tsfFormatTime(parsed.givenAt);
     }
-    const detail = (parsed.status === 'done' || parsed.status === 'late') ? 'Done' : (parsed.status === 'skipped' ? 'Skipped' : '');
+    // V-V-17: chip detail carries the late marker so a half-awake parent reading only the
+    // chip (without tapping to expand) can see retroactive logs at a glance.
+    const detail = parsed.status === 'late' ? 'Done (late)'
+                 : (parsed.status === 'done' ? 'Done'
+                 : (parsed.status === 'skipped' ? 'Skipped' : ''));
     const ev = {
       id: 'med-' + medName,
       type: 'med',
@@ -59636,6 +59693,8 @@ function skipMeals(mealKeys) {
     if (!feedingData[dateStr][m]) feedingData[dateStr][m] = '—skipped—';
   });
   save(KEYS.feeding, feedingData);
+  // V-M-70: complete the _refreshTodayMedWithFat contract on every feedingData mutation.
+  if (typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();
   renderHomeMealProgress();
   updateMealSkipButtons();
   showQLToast(mealKeys.map(m => m.charAt(0).toUpperCase() + m.slice(1)).join(' & ') + ' marked as skipped');
@@ -59654,6 +59713,8 @@ function skipSingleMeal(mealKey) {
   if (feedingData[dateStr][mealKey] && feedingData[dateStr][mealKey] !== '—skipped—') return; // already has food
   feedingData[dateStr][mealKey] = '—skipped—';
   save(KEYS.feeding, feedingData);
+  // V-M-70: complete the _refreshTodayMedWithFat contract.
+  if (dateStr === today() && typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();
   const input = document.getElementById('meal-' + mealKey);
   if (input) { input.value = ''; input.placeholder = 'Skipped'; input.disabled = true; }
   const timeInput = document.getElementById('mealtime-' + mealKey);
@@ -59669,6 +59730,8 @@ function unskipSingleMeal(mealKey) {
   if (!feedingData[dateStr]) return;
   feedingData[dateStr][mealKey] = '';
   save(KEYS.feeding, feedingData);
+  // V-M-70: complete the _refreshTodayMedWithFat contract.
+  if (dateStr === today() && typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();
   const input = document.getElementById('meal-' + mealKey);
   if (input) { input.value = ''; input.placeholder = 'Type to search foods...'; input.disabled = false; }
   const timeInput = document.getElementById('mealtime-' + mealKey);

--- a/index.html
+++ b/index.html
@@ -1,3 +1,10 @@
+audit-emoji.sh [default (5 surfaced ranges)]: 0 HR-1 violations across split, index.html, sproutlab.html
+audit-icon-text: PASS (0 unannotated `(label|text|reason|detail): (zi|iconText)(` field-assignments)
+audit-resolve-shield: PASS (4 resolve-caller(s) carry the explicit `'Resolve'` btnText shield per V-M-41 doctrine)
+audit-viz-smoke: PASS (4 ids + 5 tokens) across template.html + styles.css
+[bump-version] 2026.05.23-7 → 2026.05.23-8
+[poop-reference] wrote /home/user/sproutlab/docs/POOP_COLOR_REFERENCE.html
+[careticket-sm] wrote /home/user/sproutlab/docs/CARETICKET_STATE_MACHINE.html — 6 transitions, 0 drift flags
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -2268,7 +2275,7 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
 .supp-alert-title { flex:1; font-size:var(--fs-md); font-weight:600; color:var(--text); }
 .supp-alert.done .supp-alert-title { color:var(--tc-sage); }
 .supp-alert.missed .supp-alert-title { color:var(--tc-rose); }
-.supp-alert-action { flex-shrink:0; display:flex; gap:var(--sp-4); align-items:center; }
+.supp-alert-action { flex-shrink:0; display:flex; gap:var(--sp-4); align-items:center; flex-wrap:wrap; justify-content:flex-end; }
 .supp-alert-detail { font-size:var(--fs-base); font-weight:400; color:var(--mid); padding-left:var(--sp-24); line-height:var(--lh-normal); }
 .supp-alert.done .supp-alert-detail { color:var(--tc-sage); }
 .supp-alert.missed .supp-alert-detail { color:var(--tc-rose); }
@@ -2332,9 +2339,11 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
 }
 .med-d3-log-row {
   display:flex; gap:var(--sp-12); padding:var(--sp-2) 0;
+  flex-wrap:nowrap;
 }
+.med-d3-log-row > :last-child { min-width:0; overflow-wrap:break-word; flex:1; }
 .med-d3-log-date {
-  min-width:80px; color:var(--mid); font-weight:400;
+  min-width:64px; color:var(--mid); font-weight:400; flex-shrink:0;
 }
 
 /* ── Home stat pills ── */
@@ -10498,7 +10507,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
       <!-- VIT D3 14-DAY PATTERN -->
       <div class="card card-info col-full" id="medD3PatternCard">
         <div class="card-header">
-          <div class="card-title"><div class="icon icon-sky"><svg class="zi"><use href="#zi-sun"/></svg></div> Vitamin D3 — 14-day pattern</div>
+          <div class="card-title"><div class="icon icon-sky"><svg class="zi"><use href="#zi-sun"/></svg></div> Vitamin D3 · 14-day pattern</div>
         </div>
         <div id="medD3PatternBody"></div>
       </div>
@@ -17153,6 +17162,8 @@ function save(key, val) {
 // Every reader migrates via parseMedCheck() so writers can emit the new shape unconditionally.
 function parseMedCheck(val) {
   if (!val) return null;
+  // V-K-72: arrays are typeof 'object' but not med-check shapes — reject explicitly.
+  if (Array.isArray(val)) return null;
   if (typeof val === 'object') {
     return {
       status:   val.status || null,
@@ -17224,6 +17235,8 @@ function _hhmmToMinutes(s) {
 
 // Detect whether a fat-bearing food was logged in feedingData near `timeStr` on `dateStr`.
 // Window: ±60min default. Returns { withFat, fatFood, fatDelta } (delta signed: negative = food first).
+// V-K-69: token-equality matching (with _baseFoodName alias normalization) instead of substring
+// `indexOf` — avoids the coconut-water-matches-coconut false-positive.
 function _detectFatContextNearTime(timeStr, dateStr, windowMinutes) {
   var win = (typeof windowMinutes === 'number') ? windowMinutes : 60;
   var result = { withFat:false, fatFood:null, fatDelta:null };
@@ -17233,20 +17246,33 @@ function _detectFatContextNearTime(timeStr, dateStr, windowMinutes) {
   var day = feedingData[dateStr];
   if (!day) return result;
   var fatSet = _getFatBearingFoodNames();
+  var fatLookup = {};
+  for (var fi = 0; fi < fatSet.length; fi++) fatLookup[fatSet[fi]] = true;
   var meals = ['breakfast', 'lunch', 'dinner', 'snack'];
   var best = null;
   meals.forEach(function(m) {
     var mTime = day[m + '_time'];
     var mFoods = day[m];
-    if (!mTime || !mFoods || mFoods === '—skipped—') return;
+    if (!mTime || !mFoods || mFoods === '—skipped—' || mFoods === '—skipped—') return;
     var mMin = _hhmmToMinutes(mTime);
     if (mMin < 0) return;
     var delta = mMin - targetMin; // signed: negative = meal before dose
     if (Math.abs(delta) > win) return;
-    var lower = String(mFoods).toLowerCase();
+    // Tokenize the meal text on comma / " and " / "+" / "&". Trim each token. Empty tokens dropped.
+    var tokens = String(mFoods).toLowerCase().split(/\s*,\s*|\s+and\s+|\s*\+\s*|\s*&\s*/).map(function(s) { return s.trim(); }).filter(Boolean);
     var matched = null;
-    for (var i = 0; i < fatSet.length; i++) {
-      if (lower.indexOf(fatSet[i]) >= 0) { matched = fatSet[i]; break; }
+    for (var ti = 0; ti < tokens.length; ti++) {
+      var tok = tokens[ti];
+      // Try exact token match first.
+      if (fatLookup[tok]) { matched = tok; break; }
+      // V-K-69: if the token is itself a known NUTRITION key but NOT in fatLookup, do NOT attempt
+      // alias normalisation — the parent logged a specific known food that is NOT fat-bearing
+      // (e.g. 'coconut water' is a distinct NUTRITION entry from 'coconut'; _baseFoodName would
+      // strip 'water' as a form-word and incorrectly return 'coconut').
+      if (typeof NUTRITION === 'object' && NUTRITION[tok]) continue;
+      // Otherwise try alias-normalized base name (catches 'yogurt' → 'curd', 'fresh ghee' → 'ghee').
+      var base = (typeof _baseFoodName === 'function') ? _baseFoodName(tok) : tok;
+      if (base !== tok && fatLookup[base]) { matched = base; break; }
     }
     if (matched && (best === null || Math.abs(delta) < Math.abs(best.delta))) {
       best = { food: matched, delta: delta };
@@ -17537,6 +17563,11 @@ function init() {
     else if (action === 'resolveMissedMedSkipped' && typeof resolveMissedMed === 'function') resolveMissedMed(arg, arg2, 'skipped');
     else if (action === 'markMedDone' && typeof markMedDone === 'function') markMedDone(arg, Number(arg2));
     else if (action === 'markMedSkipped' && typeof markMedSkipped === 'function') markMedSkipped(arg, Number(arg2));
+    else if (action === 'openMedDoneAt' && typeof openMedDoneAt === 'function') openMedDoneAt(arg, Number(arg2));
+    else if (action === 'confirmMedDoneAt' && typeof confirmMedDoneAt === 'function') confirmMedDoneAt(arg, Number(arg2));
+    else if (action === 'cancelMedDoneAt' && typeof cancelMedDoneAt === 'function') cancelMedDoneAt(Number(arg2));
+    else if (action === 'openMedAdjust' && typeof openMedAdjust === 'function') openMedAdjust(arg, Number(arg2));
+    else if (action === 'confirmMedAdjust' && typeof confirmMedAdjust === 'function') confirmMedAdjust(arg, Number(arg2));
     else if (action === 'deleteFeedingEntry' && typeof deleteFeedingEntry === 'function') deleteFeedingEntry(arg);
     else if (action === 'switchFoodCatSub' && typeof switchFoodCatSub === 'function') switchFoodCatSub(arg, arg2);
     else if (action === 'expandMilestoneByIdx' && typeof expandMilestoneByIdx === 'function') expandMilestoneByIdx(Number(arg));
@@ -17873,6 +17904,11 @@ function init() {
     else if (action === 'resolveMissedMed') resolveMissedMed(arg, arg2, arg3);
     else if (action === 'markMedDone') markMedDone(arg, parseInt(arg2));
     else if (action === 'markMedSkipped') markMedSkipped(arg, parseInt(arg2));
+    else if (action === 'openMedDoneAt') openMedDoneAt(arg, parseInt(arg2));
+    else if (action === 'confirmMedDoneAt') confirmMedDoneAt(arg, parseInt(arg2));
+    else if (action === 'cancelMedDoneAt') cancelMedDoneAt(parseInt(arg2));
+    else if (action === 'openMedAdjust') openMedAdjust(arg, parseInt(arg2));
+    else if (action === 'confirmMedAdjust') confirmMedAdjust(arg, parseInt(arg2));
     else if (action === 'overrideMilestoneStatus') { const args = arg.split(',').map(s=>s.trim().replace(/^'|'$/g,'')); overrideMilestoneStatus(...args); }
     else if (action === 'upcomingToMilestone') { const args = arg.split(',').map(s=>s.trim().replace(/^'|'$/g,'')); upcomingToMilestone(...args); }
     else if (action === 'deleteFoodAndRender') { deleteFood(arg); renderFoodCatSubContent(arg2); }
@@ -18901,7 +18937,8 @@ function calcMedicalScore() {
       const ds = toDateStr(d);
       const dayChecks = medChecks[ds];
       if (dayChecks) {
-        const anyDone = Object.values(dayChecks).some(v => typeof v === 'string' && v.startsWith('done'));
+        // V-K-68: schema-aware via medCheckIsDone (handles both legacy string + new object).
+        const anyDone = Object.values(dayChecks).some(v => medCheckIsDone(v));
         if (anyDone) daysChecked++;
       }
     }
@@ -23415,7 +23452,7 @@ function renderRemindersAndAlerts() {
           <div class="supp-alert-title">Reminder — ${escHtml(m.name)}</div>
           <div class="supp-alert-action">
             <button class="supp-check-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done now</button>
-            <button class="supp-check-btn supp-check-btn-alt" data-action="openMedDoneAt" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done at...</button>
+            <button class="supp-check-btn supp-check-btn-alt" data-action="openMedDoneAt" data-arg="${escHtml(m.name)}" data-arg2="${idx}">${zi('clock')} Done at...</button>
             <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Skip</button>
           </div>
         </div>
@@ -23423,12 +23460,15 @@ function renderRemindersAndAlerts() {
       </div>`;
     } else if (isDone) {
       const givenAt = parsed && parsed.givenAt ? parsed.givenAt : null;
-      const withFat = parsed && parsed.withFat === true;
       const fatFood = parsed && parsed.fatFood ? parsed.fatFood : null;
       const timeText = givenAt ? 'Done at ' + escHtml(givenAt) : 'Done today';
-      const fatBadge = withFat && fatFood
-        ? `<span class="supp-fat-badge">${zi('check')} with ${escHtml(fatFood)}</span>`
-        : (givenAt && !withFat ? `<span class="supp-fat-badge supp-fat-badge-neutral">no fat-meal nearby</span>` : '');
+      // V-M-61: null withFat (legacy / unknown) renders no badge. V-M-63: softer framing.
+      let fatBadge = '';
+      if (parsed && parsed.withFat === true && fatFood) {
+        fatBadge = `<span class="supp-fat-badge">${zi('check')} with ${escHtml(fatFood)}</span>`;
+      } else if (parsed && parsed.withFat === false && givenAt) {
+        fatBadge = `<span class="supp-fat-badge supp-fat-badge-neutral">no fat-meal logged nearby</span>`;
+      }
       html += `
       <div class="supp-alert supp-alert-done" id="supp-alert-${idx}">
         <div class="supp-alert-top">
@@ -23598,7 +23638,9 @@ function fmtTips(s) {
 function markMedDone(name, idx, givenTime) {
   const todayStr = today();
   const now = new Date();
-  const loggedAt = now.toLocaleTimeString('en-IN', { hour:'2-digit', minute:'2-digit' });
+  // V-M-60: storage uses 24h en-GB (HH:MM). Display layer formats for the user;
+  // the storage layer must be canonical so _hhmmToMinutes parses correctly across AM/PM.
+  const loggedAt = now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
   const givenAt = (typeof givenTime === 'string' && /^\d{1,2}:\d{2}$/.test(givenTime)) ? givenTime : loggedAt;
   const fat = _detectFatContextNearTime(givenAt, todayStr);
   if (!medChecks[todayStr]) medChecks[todayStr] = {};
@@ -23659,10 +23701,11 @@ function adjustMedTime(name, idx, newTime) {
   if (!existing || existing.status === 'skipped') return;
   const fat = _detectFatContextNearTime(newTime, todayStr);
   const now = new Date();
+  // V-M-65: canonical 24h storage (en-GB).
   medChecks[todayStr][name] = {
     status:   existing.status,
     givenAt:  newTime,
-    loggedAt: existing.loggedAt || now.toLocaleTimeString('en-IN', { hour:'2-digit', minute:'2-digit' }),
+    loggedAt: existing.loggedAt || now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' }),
     withFat:  fat.withFat,
     fatFood:  fat.fatFood,
     fatDelta: fat.fatDelta,
@@ -25333,8 +25376,9 @@ function renderMedLog() {
     const [year, mon] = monthKey.split('-');
     const monthLabel = `${monthNames[parseInt(mon) - 1]} ${year}`;
     const monthId = 'ml-' + monthKey;
-    const givenCount = items.filter(e => e.status.startsWith('done')).length;
-    const skippedCount = items.filter(e => e.status === 'skipped').length;
+    // V-K-66: schema-aware filtering — items can carry legacy string status OR new object status.
+    const givenCount = items.filter(e => medCheckIsDone(e.status)).length;
+    const skippedCount = items.filter(e => medCheckSkipped(e.status)).length;
 
     html += `<div class="history-month" id="${monthId}">
       <div class="history-month-header" data-action="toggleHistoryMonth" data-arg="${monthId}" style="background:linear-gradient(135deg,var(--sky-light),var(--sky-light));border-color:rgba(168,207,224,0.4);">
@@ -25362,12 +25406,15 @@ function renderMedLog() {
       html += `<div style=""font-weight:600;font-size:var(--fs-sm);color:var(--tc-sky);margin-bottom:4px;">${dayName}, ${dayNum} ${monthNames[parseInt(mon) - 1]}</div>`;
 
       dayItems.forEach(e => {
-        const isDone = e.status.startsWith('done');
-        const timeStr = isDone ? e.status.replace('done:', '') : '';
+        // V-K-66: schema-aware status read.
+        const parsed = parseMedCheck(e.status);
+        const isDone = !!(parsed && (parsed.status === 'done' || parsed.status === 'late'));
+        const isLate = !!(parsed && parsed.status === 'late');
+        const timeStr = parsed && parsed.givenAt ? parsed.givenAt : '';
         const icon = isDone ? zi('check') : zi('skip-forward');
         const label = isDone ? 'Given' : 'Skipped';
         const color = isDone ? '#3a7060' : '#926030';
-        const timePart = timeStr && timeStr !== 'late' ? ` at ${timeStr}` : timeStr === 'late' ? ' (logged late)' : '';
+        const timePart = isLate ? ' (logged late)' : (timeStr ? ` at ${escHtml(timeStr)}` : '');
 
         html += `
           <div style="display:flex;align-items:center;gap:var(--sp-8);padding:3px 0;font-size:var(--fs-base);">
@@ -29208,7 +29255,8 @@ function renderHistoryPreviews() {
       </div>`;
     } else {
       // Show today's status
-      const todayDone = activeMeds.filter(m => todayChecks[m.name] && todayChecks[m.name].startsWith('done'));
+      // V-K-66: schema-aware via medCheckIsDone.
+      const todayDone = activeMeds.filter(m => medCheckIsDone(todayChecks[m.name]));
       if (todayDone.length === activeMeds.length && activeMeds.length > 0) {
         medPrev.innerHTML = `<div class="info-strip is-sage">
           <span><svg class="zi"><use href="#zi-check"/></svg></span>
@@ -29700,23 +29748,24 @@ function computeBaselines() {
 
   // ── Supplement adherence (D3) ──
   const activeMeds = meds.filter(m => m.active);
+  // V-K-66: schema-aware reads via medCheckIsDone / medCheckSkipped (handles legacy string + new object).
   activeMeds.forEach(m => {
     const mKey = sanitizeAlertKey(m.name);
     let streak = 0;
     for (let i = 0; i < 90; i++) {
       const d = new Date(); d.setDate(d.getDate() - i);
       const ds = toDateStr(d);
-      // Skip today if not yet resolved
-      if (i === 0) {
-        const dayLog = medChecks[ds] || {};
-        const status = dayLog[m.name];
-        if (!status || (!status.startsWith('done:') && status !== 'skipped')) continue;
-        if (status.startsWith('done:')) { streak++; continue; }
-        break; // skipped breaks streak
-      }
       const dayLog = medChecks[ds] || {};
       const status = dayLog[m.name];
-      if (status && status.startsWith('done:')) { streak++; }
+      const isDone = medCheckIsDone(status);
+      const isSkipped = medCheckSkipped(status);
+      // Skip today if not yet resolved (no entry at all)
+      if (i === 0) {
+        if (!isDone && !isSkipped) continue;
+        if (isDone) { streak++; continue; }
+        break; // skipped breaks streak
+      }
+      if (isDone) { streak++; }
       else break;
     }
     b['suppStreak_' + mKey] = streak;
@@ -29731,7 +29780,7 @@ function computeBaselines() {
       if (ds < (m.start || '2025-09-04')) continue;
       total30++;
       const dayLog = medChecks[ds] || {};
-      if (dayLog[m.name] && dayLog[m.name].startsWith('done:')) given30++;
+      if (medCheckIsDone(dayLog[m.name])) given30++;
     }
     b['suppAdherence30_' + mKey] = total30 > 0 ? Math.floor((given30 / total30) * 100) : null;
     b['suppGiven30_' + mKey] = given30;
@@ -30230,7 +30279,10 @@ function computeAlerts() {
     const ydStr = toDateStr(yd);
     const ydLog = medChecks[ydStr] || {};
     const ydStatus = ydLog[m.name];
-    const wasMissedYd = ydStr >= (medChecks._trackingSince || todayStr) && ydStr >= (m.start || '2025-09-04') && (!ydStatus || ydStatus === 'skipped');
+    // V-K-66: schema-aware "yesterday missed" check — handles both string and object shapes.
+    const ydDone = medCheckIsDone(ydStatus);
+    const ydSkipped = medCheckSkipped(ydStatus);
+    const wasMissedYd = ydStr >= (medChecks._trackingSince || todayStr) && ydStr >= (m.start || '2025-09-04') && (!ydDone && (ydSkipped || !ydStatus));
     // Count how long the prior streak was before it broke
     if (wasMissedYd && streak === 0) {
       let priorStreak = 0;
@@ -30238,7 +30290,7 @@ function computeAlerts() {
         const d = new Date(); d.setDate(d.getDate() - i);
         const ds = toDateStr(d);
         const dl = medChecks[ds] || {};
-        if (dl[m.name] && dl[m.name].startsWith('done:')) priorStreak++;
+        if (medCheckIsDone(dl[m.name])) priorStreak++;
         else break;
       }
       if (priorStreak >= 3) {
@@ -31035,13 +31087,24 @@ function renderTodayPlan() {
     });
   }
 
-  // D3 supplement
+  // D3 supplement — V-K-66: schema-aware via parseMedCheck (legacy string + new object both handled).
   const d3Med = meds.find(m => m.active && m.name.toLowerCase().includes('d3'));
   if (d3Med) {
-    const d3Done = medChecks[todayStr] && medChecks[todayStr][d3Med.name] && medChecks[todayStr][d3Med.name].startsWith('done:');
+    const d3Parsed = parseMedCheck(medChecks[todayStr] && medChecks[todayStr][d3Med.name]);
+    const d3Done = !!(d3Parsed && (d3Parsed.status === 'done' || d3Parsed.status === 'late'));
+    const d3Given = d3Parsed && d3Parsed.givenAt ? d3Parsed.givenAt : null;
+    const d3Fat = d3Parsed && d3Parsed.withFat === true && d3Parsed.fatFood ? d3Parsed.fatFood : null;
+    let doneDetail;
+    if (d3Done) {
+      const timePart = d3Given ? ' at ' + escHtml(d3Given) : '';
+      const fatPart = d3Fat ? ' · with ' + escHtml(d3Fat) : '';
+      doneDetail = '<svg class="zi"><use href="#zi-check"/></svg> Done' + timePart + fatPart;
+    } else {
+      doneDetail = d3Med.dose + ' — give with or after a feed for best absorption';
+    }
     items.push({
       time: '9 AM', icon: zi('pill'), title: d3Med.name,
-      detail: d3Done ? '<svg class="zi"><use href="#zi-check"/></svg> Done today' : d3Med.dose + ' — give with or after a feed for best absorption',
+      detail: doneDetail,
       tag: 'med', done: d3Done, htmlDetail: d3Done
     });
   }
@@ -31470,7 +31533,8 @@ function renderTrendChips() {
   const total = Math.max(Object.keys(nutrientDays).length, 5);
   chips.push({ icon:zi('bowl'), label:'Nutrients', value: covered + '/' + total + ' groups', delta: covered >= total ? 'balanced' : 'gaps', cls: covered >= total ? 'tc-good' : 'tc-warn', tab:'diet' });
 
-  // Vitamin D3 — schema-aware (legacy 'done:HH:MM' string + new object shape both handled)
+  // Vitamin D3 — schema-aware (legacy 'done:HH:MM' string + new object shape both handled).
+  // V-M-62 + V-K-70: fatFood comes from parent feedingData input — escape at this render boundary.
   if (d3Med) {
     const todayStr = today();
     const d3Val = medChecks[todayStr] && medChecks[todayStr][d3Med.name];
@@ -31479,8 +31543,8 @@ function renderTrendChips() {
     let valueText, deltaText;
     if (d3Done) {
       const t = d3Parsed.givenAt;
-      const fat = d3Parsed.withFat === true && d3Parsed.fatFood ? ' · with ' + d3Parsed.fatFood : '';
-      valueText = t ? ('Done at ' + t + fat) : 'Done today';
+      const fat = d3Parsed.withFat === true && d3Parsed.fatFood ? ' · with ' + escHtml(d3Parsed.fatFood) : '';
+      valueText = t ? ('Done at ' + escHtml(t) + fat) : 'Done today';
       deltaText = zi('check');
     } else {
       valueText = 'Pending';
@@ -38761,7 +38825,8 @@ function renderMedicalStats() {
     if (dateKey.startsWith('_') || typeof val !== 'object') return;
     if (new Date(dateKey) < weekAgo) return;
     totalDays++;
-    Object.values(val).forEach(s => { if (s.startsWith('done')) givenCount++; });
+    // V-K-66: schema-aware count — handles both legacy string and new object shapes.
+    Object.values(val).forEach(s => { if (medCheckIsDone(s)) givenCount++; });
   });
 
   el.innerHTML = `
@@ -40900,9 +40965,16 @@ function renderMedD3PatternCard() {
   doneDays.forEach(d => { if (d.parsed.fatFood) fatFoodCounts[d.parsed.fatFood] = (fatFoodCounts[d.parsed.fatFood] || 0) + 1; });
   let topFatFood = null, topN = 0;
   Object.keys(fatFoodCounts).forEach(k => { if (fatFoodCounts[k] > topN) { topFatFood = k; topN = fatFoodCounts[k]; } });
-  // Streak: consecutive done-days ending today
+  // Streak: consecutive done-days ending today.
+  // V-M-64: if today is unlogged (parent hasn't tapped Done yet), don't punish the streak —
+  // walk from yesterday and label "through yesterday" so a 30-day perfect run doesn't read as 0.
   let streak = 0;
-  for (let i = days.length - 1; i >= 0; i--) {
+  let streakLabel = 'Current streak';
+  const todayParsed = days[days.length - 1].parsed;
+  const todayResolved = !!(todayParsed && (todayParsed.status === 'done' || todayParsed.status === 'late' || todayParsed.status === 'skipped'));
+  const startIdx = todayResolved ? days.length - 1 : days.length - 2;
+  if (!todayResolved) streakLabel = 'Streak through yesterday';
+  for (let i = startIdx; i >= 0; i--) {
     if (days[i].parsed && (days[i].parsed.status === 'done' || days[i].parsed.status === 'late')) streak++;
     else break;
   }
@@ -40916,7 +40988,7 @@ function renderMedD3PatternCard() {
     summary += `<div class="med-d3-summary-row">${zi('bowl')} <span class="${fatCls}">With-fat rate: ${withFatCount} of ${withFatKnown.length} doses (${fatRate}%)</span></div>`;
   }
   if (topFatFood) summary += `<div class="med-d3-summary-row">${zi('check')} Usually paired with: <strong>${escHtml(topFatFood)}</strong></div>`;
-  if (streak > 0) summary += `<div class="med-d3-summary-row">${zi('trending-flat')} Current streak: <strong>${streak} day${streak === 1 ? '' : 's'}</strong></div>`;
+  if (streak > 0) summary += `<div class="med-d3-summary-row">${zi('trending-flat')} ${streakLabel}: <strong>${streak} day${streak === 1 ? '' : 's'}</strong></div>`;
   if (unloggedDays.length > 0) summary += `<div class="med-d3-summary-row tc-warn">${zi('warn')} ${unloggedDays.length} day${unloggedDays.length === 1 ? '' : 's'} not logged in this window</div>`;
   summary += '</div>';
   // 14-day compact list (most-recent first)
@@ -40930,9 +41002,11 @@ function renderMedD3PatternCard() {
       row = `<span class="tc-warn">Skipped</span>`;
     } else {
       const t = d.parsed.givenAt ? 'Done at ' + escHtml(d.parsed.givenAt) : 'Done';
+      // V-M-61 + V-M-63: only render the "no fat-meal" line on explicit false
+      // (not null/unknown), with softened framing.
       const fat = d.parsed.withFat === true && d.parsed.fatFood
         ? ` <span class="tc-sage">· with ${escHtml(d.parsed.fatFood)}</span>`
-        : (d.parsed.withFat === false ? ` <span class="t-sub">· no fat-meal nearby</span>` : '');
+        : (d.parsed.withFat === false ? ` <span class="t-sub">· no fat-meal logged nearby</span>` : '');
       row = t + fat;
     }
     list += `<div class="med-d3-log-row"><span class="med-d3-log-date">${escHtml(label)}</span><span>${row}</span></div>`;
@@ -46079,9 +46153,10 @@ function computeSupplementAdherence(windowDays) {
       var dow = d.getDay();
 
       var calStatus = 'missed';
-      if (status && status.indexOf('done') === 0) {
-        var timeStr = status.replace('done:', '');
-        if (timeStr === 'late') {
+      // V-K-66: schema-aware status read.
+      var parsedStatus = parseMedCheck(status);
+      if (parsedStatus && (parsedStatus.status === 'done' || parsedStatus.status === 'late')) {
+        if (parsedStatus.status === 'late') {
           lateCount++;
           calStatus = 'late';
           doneCount++; // late still counts as done for adherence
@@ -46089,10 +46164,11 @@ function computeSupplementAdherence(windowDays) {
           doneCount++;
           calStatus = 'done';
           // Parse time
+          var timeStr = parsedStatus.givenAt || '';
           var parsed = _parseSupplementTime(timeStr);
           if (parsed !== null) times.push(parsed);
         }
-      } else if (status === 'skipped') {
+      } else if (parsedStatus && parsedStatus.status === 'skipped') {
         skippedCount++;
         calStatus = 'skipped';
         dayOfWeekMisses[dow]++;
@@ -58447,37 +58523,38 @@ function _tsfCollectEvents() {
   });
 
   // ── Supplements (medChecks) today ──
+  // V-K-67: schema-aware via parseMedCheck — accepts BOTH legacy 'done:HH:MM' strings AND new object shape.
   const todayMedChecks = medChecks[t] || {};
   Object.keys(todayMedChecks).forEach(function(medName) {
     const val = todayMedChecks[medName];
-    if (typeof val !== 'string') return;
+    const parsed = parseMedCheck(val);
+    if (!parsed) return;
     let timeStr = null;
     let timeMin = null;
     let displayTime = '';
-    if (val.startsWith('done:')) {
-      const timePart = val.replace('done:', '').trim();
-      if (timePart !== 'late') {
-        timeMin = _tsfTimeToMinutes(timePart);
-        timeStr = timePart;
-        displayTime = _tsfFormatTime(timePart);
-      }
+    if ((parsed.status === 'done' || parsed.status === 'late') && parsed.givenAt) {
+      timeMin = _tsfTimeToMinutes(parsed.givenAt);
+      timeStr = parsed.givenAt;
+      displayTime = _tsfFormatTime(parsed.givenAt);
     }
+    const detail = (parsed.status === 'done' || parsed.status === 'late') ? 'Done' : (parsed.status === 'skipped' ? 'Skipped' : '');
     const ev = {
       id: 'med-' + medName,
       type: 'med',
       time: timeStr,
       timeMin: timeMin,
       label: medName,
-      detail: val.startsWith('done:') ? 'Done' : val === 'skipped' ? 'Skipped' : '',
+      detail: detail,
       icon: zi('pill'),
       color: 'sky',
       inferred: false,
       displayTime: displayTime,
-      status: val
+      status: val,
+      parsed: parsed
     };
     if (timeMin !== null) {
       events.push(ev);
-    } else if (val !== 'skipped') {
+    } else if (parsed.status !== 'skipped') {
       noTimeEvents.push(ev);
     }
   });
@@ -58513,9 +58590,9 @@ function _tsfGetAnchor() {
     poopData.filter(function(p) { return p.date === d; }).forEach(function() { dayCount++; });
     // Activities
     (activityLog[d] || []).forEach(function() { dayCount++; });
-    // Meds
+    // Meds — V-K-67: schema-aware via medCheckIsDone.
     const mc = medChecks[d] || {};
-    Object.keys(mc).forEach(function(k) { if (mc[k] && mc[k].toString().startsWith('done')) dayCount++; });
+    Object.keys(mc).forEach(function(k) { if (medCheckIsDone(mc[k])) dayCount++; });
     if (dayCount > 0) {
       totalEvents += dayCount;
       daysWithData++;
@@ -58580,11 +58657,11 @@ function _tsfDetectPatterns() {
           }
         });
       } else if (def.type === 'med' && def.medName) {
+        // V-K-67: schema-aware via parseMedCheck.
         const mc = medChecks[d] || {};
-        const val = mc[def.medName];
-        if (val && typeof val === 'string' && val.startsWith('done:')) {
-          const timePart = val.replace('done:', '').trim();
-          const mm = _tsfTimeToMinutes(timePart);
+        const parsed = parseMedCheck(mc[def.medName]);
+        if (parsed && (parsed.status === 'done' || parsed.status === 'late')) {
+          const mm = parsed.givenAt ? _tsfTimeToMinutes(parsed.givenAt) : null;
           found = true;
           if (mm !== null) foundMin = mm;
         }
@@ -58676,8 +58753,9 @@ function _tsfGetNudges() {
         return pm !== null && pm >= pat.windowStart && pm <= pat.windowEnd;
       });
     } else if (pat.type === 'med' && pat.medName) {
+      // V-K-67: schema-aware — handles both legacy string and new object shapes.
       const mc = todayMC[pat.medName];
-      alreadyLogged = mc && typeof mc === 'string' && (mc.startsWith('done') || mc === 'skipped');
+      alreadyLogged = medCheckIsDone(mc) || medCheckSkipped(mc);
     }
 
     if (alreadyLogged) return;
@@ -58729,7 +58807,19 @@ function _tsfRenderEventExpanded(ev) {
     if (ev.duration) html += '<div>Duration: ' + ev.duration + ' min</div>';
     if (ev.domains && ev.domains.length > 0) html += '<div>Domains: ' + escHtml(ev.domains.join(', ')) + '</div>';
   } else if (ev.type === 'med') {
-    if (ev.status) html += '<div>Status: ' + escHtml(ev.status.replace('done:', 'Done at ')) + '</div>';
+    // V-K-67: schema-aware via parseMedCheck (handles both legacy string + new object).
+    const parsedStatus = parseMedCheck(ev.status);
+    if (parsedStatus) {
+      let statusText;
+      if (parsedStatus.status === 'skipped') statusText = 'Skipped';
+      else if (parsedStatus.status === 'late') statusText = 'Done (logged late)';
+      else if (parsedStatus.status === 'done') statusText = parsedStatus.givenAt ? 'Done at ' + parsedStatus.givenAt : 'Done';
+      else statusText = '';
+      if (statusText) html += '<div>Status: ' + escHtml(statusText) + '</div>';
+      if (parsedStatus.withFat === true && parsedStatus.fatFood) {
+        html += '<div>With fat: ' + escHtml(parsedStatus.fatFood) + '</div>';
+      }
+    }
   }
   return html || '<div>No additional details</div>';
 }

--- a/index.html
+++ b/index.html
@@ -2293,6 +2293,50 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
 }
 .supp-skip-btn:hover { border-color:var(--rose); color:var(--rose); background:var(--rose-light); }
 
+/* Vit D3 tracking v1 — done-state card, inline time-edit, and pattern card */
+.supp-alert-done {
+  background:var(--sage-light);
+  border-left-color:var(--sage);
+}
+.supp-alert-done .supp-alert-title { color:var(--tc-sage); }
+.supp-alert-done .supp-alert-detail { color:var(--tc-sage); }
+.supp-check-btn-alt {
+  background:transparent;
+  color:var(--tc-sage);
+  border:1.5px solid var(--sage);
+}
+.supp-check-btn-alt:hover { background:var(--sage-light); }
+.supp-time-input {
+  font-family:'Nunito',sans-serif; font-size:var(--fs-base);
+  padding:var(--sp-6) var(--sp-10); border-radius:var(--r-md);
+  border:1.5px solid var(--border); background:var(--bg);
+  color:var(--text); min-height:40px;
+}
+.supp-fat-badge {
+  display:inline-flex; align-items:center; gap:var(--sp-4);
+  font-size:var(--fs-sm); color:var(--tc-sage); font-weight:600;
+}
+.supp-fat-badge-neutral { color:var(--mid); font-weight:400; }
+.supp-adjust-btn {
+  font-size:var(--fs-sm); padding:var(--sp-4) var(--sp-10);
+  min-height:auto;
+}
+.med-d3-summary {
+  padding:var(--sp-8) 0; line-height:var(--lh-relaxed);
+  font-size:var(--fs-base); color:var(--mid);
+}
+.med-d3-summary-row { padding:var(--sp-2) 0; }
+.med-d3-log {
+  padding-top:var(--sp-6); border-top:1px solid var(--border);
+  font-size:var(--fs-sm); line-height:var(--lh-normal);
+}
+.med-d3-log-row {
+  display:flex; gap:var(--sp-12); padding:var(--sp-2) 0;
+}
+.med-d3-log-date {
+  min-width:80px; color:var(--mid); font-weight:400;
+}
+
 /* ── Home stat pills ── */
 /* ── Stat pills grid — balanced sizing ── */
 .stat-pills-grid {
@@ -10451,6 +10495,14 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
         <div class="med-list" id="medList"></div>
       </div>
 
+      <!-- VIT D3 14-DAY PATTERN -->
+      <div class="card card-info col-full" id="medD3PatternCard">
+        <div class="card-header">
+          <div class="card-title"><div class="icon icon-sky"><svg class="zi"><use href="#zi-sun"/></svg></div> Vitamin D3 — 14-day pattern</div>
+        </div>
+        <div id="medD3PatternBody"></div>
+      </div>
+
       <!-- VACCINATION COVERAGE CHECK -->
       <div class="card card-info col-full" id="medVaccCoverage">
         <div class="card-header" data-collapse-target="vaccCoverageBody" data-collapse-chevron="vaccCoverageChevron">
@@ -17093,6 +17145,122 @@ function save(key, val) {
 }
 
 // ─────────────────────────────────────────
+// MED-CHECK SCHEMA HELPERS — v1 Vit D3 tracking
+// ─────────────────────────────────────────
+// medChecks[date][medName] accepts two shapes (backwards-compat, non-destructive migration):
+//   • Legacy string: 'done:HH:MM' | 'done:late' | 'done' | 'skipped'  — HH:MM was tap-time
+//   • New object: { status, givenAt, loggedAt, withFat, fatFood, fatDelta }
+// Every reader migrates via parseMedCheck() so writers can emit the new shape unconditionally.
+function parseMedCheck(val) {
+  if (!val) return null;
+  if (typeof val === 'object') {
+    return {
+      status:   val.status || null,
+      givenAt:  val.givenAt || null,
+      loggedAt: val.loggedAt || null,
+      withFat:  typeof val.withFat === 'boolean' ? val.withFat : null,
+      fatFood:  val.fatFood || null,
+      fatDelta: typeof val.fatDelta === 'number' ? val.fatDelta : null,
+    };
+  }
+  if (typeof val !== 'string') return null;
+  if (val === 'skipped') return { status:'skipped', givenAt:null, loggedAt:null, withFat:null, fatFood:null, fatDelta:null };
+  if (val === 'done:late' || val === 'done') return { status:'late', givenAt:null, loggedAt:null, withFat:null, fatFood:null, fatDelta:null };
+  if (val.indexOf('done:') === 0) {
+    var t = val.slice(5);
+    var isTime = /^\d{1,2}:\d{2}$/.test(t);
+    return {
+      status: isTime ? 'done' : (t === 'late' ? 'late' : 'done'),
+      givenAt: isTime ? t : null,
+      loggedAt: null, // legacy didn't separate; givenAt was actually tap-time but treat as best-known
+      withFat: null,
+      fatFood: null,
+      fatDelta: null,
+    };
+  }
+  return null;
+}
+function medCheckIsDone(val) {
+  var p = parseMedCheck(val);
+  return !!(p && (p.status === 'done' || p.status === 'late'));
+}
+function medCheckSkipped(val) {
+  var p = parseMedCheck(val);
+  return !!(p && p.status === 'skipped');
+}
+function medCheckGivenAt(val) {
+  var p = parseMedCheck(val);
+  return p ? p.givenAt : null;
+}
+
+// Derive fat-bearing food names from NUTRITION (memoised). Computed-not-hardcoded so
+// the C-1.5 factuality work flows through automatically — no second source of truth.
+var _fatBearingFoodNamesCache = null;
+function _getFatBearingFoodNames() {
+  if (_fatBearingFoodNamesCache) return _fatBearingFoodNamesCache;
+  var out = [];
+  if (typeof NUTRITION === 'object' && NUTRITION) {
+    Object.keys(NUTRITION).forEach(function(name) {
+      var e = NUTRITION[name];
+      if (!e) return;
+      var tags = e.tags || [];
+      var nuts = e.nutrients || [];
+      if (tags.indexOf('healthy-fats') >= 0 || nuts.indexOf('healthy fats') >= 0 ||
+          nuts.indexOf('omega-3') >= 0 || nuts.indexOf('MCTs') >= 0) {
+        out.push(name);
+      }
+    });
+  }
+  // Indian-prep augmentation: paratha carries ghee in default preparation.
+  if (out.indexOf('paratha') < 0) out.push('paratha');
+  _fatBearingFoodNamesCache = out;
+  return out;
+}
+function _hhmmToMinutes(s) {
+  if (!s) return -1;
+  var m = String(s).match(/^(\d{1,2}):(\d{2})/);
+  return m ? (parseInt(m[1], 10) * 60 + parseInt(m[2], 10)) : -1;
+}
+
+// Detect whether a fat-bearing food was logged in feedingData near `timeStr` on `dateStr`.
+// Window: ±60min default. Returns { withFat, fatFood, fatDelta } (delta signed: negative = food first).
+function _detectFatContextNearTime(timeStr, dateStr, windowMinutes) {
+  var win = (typeof windowMinutes === 'number') ? windowMinutes : 60;
+  var result = { withFat:false, fatFood:null, fatDelta:null };
+  var targetMin = _hhmmToMinutes(timeStr);
+  if (targetMin < 0) return result;
+  if (typeof feedingData !== 'object' || !feedingData) return result;
+  var day = feedingData[dateStr];
+  if (!day) return result;
+  var fatSet = _getFatBearingFoodNames();
+  var meals = ['breakfast', 'lunch', 'dinner', 'snack'];
+  var best = null;
+  meals.forEach(function(m) {
+    var mTime = day[m + '_time'];
+    var mFoods = day[m];
+    if (!mTime || !mFoods || mFoods === '—skipped—') return;
+    var mMin = _hhmmToMinutes(mTime);
+    if (mMin < 0) return;
+    var delta = mMin - targetMin; // signed: negative = meal before dose
+    if (Math.abs(delta) > win) return;
+    var lower = String(mFoods).toLowerCase();
+    var matched = null;
+    for (var i = 0; i < fatSet.length; i++) {
+      if (lower.indexOf(fatSet[i]) >= 0) { matched = fatSet[i]; break; }
+    }
+    if (matched && (best === null || Math.abs(delta) < Math.abs(best.delta))) {
+      best = { food: matched, delta: delta };
+    }
+  });
+  if (best) {
+    result.withFat = true;
+    result.fatFood = best.food;
+    result.fatDelta = best.delta;
+  }
+  return result;
+}
+
+// ─────────────────────────────────────────
 // DEFAULT DATA (pre-loaded)
 // ─────────────────────────────────────────
 const DOB        = new Date(2025, 8, 4, 17, 9); // Sep 4, 2025 at 17:09 IST
@@ -23226,39 +23394,57 @@ function renderRemindersAndAlerts() {
     </div>`;
   }
 
-  // ── 4. TODAY'S MED REMINDERS — only show unresolved ones ──
+  // ── 4. TODAY'S MED REMINDERS — show pending with two-button + Adjust on done ──
+  // Vit D3 tracking v1: pending state offers "Done now" + "Done at..." + Skip.
+  // Done state renders captured givenAt + with-fat context with a reachable Adjust.
   let allTodayResolved = true;
   activeMeds.forEach((m, idx) => {
     const dayLog = medChecks[todayStr] || {};
     const status = dayLog[m.name];
-    const isDone = status && status.startsWith('done:');
-    const isSkipped = status === 'skipped';
+    const parsed = parseMedCheck(status);
+    const isDone = !!(parsed && (parsed.status === 'done' || parsed.status === 'late'));
+    const isSkipped = !!(parsed && parsed.status === 'skipped');
     const isResolved = isDone || isSkipped;
     if (!isResolved) allTodayResolved = false;
 
     if (!isResolved) {
-      // Only show unresolved meds
       html += `
       <div class="supp-alert" id="supp-alert-${idx}">
         <div class="supp-alert-top">
           <div class="supp-alert-icon">${zi('warn')}</div>
           <div class="supp-alert-title">Reminder — ${escHtml(m.name)}</div>
           <div class="supp-alert-action">
-            <button class="supp-check-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done</button>
+            <button class="supp-check-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done now</button>
+            <button class="supp-check-btn supp-check-btn-alt" data-action="openMedDoneAt" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done at...</button>
             <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Skip</button>
           </div>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${escHtml(m.freq || 'As prescribed')}</div>
       </div>`;
+    } else if (isDone) {
+      const givenAt = parsed && parsed.givenAt ? parsed.givenAt : null;
+      const withFat = parsed && parsed.withFat === true;
+      const fatFood = parsed && parsed.fatFood ? parsed.fatFood : null;
+      const timeText = givenAt ? 'Done at ' + escHtml(givenAt) : 'Done today';
+      const fatBadge = withFat && fatFood
+        ? `<span class="supp-fat-badge">${zi('check')} with ${escHtml(fatFood)}</span>`
+        : (givenAt && !withFat ? `<span class="supp-fat-badge supp-fat-badge-neutral">no fat-meal nearby</span>` : '');
+      html += `
+      <div class="supp-alert supp-alert-done" id="supp-alert-${idx}">
+        <div class="supp-alert-top">
+          <div class="supp-alert-icon">${zi('check')}</div>
+          <div class="supp-alert-title">${timeText} — ${escHtml(m.name)}</div>
+          <div class="supp-alert-action">
+            <button class="supp-skip-btn supp-adjust-btn" data-action="openMedAdjust" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Adjust</button>
+          </div>
+        </div>
+        <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${fatBadge}</div>
+      </div>`;
     }
   });
 
-  // If all today's meds are resolved, show a compact summary instead
-  if (activeMeds.length > 0 && allTodayResolved) {
-    html += `<div style="display:flex;align-items:center;gap:var(--sp-8);padding:8px 12px;border-radius:var(--r-lg);background:var(--sage-light);font-size:var(--fs-base);color:var(--tc-sage);">
-      <span><svg class="zi"><use href="#zi-check"/></svg></span> All medications done for today
-    </div>`;
-  }
+  // Vit D3 tracking v1: the all-resolved banner is redundant now that done-state
+  // cards render their own captured time + with-fat context. Removed.
 
   // v2.3: Store HTML — renderHomeContextAlerts will combine and render both
   window._remindersHTML = html;
@@ -23405,12 +23591,25 @@ function fmtTips(s) {
           .replace(/\{\{NO\}\}/g, '<span class="icon-rose">' + zi('warn') + '</span>');
 }
 
-function markMedDone(name, idx) {
+// Vit D3 tracking v1: markMedDone emits the new object schema with
+// actual administration time (givenAt) + auto-detected fat-meal context.
+// givenTime is optional — defaults to "now" (the "Done now" button path).
+// The "Done at..." flow passes a parent-stated HH:MM string.
+function markMedDone(name, idx, givenTime) {
   const todayStr = today();
   const now = new Date();
-  const timeStr = now.toLocaleTimeString('en-IN', { hour:'2-digit', minute:'2-digit' });
+  const loggedAt = now.toLocaleTimeString('en-IN', { hour:'2-digit', minute:'2-digit' });
+  const givenAt = (typeof givenTime === 'string' && /^\d{1,2}:\d{2}$/.test(givenTime)) ? givenTime : loggedAt;
+  const fat = _detectFatContextNearTime(givenAt, todayStr);
   if (!medChecks[todayStr]) medChecks[todayStr] = {};
-  medChecks[todayStr][name] = 'done:' + timeStr;
+  medChecks[todayStr][name] = {
+    status:   'done',
+    givenAt:  givenAt,
+    loggedAt: loggedAt,
+    withFat:  fat.withFat,
+    fatFood:  fat.fatFood,
+    fatDelta: fat.fatDelta,
+  };
   save(KEYS.medChecks, medChecks);
   _tsfMarkDirty();
   _islMarkDirty('medical');
@@ -23422,6 +23621,77 @@ function markMedDone(name, idx) {
   } else {
     renderRemindersAndAlerts(); renderHomeContextAlerts();
   }
+}
+
+// Open the inline "Done at..." time-edit in the reminder card. Reveals a
+// time-input + Save/Cancel pair inside the card without a modal.
+function openMedDoneAt(name, idx) {
+  const card = document.getElementById('supp-alert-' + idx);
+  if (!card) return;
+  const actionRow = card.querySelector('.supp-alert-action');
+  if (!actionRow || actionRow.dataset.editing === '1') return;
+  actionRow.dataset.editing = '1';
+  const now = new Date();
+  const nowStr = now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' }); // HH:MM 24h for input
+  actionRow.innerHTML =
+    '<input type="time" class="supp-time-input" id="supp-time-' + idx + '" value="' + escAttr(nowStr) + '">' +
+    '<button class="supp-check-btn" data-action="confirmMedDoneAt" data-arg="' + escAttr(name) + '" data-arg2="' + idx + '">Save</button>' +
+    '<button class="supp-skip-btn" data-action="cancelMedDoneAt" data-arg2="' + idx + '">Cancel</button>';
+}
+function confirmMedDoneAt(name, idx) {
+  const input = document.getElementById('supp-time-' + idx);
+  const picked = input && input.value ? input.value : null;
+  markMedDone(name, idx, picked);
+}
+function cancelMedDoneAt(idx) {
+  renderRemindersAndAlerts();
+  renderHomeContextAlerts();
+}
+
+// Adjust the administration time of an already-logged dose. Re-runs with-fat
+// detection on the new givenAt. Works on today's dose (the only adjust surface
+// in v1; past-day adjusts continue to use resolveMissedMed).
+function adjustMedTime(name, idx, newTime) {
+  const todayStr = today();
+  if (!medChecks[todayStr] || !medChecks[todayStr][name]) return;
+  if (!newTime || !/^\d{1,2}:\d{2}$/.test(newTime)) return;
+  const existing = parseMedCheck(medChecks[todayStr][name]);
+  if (!existing || existing.status === 'skipped') return;
+  const fat = _detectFatContextNearTime(newTime, todayStr);
+  const now = new Date();
+  medChecks[todayStr][name] = {
+    status:   existing.status,
+    givenAt:  newTime,
+    loggedAt: existing.loggedAt || now.toLocaleTimeString('en-IN', { hour:'2-digit', minute:'2-digit' }),
+    withFat:  fat.withFat,
+    fatFood:  fat.fatFood,
+    fatDelta: fat.fatDelta,
+  };
+  save(KEYS.medChecks, medChecks);
+  _tsfMarkDirty();
+  _islMarkDirty('medical');
+  renderRemindersAndAlerts();
+  renderHomeContextAlerts();
+}
+function openMedAdjust(name, idx) {
+  const card = document.getElementById('supp-alert-' + idx);
+  if (!card) return;
+  const actionRow = card.querySelector('.supp-alert-action');
+  if (!actionRow || actionRow.dataset.editing === '1') return;
+  actionRow.dataset.editing = '1';
+  const cur = parseMedCheck(medChecks[today()] && medChecks[today()][name]);
+  const curAt = (cur && cur.givenAt) || new Date().toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
+  // Re-format HH:MM (handle "08:42 AM" legacy by stripping any AM/PM tail)
+  const norm = String(curAt).replace(/\s*(AM|PM)\s*$/i, '');
+  actionRow.innerHTML =
+    '<input type="time" class="supp-time-input" id="supp-time-' + idx + '" value="' + escAttr(norm) + '">' +
+    '<button class="supp-check-btn" data-action="confirmMedAdjust" data-arg="' + escAttr(name) + '" data-arg2="' + idx + '">Save</button>' +
+    '<button class="supp-skip-btn" data-action="cancelMedDoneAt" data-arg2="' + idx + '">Cancel</button>';
+}
+function confirmMedAdjust(name, idx) {
+  const input = document.getElementById('supp-time-' + idx);
+  const picked = input && input.value ? input.value : null;
+  adjustMedTime(name, idx, picked);
 }
 
 function markMedSkipped(name, idx) {
@@ -27685,24 +27955,19 @@ function _obIsTeethingActive() {
 }
 
 function _obCheckVitD3() {
-  // Check if Vit D3 hasn't been given today
+  // Returns true if Vit D3 needs attention (not given today or no D3 med tracked).
+  // Schema-aware via medCheckIsDone (handles both legacy 'done:HH:MM' string and new object shape).
   var todayStr = today();
   var dayEntry = medChecks ? medChecks[todayStr] : null;
   if (!dayEntry) return true;
-  // Check all meds for D3
   var d3Given = false;
-  var d3Found = false;
   var activeMeds = (meds || []).filter(function(m) { return m.active; });
   activeMeds.forEach(function(m) {
     if (m.name && m.name.toLowerCase().indexOf('d3') >= 0) {
-      d3Found = true;
-      var status = dayEntry[m.name];
-      if (status && status.indexOf('done') === 0) d3Given = true;
+      if (medCheckIsDone(dayEntry[m.name])) d3Given = true;
     }
   });
-  // If no D3 med tracked, or D3 not given today
-  if (!d3Given) return true;
-  return false;
+  return !d3Given;
 }
 
 function _obGetNextVaccine() {
@@ -31205,11 +31470,23 @@ function renderTrendChips() {
   const total = Math.max(Object.keys(nutrientDays).length, 5);
   chips.push({ icon:zi('bowl'), label:'Nutrients', value: covered + '/' + total + ' groups', delta: covered >= total ? 'balanced' : 'gaps', cls: covered >= total ? 'tc-good' : 'tc-warn', tab:'diet' });
 
-  // Vitamin D3
+  // Vitamin D3 — schema-aware (legacy 'done:HH:MM' string + new object shape both handled)
   if (d3Med) {
     const todayStr = today();
-    const d3Done = medChecks[todayStr] && medChecks[todayStr][d3Med.name] && medChecks[todayStr][d3Med.name].startsWith('done:');
-    chips.push({ icon:zi('sun'), label:'Vitamin D3', value: d3Done ? 'Done today' : 'Pending', delta: d3Done ? zi('check') : 'pending', cls: d3Done ? 'tc-good' : 'tc-warn', tab:'medical' });
+    const d3Val = medChecks[todayStr] && medChecks[todayStr][d3Med.name];
+    const d3Parsed = parseMedCheck(d3Val);
+    const d3Done = !!(d3Parsed && (d3Parsed.status === 'done' || d3Parsed.status === 'late'));
+    let valueText, deltaText;
+    if (d3Done) {
+      const t = d3Parsed.givenAt;
+      const fat = d3Parsed.withFat === true && d3Parsed.fatFood ? ' · with ' + d3Parsed.fatFood : '';
+      valueText = t ? ('Done at ' + t + fat) : 'Done today';
+      deltaText = zi('check');
+    } else {
+      valueText = 'Pending';
+      deltaText = 'pending';
+    }
+    chips.push({ icon:zi('sun'), label:'Vitamin D3', value: valueText, delta: deltaText, cls: d3Done ? 'tc-good' : 'tc-warn', tab:'medical' });
   }
 
   let html = '';
@@ -40575,6 +40852,101 @@ function renderMeds() {
     `;
     list.appendChild(div);
   });
+  // Vit D3 tracking v1: refresh the 14-day pattern card whenever meds re-render.
+  renderMedD3PatternCard();
+}
+
+// Vit D3 tracking v1: 14-day pattern card.
+// Renders adherence %, usual-time band, with-fat rate, top fat pairing, current streak,
+// and a compact 14-day log. Hidden if no active D3 med tracked.
+function renderMedD3PatternCard() {
+  const card = document.getElementById('medD3PatternCard');
+  const body = document.getElementById('medD3PatternBody');
+  if (!card || !body) return;
+  const d3Med = (meds || []).find(m => m.active && m.name && m.name.toLowerCase().indexOf('d3') >= 0);
+  if (!d3Med) { card.style.display = 'none'; return; }
+  card.style.display = '';
+  const todayStr = today();
+  // 14-day window ending today
+  const days = [];
+  for (let i = 13; i >= 0; i--) {
+    const d = new Date();
+    d.setDate(d.getDate() - i);
+    const ds = d.getFullYear() + '-' + String(d.getMonth()+1).padStart(2,'0') + '-' + String(d.getDate()).padStart(2,'0');
+    const parsed = parseMedCheck(medChecks[ds] && medChecks[ds][d3Med.name]);
+    days.push({ date: ds, parsed: parsed });
+  }
+  // Aggregate stats
+  const doneDays = days.filter(d => d.parsed && (d.parsed.status === 'done' || d.parsed.status === 'late'));
+  const skippedDays = days.filter(d => d.parsed && d.parsed.status === 'skipped');
+  const unloggedDays = days.filter(d => !d.parsed);
+  const adherence = days.length > 0 ? Math.round((doneDays.length / days.length) * 100) : 0;
+  // Usual-time band: take givenAt minutes, find central 80% range
+  const mins = doneDays.map(d => _hhmmToMinutes(d.parsed.givenAt)).filter(m => m >= 0).sort((a,b) => a-b);
+  let usualBand = null;
+  if (mins.length >= 3) {
+    const lo = mins[Math.floor(mins.length * 0.1)];
+    const hi = mins[Math.floor(mins.length * 0.9)];
+    usualBand = _minutesToHhmm(lo) + '–' + _minutesToHhmm(hi);
+  } else if (mins.length > 0) {
+    usualBand = _minutesToHhmm(mins[0]) + (mins.length > 1 ? '–' + _minutesToHhmm(mins[mins.length-1]) : '');
+  }
+  // With-fat rate
+  const withFatKnown = doneDays.filter(d => d.parsed.withFat === true || d.parsed.withFat === false);
+  const withFatCount = doneDays.filter(d => d.parsed.withFat === true).length;
+  const fatRate = withFatKnown.length > 0 ? Math.round((withFatCount / withFatKnown.length) * 100) : null;
+  // Top fat food
+  const fatFoodCounts = {};
+  doneDays.forEach(d => { if (d.parsed.fatFood) fatFoodCounts[d.parsed.fatFood] = (fatFoodCounts[d.parsed.fatFood] || 0) + 1; });
+  let topFatFood = null, topN = 0;
+  Object.keys(fatFoodCounts).forEach(k => { if (fatFoodCounts[k] > topN) { topFatFood = k; topN = fatFoodCounts[k]; } });
+  // Streak: consecutive done-days ending today
+  let streak = 0;
+  for (let i = days.length - 1; i >= 0; i--) {
+    if (days[i].parsed && (days[i].parsed.status === 'done' || days[i].parsed.status === 'late')) streak++;
+    else break;
+  }
+  // Build summary lines
+  const sigClass = adherence >= 90 ? 'tc-sage' : adherence >= 70 ? 'tc-warn' : 'tc-rose';
+  let summary = '<div class="med-d3-summary">';
+  summary += `<div class="med-d3-summary-row"><strong class="${sigClass}">Adherence: ${doneDays.length}/${days.length} days (${adherence}%)</strong></div>`;
+  if (usualBand) summary += `<div class="med-d3-summary-row">${zi('clock')} Usual time: ${escHtml(usualBand)}</div>`;
+  if (fatRate !== null) {
+    const fatCls = fatRate >= 70 ? 'tc-sage' : 'tc-warn';
+    summary += `<div class="med-d3-summary-row">${zi('bowl')} <span class="${fatCls}">With-fat rate: ${withFatCount} of ${withFatKnown.length} doses (${fatRate}%)</span></div>`;
+  }
+  if (topFatFood) summary += `<div class="med-d3-summary-row">${zi('check')} Usually paired with: <strong>${escHtml(topFatFood)}</strong></div>`;
+  if (streak > 0) summary += `<div class="med-d3-summary-row">${zi('trending-flat')} Current streak: <strong>${streak} day${streak === 1 ? '' : 's'}</strong></div>`;
+  if (unloggedDays.length > 0) summary += `<div class="med-d3-summary-row tc-warn">${zi('warn')} ${unloggedDays.length} day${unloggedDays.length === 1 ? '' : 's'} not logged in this window</div>`;
+  summary += '</div>';
+  // 14-day compact list (most-recent first)
+  let list = '<div class="med-d3-log">';
+  days.slice().reverse().forEach(d => {
+    const label = d.date === todayStr ? 'Today' : formatDate(d.date);
+    let row;
+    if (!d.parsed) {
+      row = `<span class="tc-warn">Not logged</span>`;
+    } else if (d.parsed.status === 'skipped') {
+      row = `<span class="tc-warn">Skipped</span>`;
+    } else {
+      const t = d.parsed.givenAt ? 'Done at ' + escHtml(d.parsed.givenAt) : 'Done';
+      const fat = d.parsed.withFat === true && d.parsed.fatFood
+        ? ` <span class="tc-sage">· with ${escHtml(d.parsed.fatFood)}</span>`
+        : (d.parsed.withFat === false ? ` <span class="t-sub">· no fat-meal nearby</span>` : '');
+      row = t + fat;
+    }
+    list += `<div class="med-d3-log-row"><span class="med-d3-log-date">${escHtml(label)}</span><span>${row}</span></div>`;
+  });
+  list += '</div>';
+  body.innerHTML = summary + list;
+}
+
+// Helper: HH:MM minutes → "HH:MM" 24h string.
+function _minutesToHhmm(m) {
+  if (typeof m !== 'number' || m < 0) return '';
+  const h = Math.floor(m / 60);
+  const mm = m % 60;
+  return String(h).padStart(2, '0') + ':' + String(mm).padStart(2, '0');
 }
 
 function openMedModal() {
@@ -47278,18 +47650,27 @@ function _islMedicalData(startDate, endDate) {
   var suppTotal = 0;
   var d3Times = [];
 
+  // Vit D3 tracking v1: schema-aware via parseMedCheck (handles legacy string + new object shape).
+  // d3Times now also carries the with-fat context for downstream analysis surfaces.
+  var d3WithFat = 0;
+  var d3WithoutFat = 0;
+  var d3FatFoods = [];
   dates.forEach(function(ds) {
     var dayChecks = medChecks[ds];
     if (dayChecks) {
       var anyDone = false;
       Object.keys(dayChecks).forEach(function(name) {
-        var val = dayChecks[name];
-        if (typeof val === 'string' && val.startsWith('done')) {
+        var parsed = parseMedCheck(dayChecks[name]);
+        if (parsed && (parsed.status === 'done' || parsed.status === 'late')) {
           anyDone = true;
-          // Extract D3 time
           if (/d3|vitamin d/i.test(name)) {
-            var timePart = val.replace('done:', '').replace('done', '');
-            if (timePart) d3Times.push(timePart);
+            if (parsed.givenAt) d3Times.push(parsed.givenAt);
+            if (parsed.withFat === true) {
+              d3WithFat++;
+              if (parsed.fatFood) d3FatFoods.push(parsed.fatFood);
+            } else if (parsed.withFat === false) {
+              d3WithoutFat++;
+            }
           }
         }
       });
@@ -47320,11 +47701,26 @@ function _islMedicalData(startDate, endDate) {
 
   var medScore = calcMedicalScore();
 
+  var d3FatTotal = d3WithFat + d3WithoutFat;
+  var d3FatRate = d3FatTotal > 0 ? Math.round((d3WithFat / d3FatTotal) * 100) : null;
+  // Most-common fat food across the window (Mode of d3FatFoods)
+  var d3FatTopFood = null;
+  if (d3FatFoods.length > 0) {
+    var counts = {};
+    d3FatFoods.forEach(function(f) { counts[f] = (counts[f] || 0) + 1; });
+    var top = null, topN = 0;
+    Object.keys(counts).forEach(function(k) { if (counts[k] > topN) { top = k; topN = counts[k]; } });
+    d3FatTopFood = top;
+  }
   return {
     suppAdherence: suppTotal > 0 ? Math.round((suppDays / suppTotal) * 100) : null,
     suppDays: suppDays,
     suppTotal: suppTotal,
     d3Times: d3Times,
+    d3WithFat: d3WithFat,
+    d3WithoutFat: d3WithoutFat,
+    d3FatRate: d3FatRate,
+    d3FatTopFood: d3FatTopFood,
     vaccCompleted: completed.length,
     vaccUpcoming: upcoming.length > 0 ? upcoming[0] : null,
     growthInRange: rangeGrowth,
@@ -50314,7 +50710,13 @@ function _qaRoutine() {
   if (pp.totalCount > 0) items.push({ text: 'Poop: avg ' + pp.avgPerDay + '/day, mostly ' + (pp.mostCommonConsistency || 'normal'), signal: 'neutral', icon: zi('diaper') });
 
   var md = getDomainData('medical', _offsetDateStr(today(), -6), today());
-  if (md.suppAdherence !== null) items.push({ text: 'Vit D3: ' + md.suppAdherence + '% adherence', signal: md.suppAdherence >= ISL_THRESHOLDS.D3_ADHERENCE_GOOD_PCT ? 'good' : 'warn', icon: zi('pill') });
+  if (md.suppAdherence !== null) {
+    var d3Text = 'Vit D3: ' + md.suppAdherence + '% adherence';
+    if (md.d3FatRate !== null && (md.d3WithFat + md.d3WithoutFat) >= 3) {
+      d3Text += ' · ' + md.d3FatRate + '% with fat';
+    }
+    items.push({ text: d3Text, signal: md.suppAdherence >= ISL_THRESHOLDS.D3_ADHERENCE_GOOD_PCT ? 'good' : 'warn', icon: zi('pill') });
+  }
 
   var age = ageAt();
   return {
@@ -50541,9 +50943,14 @@ function _qaDoctorPrep() {
     items.push({ text: 'Next vaccine: ' + gd.vaccUpcoming.name + (vDays > 0 ? ' in ' + vDays + ' days' : ' \u2014 due now'), signal: vDays <= 3 ? 'action' : 'info' });
   }
 
-  // D3 adherence
+  // D3 adherence + with-fat enrichment (only if we have enough samples to be meaningful)
   if (gd.suppAdherence !== null) {
     items.push({ text: 'D3 adherence (30d): ' + gd.suppAdherence + '%', signal: gd.suppAdherence >= ISL_THRESHOLDS.D3_ADHERENCE_GOOD_PCT ? 'good' : 'warn' });
+    if (gd.d3FatRate !== null && (gd.d3WithFat + gd.d3WithoutFat) >= 5) {
+      var fatText = 'D3 with-fat absorption (30d): ' + gd.d3FatRate + '% of doses';
+      if (gd.d3FatTopFood) fatText += ' · most often ' + gd.d3FatTopFood;
+      items.push({ text: fatText, signal: gd.d3FatRate >= 70 ? 'good' : 'info' });
+    }
   }
 
   // Recent concerns from last 7 days

--- a/index.html
+++ b/index.html
@@ -1,10 +1,3 @@
-audit-emoji.sh [default (5 surfaced ranges)]: 0 HR-1 violations across split, index.html, sproutlab.html
-audit-icon-text: PASS (0 unannotated `(label|text|reason|detail): (zi|iconText)(` field-assignments)
-audit-resolve-shield: PASS (4 resolve-caller(s) carry the explicit `'Resolve'` btnText shield per V-M-41 doctrine)
-audit-viz-smoke: PASS (4 ids + 5 tokens) across template.html + styles.css
-[bump-version] 2026.05.23-8 → 2026.05.23-9
-[poop-reference] wrote /home/user/sproutlab/docs/POOP_COLOR_REFERENCE.html
-[careticket-sm] wrote /home/user/sproutlab/docs/CARETICKET_STATE_MACHINE.html — 6 transitions, 0 drift flags
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -2327,6 +2320,18 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
 .supp-adjust-btn {
   font-size:var(--fs-sm); padding:var(--sp-4) var(--sp-10);
   min-height:auto;
+}
+/* CR-5: skipped-state reminder card variant — distinct from done/missed */
+.supp-alert-skipped {
+  background:var(--amber-light);
+  border-left-color:var(--amber);
+}
+.supp-alert-skipped .supp-alert-title { color:var(--tc-warn); }
+.supp-alert-skipped .supp-alert-detail { color:var(--tc-warn); }
+/* CR-7: openMedAdjust hint when no historical time was captured */
+.supp-adjust-hint {
+  display:inline-block; margin-right:var(--sp-6);
+  font-style:italic;
 }
 .med-d3-summary {
   padding:var(--sp-8) 0; line-height:var(--lh-relaxed);
@@ -17179,11 +17184,26 @@ function parseMedCheck(val) {
   if (val === 'done:late' || val === 'done') return { status:'late', givenAt:null, loggedAt:null, withFat:null, fatFood:null, fatDelta:null };
   if (val.indexOf('done:') === 0) {
     var t = val.slice(5);
-    var isTime = /^\d{1,2}:\d{2}$/.test(t);
+    // CR-2: accept BOTH 'HH:MM' (24h) AND 'HH:MM am|pm' / 'HH:MM AM|PM' (legacy en-IN 12h).
+    // The pre-v1 markMedDone used en-IN locale which produced 12h+suffix strings;
+    // those must round-trip through parseMedCheck without losing givenAt.
+    var isHHMM24 = /^\d{1,2}:\d{2}$/.test(t);
+    var ampmMatch = t.match(/^(\d{1,2}):(\d{2})\s*(am|pm)$/i);
+    var givenAt = null;
+    if (isHHMM24) {
+      givenAt = t;
+    } else if (ampmMatch) {
+      var h = parseInt(ampmMatch[1], 10);
+      var mm = ampmMatch[2];
+      var ampm = ampmMatch[3].toLowerCase();
+      if (ampm === 'pm' && h !== 12) h += 12;
+      if (ampm === 'am' && h === 12) h = 0;
+      givenAt = (h < 10 ? '0' + h : String(h)) + ':' + mm;
+    }
     return {
-      status: isTime ? 'done' : (t === 'late' ? 'late' : 'done'),
-      givenAt: isTime ? t : null,
-      loggedAt: null, // legacy didn't separate; givenAt was actually tap-time but treat as best-known
+      status: givenAt !== null ? 'done' : (t === 'late' ? 'late' : 'done'),
+      givenAt: givenAt,
+      loggedAt: null,
       withFat: null,
       fatFood: null,
       fatDelta: null,
@@ -17233,6 +17253,59 @@ function _hhmmToMinutes(s) {
   return m ? (parseInt(m[1], 10) * 60 + parseInt(m[2], 10)) : -1;
 }
 
+// CR-14: re-run with-fat detection on today's dose entries that currently report withFat:false.
+// markMedDone freezes withFat at log-time against the feedingData snapshot; if the parent logs
+// the dose BEFORE typing the breakfast row that accompanied it, withFat stays permanently false
+// unless they tap Adjust. This helper is called from the feedingData save paths to catch the
+// "logged dose first, logged meal second" sequence within the ±60min window.
+// Only flips withFat:false → true (never the reverse — never erases a real positive observation).
+// Returns true if any record was updated.
+function _refreshTodayMedWithFat() {
+  if (typeof medChecks !== 'object' || !medChecks) return false;
+  var t = today();
+  var dayMC = medChecks[t];
+  if (!dayMC) return false;
+  var mutated = false;
+  Object.keys(dayMC).forEach(function(name) {
+    var parsed = parseMedCheck(dayMC[name]);
+    if (!parsed) return;
+    if (parsed.status !== 'done' && parsed.status !== 'late') return;
+    if (!parsed.givenAt) return;
+    if (parsed.withFat !== false) return; // only redetect when previously negative
+    var fresh = _detectFatContextNearTime(parsed.givenAt, t);
+    if (fresh.withFat === true) {
+      // Preserve the rest of the object; only update the fat fields.
+      var cur = (typeof dayMC[name] === 'object' && !Array.isArray(dayMC[name])) ? dayMC[name] : parsed;
+      dayMC[name] = Object.assign({}, cur, {
+        withFat:  true,
+        fatFood:  fresh.fatFood,
+        fatDelta: fresh.fatDelta,
+      });
+      mutated = true;
+    }
+  });
+  if (mutated) {
+    save(KEYS.medChecks, medChecks);
+    if (typeof _tsfMarkDirty === 'function') _tsfMarkDirty();
+    if (typeof _islMarkDirty === 'function') _islMarkDirty('medical');
+  }
+  return mutated;
+}
+
+// CR-9: display formatter — 24h canonical 'HH:MM' → '8:42 AM' / '2:30 PM' for parent-facing surfaces.
+// The schema stores 24h (en-GB canonical) per V-M-60; this formatter renders the Indian-parent 12h convention.
+function _formatTime12h(hhmm) {
+  if (!hhmm || !/^\d{1,2}:\d{2}$/.test(hhmm)) return hhmm || '';
+  var parts = hhmm.split(':');
+  var h = parseInt(parts[0], 10);
+  var m = parts[1];
+  if (isNaN(h) || h < 0 || h > 23) return hhmm;
+  if (h === 0) return '12:' + m + ' AM';
+  if (h === 12) return '12:' + m + ' PM';
+  if (h > 12) return (h - 12) + ':' + m + ' PM';
+  return h + ':' + m + ' AM';
+}
+
 // Detect whether a fat-bearing food was logged in feedingData near `timeStr` on `dateStr`.
 // Window: ±60min default. Returns { withFat, fatFood, fatDelta } (delta signed: negative = food first).
 // V-K-69: token-equality matching (with _baseFoodName alias normalization) instead of substring
@@ -17248,18 +17321,28 @@ function _detectFatContextNearTime(timeStr, dateStr, windowMinutes) {
   var fatSet = _getFatBearingFoodNames();
   var fatLookup = {};
   for (var fi = 0; fi < fatSet.length; fi++) fatLookup[fatSet[fi]] = true;
+  // CR-12: iterate meals in chronological proximity order (closest-to-dose-time first)
+  // instead of the hard-coded ['breakfast','lunch','dinner','snack'] order — eliminates
+  // the meal-name-iteration bias when two meals tie in absolute delta.
   var meals = ['breakfast', 'lunch', 'dinner', 'snack'];
-  var best = null;
+  var mealEntries = [];
   meals.forEach(function(m) {
     var mTime = day[m + '_time'];
     var mFoods = day[m];
     if (!mTime || !mFoods || mFoods === '—skipped—') return;
     var mMin = _hhmmToMinutes(mTime);
     if (mMin < 0) return;
-    var delta = mMin - targetMin; // signed: negative = meal before dose
+    var delta = mMin - targetMin;
     if (Math.abs(delta) > win) return;
+    mealEntries.push({ meal: m, foods: mFoods, min: mMin, delta: delta, abs: Math.abs(delta) });
+  });
+  mealEntries.sort(function(a, b) { return a.abs - b.abs; });
+
+  var best = null;
+  mealEntries.forEach(function(entry) {
+    if (best !== null) return; // already found the closest match
     // Tokenize the meal text on comma / " and " / "+" / "&". Trim each token. Empty tokens dropped.
-    var tokens = String(mFoods).toLowerCase().split(/\s*,\s*|\s+and\s+|\s*\+\s*|\s*&\s*/).map(function(s) { return s.trim(); }).filter(Boolean);
+    var tokens = String(entry.foods).toLowerCase().split(/\s*,\s*|\s+and\s+|\s*\+\s*|\s*&\s*/).map(function(s) { return s.trim(); }).filter(Boolean);
     var matched = null;
     for (var ti = 0; ti < tokens.length; ti++) {
       var tok = tokens[ti];
@@ -17273,9 +17356,18 @@ function _detectFatContextNearTime(timeStr, dateStr, windowMinutes) {
       // Otherwise try alias-normalized base name (catches 'yogurt' → 'curd', 'fresh ghee' → 'ghee').
       var base = (typeof _baseFoodName === 'function') ? _baseFoodName(tok) : tok;
       if (base !== tok && fatLookup[base]) { matched = base; break; }
+      // CR-13: plural/singular drift — NUTRITION is keyed inconsistently ('almonds' plural,
+      // 'walnut' singular). Try both depluralization and pluralization against fatLookup directly.
+      if (tok.length > 3 && tok.charAt(tok.length - 1) === 's') {
+        var singular = tok.slice(0, -1);
+        if (fatLookup[singular]) { matched = singular; break; }
+      } else if (tok.length > 2) {
+        var plural = tok + 's';
+        if (fatLookup[plural]) { matched = plural; break; }
+      }
     }
-    if (matched && (best === null || Math.abs(delta) < Math.abs(best.delta))) {
-      best = { food: matched, delta: delta };
+    if (matched) {
+      best = { food: matched, delta: entry.delta };
     }
   });
   if (best) {
@@ -23461,7 +23553,14 @@ function renderRemindersAndAlerts() {
     } else if (isDone) {
       const givenAt = parsed && parsed.givenAt ? parsed.givenAt : null;
       const fatFood = parsed && parsed.fatFood ? parsed.fatFood : null;
-      const timeText = givenAt ? 'Done at ' + escHtml(givenAt) : 'Done today';
+      const isLate = parsed && parsed.status === 'late';
+      // CR-9: render 12h for parent-facing surfaces. Storage stays 24h en-GB canonical.
+      // CR-15: surface 'logged late' marker on the title here too — was inconsistent
+      // vs the TSF event-detail expansion which always showed it.
+      let timeText;
+      if (givenAt) timeText = 'Done at ' + escHtml(_formatTime12h(givenAt)) + (isLate ? ' (logged late)' : '');
+      else if (isLate) timeText = 'Done — logged late';
+      else timeText = 'Done today';
       // V-M-61: null withFat (legacy / unknown) renders no badge. V-M-63: softer framing.
       let fatBadge = '';
       if (parsed && parsed.withFat === true && fatFood) {
@@ -23479,6 +23578,22 @@ function renderRemindersAndAlerts() {
           </div>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${fatBadge}</div>
+      </div>`;
+    } else if (isSkipped) {
+      // CR-5: NEW skipped-state render. Pre-fix, the skipped branch produced no card at all
+      // and the 'All medications done for today' banner was removed — the parent got zero
+      // visual acknowledgement of their explicit skip, while _obCheckVitD3 kept flagging
+      // 'Vit D3 pending' on the home overlay, contradicting the just-recorded action.
+      html += `
+      <div class="supp-alert supp-alert-skipped" id="supp-alert-${idx}">
+        <div class="supp-alert-top">
+          <div class="supp-alert-icon">${zi('skip-forward')}</div>
+          <div class="supp-alert-title">Skipped today — ${escHtml(m.name)}</div>
+          <div class="supp-alert-action">
+            <button class="supp-skip-btn supp-adjust-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Undo skip</button>
+          </div>
+        </div>
+        <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}Skip recorded — tap Undo to revert and log a dose.</div>
       </div>`;
     }
   });
@@ -23681,8 +23796,15 @@ function openMedDoneAt(name, idx) {
     '<button class="supp-skip-btn" data-action="cancelMedDoneAt" data-arg2="' + idx + '">Cancel</button>';
 }
 function confirmMedDoneAt(name, idx) {
+  // CR-4: validate before falling through to markMedDone — empty / malformed input must
+  // surface an error, not silently substitute tap-time and overwrite the parent's intent.
   const input = document.getElementById('supp-time-' + idx);
   const picked = input && input.value ? input.value : null;
+  if (!picked || !/^\d{1,2}:\d{2}$/.test(picked)) {
+    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Pick a time, or tap Cancel');
+    if (input) { try { input.focus(); } catch(e) {} }
+    return;
+  }
   markMedDone(name, idx, picked);
 }
 function cancelMedDoneAt(idx) {
@@ -23722,26 +23844,50 @@ function openMedAdjust(name, idx) {
   const actionRow = card.querySelector('.supp-alert-action');
   if (!actionRow || actionRow.dataset.editing === '1') return;
   actionRow.dataset.editing = '1';
+  // CR-7: prefill with the captured givenAt if present; if absent (legacy record with no
+  // time captured), leave the input EMPTY rather than substituting the current clock time.
+  // confirmMedAdjust's CR-8 validation will block a save with no time, so the parent must
+  // actively type a value to overwrite the historical record — no accidental clobbers.
   const cur = parseMedCheck(medChecks[today()] && medChecks[today()][name]);
-  const curAt = (cur && cur.givenAt) || new Date().toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
-  // Re-format HH:MM (handle "08:42 AM" legacy by stripping any AM/PM tail)
+  const curAt = cur && cur.givenAt ? cur.givenAt : '';
   const norm = String(curAt).replace(/\s*(AM|PM)\s*$/i, '');
+  const hint = norm ? '' : '<span class="supp-adjust-hint t-sub t-sm">No time captured — enter actual time:</span>';
   actionRow.innerHTML =
+    hint +
     '<input type="time" class="supp-time-input" id="supp-time-' + idx + '" value="' + escAttr(norm) + '">' +
     '<button class="supp-check-btn" data-action="confirmMedAdjust" data-arg="' + escAttr(name) + '" data-arg2="' + idx + '">Save</button>' +
     '<button class="supp-skip-btn" data-action="cancelMedDoneAt" data-arg2="' + idx + '">Cancel</button>';
 }
 function confirmMedAdjust(name, idx) {
+  // CR-8: validate before falling through to adjustMedTime — empty / malformed input
+  // must surface an error and NOT wedge the editor (adjustMedTime's old early-return
+  // left dataset.editing='1' set, blocking reopens).
   const input = document.getElementById('supp-time-' + idx);
   const picked = input && input.value ? input.value : null;
+  if (!picked || !/^\d{1,2}:\d{2}$/.test(picked)) {
+    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Pick a time, or tap Cancel');
+    if (input) { try { input.focus(); } catch(e) {} }
+    return;
+  }
   adjustMedTime(name, idx, picked);
 }
 
 function markMedSkipped(name, idx) {
+  // CR-10: emit new object schema. Skipped doses now carry loggedAt for audit trail.
   const todayStr = today();
+  const now = new Date();
+  const loggedAt = now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
   if (!medChecks[todayStr]) medChecks[todayStr] = {};
-  medChecks[todayStr][name] = 'skipped';
+  medChecks[todayStr][name] = {
+    status:   'skipped',
+    givenAt:  null,
+    loggedAt: loggedAt,
+    withFat:  null,
+    fatFood:  null,
+    fatDelta: null,
+  };
   save(KEYS.medChecks, medChecks);
+  _tsfMarkDirty();
   _islMarkDirty('medical');
 
   const el = document.getElementById('supp-alert-' + idx);
@@ -23754,13 +23900,34 @@ function markMedSkipped(name, idx) {
 }
 
 function resolveMissedMed(name, dateStr, action) {
+  // CR-10: emit new object schema for both retroactive done-mark and retroactive skip.
+  // Retroactive done has no givenAt (no specific administration time was captured) so
+  // with-fat detection is left null — the 14-day card's withFatKnown denominator
+  // correctly excludes records with no time-anchored fat context.
   if (!medChecks[dateStr]) medChecks[dateStr] = {};
+  const now = new Date();
+  const loggedAt = now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
   if (action === 'done') {
-    medChecks[dateStr][name] = 'done:late';
+    medChecks[dateStr][name] = {
+      status:   'late',
+      givenAt:  null,
+      loggedAt: loggedAt,
+      withFat:  null,
+      fatFood:  null,
+      fatDelta: null,
+    };
   } else {
-    medChecks[dateStr][name] = 'skipped';
+    medChecks[dateStr][name] = {
+      status:   'skipped',
+      givenAt:  null,
+      loggedAt: loggedAt,
+      withFat:  null,
+      fatFood:  null,
+      fatDelta: null,
+    };
   }
   save(KEYS.medChecks, medChecks);
+  _tsfMarkDirty();
   _islMarkDirty('medical');
   renderRemindersAndAlerts(); renderHomeContextAlerts();
 }
@@ -25406,7 +25573,8 @@ function renderMedLog() {
       html += `<div style=""font-weight:600;font-size:var(--fs-sm);color:var(--tc-sky);margin-bottom:4px;">${dayName}, ${dayNum} ${monthNames[parseInt(mon) - 1]}</div>`;
 
       dayItems.forEach(e => {
-        // V-K-66: schema-aware status read.
+        // V-K-66: schema-aware status read. CR-9: 12h display for parent-facing time.
+        // CR-15: when both givenAt AND late are present, surface "at HH:MM (late)" — not just "(logged late)".
         const parsed = parseMedCheck(e.status);
         const isDone = !!(parsed && (parsed.status === 'done' || parsed.status === 'late'));
         const isLate = !!(parsed && parsed.status === 'late');
@@ -25414,7 +25582,9 @@ function renderMedLog() {
         const icon = isDone ? zi('check') : zi('skip-forward');
         const label = isDone ? 'Given' : 'Skipped';
         const color = isDone ? '#3a7060' : '#926030';
-        const timePart = isLate ? ' (logged late)' : (timeStr ? ` at ${escHtml(timeStr)}` : '');
+        let timePart = '';
+        if (timeStr) timePart = ' at ' + escHtml(_formatTime12h(timeStr)) + (isLate ? ' (late)' : '');
+        else if (isLate) timePart = ' (logged late)';
 
         html += `
           <div style="display:flex;align-items:center;gap:var(--sp-8);padding:3px 0;font-size:var(--fs-base);">
@@ -28002,19 +28172,23 @@ function _obIsTeethingActive() {
 }
 
 function _obCheckVitD3() {
-  // Returns true if Vit D3 needs attention (not given today or no D3 med tracked).
-  // Schema-aware via medCheckIsDone (handles both legacy 'done:HH:MM' string and new object shape).
+  // Returns true if Vit D3 needs attention.
+  // CR-5: Skipped doses count as RESOLVED — parent explicitly chose to skip and
+  // _obCheckVitD3 must respect that decision, otherwise the home overlay keeps
+  // flagging 'D3 pending' in contradiction to the parent's just-recorded skip.
   var todayStr = today();
   var dayEntry = medChecks ? medChecks[todayStr] : null;
   if (!dayEntry) return true;
-  var d3Given = false;
+  var d3Resolved = false;
   var activeMeds = (meds || []).filter(function(m) { return m.active; });
   activeMeds.forEach(function(m) {
     if (m.name && m.name.toLowerCase().indexOf('d3') >= 0) {
-      if (medCheckIsDone(dayEntry[m.name])) d3Given = true;
+      if (medCheckIsDone(dayEntry[m.name]) || medCheckSkipped(dayEntry[m.name])) {
+        d3Resolved = true;
+      }
     }
   });
-  return !d3Given;
+  return !d3Resolved;
 }
 
 function _obGetNextVaccine() {
@@ -31088,17 +31262,20 @@ function renderTodayPlan() {
   }
 
   // D3 supplement — V-K-66: schema-aware via parseMedCheck (legacy string + new object both handled).
+  // CR-9: 12h display via _formatTime12h. CR-15: surface 'logged late' marker.
   const d3Med = meds.find(m => m.active && m.name.toLowerCase().includes('d3'));
   if (d3Med) {
     const d3Parsed = parseMedCheck(medChecks[todayStr] && medChecks[todayStr][d3Med.name]);
     const d3Done = !!(d3Parsed && (d3Parsed.status === 'done' || d3Parsed.status === 'late'));
+    const d3Late = !!(d3Parsed && d3Parsed.status === 'late');
     const d3Given = d3Parsed && d3Parsed.givenAt ? d3Parsed.givenAt : null;
     const d3Fat = d3Parsed && d3Parsed.withFat === true && d3Parsed.fatFood ? d3Parsed.fatFood : null;
     let doneDetail;
     if (d3Done) {
-      const timePart = d3Given ? ' at ' + escHtml(d3Given) : '';
+      const timePart = d3Given ? ' at ' + escHtml(_formatTime12h(d3Given)) : '';
+      const latePart = d3Late ? ' (logged late)' : '';
       const fatPart = d3Fat ? ' · with ' + escHtml(d3Fat) : '';
-      doneDetail = '<svg class="zi"><use href="#zi-check"/></svg> Done' + timePart + fatPart;
+      doneDetail = '<svg class="zi"><use href="#zi-check"/></svg> Done' + timePart + latePart + fatPart;
     } else {
       doneDetail = d3Med.dose + ' — give with or after a feed for best absorption';
     }
@@ -31535,22 +31712,34 @@ function renderTrendChips() {
 
   // Vitamin D3 — schema-aware (legacy 'done:HH:MM' string + new object shape both handled).
   // V-M-62 + V-K-70: fatFood comes from parent feedingData input — escape at this render boundary.
+  // CR-9: 12h display formatter for parent-facing time.
+  // CR-15: surface 'logged late' marker so chip and event-detail agree on status.
+  // CR-5: also render explicit "Skipped today" rather than "Pending" when status:'skipped'.
   if (d3Med) {
     const todayStr = today();
     const d3Val = medChecks[todayStr] && medChecks[todayStr][d3Med.name];
     const d3Parsed = parseMedCheck(d3Val);
     const d3Done = !!(d3Parsed && (d3Parsed.status === 'done' || d3Parsed.status === 'late'));
-    let valueText, deltaText;
+    const d3Skipped = !!(d3Parsed && d3Parsed.status === 'skipped');
+    const d3Late = !!(d3Parsed && d3Parsed.status === 'late');
+    let valueText, deltaText, cls;
     if (d3Done) {
       const t = d3Parsed.givenAt;
       const fat = d3Parsed.withFat === true && d3Parsed.fatFood ? ' · with ' + escHtml(d3Parsed.fatFood) : '';
-      valueText = t ? ('Done at ' + escHtml(t) + fat) : 'Done today';
+      const lateTag = d3Late ? ' (late)' : '';
+      valueText = t ? ('Done at ' + escHtml(_formatTime12h(t)) + lateTag + fat) : (d3Late ? 'Done — logged late' : 'Done today');
       deltaText = zi('check');
+      cls = 'tc-good';
+    } else if (d3Skipped) {
+      valueText = 'Skipped today';
+      deltaText = 'skipped';
+      cls = 'tc-warn';
     } else {
       valueText = 'Pending';
       deltaText = 'pending';
+      cls = 'tc-warn';
     }
-    chips.push({ icon:zi('sun'), label:'Vitamin D3', value: valueText, delta: deltaText, cls: d3Done ? 'tc-good' : 'tc-warn', tab:'medical' });
+    chips.push({ icon:zi('sun'), label:'Vitamin D3', value: valueText, delta: deltaText, cls: cls, tab:'medical' });
   }
 
   let html = '';
@@ -40941,20 +41130,34 @@ function renderMedD3PatternCard() {
     const parsed = parseMedCheck(medChecks[ds] && medChecks[ds][d3Med.name]);
     days.push({ date: ds, parsed: parsed });
   }
-  // Aggregate stats
-  const doneDays = days.filter(d => d.parsed && (d.parsed.status === 'done' || d.parsed.status === 'late'));
-  const skippedDays = days.filter(d => d.parsed && d.parsed.status === 'skipped');
-  const unloggedDays = days.filter(d => !d.parsed);
-  const adherence = days.length > 0 ? Math.round((doneDays.length / days.length) * 100) : 0;
-  // Usual-time band: take givenAt minutes, find central 80% range
+  // CR-6: adherence denominator must respect d3Med.start AND medChecks._trackingSince —
+  // pre-fix divided by the full 14-day window unconditionally, giving wildly different
+  // numbers vs computeSupplementAdherence on the same screen for a recently-activated med.
+  const medStart = d3Med.start || '2025-09-04';
+  const trackStart = medChecks._trackingSince || '0000-00-00';
+  const effectiveStart = medStart > trackStart ? medStart : trackStart;
+  const eligibleDays = days.filter(d => d.date >= effectiveStart);
+  const doneDays = eligibleDays.filter(d => d.parsed && (d.parsed.status === 'done' || d.parsed.status === 'late'));
+  const skippedDays = eligibleDays.filter(d => d.parsed && d.parsed.status === 'skipped');
+  const unloggedDays = eligibleDays.filter(d => !d.parsed);
+  const adherence = eligibleDays.length > 0 ? Math.round((doneDays.length / eligibleDays.length) * 100) : 0;
+  // Usual-time band: take givenAt minutes, find central 80% range.
+  // CR-11: use (N-1)*p indexing instead of N*p (which collapsed to the max for many N
+  // and degraded 'central 80%' into 'min-to-max range') AND require N>=5 for the band
+  // to be statistically meaningful — below that, show honest min-max range with a tag.
   const mins = doneDays.map(d => _hhmmToMinutes(d.parsed.givenAt)).filter(m => m >= 0).sort((a,b) => a-b);
   let usualBand = null;
-  if (mins.length >= 3) {
-    const lo = mins[Math.floor(mins.length * 0.1)];
-    const hi = mins[Math.floor(mins.length * 0.9)];
+  let usualBandLabel = 'Usual time';
+  if (mins.length >= 5) {
+    const lo = mins[Math.floor((mins.length - 1) * 0.1)];
+    const hi = mins[Math.floor((mins.length - 1) * 0.9)];
     usualBand = _minutesToHhmm(lo) + '–' + _minutesToHhmm(hi);
-  } else if (mins.length > 0) {
-    usualBand = _minutesToHhmm(mins[0]) + (mins.length > 1 ? '–' + _minutesToHhmm(mins[mins.length-1]) : '');
+  } else if (mins.length >= 2) {
+    usualBand = _minutesToHhmm(mins[0]) + '–' + _minutesToHhmm(mins[mins.length-1]);
+    usualBandLabel = 'Time range so far';
+  } else if (mins.length === 1) {
+    usualBand = _minutesToHhmm(mins[0]);
+    usualBandLabel = 'Only one timed dose';
   }
   // With-fat rate
   const withFatKnown = doneDays.filter(d => d.parsed.withFat === true || d.parsed.withFat === false);
@@ -40968,21 +41171,27 @@ function renderMedD3PatternCard() {
   // Streak: consecutive done-days ending today.
   // V-M-64: if today is unlogged (parent hasn't tapped Done yet), don't punish the streak —
   // walk from yesterday and label "through yesterday" so a 30-day perfect run doesn't read as 0.
+  // CR-6: walk over eligibleDays (post-medStart) not raw days, so a recently-activated med
+  // doesn't see its streak punished by pre-activation no-data rows.
   let streak = 0;
   let streakLabel = 'Current streak';
-  const todayParsed = days[days.length - 1].parsed;
+  const todayParsed = eligibleDays.length > 0 ? eligibleDays[eligibleDays.length - 1].parsed : null;
   const todayResolved = !!(todayParsed && (todayParsed.status === 'done' || todayParsed.status === 'late' || todayParsed.status === 'skipped'));
-  const startIdx = todayResolved ? days.length - 1 : days.length - 2;
+  const startIdx = todayResolved ? eligibleDays.length - 1 : eligibleDays.length - 2;
   if (!todayResolved) streakLabel = 'Streak through yesterday';
   for (let i = startIdx; i >= 0; i--) {
-    if (days[i].parsed && (days[i].parsed.status === 'done' || days[i].parsed.status === 'late')) streak++;
+    if (eligibleDays[i] && eligibleDays[i].parsed && (eligibleDays[i].parsed.status === 'done' || eligibleDays[i].parsed.status === 'late')) streak++;
     else break;
   }
   // Build summary lines
   const sigClass = adherence >= 90 ? 'tc-sage' : adherence >= 70 ? 'tc-warn' : 'tc-rose';
   let summary = '<div class="med-d3-summary">';
-  summary += `<div class="med-d3-summary-row"><strong class="${sigClass}">Adherence: ${doneDays.length}/${days.length} days (${adherence}%)</strong></div>`;
-  if (usualBand) summary += `<div class="med-d3-summary-row">${zi('clock')} Usual time: ${escHtml(usualBand)}</div>`;
+  summary += `<div class="med-d3-summary-row"><strong class="${sigClass}">Adherence: ${doneDays.length}/${eligibleDays.length} days (${adherence}%)</strong></div>`;
+  // CR-9: render times in 12h for parent-facing display.
+  if (usualBand) {
+    const bandDisplay = usualBand.split('–').map(t => _formatTime12h(t)).join('–');
+    summary += `<div class="med-d3-summary-row">${zi('clock')} ${escHtml(usualBandLabel)}: ${escHtml(bandDisplay)}</div>`;
+  }
   if (fatRate !== null) {
     const fatCls = fatRate >= 70 ? 'tc-sage' : 'tc-warn';
     summary += `<div class="med-d3-summary-row">${zi('bowl')} <span class="${fatCls}">With-fat rate: ${withFatCount} of ${withFatKnown.length} doses (${fatRate}%)</span></div>`;
@@ -40991,19 +41200,25 @@ function renderMedD3PatternCard() {
   if (streak > 0) summary += `<div class="med-d3-summary-row">${zi('trending-flat')} ${streakLabel}: <strong>${streak} day${streak === 1 ? '' : 's'}</strong></div>`;
   if (unloggedDays.length > 0) summary += `<div class="med-d3-summary-row tc-warn">${zi('warn')} ${unloggedDays.length} day${unloggedDays.length === 1 ? '' : 's'} not logged in this window</div>`;
   summary += '</div>';
-  // 14-day compact list (most-recent first)
+  // 14-day compact list (most-recent first) — iterates raw days (so pre-medStart rows
+  // show 'Not tracked yet' rather than vanishing entirely; the adherence math above
+  // uses eligibleDays so the user-visible numbers are correct).
   let list = '<div class="med-d3-log">';
   days.slice().reverse().forEach(d => {
     const label = d.date === todayStr ? 'Today' : formatDate(d.date);
     let row;
-    if (!d.parsed) {
+    if (d.date < effectiveStart) {
+      row = `<span class="t-sub">Not tracked yet</span>`;
+    } else if (!d.parsed) {
       row = `<span class="tc-warn">Not logged</span>`;
     } else if (d.parsed.status === 'skipped') {
       row = `<span class="tc-warn">Skipped</span>`;
     } else {
-      const t = d.parsed.givenAt ? 'Done at ' + escHtml(d.parsed.givenAt) : 'Done';
-      // V-M-61 + V-M-63: only render the "no fat-meal" line on explicit false
-      // (not null/unknown), with softened framing.
+      // CR-9 + CR-15: 12h display, surface 'logged late' marker consistently.
+      const isLate = d.parsed.status === 'late';
+      const t = d.parsed.givenAt
+        ? 'Done at ' + escHtml(_formatTime12h(d.parsed.givenAt)) + (isLate ? ' (late)' : '')
+        : (isLate ? 'Done (logged late)' : 'Done');
       const fat = d.parsed.withFat === true && d.parsed.fatFood
         ? ` <span class="tc-sage">· with ${escHtml(d.parsed.fatFood)}</span>`
         : (d.parsed.withFat === false ? ` <span class="t-sub">· no fat-meal logged nearby</span>` : '');
@@ -46275,14 +46490,23 @@ function computeSupplementAdherence(windowDays) {
 }
 
 function _parseSupplementTime(str) {
-  // Parse 'HH:MM am/pm' or 'HH:MM AM/PM' to minutes since midnight
+  // CR-3: parse BOTH 24h 'HH:MM' (new schema writes via en-GB) AND 12h 'HH:MM am|pm' (legacy)
+  // to minutes since midnight. Pre-CR3 this only accepted the 12h suffixed form, so every
+  // post-v1 24h write returned null and the timing-analysis surface silently died.
   if (!str || str === 'late') return null;
   str = str.trim().toLowerCase();
-  var match = str.match(/^(\d{1,2}):(\d{2})\s*(am|pm)$/);
-  if (!match) return null;
-  var h = parseInt(match[1], 10);
-  var m = parseInt(match[2], 10);
-  var ampm = match[3];
+  var match24 = str.match(/^(\d{1,2}):(\d{2})$/);
+  if (match24) {
+    var h24 = parseInt(match24[1], 10);
+    var m24 = parseInt(match24[2], 10);
+    if (h24 < 0 || h24 > 23 || m24 < 0 || m24 > 59) return null;
+    return h24 * 60 + m24;
+  }
+  var match12 = str.match(/^(\d{1,2}):(\d{2})\s*(am|pm)$/);
+  if (!match12) return null;
+  var h = parseInt(match12[1], 10);
+  var m = parseInt(match12[2], 10);
+  var ampm = match12[3];
   if (ampm === 'pm' && h !== 12) h += 12;
   if (ampm === 'am' && h === 12) h = 0;
   return h * 60 + m;
@@ -53517,14 +53741,19 @@ function qaAnswerSupplement(intentId) {
         actionItems.push({ text: 'Set extra reminders for ' + s.flaggedDays.join(', '), signal: 'action' });
       }
 
-      // Today's status
+      // Today's status — CR-1: schema-aware via parseMedCheck (handles both legacy string + new object).
       var todayEntry = (medChecks || {})[today()];
       var todayStatus = todayEntry ? todayEntry[s.name] : undefined;
-      if (!todayStatus) {
+      var todayParsed = parseMedCheck(todayStatus);
+      if (!todayParsed) {
         actionItems.push({ text: 'Not given today yet — don\'t forget!', signal: 'action' });
-      } else if (todayStatus.indexOf('done') === 0) {
-        var timeGiven = todayStatus.replace('done:', '');
-        actionItems.push({ text: 'Given today at ' + timeGiven, signal: 'good' });
+      } else if (todayParsed.status === 'done' || todayParsed.status === 'late') {
+        var timeGiven = todayParsed.givenAt ? _formatTime12h(todayParsed.givenAt) : 'unrecorded time';
+        var lateTag = todayParsed.status === 'late' ? ' (logged late)' : '';
+        var fatTag = todayParsed.withFat === true && todayParsed.fatFood ? ' with ' + todayParsed.fatFood : '';
+        actionItems.push({ text: 'Given today at ' + timeGiven + fatTag + lateTag, signal: 'good' });
+      } else if (todayParsed.status === 'skipped') {
+        actionItems.push({ text: 'Skipped today', signal: 'info' });
       }
     });
   } catch(e) {
@@ -56173,6 +56402,8 @@ function saveFeedingDay() {
   save(KEYS.feeding, feedingData);
   _tsfMarkDirty();
   _islMarkDirty('diet');
+  // CR-14: re-evaluate with-fat for today's dose entries that were logged before this meal.
+  if (d === today() && typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();
   // Auto-introduce any new foods from all meal slots
   autoIntroduceFoodsFromDay(d);
   renderFeedingHistory();
@@ -58072,6 +58303,8 @@ function saveQLFeed() {
   _tsfMarkDirty();
 
   _islMarkDirty('diet');
+  // CR-14: re-evaluate with-fat for today's dose entries that were logged before this meal.
+  if (dateStr === today() && typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();
   // Auto-introduce new foods
   autoIntroduceFoodsFromDay(dateStr);
 
@@ -58808,13 +59041,18 @@ function _tsfRenderEventExpanded(ev) {
     if (ev.domains && ev.domains.length > 0) html += '<div>Domains: ' + escHtml(ev.domains.join(', ')) + '</div>';
   } else if (ev.type === 'med') {
     // V-K-67: schema-aware via parseMedCheck (handles both legacy string + new object).
+    // CR-9 + CR-15: 12h display via _formatTime12h, unified late surface ('Done at X (logged late)').
     const parsedStatus = parseMedCheck(ev.status);
     if (parsedStatus) {
       let statusText;
       if (parsedStatus.status === 'skipped') statusText = 'Skipped';
-      else if (parsedStatus.status === 'late') statusText = 'Done (logged late)';
-      else if (parsedStatus.status === 'done') statusText = parsedStatus.givenAt ? 'Done at ' + parsedStatus.givenAt : 'Done';
-      else statusText = '';
+      else if (parsedStatus.status === 'late') {
+        statusText = parsedStatus.givenAt
+          ? 'Done at ' + _formatTime12h(parsedStatus.givenAt) + ' (logged late)'
+          : 'Done (logged late)';
+      } else if (parsedStatus.status === 'done') {
+        statusText = parsedStatus.givenAt ? 'Done at ' + _formatTime12h(parsedStatus.givenAt) : 'Done';
+      } else statusText = '';
       if (statusText) html += '<div>Status: ' + escHtml(statusText) + '</div>';
       if (parsedStatus.withFat === true && parsedStatus.fatFood) {
         html += '<div>With fat: ' + escHtml(parsedStatus.fatFood) + '</div>';

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@ audit-emoji.sh [default (5 surfaced ranges)]: 0 HR-1 violations across split, in
 audit-icon-text: PASS (0 unannotated `(label|text|reason|detail): (zi|iconText)(` field-assignments)
 audit-resolve-shield: PASS (4 resolve-caller(s) carry the explicit `'Resolve'` btnText shield per V-M-41 doctrine)
 audit-viz-smoke: PASS (4 ids + 5 tokens) across template.html + styles.css
-[bump-version] 2026.05.24-1 → 2026.05.24-2
+[bump-version] 2026.05.24-3 → 2026.05.24-4
 [poop-reference] wrote /home/user/sproutlab/docs/POOP_COLOR_REFERENCE.html
 [careticket-sm] wrote /home/user/sproutlab/docs/CARETICKET_STATE_MACHINE.html — 6 transitions, 0 drift flags
 <!DOCTYPE html>

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.23-8",
+  "version": "2026.05.23-9",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.24-1",
+  "version": "2026.05.24-2",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.23-9",
+  "version": "2026.05.24-1",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.24-2",
+  "version": "2026.05.24-3",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.23-5",
+  "version": "2026.05.23-6",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.24-3",
+  "version": "2026.05.24-4",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.23-6",
+  "version": "2026.05.23-8",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -93,11 +93,15 @@ function parseMedCheck(val) {
     // CR-2: accept BOTH 'HH:MM' (24h) AND 'HH:MM am|pm' / 'HH:MM AM|PM' (legacy en-IN 12h).
     // The pre-v1 markMedDone used en-IN locale which produced 12h+suffix strings;
     // those must round-trip through parseMedCheck without losing givenAt.
-    var isHHMM24 = /^\d{1,2}:\d{2}$/.test(t);
+    // V-K-73: tighten range validation — pre-fix, '24:00' / '25:99' passed the structural
+    // regex and stored as givenAt, then _hhmmToMinutes returned out-of-range minutes (1440+).
+    var hhmm24 = t.match(/^(\d{1,2}):(\d{2})$/);
     var ampmMatch = t.match(/^(\d{1,2}):(\d{2})\s*(am|pm)$/i);
     var givenAt = null;
-    if (isHHMM24) {
-      givenAt = t;
+    if (hhmm24) {
+      var h24 = parseInt(hhmm24[1], 10);
+      var m24 = parseInt(hhmm24[2], 10);
+      if (h24 >= 0 && h24 <= 23 && m24 >= 0 && m24 <= 59) givenAt = t;
     } else if (ampmMatch) {
       var h = parseInt(ampmMatch[1], 10);
       var mm = ampmMatch[2];
@@ -201,7 +205,10 @@ function _refreshTodayMedWithFat() {
 // CR-9: display formatter — 24h canonical 'HH:MM' → '8:42 AM' / '2:30 PM' for parent-facing surfaces.
 // The schema stores 24h (en-GB canonical) per V-M-60; this formatter renders the Indian-parent 12h convention.
 function _formatTime12h(hhmm) {
-  if (!hhmm || !/^\d{1,2}:\d{2}$/.test(hhmm)) return hhmm || '';
+  // V-M-72: string-only guard at entry so a future render site without an outer
+  // `if (givenAt)` check can't leak literal 'null' / 'undefined' to the parent.
+  if (typeof hhmm !== 'string' || !hhmm) return '';
+  if (!/^\d{1,2}:\d{2}$/.test(hhmm)) return hhmm;
   var parts = hhmm.split(':');
   var h = parseInt(parts[0], 10);
   var m = parts[1];
@@ -566,6 +573,7 @@ function init() {
     else if (action === 'cancelMedDoneAt' && typeof cancelMedDoneAt === 'function') cancelMedDoneAt(Number(arg2));
     else if (action === 'openMedAdjust' && typeof openMedAdjust === 'function') openMedAdjust(arg, Number(arg2));
     else if (action === 'confirmMedAdjust' && typeof confirmMedAdjust === 'function') confirmMedAdjust(arg, Number(arg2));
+    else if (action === 'undoMedSkip' && typeof undoMedSkip === 'function') undoMedSkip(arg, Number(arg2));
     else if (action === 'deleteFeedingEntry' && typeof deleteFeedingEntry === 'function') deleteFeedingEntry(arg);
     else if (action === 'switchFoodCatSub' && typeof switchFoodCatSub === 'function') switchFoodCatSub(arg, arg2);
     else if (action === 'expandMilestoneByIdx' && typeof expandMilestoneByIdx === 'function') expandMilestoneByIdx(Number(arg));
@@ -907,6 +915,7 @@ function init() {
     else if (action === 'cancelMedDoneAt') cancelMedDoneAt(parseInt(arg2));
     else if (action === 'openMedAdjust') openMedAdjust(arg, parseInt(arg2));
     else if (action === 'confirmMedAdjust') confirmMedAdjust(arg, parseInt(arg2));
+    else if (action === 'undoMedSkip') undoMedSkip(arg, parseInt(arg2));
     else if (action === 'overrideMilestoneStatus') { const args = arg.split(',').map(s=>s.trim().replace(/^'|'$/g,'')); overrideMilestoneStatus(...args); }
     else if (action === 'upcomingToMilestone') { const args = arg.split(',').map(s=>s.trim().replace(/^'|'$/g,'')); upcomingToMilestone(...args); }
     else if (action === 'deleteFoodAndRender') { deleteFood(arg); renderFoodCatSubContent(arg2); }

--- a/split/core.js
+++ b/split/core.js
@@ -73,6 +73,8 @@ function save(key, val) {
 // Every reader migrates via parseMedCheck() so writers can emit the new shape unconditionally.
 function parseMedCheck(val) {
   if (!val) return null;
+  // V-K-72: arrays are typeof 'object' but not med-check shapes — reject explicitly.
+  if (Array.isArray(val)) return null;
   if (typeof val === 'object') {
     return {
       status:   val.status || null,
@@ -144,6 +146,8 @@ function _hhmmToMinutes(s) {
 
 // Detect whether a fat-bearing food was logged in feedingData near `timeStr` on `dateStr`.
 // Window: ±60min default. Returns { withFat, fatFood, fatDelta } (delta signed: negative = food first).
+// V-K-69: token-equality matching (with _baseFoodName alias normalization) instead of substring
+// `indexOf` — avoids the coconut-water-matches-coconut false-positive.
 function _detectFatContextNearTime(timeStr, dateStr, windowMinutes) {
   var win = (typeof windowMinutes === 'number') ? windowMinutes : 60;
   var result = { withFat:false, fatFood:null, fatDelta:null };
@@ -153,20 +157,33 @@ function _detectFatContextNearTime(timeStr, dateStr, windowMinutes) {
   var day = feedingData[dateStr];
   if (!day) return result;
   var fatSet = _getFatBearingFoodNames();
+  var fatLookup = {};
+  for (var fi = 0; fi < fatSet.length; fi++) fatLookup[fatSet[fi]] = true;
   var meals = ['breakfast', 'lunch', 'dinner', 'snack'];
   var best = null;
   meals.forEach(function(m) {
     var mTime = day[m + '_time'];
     var mFoods = day[m];
-    if (!mTime || !mFoods || mFoods === '—skipped—') return;
+    if (!mTime || !mFoods || mFoods === '—skipped—' || mFoods === '—skipped—') return;
     var mMin = _hhmmToMinutes(mTime);
     if (mMin < 0) return;
     var delta = mMin - targetMin; // signed: negative = meal before dose
     if (Math.abs(delta) > win) return;
-    var lower = String(mFoods).toLowerCase();
+    // Tokenize the meal text on comma / " and " / "+" / "&". Trim each token. Empty tokens dropped.
+    var tokens = String(mFoods).toLowerCase().split(/\s*,\s*|\s+and\s+|\s*\+\s*|\s*&\s*/).map(function(s) { return s.trim(); }).filter(Boolean);
     var matched = null;
-    for (var i = 0; i < fatSet.length; i++) {
-      if (lower.indexOf(fatSet[i]) >= 0) { matched = fatSet[i]; break; }
+    for (var ti = 0; ti < tokens.length; ti++) {
+      var tok = tokens[ti];
+      // Try exact token match first.
+      if (fatLookup[tok]) { matched = tok; break; }
+      // V-K-69: if the token is itself a known NUTRITION key but NOT in fatLookup, do NOT attempt
+      // alias normalisation — the parent logged a specific known food that is NOT fat-bearing
+      // (e.g. 'coconut water' is a distinct NUTRITION entry from 'coconut'; _baseFoodName would
+      // strip 'water' as a form-word and incorrectly return 'coconut').
+      if (typeof NUTRITION === 'object' && NUTRITION[tok]) continue;
+      // Otherwise try alias-normalized base name (catches 'yogurt' → 'curd', 'fresh ghee' → 'ghee').
+      var base = (typeof _baseFoodName === 'function') ? _baseFoodName(tok) : tok;
+      if (base !== tok && fatLookup[base]) { matched = base; break; }
     }
     if (matched && (best === null || Math.abs(delta) < Math.abs(best.delta))) {
       best = { food: matched, delta: delta };
@@ -457,6 +474,11 @@ function init() {
     else if (action === 'resolveMissedMedSkipped' && typeof resolveMissedMed === 'function') resolveMissedMed(arg, arg2, 'skipped');
     else if (action === 'markMedDone' && typeof markMedDone === 'function') markMedDone(arg, Number(arg2));
     else if (action === 'markMedSkipped' && typeof markMedSkipped === 'function') markMedSkipped(arg, Number(arg2));
+    else if (action === 'openMedDoneAt' && typeof openMedDoneAt === 'function') openMedDoneAt(arg, Number(arg2));
+    else if (action === 'confirmMedDoneAt' && typeof confirmMedDoneAt === 'function') confirmMedDoneAt(arg, Number(arg2));
+    else if (action === 'cancelMedDoneAt' && typeof cancelMedDoneAt === 'function') cancelMedDoneAt(Number(arg2));
+    else if (action === 'openMedAdjust' && typeof openMedAdjust === 'function') openMedAdjust(arg, Number(arg2));
+    else if (action === 'confirmMedAdjust' && typeof confirmMedAdjust === 'function') confirmMedAdjust(arg, Number(arg2));
     else if (action === 'deleteFeedingEntry' && typeof deleteFeedingEntry === 'function') deleteFeedingEntry(arg);
     else if (action === 'switchFoodCatSub' && typeof switchFoodCatSub === 'function') switchFoodCatSub(arg, arg2);
     else if (action === 'expandMilestoneByIdx' && typeof expandMilestoneByIdx === 'function') expandMilestoneByIdx(Number(arg));
@@ -793,6 +815,11 @@ function init() {
     else if (action === 'resolveMissedMed') resolveMissedMed(arg, arg2, arg3);
     else if (action === 'markMedDone') markMedDone(arg, parseInt(arg2));
     else if (action === 'markMedSkipped') markMedSkipped(arg, parseInt(arg2));
+    else if (action === 'openMedDoneAt') openMedDoneAt(arg, parseInt(arg2));
+    else if (action === 'confirmMedDoneAt') confirmMedDoneAt(arg, parseInt(arg2));
+    else if (action === 'cancelMedDoneAt') cancelMedDoneAt(parseInt(arg2));
+    else if (action === 'openMedAdjust') openMedAdjust(arg, parseInt(arg2));
+    else if (action === 'confirmMedAdjust') confirmMedAdjust(arg, parseInt(arg2));
     else if (action === 'overrideMilestoneStatus') { const args = arg.split(',').map(s=>s.trim().replace(/^'|'$/g,'')); overrideMilestoneStatus(...args); }
     else if (action === 'upcomingToMilestone') { const args = arg.split(',').map(s=>s.trim().replace(/^'|'$/g,'')); upcomingToMilestone(...args); }
     else if (action === 'deleteFoodAndRender') { deleteFood(arg); renderFoodCatSubContent(arg2); }
@@ -1821,7 +1848,8 @@ function calcMedicalScore() {
       const ds = toDateStr(d);
       const dayChecks = medChecks[ds];
       if (dayChecks) {
-        const anyDone = Object.values(dayChecks).some(v => typeof v === 'string' && v.startsWith('done'));
+        // V-K-68: schema-aware via medCheckIsDone (handles both legacy string + new object).
+        const anyDone = Object.values(dayChecks).some(v => medCheckIsDone(v));
         if (anyDone) daysChecked++;
       }
     }

--- a/split/core.js
+++ b/split/core.js
@@ -90,11 +90,26 @@ function parseMedCheck(val) {
   if (val === 'done:late' || val === 'done') return { status:'late', givenAt:null, loggedAt:null, withFat:null, fatFood:null, fatDelta:null };
   if (val.indexOf('done:') === 0) {
     var t = val.slice(5);
-    var isTime = /^\d{1,2}:\d{2}$/.test(t);
+    // CR-2: accept BOTH 'HH:MM' (24h) AND 'HH:MM am|pm' / 'HH:MM AM|PM' (legacy en-IN 12h).
+    // The pre-v1 markMedDone used en-IN locale which produced 12h+suffix strings;
+    // those must round-trip through parseMedCheck without losing givenAt.
+    var isHHMM24 = /^\d{1,2}:\d{2}$/.test(t);
+    var ampmMatch = t.match(/^(\d{1,2}):(\d{2})\s*(am|pm)$/i);
+    var givenAt = null;
+    if (isHHMM24) {
+      givenAt = t;
+    } else if (ampmMatch) {
+      var h = parseInt(ampmMatch[1], 10);
+      var mm = ampmMatch[2];
+      var ampm = ampmMatch[3].toLowerCase();
+      if (ampm === 'pm' && h !== 12) h += 12;
+      if (ampm === 'am' && h === 12) h = 0;
+      givenAt = (h < 10 ? '0' + h : String(h)) + ':' + mm;
+    }
     return {
-      status: isTime ? 'done' : (t === 'late' ? 'late' : 'done'),
-      givenAt: isTime ? t : null,
-      loggedAt: null, // legacy didn't separate; givenAt was actually tap-time but treat as best-known
+      status: givenAt !== null ? 'done' : (t === 'late' ? 'late' : 'done'),
+      givenAt: givenAt,
+      loggedAt: null,
       withFat: null,
       fatFood: null,
       fatDelta: null,
@@ -144,6 +159,59 @@ function _hhmmToMinutes(s) {
   return m ? (parseInt(m[1], 10) * 60 + parseInt(m[2], 10)) : -1;
 }
 
+// CR-14: re-run with-fat detection on today's dose entries that currently report withFat:false.
+// markMedDone freezes withFat at log-time against the feedingData snapshot; if the parent logs
+// the dose BEFORE typing the breakfast row that accompanied it, withFat stays permanently false
+// unless they tap Adjust. This helper is called from the feedingData save paths to catch the
+// "logged dose first, logged meal second" sequence within the ±60min window.
+// Only flips withFat:false → true (never the reverse — never erases a real positive observation).
+// Returns true if any record was updated.
+function _refreshTodayMedWithFat() {
+  if (typeof medChecks !== 'object' || !medChecks) return false;
+  var t = today();
+  var dayMC = medChecks[t];
+  if (!dayMC) return false;
+  var mutated = false;
+  Object.keys(dayMC).forEach(function(name) {
+    var parsed = parseMedCheck(dayMC[name]);
+    if (!parsed) return;
+    if (parsed.status !== 'done' && parsed.status !== 'late') return;
+    if (!parsed.givenAt) return;
+    if (parsed.withFat !== false) return; // only redetect when previously negative
+    var fresh = _detectFatContextNearTime(parsed.givenAt, t);
+    if (fresh.withFat === true) {
+      // Preserve the rest of the object; only update the fat fields.
+      var cur = (typeof dayMC[name] === 'object' && !Array.isArray(dayMC[name])) ? dayMC[name] : parsed;
+      dayMC[name] = Object.assign({}, cur, {
+        withFat:  true,
+        fatFood:  fresh.fatFood,
+        fatDelta: fresh.fatDelta,
+      });
+      mutated = true;
+    }
+  });
+  if (mutated) {
+    save(KEYS.medChecks, medChecks);
+    if (typeof _tsfMarkDirty === 'function') _tsfMarkDirty();
+    if (typeof _islMarkDirty === 'function') _islMarkDirty('medical');
+  }
+  return mutated;
+}
+
+// CR-9: display formatter — 24h canonical 'HH:MM' → '8:42 AM' / '2:30 PM' for parent-facing surfaces.
+// The schema stores 24h (en-GB canonical) per V-M-60; this formatter renders the Indian-parent 12h convention.
+function _formatTime12h(hhmm) {
+  if (!hhmm || !/^\d{1,2}:\d{2}$/.test(hhmm)) return hhmm || '';
+  var parts = hhmm.split(':');
+  var h = parseInt(parts[0], 10);
+  var m = parts[1];
+  if (isNaN(h) || h < 0 || h > 23) return hhmm;
+  if (h === 0) return '12:' + m + ' AM';
+  if (h === 12) return '12:' + m + ' PM';
+  if (h > 12) return (h - 12) + ':' + m + ' PM';
+  return h + ':' + m + ' AM';
+}
+
 // Detect whether a fat-bearing food was logged in feedingData near `timeStr` on `dateStr`.
 // Window: ±60min default. Returns { withFat, fatFood, fatDelta } (delta signed: negative = food first).
 // V-K-69: token-equality matching (with _baseFoodName alias normalization) instead of substring
@@ -159,18 +227,28 @@ function _detectFatContextNearTime(timeStr, dateStr, windowMinutes) {
   var fatSet = _getFatBearingFoodNames();
   var fatLookup = {};
   for (var fi = 0; fi < fatSet.length; fi++) fatLookup[fatSet[fi]] = true;
+  // CR-12: iterate meals in chronological proximity order (closest-to-dose-time first)
+  // instead of the hard-coded ['breakfast','lunch','dinner','snack'] order — eliminates
+  // the meal-name-iteration bias when two meals tie in absolute delta.
   var meals = ['breakfast', 'lunch', 'dinner', 'snack'];
-  var best = null;
+  var mealEntries = [];
   meals.forEach(function(m) {
     var mTime = day[m + '_time'];
     var mFoods = day[m];
     if (!mTime || !mFoods || mFoods === '—skipped—') return;
     var mMin = _hhmmToMinutes(mTime);
     if (mMin < 0) return;
-    var delta = mMin - targetMin; // signed: negative = meal before dose
+    var delta = mMin - targetMin;
     if (Math.abs(delta) > win) return;
+    mealEntries.push({ meal: m, foods: mFoods, min: mMin, delta: delta, abs: Math.abs(delta) });
+  });
+  mealEntries.sort(function(a, b) { return a.abs - b.abs; });
+
+  var best = null;
+  mealEntries.forEach(function(entry) {
+    if (best !== null) return; // already found the closest match
     // Tokenize the meal text on comma / " and " / "+" / "&". Trim each token. Empty tokens dropped.
-    var tokens = String(mFoods).toLowerCase().split(/\s*,\s*|\s+and\s+|\s*\+\s*|\s*&\s*/).map(function(s) { return s.trim(); }).filter(Boolean);
+    var tokens = String(entry.foods).toLowerCase().split(/\s*,\s*|\s+and\s+|\s*\+\s*|\s*&\s*/).map(function(s) { return s.trim(); }).filter(Boolean);
     var matched = null;
     for (var ti = 0; ti < tokens.length; ti++) {
       var tok = tokens[ti];
@@ -184,9 +262,18 @@ function _detectFatContextNearTime(timeStr, dateStr, windowMinutes) {
       // Otherwise try alias-normalized base name (catches 'yogurt' → 'curd', 'fresh ghee' → 'ghee').
       var base = (typeof _baseFoodName === 'function') ? _baseFoodName(tok) : tok;
       if (base !== tok && fatLookup[base]) { matched = base; break; }
+      // CR-13: plural/singular drift — NUTRITION is keyed inconsistently ('almonds' plural,
+      // 'walnut' singular). Try both depluralization and pluralization against fatLookup directly.
+      if (tok.length > 3 && tok.charAt(tok.length - 1) === 's') {
+        var singular = tok.slice(0, -1);
+        if (fatLookup[singular]) { matched = singular; break; }
+      } else if (tok.length > 2) {
+        var plural = tok + 's';
+        if (fatLookup[plural]) { matched = plural; break; }
+      }
     }
-    if (matched && (best === null || Math.abs(delta) < Math.abs(best.delta))) {
-      best = { food: matched, delta: delta };
+    if (matched) {
+      best = { food: matched, delta: entry.delta };
     }
   });
   if (best) {

--- a/split/core.js
+++ b/split/core.js
@@ -164,7 +164,7 @@ function _detectFatContextNearTime(timeStr, dateStr, windowMinutes) {
   meals.forEach(function(m) {
     var mTime = day[m + '_time'];
     var mFoods = day[m];
-    if (!mTime || !mFoods || mFoods === '—skipped—' || mFoods === '—skipped—') return;
+    if (!mTime || !mFoods || mFoods === '—skipped—') return;
     var mMin = _hhmmToMinutes(mTime);
     if (mMin < 0) return;
     var delta = mMin - targetMin; // signed: negative = meal before dose

--- a/split/core.js
+++ b/split/core.js
@@ -65,6 +65,122 @@ function save(key, val) {
 }
 
 // ─────────────────────────────────────────
+// MED-CHECK SCHEMA HELPERS — v1 Vit D3 tracking
+// ─────────────────────────────────────────
+// medChecks[date][medName] accepts two shapes (backwards-compat, non-destructive migration):
+//   • Legacy string: 'done:HH:MM' | 'done:late' | 'done' | 'skipped'  — HH:MM was tap-time
+//   • New object: { status, givenAt, loggedAt, withFat, fatFood, fatDelta }
+// Every reader migrates via parseMedCheck() so writers can emit the new shape unconditionally.
+function parseMedCheck(val) {
+  if (!val) return null;
+  if (typeof val === 'object') {
+    return {
+      status:   val.status || null,
+      givenAt:  val.givenAt || null,
+      loggedAt: val.loggedAt || null,
+      withFat:  typeof val.withFat === 'boolean' ? val.withFat : null,
+      fatFood:  val.fatFood || null,
+      fatDelta: typeof val.fatDelta === 'number' ? val.fatDelta : null,
+    };
+  }
+  if (typeof val !== 'string') return null;
+  if (val === 'skipped') return { status:'skipped', givenAt:null, loggedAt:null, withFat:null, fatFood:null, fatDelta:null };
+  if (val === 'done:late' || val === 'done') return { status:'late', givenAt:null, loggedAt:null, withFat:null, fatFood:null, fatDelta:null };
+  if (val.indexOf('done:') === 0) {
+    var t = val.slice(5);
+    var isTime = /^\d{1,2}:\d{2}$/.test(t);
+    return {
+      status: isTime ? 'done' : (t === 'late' ? 'late' : 'done'),
+      givenAt: isTime ? t : null,
+      loggedAt: null, // legacy didn't separate; givenAt was actually tap-time but treat as best-known
+      withFat: null,
+      fatFood: null,
+      fatDelta: null,
+    };
+  }
+  return null;
+}
+function medCheckIsDone(val) {
+  var p = parseMedCheck(val);
+  return !!(p && (p.status === 'done' || p.status === 'late'));
+}
+function medCheckSkipped(val) {
+  var p = parseMedCheck(val);
+  return !!(p && p.status === 'skipped');
+}
+function medCheckGivenAt(val) {
+  var p = parseMedCheck(val);
+  return p ? p.givenAt : null;
+}
+
+// Derive fat-bearing food names from NUTRITION (memoised). Computed-not-hardcoded so
+// the C-1.5 factuality work flows through automatically — no second source of truth.
+var _fatBearingFoodNamesCache = null;
+function _getFatBearingFoodNames() {
+  if (_fatBearingFoodNamesCache) return _fatBearingFoodNamesCache;
+  var out = [];
+  if (typeof NUTRITION === 'object' && NUTRITION) {
+    Object.keys(NUTRITION).forEach(function(name) {
+      var e = NUTRITION[name];
+      if (!e) return;
+      var tags = e.tags || [];
+      var nuts = e.nutrients || [];
+      if (tags.indexOf('healthy-fats') >= 0 || nuts.indexOf('healthy fats') >= 0 ||
+          nuts.indexOf('omega-3') >= 0 || nuts.indexOf('MCTs') >= 0) {
+        out.push(name);
+      }
+    });
+  }
+  // Indian-prep augmentation: paratha carries ghee in default preparation.
+  if (out.indexOf('paratha') < 0) out.push('paratha');
+  _fatBearingFoodNamesCache = out;
+  return out;
+}
+function _hhmmToMinutes(s) {
+  if (!s) return -1;
+  var m = String(s).match(/^(\d{1,2}):(\d{2})/);
+  return m ? (parseInt(m[1], 10) * 60 + parseInt(m[2], 10)) : -1;
+}
+
+// Detect whether a fat-bearing food was logged in feedingData near `timeStr` on `dateStr`.
+// Window: ±60min default. Returns { withFat, fatFood, fatDelta } (delta signed: negative = food first).
+function _detectFatContextNearTime(timeStr, dateStr, windowMinutes) {
+  var win = (typeof windowMinutes === 'number') ? windowMinutes : 60;
+  var result = { withFat:false, fatFood:null, fatDelta:null };
+  var targetMin = _hhmmToMinutes(timeStr);
+  if (targetMin < 0) return result;
+  if (typeof feedingData !== 'object' || !feedingData) return result;
+  var day = feedingData[dateStr];
+  if (!day) return result;
+  var fatSet = _getFatBearingFoodNames();
+  var meals = ['breakfast', 'lunch', 'dinner', 'snack'];
+  var best = null;
+  meals.forEach(function(m) {
+    var mTime = day[m + '_time'];
+    var mFoods = day[m];
+    if (!mTime || !mFoods || mFoods === '—skipped—') return;
+    var mMin = _hhmmToMinutes(mTime);
+    if (mMin < 0) return;
+    var delta = mMin - targetMin; // signed: negative = meal before dose
+    if (Math.abs(delta) > win) return;
+    var lower = String(mFoods).toLowerCase();
+    var matched = null;
+    for (var i = 0; i < fatSet.length; i++) {
+      if (lower.indexOf(fatSet[i]) >= 0) { matched = fatSet[i]; break; }
+    }
+    if (matched && (best === null || Math.abs(delta) < Math.abs(best.delta))) {
+      best = { food: matched, delta: delta };
+    }
+  });
+  if (best) {
+    result.withFat = true;
+    result.fatFood = best.food;
+    result.fatDelta = best.delta;
+  }
+  return result;
+}
+
+// ─────────────────────────────────────────
 // DEFAULT DATA (pre-loaded)
 // ─────────────────────────────────────────
 const DOB        = new Date(2025, 8, 4, 17, 9); // Sep 4, 2025 at 17:09 IST

--- a/split/diet.js
+++ b/split/diet.js
@@ -2413,6 +2413,10 @@ function _miSetIntake(dateStr, meal, value) {
   feedingData[dateStr][meal + '_intake'] = value;
   save(KEYS.feeding, feedingData);
   _islMarkDirty('diet');
+  // V-M-70: intake adjustment alone doesn't change meal content (so withFat won't flip),
+  // but completes the contract that EVERY feedingData mutation re-evaluates today's
+  // negative-withFat doses. Defensive — harmless when nothing matches.
+  if (dateStr === today() && typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();
 }
 
 function _miLevelFor(value) {

--- a/split/home.js
+++ b/split/home.js
@@ -711,7 +711,7 @@ function renderRemindersAndAlerts() {
           <div class="supp-alert-title">Reminder — ${escHtml(m.name)}</div>
           <div class="supp-alert-action">
             <button class="supp-check-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done now</button>
-            <button class="supp-check-btn supp-check-btn-alt" data-action="openMedDoneAt" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done at...</button>
+            <button class="supp-check-btn supp-check-btn-alt" data-action="openMedDoneAt" data-arg="${escHtml(m.name)}" data-arg2="${idx}">${zi('clock')} Done at...</button>
             <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Skip</button>
           </div>
         </div>
@@ -719,12 +719,15 @@ function renderRemindersAndAlerts() {
       </div>`;
     } else if (isDone) {
       const givenAt = parsed && parsed.givenAt ? parsed.givenAt : null;
-      const withFat = parsed && parsed.withFat === true;
       const fatFood = parsed && parsed.fatFood ? parsed.fatFood : null;
       const timeText = givenAt ? 'Done at ' + escHtml(givenAt) : 'Done today';
-      const fatBadge = withFat && fatFood
-        ? `<span class="supp-fat-badge">${zi('check')} with ${escHtml(fatFood)}</span>`
-        : (givenAt && !withFat ? `<span class="supp-fat-badge supp-fat-badge-neutral">no fat-meal nearby</span>` : '');
+      // V-M-61: null withFat (legacy / unknown) renders no badge. V-M-63: softer framing.
+      let fatBadge = '';
+      if (parsed && parsed.withFat === true && fatFood) {
+        fatBadge = `<span class="supp-fat-badge">${zi('check')} with ${escHtml(fatFood)}</span>`;
+      } else if (parsed && parsed.withFat === false && givenAt) {
+        fatBadge = `<span class="supp-fat-badge supp-fat-badge-neutral">no fat-meal logged nearby</span>`;
+      }
       html += `
       <div class="supp-alert supp-alert-done" id="supp-alert-${idx}">
         <div class="supp-alert-top">
@@ -894,7 +897,9 @@ function fmtTips(s) {
 function markMedDone(name, idx, givenTime) {
   const todayStr = today();
   const now = new Date();
-  const loggedAt = now.toLocaleTimeString('en-IN', { hour:'2-digit', minute:'2-digit' });
+  // V-M-60: storage uses 24h en-GB (HH:MM). Display layer formats for the user;
+  // the storage layer must be canonical so _hhmmToMinutes parses correctly across AM/PM.
+  const loggedAt = now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
   const givenAt = (typeof givenTime === 'string' && /^\d{1,2}:\d{2}$/.test(givenTime)) ? givenTime : loggedAt;
   const fat = _detectFatContextNearTime(givenAt, todayStr);
   if (!medChecks[todayStr]) medChecks[todayStr] = {};
@@ -955,10 +960,11 @@ function adjustMedTime(name, idx, newTime) {
   if (!existing || existing.status === 'skipped') return;
   const fat = _detectFatContextNearTime(newTime, todayStr);
   const now = new Date();
+  // V-M-65: canonical 24h storage (en-GB).
   medChecks[todayStr][name] = {
     status:   existing.status,
     givenAt:  newTime,
-    loggedAt: existing.loggedAt || now.toLocaleTimeString('en-IN', { hour:'2-digit', minute:'2-digit' }),
+    loggedAt: existing.loggedAt || now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' }),
     withFat:  fat.withFat,
     fatFood:  fat.fatFood,
     fatDelta: fat.fatDelta,
@@ -2629,8 +2635,9 @@ function renderMedLog() {
     const [year, mon] = monthKey.split('-');
     const monthLabel = `${monthNames[parseInt(mon) - 1]} ${year}`;
     const monthId = 'ml-' + monthKey;
-    const givenCount = items.filter(e => e.status.startsWith('done')).length;
-    const skippedCount = items.filter(e => e.status === 'skipped').length;
+    // V-K-66: schema-aware filtering — items can carry legacy string status OR new object status.
+    const givenCount = items.filter(e => medCheckIsDone(e.status)).length;
+    const skippedCount = items.filter(e => medCheckSkipped(e.status)).length;
 
     html += `<div class="history-month" id="${monthId}">
       <div class="history-month-header" data-action="toggleHistoryMonth" data-arg="${monthId}" style="background:linear-gradient(135deg,var(--sky-light),var(--sky-light));border-color:rgba(168,207,224,0.4);">
@@ -2658,12 +2665,15 @@ function renderMedLog() {
       html += `<div style=""font-weight:600;font-size:var(--fs-sm);color:var(--tc-sky);margin-bottom:4px;">${dayName}, ${dayNum} ${monthNames[parseInt(mon) - 1]}</div>`;
 
       dayItems.forEach(e => {
-        const isDone = e.status.startsWith('done');
-        const timeStr = isDone ? e.status.replace('done:', '') : '';
+        // V-K-66: schema-aware status read.
+        const parsed = parseMedCheck(e.status);
+        const isDone = !!(parsed && (parsed.status === 'done' || parsed.status === 'late'));
+        const isLate = !!(parsed && parsed.status === 'late');
+        const timeStr = parsed && parsed.givenAt ? parsed.givenAt : '';
         const icon = isDone ? zi('check') : zi('skip-forward');
         const label = isDone ? 'Given' : 'Skipped';
         const color = isDone ? '#3a7060' : '#926030';
-        const timePart = timeStr && timeStr !== 'late' ? ` at ${timeStr}` : timeStr === 'late' ? ' (logged late)' : '';
+        const timePart = isLate ? ' (logged late)' : (timeStr ? ` at ${escHtml(timeStr)}` : '');
 
         html += `
           <div style="display:flex;align-items:center;gap:var(--sp-8);padding:3px 0;font-size:var(--fs-base);">
@@ -6504,7 +6514,8 @@ function renderHistoryPreviews() {
       </div>`;
     } else {
       // Show today's status
-      const todayDone = activeMeds.filter(m => todayChecks[m.name] && todayChecks[m.name].startsWith('done'));
+      // V-K-66: schema-aware via medCheckIsDone.
+      const todayDone = activeMeds.filter(m => medCheckIsDone(todayChecks[m.name]));
       if (todayDone.length === activeMeds.length && activeMeds.length > 0) {
         medPrev.innerHTML = `<div class="info-strip is-sage">
           <span><svg class="zi"><use href="#zi-check"/></svg></span>
@@ -6996,23 +7007,24 @@ function computeBaselines() {
 
   // ── Supplement adherence (D3) ──
   const activeMeds = meds.filter(m => m.active);
+  // V-K-66: schema-aware reads via medCheckIsDone / medCheckSkipped (handles legacy string + new object).
   activeMeds.forEach(m => {
     const mKey = sanitizeAlertKey(m.name);
     let streak = 0;
     for (let i = 0; i < 90; i++) {
       const d = new Date(); d.setDate(d.getDate() - i);
       const ds = toDateStr(d);
-      // Skip today if not yet resolved
-      if (i === 0) {
-        const dayLog = medChecks[ds] || {};
-        const status = dayLog[m.name];
-        if (!status || (!status.startsWith('done:') && status !== 'skipped')) continue;
-        if (status.startsWith('done:')) { streak++; continue; }
-        break; // skipped breaks streak
-      }
       const dayLog = medChecks[ds] || {};
       const status = dayLog[m.name];
-      if (status && status.startsWith('done:')) { streak++; }
+      const isDone = medCheckIsDone(status);
+      const isSkipped = medCheckSkipped(status);
+      // Skip today if not yet resolved (no entry at all)
+      if (i === 0) {
+        if (!isDone && !isSkipped) continue;
+        if (isDone) { streak++; continue; }
+        break; // skipped breaks streak
+      }
+      if (isDone) { streak++; }
       else break;
     }
     b['suppStreak_' + mKey] = streak;
@@ -7027,7 +7039,7 @@ function computeBaselines() {
       if (ds < (m.start || '2025-09-04')) continue;
       total30++;
       const dayLog = medChecks[ds] || {};
-      if (dayLog[m.name] && dayLog[m.name].startsWith('done:')) given30++;
+      if (medCheckIsDone(dayLog[m.name])) given30++;
     }
     b['suppAdherence30_' + mKey] = total30 > 0 ? Math.floor((given30 / total30) * 100) : null;
     b['suppGiven30_' + mKey] = given30;
@@ -7526,7 +7538,10 @@ function computeAlerts() {
     const ydStr = toDateStr(yd);
     const ydLog = medChecks[ydStr] || {};
     const ydStatus = ydLog[m.name];
-    const wasMissedYd = ydStr >= (medChecks._trackingSince || todayStr) && ydStr >= (m.start || '2025-09-04') && (!ydStatus || ydStatus === 'skipped');
+    // V-K-66: schema-aware "yesterday missed" check — handles both string and object shapes.
+    const ydDone = medCheckIsDone(ydStatus);
+    const ydSkipped = medCheckSkipped(ydStatus);
+    const wasMissedYd = ydStr >= (medChecks._trackingSince || todayStr) && ydStr >= (m.start || '2025-09-04') && (!ydDone && (ydSkipped || !ydStatus));
     // Count how long the prior streak was before it broke
     if (wasMissedYd && streak === 0) {
       let priorStreak = 0;
@@ -7534,7 +7549,7 @@ function computeAlerts() {
         const d = new Date(); d.setDate(d.getDate() - i);
         const ds = toDateStr(d);
         const dl = medChecks[ds] || {};
-        if (dl[m.name] && dl[m.name].startsWith('done:')) priorStreak++;
+        if (medCheckIsDone(dl[m.name])) priorStreak++;
         else break;
       }
       if (priorStreak >= 3) {
@@ -8331,13 +8346,24 @@ function renderTodayPlan() {
     });
   }
 
-  // D3 supplement
+  // D3 supplement — V-K-66: schema-aware via parseMedCheck (legacy string + new object both handled).
   const d3Med = meds.find(m => m.active && m.name.toLowerCase().includes('d3'));
   if (d3Med) {
-    const d3Done = medChecks[todayStr] && medChecks[todayStr][d3Med.name] && medChecks[todayStr][d3Med.name].startsWith('done:');
+    const d3Parsed = parseMedCheck(medChecks[todayStr] && medChecks[todayStr][d3Med.name]);
+    const d3Done = !!(d3Parsed && (d3Parsed.status === 'done' || d3Parsed.status === 'late'));
+    const d3Given = d3Parsed && d3Parsed.givenAt ? d3Parsed.givenAt : null;
+    const d3Fat = d3Parsed && d3Parsed.withFat === true && d3Parsed.fatFood ? d3Parsed.fatFood : null;
+    let doneDetail;
+    if (d3Done) {
+      const timePart = d3Given ? ' at ' + escHtml(d3Given) : '';
+      const fatPart = d3Fat ? ' · with ' + escHtml(d3Fat) : '';
+      doneDetail = '<svg class="zi"><use href="#zi-check"/></svg> Done' + timePart + fatPart;
+    } else {
+      doneDetail = d3Med.dose + ' — give with or after a feed for best absorption';
+    }
     items.push({
       time: '9 AM', icon: zi('pill'), title: d3Med.name,
-      detail: d3Done ? '<svg class="zi"><use href="#zi-check"/></svg> Done today' : d3Med.dose + ' — give with or after a feed for best absorption',
+      detail: doneDetail,
       tag: 'med', done: d3Done, htmlDetail: d3Done
     });
   }
@@ -8766,7 +8792,8 @@ function renderTrendChips() {
   const total = Math.max(Object.keys(nutrientDays).length, 5);
   chips.push({ icon:zi('bowl'), label:'Nutrients', value: covered + '/' + total + ' groups', delta: covered >= total ? 'balanced' : 'gaps', cls: covered >= total ? 'tc-good' : 'tc-warn', tab:'diet' });
 
-  // Vitamin D3 — schema-aware (legacy 'done:HH:MM' string + new object shape both handled)
+  // Vitamin D3 — schema-aware (legacy 'done:HH:MM' string + new object shape both handled).
+  // V-M-62 + V-K-70: fatFood comes from parent feedingData input — escape at this render boundary.
   if (d3Med) {
     const todayStr = today();
     const d3Val = medChecks[todayStr] && medChecks[todayStr][d3Med.name];
@@ -8775,8 +8802,8 @@ function renderTrendChips() {
     let valueText, deltaText;
     if (d3Done) {
       const t = d3Parsed.givenAt;
-      const fat = d3Parsed.withFat === true && d3Parsed.fatFood ? ' · with ' + d3Parsed.fatFood : '';
-      valueText = t ? ('Done at ' + t + fat) : 'Done today';
+      const fat = d3Parsed.withFat === true && d3Parsed.fatFood ? ' · with ' + escHtml(d3Parsed.fatFood) : '';
+      valueText = t ? ('Done at ' + escHtml(t) + fat) : 'Done today';
       deltaText = zi('check');
     } else {
       valueText = 'Pending';

--- a/split/home.js
+++ b/split/home.js
@@ -747,20 +747,22 @@ function renderRemindersAndAlerts() {
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${fatBadge}</div>
       </div>`;
     } else if (isSkipped) {
-      // CR-5: NEW skipped-state render. Pre-fix, the skipped branch produced no card at all
-      // and the 'All medications done for today' banner was removed — the parent got zero
-      // visual acknowledgement of their explicit skip, while _obCheckVitD3 kept flagging
-      // 'Vit D3 pending' on the home overlay, contradicting the just-recorded action.
+      // CR-5: skipped-state render with explicit acknowledgement + Undo affordance.
+      // V-M-68 + V-M-73 fix: Undo no longer calls markMedDone(name, idx) directly (which
+      // silently substituted tap-time as the administration time, exactly the CR-4 class
+      // of bug). Instead Undo clears the skip back to PENDING — the card re-renders with
+      // the standard [Done now] [Done at...] [Skip] buttons, forcing the parent to make
+      // an explicit choice. No fabricated time, no destroyed audit trail.
       html += `
       <div class="supp-alert supp-alert-skipped" id="supp-alert-${idx}">
         <div class="supp-alert-top">
           <div class="supp-alert-icon">${zi('skip-forward')}</div>
           <div class="supp-alert-title">Skipped today — ${escHtml(m.name)}</div>
           <div class="supp-alert-action">
-            <button class="supp-skip-btn supp-adjust-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Undo skip</button>
+            <button class="supp-skip-btn supp-adjust-btn" data-action="undoMedSkip" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Undo skip</button>
           </div>
         </div>
-        <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}Skip recorded — tap Undo to revert and log a dose.</div>
+        <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}Skip recorded — tap Undo to clear and log the dose.</div>
       </div>`;
     }
   });
@@ -975,6 +977,22 @@ function confirmMedDoneAt(name, idx) {
   markMedDone(name, idx, picked);
 }
 function cancelMedDoneAt(idx) {
+  renderRemindersAndAlerts();
+  renderHomeContextAlerts();
+}
+
+// V-M-68 + V-M-73: revert a skip back to PENDING (not to "Done at tap-time"). The skip's
+// loggedAt audit trail is dropped — acceptable because the parent's post-Undo intent is
+// "I want to log the dose properly now," not "preserve the misclick." Re-renders so the
+// parent sees the original [Done now] [Done at...] [Skip] choice without a fabricated time.
+function undoMedSkip(name, idx) {
+  const todayStr = today();
+  if (medChecks[todayStr] && medChecks[todayStr][name] !== undefined) {
+    delete medChecks[todayStr][name];
+    save(KEYS.medChecks, medChecks);
+    _tsfMarkDirty();
+    _islMarkDirty('medical');
+  }
   renderRemindersAndAlerts();
   renderHomeContextAlerts();
 }
@@ -6578,9 +6596,11 @@ function renderHistoryPreviews() {
     const ydChecks = medChecks[ydKey] || {};
     const activeMeds = meds.filter(m => m.active);
 
-    // Check yesterday for missed/skipped
-    const ydMissed = activeMeds.filter(m => !ydChecks[m.name]);
-    const ydSkipped = activeMeds.filter(m => ydChecks[m.name] === 'skipped');
+    // Check yesterday for missed/skipped — V-K-74: schema-aware via medCheckSkipped.
+    // Pre-fix `=== 'skipped'` missed the new object shape; parent who skipped yesterday
+    // saw the "Yesterday's meds not logged" danger strip instead of "Skipped yesterday".
+    const ydMissed = activeMeds.filter(m => !ydChecks[m.name] || (!medCheckIsDone(ydChecks[m.name]) && !medCheckSkipped(ydChecks[m.name])));
+    const ydSkipped = activeMeds.filter(m => medCheckSkipped(ydChecks[m.name]));
 
     if (ydMissed.length > 0) {
       medPrev.innerHTML = `<div class="info-strip is-danger">

--- a/split/home.js
+++ b/split/home.js
@@ -690,39 +690,57 @@ function renderRemindersAndAlerts() {
     </div>`;
   }
 
-  // ── 4. TODAY'S MED REMINDERS — only show unresolved ones ──
+  // ── 4. TODAY'S MED REMINDERS — show pending with two-button + Adjust on done ──
+  // Vit D3 tracking v1: pending state offers "Done now" + "Done at..." + Skip.
+  // Done state renders captured givenAt + with-fat context with a reachable Adjust.
   let allTodayResolved = true;
   activeMeds.forEach((m, idx) => {
     const dayLog = medChecks[todayStr] || {};
     const status = dayLog[m.name];
-    const isDone = status && status.startsWith('done:');
-    const isSkipped = status === 'skipped';
+    const parsed = parseMedCheck(status);
+    const isDone = !!(parsed && (parsed.status === 'done' || parsed.status === 'late'));
+    const isSkipped = !!(parsed && parsed.status === 'skipped');
     const isResolved = isDone || isSkipped;
     if (!isResolved) allTodayResolved = false;
 
     if (!isResolved) {
-      // Only show unresolved meds
       html += `
       <div class="supp-alert" id="supp-alert-${idx}">
         <div class="supp-alert-top">
           <div class="supp-alert-icon">${zi('warn')}</div>
           <div class="supp-alert-title">Reminder — ${escHtml(m.name)}</div>
           <div class="supp-alert-action">
-            <button class="supp-check-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done</button>
+            <button class="supp-check-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done now</button>
+            <button class="supp-check-btn supp-check-btn-alt" data-action="openMedDoneAt" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done at...</button>
             <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Skip</button>
           </div>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${escHtml(m.freq || 'As prescribed')}</div>
       </div>`;
+    } else if (isDone) {
+      const givenAt = parsed && parsed.givenAt ? parsed.givenAt : null;
+      const withFat = parsed && parsed.withFat === true;
+      const fatFood = parsed && parsed.fatFood ? parsed.fatFood : null;
+      const timeText = givenAt ? 'Done at ' + escHtml(givenAt) : 'Done today';
+      const fatBadge = withFat && fatFood
+        ? `<span class="supp-fat-badge">${zi('check')} with ${escHtml(fatFood)}</span>`
+        : (givenAt && !withFat ? `<span class="supp-fat-badge supp-fat-badge-neutral">no fat-meal nearby</span>` : '');
+      html += `
+      <div class="supp-alert supp-alert-done" id="supp-alert-${idx}">
+        <div class="supp-alert-top">
+          <div class="supp-alert-icon">${zi('check')}</div>
+          <div class="supp-alert-title">${timeText} — ${escHtml(m.name)}</div>
+          <div class="supp-alert-action">
+            <button class="supp-skip-btn supp-adjust-btn" data-action="openMedAdjust" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Adjust</button>
+          </div>
+        </div>
+        <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${fatBadge}</div>
+      </div>`;
     }
   });
 
-  // If all today's meds are resolved, show a compact summary instead
-  if (activeMeds.length > 0 && allTodayResolved) {
-    html += `<div style="display:flex;align-items:center;gap:var(--sp-8);padding:8px 12px;border-radius:var(--r-lg);background:var(--sage-light);font-size:var(--fs-base);color:var(--tc-sage);">
-      <span><svg class="zi"><use href="#zi-check"/></svg></span> All medications done for today
-    </div>`;
-  }
+  // Vit D3 tracking v1: the all-resolved banner is redundant now that done-state
+  // cards render their own captured time + with-fat context. Removed.
 
   // v2.3: Store HTML — renderHomeContextAlerts will combine and render both
   window._remindersHTML = html;
@@ -869,12 +887,25 @@ function fmtTips(s) {
           .replace(/\{\{NO\}\}/g, '<span class="icon-rose">' + zi('warn') + '</span>');
 }
 
-function markMedDone(name, idx) {
+// Vit D3 tracking v1: markMedDone emits the new object schema with
+// actual administration time (givenAt) + auto-detected fat-meal context.
+// givenTime is optional — defaults to "now" (the "Done now" button path).
+// The "Done at..." flow passes a parent-stated HH:MM string.
+function markMedDone(name, idx, givenTime) {
   const todayStr = today();
   const now = new Date();
-  const timeStr = now.toLocaleTimeString('en-IN', { hour:'2-digit', minute:'2-digit' });
+  const loggedAt = now.toLocaleTimeString('en-IN', { hour:'2-digit', minute:'2-digit' });
+  const givenAt = (typeof givenTime === 'string' && /^\d{1,2}:\d{2}$/.test(givenTime)) ? givenTime : loggedAt;
+  const fat = _detectFatContextNearTime(givenAt, todayStr);
   if (!medChecks[todayStr]) medChecks[todayStr] = {};
-  medChecks[todayStr][name] = 'done:' + timeStr;
+  medChecks[todayStr][name] = {
+    status:   'done',
+    givenAt:  givenAt,
+    loggedAt: loggedAt,
+    withFat:  fat.withFat,
+    fatFood:  fat.fatFood,
+    fatDelta: fat.fatDelta,
+  };
   save(KEYS.medChecks, medChecks);
   _tsfMarkDirty();
   _islMarkDirty('medical');
@@ -886,6 +917,77 @@ function markMedDone(name, idx) {
   } else {
     renderRemindersAndAlerts(); renderHomeContextAlerts();
   }
+}
+
+// Open the inline "Done at..." time-edit in the reminder card. Reveals a
+// time-input + Save/Cancel pair inside the card without a modal.
+function openMedDoneAt(name, idx) {
+  const card = document.getElementById('supp-alert-' + idx);
+  if (!card) return;
+  const actionRow = card.querySelector('.supp-alert-action');
+  if (!actionRow || actionRow.dataset.editing === '1') return;
+  actionRow.dataset.editing = '1';
+  const now = new Date();
+  const nowStr = now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' }); // HH:MM 24h for input
+  actionRow.innerHTML =
+    '<input type="time" class="supp-time-input" id="supp-time-' + idx + '" value="' + escAttr(nowStr) + '">' +
+    '<button class="supp-check-btn" data-action="confirmMedDoneAt" data-arg="' + escAttr(name) + '" data-arg2="' + idx + '">Save</button>' +
+    '<button class="supp-skip-btn" data-action="cancelMedDoneAt" data-arg2="' + idx + '">Cancel</button>';
+}
+function confirmMedDoneAt(name, idx) {
+  const input = document.getElementById('supp-time-' + idx);
+  const picked = input && input.value ? input.value : null;
+  markMedDone(name, idx, picked);
+}
+function cancelMedDoneAt(idx) {
+  renderRemindersAndAlerts();
+  renderHomeContextAlerts();
+}
+
+// Adjust the administration time of an already-logged dose. Re-runs with-fat
+// detection on the new givenAt. Works on today's dose (the only adjust surface
+// in v1; past-day adjusts continue to use resolveMissedMed).
+function adjustMedTime(name, idx, newTime) {
+  const todayStr = today();
+  if (!medChecks[todayStr] || !medChecks[todayStr][name]) return;
+  if (!newTime || !/^\d{1,2}:\d{2}$/.test(newTime)) return;
+  const existing = parseMedCheck(medChecks[todayStr][name]);
+  if (!existing || existing.status === 'skipped') return;
+  const fat = _detectFatContextNearTime(newTime, todayStr);
+  const now = new Date();
+  medChecks[todayStr][name] = {
+    status:   existing.status,
+    givenAt:  newTime,
+    loggedAt: existing.loggedAt || now.toLocaleTimeString('en-IN', { hour:'2-digit', minute:'2-digit' }),
+    withFat:  fat.withFat,
+    fatFood:  fat.fatFood,
+    fatDelta: fat.fatDelta,
+  };
+  save(KEYS.medChecks, medChecks);
+  _tsfMarkDirty();
+  _islMarkDirty('medical');
+  renderRemindersAndAlerts();
+  renderHomeContextAlerts();
+}
+function openMedAdjust(name, idx) {
+  const card = document.getElementById('supp-alert-' + idx);
+  if (!card) return;
+  const actionRow = card.querySelector('.supp-alert-action');
+  if (!actionRow || actionRow.dataset.editing === '1') return;
+  actionRow.dataset.editing = '1';
+  const cur = parseMedCheck(medChecks[today()] && medChecks[today()][name]);
+  const curAt = (cur && cur.givenAt) || new Date().toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
+  // Re-format HH:MM (handle "08:42 AM" legacy by stripping any AM/PM tail)
+  const norm = String(curAt).replace(/\s*(AM|PM)\s*$/i, '');
+  actionRow.innerHTML =
+    '<input type="time" class="supp-time-input" id="supp-time-' + idx + '" value="' + escAttr(norm) + '">' +
+    '<button class="supp-check-btn" data-action="confirmMedAdjust" data-arg="' + escAttr(name) + '" data-arg2="' + idx + '">Save</button>' +
+    '<button class="supp-skip-btn" data-action="cancelMedDoneAt" data-arg2="' + idx + '">Cancel</button>';
+}
+function confirmMedAdjust(name, idx) {
+  const input = document.getElementById('supp-time-' + idx);
+  const picked = input && input.value ? input.value : null;
+  adjustMedTime(name, idx, picked);
 }
 
 function markMedSkipped(name, idx) {
@@ -5149,24 +5251,19 @@ function _obIsTeethingActive() {
 }
 
 function _obCheckVitD3() {
-  // Check if Vit D3 hasn't been given today
+  // Returns true if Vit D3 needs attention (not given today or no D3 med tracked).
+  // Schema-aware via medCheckIsDone (handles both legacy 'done:HH:MM' string and new object shape).
   var todayStr = today();
   var dayEntry = medChecks ? medChecks[todayStr] : null;
   if (!dayEntry) return true;
-  // Check all meds for D3
   var d3Given = false;
-  var d3Found = false;
   var activeMeds = (meds || []).filter(function(m) { return m.active; });
   activeMeds.forEach(function(m) {
     if (m.name && m.name.toLowerCase().indexOf('d3') >= 0) {
-      d3Found = true;
-      var status = dayEntry[m.name];
-      if (status && status.indexOf('done') === 0) d3Given = true;
+      if (medCheckIsDone(dayEntry[m.name])) d3Given = true;
     }
   });
-  // If no D3 med tracked, or D3 not given today
-  if (!d3Given) return true;
-  return false;
+  return !d3Given;
 }
 
 function _obGetNextVaccine() {
@@ -8669,11 +8766,23 @@ function renderTrendChips() {
   const total = Math.max(Object.keys(nutrientDays).length, 5);
   chips.push({ icon:zi('bowl'), label:'Nutrients', value: covered + '/' + total + ' groups', delta: covered >= total ? 'balanced' : 'gaps', cls: covered >= total ? 'tc-good' : 'tc-warn', tab:'diet' });
 
-  // Vitamin D3
+  // Vitamin D3 — schema-aware (legacy 'done:HH:MM' string + new object shape both handled)
   if (d3Med) {
     const todayStr = today();
-    const d3Done = medChecks[todayStr] && medChecks[todayStr][d3Med.name] && medChecks[todayStr][d3Med.name].startsWith('done:');
-    chips.push({ icon:zi('sun'), label:'Vitamin D3', value: d3Done ? 'Done today' : 'Pending', delta: d3Done ? zi('check') : 'pending', cls: d3Done ? 'tc-good' : 'tc-warn', tab:'medical' });
+    const d3Val = medChecks[todayStr] && medChecks[todayStr][d3Med.name];
+    const d3Parsed = parseMedCheck(d3Val);
+    const d3Done = !!(d3Parsed && (d3Parsed.status === 'done' || d3Parsed.status === 'late'));
+    let valueText, deltaText;
+    if (d3Done) {
+      const t = d3Parsed.givenAt;
+      const fat = d3Parsed.withFat === true && d3Parsed.fatFood ? ' · with ' + d3Parsed.fatFood : '';
+      valueText = t ? ('Done at ' + t + fat) : 'Done today';
+      deltaText = zi('check');
+    } else {
+      valueText = 'Pending';
+      deltaText = 'pending';
+    }
+    chips.push({ icon:zi('sun'), label:'Vitamin D3', value: valueText, delta: deltaText, cls: d3Done ? 'tc-good' : 'tc-warn', tab:'medical' });
   }
 
   let html = '';

--- a/split/home.js
+++ b/split/home.js
@@ -720,7 +720,14 @@ function renderRemindersAndAlerts() {
     } else if (isDone) {
       const givenAt = parsed && parsed.givenAt ? parsed.givenAt : null;
       const fatFood = parsed && parsed.fatFood ? parsed.fatFood : null;
-      const timeText = givenAt ? 'Done at ' + escHtml(givenAt) : 'Done today';
+      const isLate = parsed && parsed.status === 'late';
+      // CR-9: render 12h for parent-facing surfaces. Storage stays 24h en-GB canonical.
+      // CR-15: surface 'logged late' marker on the title here too — was inconsistent
+      // vs the TSF event-detail expansion which always showed it.
+      let timeText;
+      if (givenAt) timeText = 'Done at ' + escHtml(_formatTime12h(givenAt)) + (isLate ? ' (logged late)' : '');
+      else if (isLate) timeText = 'Done — logged late';
+      else timeText = 'Done today';
       // V-M-61: null withFat (legacy / unknown) renders no badge. V-M-63: softer framing.
       let fatBadge = '';
       if (parsed && parsed.withFat === true && fatFood) {
@@ -738,6 +745,22 @@ function renderRemindersAndAlerts() {
           </div>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${fatBadge}</div>
+      </div>`;
+    } else if (isSkipped) {
+      // CR-5: NEW skipped-state render. Pre-fix, the skipped branch produced no card at all
+      // and the 'All medications done for today' banner was removed — the parent got zero
+      // visual acknowledgement of their explicit skip, while _obCheckVitD3 kept flagging
+      // 'Vit D3 pending' on the home overlay, contradicting the just-recorded action.
+      html += `
+      <div class="supp-alert supp-alert-skipped" id="supp-alert-${idx}">
+        <div class="supp-alert-top">
+          <div class="supp-alert-icon">${zi('skip-forward')}</div>
+          <div class="supp-alert-title">Skipped today — ${escHtml(m.name)}</div>
+          <div class="supp-alert-action">
+            <button class="supp-skip-btn supp-adjust-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Undo skip</button>
+          </div>
+        </div>
+        <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}Skip recorded — tap Undo to revert and log a dose.</div>
       </div>`;
     }
   });
@@ -940,8 +963,15 @@ function openMedDoneAt(name, idx) {
     '<button class="supp-skip-btn" data-action="cancelMedDoneAt" data-arg2="' + idx + '">Cancel</button>';
 }
 function confirmMedDoneAt(name, idx) {
+  // CR-4: validate before falling through to markMedDone — empty / malformed input must
+  // surface an error, not silently substitute tap-time and overwrite the parent's intent.
   const input = document.getElementById('supp-time-' + idx);
   const picked = input && input.value ? input.value : null;
+  if (!picked || !/^\d{1,2}:\d{2}$/.test(picked)) {
+    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Pick a time, or tap Cancel');
+    if (input) { try { input.focus(); } catch(e) {} }
+    return;
+  }
   markMedDone(name, idx, picked);
 }
 function cancelMedDoneAt(idx) {
@@ -981,26 +1011,50 @@ function openMedAdjust(name, idx) {
   const actionRow = card.querySelector('.supp-alert-action');
   if (!actionRow || actionRow.dataset.editing === '1') return;
   actionRow.dataset.editing = '1';
+  // CR-7: prefill with the captured givenAt if present; if absent (legacy record with no
+  // time captured), leave the input EMPTY rather than substituting the current clock time.
+  // confirmMedAdjust's CR-8 validation will block a save with no time, so the parent must
+  // actively type a value to overwrite the historical record — no accidental clobbers.
   const cur = parseMedCheck(medChecks[today()] && medChecks[today()][name]);
-  const curAt = (cur && cur.givenAt) || new Date().toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
-  // Re-format HH:MM (handle "08:42 AM" legacy by stripping any AM/PM tail)
+  const curAt = cur && cur.givenAt ? cur.givenAt : '';
   const norm = String(curAt).replace(/\s*(AM|PM)\s*$/i, '');
+  const hint = norm ? '' : '<span class="supp-adjust-hint t-sub t-sm">No time captured — enter actual time:</span>';
   actionRow.innerHTML =
+    hint +
     '<input type="time" class="supp-time-input" id="supp-time-' + idx + '" value="' + escAttr(norm) + '">' +
     '<button class="supp-check-btn" data-action="confirmMedAdjust" data-arg="' + escAttr(name) + '" data-arg2="' + idx + '">Save</button>' +
     '<button class="supp-skip-btn" data-action="cancelMedDoneAt" data-arg2="' + idx + '">Cancel</button>';
 }
 function confirmMedAdjust(name, idx) {
+  // CR-8: validate before falling through to adjustMedTime — empty / malformed input
+  // must surface an error and NOT wedge the editor (adjustMedTime's old early-return
+  // left dataset.editing='1' set, blocking reopens).
   const input = document.getElementById('supp-time-' + idx);
   const picked = input && input.value ? input.value : null;
+  if (!picked || !/^\d{1,2}:\d{2}$/.test(picked)) {
+    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Pick a time, or tap Cancel');
+    if (input) { try { input.focus(); } catch(e) {} }
+    return;
+  }
   adjustMedTime(name, idx, picked);
 }
 
 function markMedSkipped(name, idx) {
+  // CR-10: emit new object schema. Skipped doses now carry loggedAt for audit trail.
   const todayStr = today();
+  const now = new Date();
+  const loggedAt = now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
   if (!medChecks[todayStr]) medChecks[todayStr] = {};
-  medChecks[todayStr][name] = 'skipped';
+  medChecks[todayStr][name] = {
+    status:   'skipped',
+    givenAt:  null,
+    loggedAt: loggedAt,
+    withFat:  null,
+    fatFood:  null,
+    fatDelta: null,
+  };
   save(KEYS.medChecks, medChecks);
+  _tsfMarkDirty();
   _islMarkDirty('medical');
 
   const el = document.getElementById('supp-alert-' + idx);
@@ -1013,13 +1067,34 @@ function markMedSkipped(name, idx) {
 }
 
 function resolveMissedMed(name, dateStr, action) {
+  // CR-10: emit new object schema for both retroactive done-mark and retroactive skip.
+  // Retroactive done has no givenAt (no specific administration time was captured) so
+  // with-fat detection is left null — the 14-day card's withFatKnown denominator
+  // correctly excludes records with no time-anchored fat context.
   if (!medChecks[dateStr]) medChecks[dateStr] = {};
+  const now = new Date();
+  const loggedAt = now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
   if (action === 'done') {
-    medChecks[dateStr][name] = 'done:late';
+    medChecks[dateStr][name] = {
+      status:   'late',
+      givenAt:  null,
+      loggedAt: loggedAt,
+      withFat:  null,
+      fatFood:  null,
+      fatDelta: null,
+    };
   } else {
-    medChecks[dateStr][name] = 'skipped';
+    medChecks[dateStr][name] = {
+      status:   'skipped',
+      givenAt:  null,
+      loggedAt: loggedAt,
+      withFat:  null,
+      fatFood:  null,
+      fatDelta: null,
+    };
   }
   save(KEYS.medChecks, medChecks);
+  _tsfMarkDirty();
   _islMarkDirty('medical');
   renderRemindersAndAlerts(); renderHomeContextAlerts();
 }
@@ -2665,7 +2740,8 @@ function renderMedLog() {
       html += `<div style=""font-weight:600;font-size:var(--fs-sm);color:var(--tc-sky);margin-bottom:4px;">${dayName}, ${dayNum} ${monthNames[parseInt(mon) - 1]}</div>`;
 
       dayItems.forEach(e => {
-        // V-K-66: schema-aware status read.
+        // V-K-66: schema-aware status read. CR-9: 12h display for parent-facing time.
+        // CR-15: when both givenAt AND late are present, surface "at HH:MM (late)" — not just "(logged late)".
         const parsed = parseMedCheck(e.status);
         const isDone = !!(parsed && (parsed.status === 'done' || parsed.status === 'late'));
         const isLate = !!(parsed && parsed.status === 'late');
@@ -2673,7 +2749,9 @@ function renderMedLog() {
         const icon = isDone ? zi('check') : zi('skip-forward');
         const label = isDone ? 'Given' : 'Skipped';
         const color = isDone ? '#3a7060' : '#926030';
-        const timePart = isLate ? ' (logged late)' : (timeStr ? ` at ${escHtml(timeStr)}` : '');
+        let timePart = '';
+        if (timeStr) timePart = ' at ' + escHtml(_formatTime12h(timeStr)) + (isLate ? ' (late)' : '');
+        else if (isLate) timePart = ' (logged late)';
 
         html += `
           <div style="display:flex;align-items:center;gap:var(--sp-8);padding:3px 0;font-size:var(--fs-base);">
@@ -5261,19 +5339,23 @@ function _obIsTeethingActive() {
 }
 
 function _obCheckVitD3() {
-  // Returns true if Vit D3 needs attention (not given today or no D3 med tracked).
-  // Schema-aware via medCheckIsDone (handles both legacy 'done:HH:MM' string and new object shape).
+  // Returns true if Vit D3 needs attention.
+  // CR-5: Skipped doses count as RESOLVED — parent explicitly chose to skip and
+  // _obCheckVitD3 must respect that decision, otherwise the home overlay keeps
+  // flagging 'D3 pending' in contradiction to the parent's just-recorded skip.
   var todayStr = today();
   var dayEntry = medChecks ? medChecks[todayStr] : null;
   if (!dayEntry) return true;
-  var d3Given = false;
+  var d3Resolved = false;
   var activeMeds = (meds || []).filter(function(m) { return m.active; });
   activeMeds.forEach(function(m) {
     if (m.name && m.name.toLowerCase().indexOf('d3') >= 0) {
-      if (medCheckIsDone(dayEntry[m.name])) d3Given = true;
+      if (medCheckIsDone(dayEntry[m.name]) || medCheckSkipped(dayEntry[m.name])) {
+        d3Resolved = true;
+      }
     }
   });
-  return !d3Given;
+  return !d3Resolved;
 }
 
 function _obGetNextVaccine() {
@@ -8347,17 +8429,20 @@ function renderTodayPlan() {
   }
 
   // D3 supplement — V-K-66: schema-aware via parseMedCheck (legacy string + new object both handled).
+  // CR-9: 12h display via _formatTime12h. CR-15: surface 'logged late' marker.
   const d3Med = meds.find(m => m.active && m.name.toLowerCase().includes('d3'));
   if (d3Med) {
     const d3Parsed = parseMedCheck(medChecks[todayStr] && medChecks[todayStr][d3Med.name]);
     const d3Done = !!(d3Parsed && (d3Parsed.status === 'done' || d3Parsed.status === 'late'));
+    const d3Late = !!(d3Parsed && d3Parsed.status === 'late');
     const d3Given = d3Parsed && d3Parsed.givenAt ? d3Parsed.givenAt : null;
     const d3Fat = d3Parsed && d3Parsed.withFat === true && d3Parsed.fatFood ? d3Parsed.fatFood : null;
     let doneDetail;
     if (d3Done) {
-      const timePart = d3Given ? ' at ' + escHtml(d3Given) : '';
+      const timePart = d3Given ? ' at ' + escHtml(_formatTime12h(d3Given)) : '';
+      const latePart = d3Late ? ' (logged late)' : '';
       const fatPart = d3Fat ? ' · with ' + escHtml(d3Fat) : '';
-      doneDetail = '<svg class="zi"><use href="#zi-check"/></svg> Done' + timePart + fatPart;
+      doneDetail = '<svg class="zi"><use href="#zi-check"/></svg> Done' + timePart + latePart + fatPart;
     } else {
       doneDetail = d3Med.dose + ' — give with or after a feed for best absorption';
     }
@@ -8794,22 +8879,34 @@ function renderTrendChips() {
 
   // Vitamin D3 — schema-aware (legacy 'done:HH:MM' string + new object shape both handled).
   // V-M-62 + V-K-70: fatFood comes from parent feedingData input — escape at this render boundary.
+  // CR-9: 12h display formatter for parent-facing time.
+  // CR-15: surface 'logged late' marker so chip and event-detail agree on status.
+  // CR-5: also render explicit "Skipped today" rather than "Pending" when status:'skipped'.
   if (d3Med) {
     const todayStr = today();
     const d3Val = medChecks[todayStr] && medChecks[todayStr][d3Med.name];
     const d3Parsed = parseMedCheck(d3Val);
     const d3Done = !!(d3Parsed && (d3Parsed.status === 'done' || d3Parsed.status === 'late'));
-    let valueText, deltaText;
+    const d3Skipped = !!(d3Parsed && d3Parsed.status === 'skipped');
+    const d3Late = !!(d3Parsed && d3Parsed.status === 'late');
+    let valueText, deltaText, cls;
     if (d3Done) {
       const t = d3Parsed.givenAt;
       const fat = d3Parsed.withFat === true && d3Parsed.fatFood ? ' · with ' + escHtml(d3Parsed.fatFood) : '';
-      valueText = t ? ('Done at ' + escHtml(t) + fat) : 'Done today';
+      const lateTag = d3Late ? ' (late)' : '';
+      valueText = t ? ('Done at ' + escHtml(_formatTime12h(t)) + lateTag + fat) : (d3Late ? 'Done — logged late' : 'Done today');
       deltaText = zi('check');
+      cls = 'tc-good';
+    } else if (d3Skipped) {
+      valueText = 'Skipped today';
+      deltaText = 'skipped';
+      cls = 'tc-warn';
     } else {
       valueText = 'Pending';
       deltaText = 'pending';
+      cls = 'tc-warn';
     }
-    chips.push({ icon:zi('sun'), label:'Vitamin D3', value: valueText, delta: deltaText, cls: d3Done ? 'tc-good' : 'tc-warn', tab:'medical' });
+    chips.push({ icon:zi('sun'), label:'Vitamin D3', value: valueText, delta: deltaText, cls: cls, tab:'medical' });
   }
 
   let html = '';

--- a/split/intelligence-illness.js
+++ b/split/intelligence-illness.js
@@ -2062,6 +2062,8 @@ function saveFeedingDay() {
   save(KEYS.feeding, feedingData);
   _tsfMarkDirty();
   _islMarkDirty('diet');
+  // CR-14: re-evaluate with-fat for today's dose entries that were logged before this meal.
+  if (d === today() && typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();
   // Auto-introduce any new foods from all meal slots
   autoIntroduceFoodsFromDay(d);
   renderFeedingHistory();

--- a/split/intelligence-isl.js
+++ b/split/intelligence-isl.js
@@ -546,18 +546,27 @@ function _islMedicalData(startDate, endDate) {
   var suppTotal = 0;
   var d3Times = [];
 
+  // Vit D3 tracking v1: schema-aware via parseMedCheck (handles legacy string + new object shape).
+  // d3Times now also carries the with-fat context for downstream analysis surfaces.
+  var d3WithFat = 0;
+  var d3WithoutFat = 0;
+  var d3FatFoods = [];
   dates.forEach(function(ds) {
     var dayChecks = medChecks[ds];
     if (dayChecks) {
       var anyDone = false;
       Object.keys(dayChecks).forEach(function(name) {
-        var val = dayChecks[name];
-        if (typeof val === 'string' && val.startsWith('done')) {
+        var parsed = parseMedCheck(dayChecks[name]);
+        if (parsed && (parsed.status === 'done' || parsed.status === 'late')) {
           anyDone = true;
-          // Extract D3 time
           if (/d3|vitamin d/i.test(name)) {
-            var timePart = val.replace('done:', '').replace('done', '');
-            if (timePart) d3Times.push(timePart);
+            if (parsed.givenAt) d3Times.push(parsed.givenAt);
+            if (parsed.withFat === true) {
+              d3WithFat++;
+              if (parsed.fatFood) d3FatFoods.push(parsed.fatFood);
+            } else if (parsed.withFat === false) {
+              d3WithoutFat++;
+            }
           }
         }
       });
@@ -588,11 +597,26 @@ function _islMedicalData(startDate, endDate) {
 
   var medScore = calcMedicalScore();
 
+  var d3FatTotal = d3WithFat + d3WithoutFat;
+  var d3FatRate = d3FatTotal > 0 ? Math.round((d3WithFat / d3FatTotal) * 100) : null;
+  // Most-common fat food across the window (Mode of d3FatFoods)
+  var d3FatTopFood = null;
+  if (d3FatFoods.length > 0) {
+    var counts = {};
+    d3FatFoods.forEach(function(f) { counts[f] = (counts[f] || 0) + 1; });
+    var top = null, topN = 0;
+    Object.keys(counts).forEach(function(k) { if (counts[k] > topN) { top = k; topN = counts[k]; } });
+    d3FatTopFood = top;
+  }
   return {
     suppAdherence: suppTotal > 0 ? Math.round((suppDays / suppTotal) * 100) : null,
     suppDays: suppDays,
     suppTotal: suppTotal,
     d3Times: d3Times,
+    d3WithFat: d3WithFat,
+    d3WithoutFat: d3WithoutFat,
+    d3FatRate: d3FatRate,
+    d3FatTopFood: d3FatTopFood,
     vaccCompleted: completed.length,
     vaccUpcoming: upcoming.length > 0 ? upcoming[0] : null,
     growthInRange: rangeGrowth,

--- a/split/intelligence-qa-handlers.js
+++ b/split/intelligence-qa-handlers.js
@@ -317,7 +317,13 @@ function _qaRoutine() {
   if (pp.totalCount > 0) items.push({ text: 'Poop: avg ' + pp.avgPerDay + '/day, mostly ' + (pp.mostCommonConsistency || 'normal'), signal: 'neutral', icon: zi('diaper') });
 
   var md = getDomainData('medical', _offsetDateStr(today(), -6), today());
-  if (md.suppAdherence !== null) items.push({ text: 'Vit D3: ' + md.suppAdherence + '% adherence', signal: md.suppAdherence >= ISL_THRESHOLDS.D3_ADHERENCE_GOOD_PCT ? 'good' : 'warn', icon: zi('pill') });
+  if (md.suppAdherence !== null) {
+    var d3Text = 'Vit D3: ' + md.suppAdherence + '% adherence';
+    if (md.d3FatRate !== null && (md.d3WithFat + md.d3WithoutFat) >= 3) {
+      d3Text += ' · ' + md.d3FatRate + '% with fat';
+    }
+    items.push({ text: d3Text, signal: md.suppAdherence >= ISL_THRESHOLDS.D3_ADHERENCE_GOOD_PCT ? 'good' : 'warn', icon: zi('pill') });
+  }
 
   var age = ageAt();
   return {
@@ -544,9 +550,14 @@ function _qaDoctorPrep() {
     items.push({ text: 'Next vaccine: ' + gd.vaccUpcoming.name + (vDays > 0 ? ' in ' + vDays + ' days' : ' \u2014 due now'), signal: vDays <= 3 ? 'action' : 'info' });
   }
 
-  // D3 adherence
+  // D3 adherence + with-fat enrichment (only if we have enough samples to be meaningful)
   if (gd.suppAdherence !== null) {
     items.push({ text: 'D3 adherence (30d): ' + gd.suppAdherence + '%', signal: gd.suppAdherence >= ISL_THRESHOLDS.D3_ADHERENCE_GOOD_PCT ? 'good' : 'warn' });
+    if (gd.d3FatRate !== null && (gd.d3WithFat + gd.d3WithoutFat) >= 5) {
+      var fatText = 'D3 with-fat absorption (30d): ' + gd.d3FatRate + '% of doses';
+      if (gd.d3FatTopFood) fatText += ' · most often ' + gd.d3FatTopFood;
+      items.push({ text: fatText, signal: gd.d3FatRate >= 70 ? 'good' : 'info' });
+    }
   }
 
   // Recent concerns from last 7 days

--- a/split/intelligence-qa-handlers.js
+++ b/split/intelligence-qa-handlers.js
@@ -3048,14 +3048,19 @@ function qaAnswerSupplement(intentId) {
         actionItems.push({ text: 'Set extra reminders for ' + s.flaggedDays.join(', '), signal: 'action' });
       }
 
-      // Today's status
+      // Today's status — CR-1: schema-aware via parseMedCheck (handles both legacy string + new object).
       var todayEntry = (medChecks || {})[today()];
       var todayStatus = todayEntry ? todayEntry[s.name] : undefined;
-      if (!todayStatus) {
+      var todayParsed = parseMedCheck(todayStatus);
+      if (!todayParsed) {
         actionItems.push({ text: 'Not given today yet — don\'t forget!', signal: 'action' });
-      } else if (todayStatus.indexOf('done') === 0) {
-        var timeGiven = todayStatus.replace('done:', '');
-        actionItems.push({ text: 'Given today at ' + timeGiven, signal: 'good' });
+      } else if (todayParsed.status === 'done' || todayParsed.status === 'late') {
+        var timeGiven = todayParsed.givenAt ? _formatTime12h(todayParsed.givenAt) : 'unrecorded time';
+        var lateTag = todayParsed.status === 'late' ? ' (logged late)' : '';
+        var fatTag = todayParsed.withFat === true && todayParsed.fatFood ? ' with ' + todayParsed.fatFood : '';
+        actionItems.push({ text: 'Given today at ' + timeGiven + fatTag + lateTag, signal: 'good' });
+      } else if (todayParsed.status === 'skipped') {
+        actionItems.push({ text: 'Skipped today', signal: 'info' });
       }
     });
   } catch(e) {

--- a/split/intelligence-quicklog.js
+++ b/split/intelligence-quicklog.js
@@ -1420,6 +1420,8 @@ function saveQLFeed() {
   _tsfMarkDirty();
 
   _islMarkDirty('diet');
+  // CR-14: re-evaluate with-fat for today's dose entries that were logged before this meal.
+  if (dateStr === today() && typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();
   // Auto-introduce new foods
   autoIntroduceFoodsFromDay(dateStr);
 
@@ -2156,13 +2158,18 @@ function _tsfRenderEventExpanded(ev) {
     if (ev.domains && ev.domains.length > 0) html += '<div>Domains: ' + escHtml(ev.domains.join(', ')) + '</div>';
   } else if (ev.type === 'med') {
     // V-K-67: schema-aware via parseMedCheck (handles both legacy string + new object).
+    // CR-9 + CR-15: 12h display via _formatTime12h, unified late surface ('Done at X (logged late)').
     const parsedStatus = parseMedCheck(ev.status);
     if (parsedStatus) {
       let statusText;
       if (parsedStatus.status === 'skipped') statusText = 'Skipped';
-      else if (parsedStatus.status === 'late') statusText = 'Done (logged late)';
-      else if (parsedStatus.status === 'done') statusText = parsedStatus.givenAt ? 'Done at ' + parsedStatus.givenAt : 'Done';
-      else statusText = '';
+      else if (parsedStatus.status === 'late') {
+        statusText = parsedStatus.givenAt
+          ? 'Done at ' + _formatTime12h(parsedStatus.givenAt) + ' (logged late)'
+          : 'Done (logged late)';
+      } else if (parsedStatus.status === 'done') {
+        statusText = parsedStatus.givenAt ? 'Done at ' + _formatTime12h(parsedStatus.givenAt) : 'Done';
+      } else statusText = '';
       if (statusText) html += '<div>Status: ' + escHtml(statusText) + '</div>';
       if (parsedStatus.withFat === true && parsedStatus.fatFood) {
         html += '<div>With fat: ' + escHtml(parsedStatus.fatFood) + '</div>';

--- a/split/intelligence-quicklog.js
+++ b/split/intelligence-quicklog.js
@@ -1871,37 +1871,38 @@ function _tsfCollectEvents() {
   });
 
   // ── Supplements (medChecks) today ──
+  // V-K-67: schema-aware via parseMedCheck — accepts BOTH legacy 'done:HH:MM' strings AND new object shape.
   const todayMedChecks = medChecks[t] || {};
   Object.keys(todayMedChecks).forEach(function(medName) {
     const val = todayMedChecks[medName];
-    if (typeof val !== 'string') return;
+    const parsed = parseMedCheck(val);
+    if (!parsed) return;
     let timeStr = null;
     let timeMin = null;
     let displayTime = '';
-    if (val.startsWith('done:')) {
-      const timePart = val.replace('done:', '').trim();
-      if (timePart !== 'late') {
-        timeMin = _tsfTimeToMinutes(timePart);
-        timeStr = timePart;
-        displayTime = _tsfFormatTime(timePart);
-      }
+    if ((parsed.status === 'done' || parsed.status === 'late') && parsed.givenAt) {
+      timeMin = _tsfTimeToMinutes(parsed.givenAt);
+      timeStr = parsed.givenAt;
+      displayTime = _tsfFormatTime(parsed.givenAt);
     }
+    const detail = (parsed.status === 'done' || parsed.status === 'late') ? 'Done' : (parsed.status === 'skipped' ? 'Skipped' : '');
     const ev = {
       id: 'med-' + medName,
       type: 'med',
       time: timeStr,
       timeMin: timeMin,
       label: medName,
-      detail: val.startsWith('done:') ? 'Done' : val === 'skipped' ? 'Skipped' : '',
+      detail: detail,
       icon: zi('pill'),
       color: 'sky',
       inferred: false,
       displayTime: displayTime,
-      status: val
+      status: val,
+      parsed: parsed
     };
     if (timeMin !== null) {
       events.push(ev);
-    } else if (val !== 'skipped') {
+    } else if (parsed.status !== 'skipped') {
       noTimeEvents.push(ev);
     }
   });
@@ -1937,9 +1938,9 @@ function _tsfGetAnchor() {
     poopData.filter(function(p) { return p.date === d; }).forEach(function() { dayCount++; });
     // Activities
     (activityLog[d] || []).forEach(function() { dayCount++; });
-    // Meds
+    // Meds — V-K-67: schema-aware via medCheckIsDone.
     const mc = medChecks[d] || {};
-    Object.keys(mc).forEach(function(k) { if (mc[k] && mc[k].toString().startsWith('done')) dayCount++; });
+    Object.keys(mc).forEach(function(k) { if (medCheckIsDone(mc[k])) dayCount++; });
     if (dayCount > 0) {
       totalEvents += dayCount;
       daysWithData++;
@@ -2004,11 +2005,11 @@ function _tsfDetectPatterns() {
           }
         });
       } else if (def.type === 'med' && def.medName) {
+        // V-K-67: schema-aware via parseMedCheck.
         const mc = medChecks[d] || {};
-        const val = mc[def.medName];
-        if (val && typeof val === 'string' && val.startsWith('done:')) {
-          const timePart = val.replace('done:', '').trim();
-          const mm = _tsfTimeToMinutes(timePart);
+        const parsed = parseMedCheck(mc[def.medName]);
+        if (parsed && (parsed.status === 'done' || parsed.status === 'late')) {
+          const mm = parsed.givenAt ? _tsfTimeToMinutes(parsed.givenAt) : null;
           found = true;
           if (mm !== null) foundMin = mm;
         }
@@ -2100,8 +2101,9 @@ function _tsfGetNudges() {
         return pm !== null && pm >= pat.windowStart && pm <= pat.windowEnd;
       });
     } else if (pat.type === 'med' && pat.medName) {
+      // V-K-67: schema-aware — handles both legacy string and new object shapes.
       const mc = todayMC[pat.medName];
-      alreadyLogged = mc && typeof mc === 'string' && (mc.startsWith('done') || mc === 'skipped');
+      alreadyLogged = medCheckIsDone(mc) || medCheckSkipped(mc);
     }
 
     if (alreadyLogged) return;
@@ -2153,7 +2155,19 @@ function _tsfRenderEventExpanded(ev) {
     if (ev.duration) html += '<div>Duration: ' + ev.duration + ' min</div>';
     if (ev.domains && ev.domains.length > 0) html += '<div>Domains: ' + escHtml(ev.domains.join(', ')) + '</div>';
   } else if (ev.type === 'med') {
-    if (ev.status) html += '<div>Status: ' + escHtml(ev.status.replace('done:', 'Done at ')) + '</div>';
+    // V-K-67: schema-aware via parseMedCheck (handles both legacy string + new object).
+    const parsedStatus = parseMedCheck(ev.status);
+    if (parsedStatus) {
+      let statusText;
+      if (parsedStatus.status === 'skipped') statusText = 'Skipped';
+      else if (parsedStatus.status === 'late') statusText = 'Done (logged late)';
+      else if (parsedStatus.status === 'done') statusText = parsedStatus.givenAt ? 'Done at ' + parsedStatus.givenAt : 'Done';
+      else statusText = '';
+      if (statusText) html += '<div>Status: ' + escHtml(statusText) + '</div>';
+      if (parsedStatus.withFat === true && parsedStatus.fatFood) {
+        html += '<div>With fat: ' + escHtml(parsedStatus.fatFood) + '</div>';
+      }
+    }
   }
   return html || '<div>No additional details</div>';
 }

--- a/split/intelligence-quicklog.js
+++ b/split/intelligence-quicklog.js
@@ -1887,7 +1887,11 @@ function _tsfCollectEvents() {
       timeStr = parsed.givenAt;
       displayTime = _tsfFormatTime(parsed.givenAt);
     }
-    const detail = (parsed.status === 'done' || parsed.status === 'late') ? 'Done' : (parsed.status === 'skipped' ? 'Skipped' : '');
+    // V-V-17: chip detail carries the late marker so a half-awake parent reading only the
+    // chip (without tapping to expand) can see retroactive logs at a glance.
+    const detail = parsed.status === 'late' ? 'Done (late)'
+                 : (parsed.status === 'done' ? 'Done'
+                 : (parsed.status === 'skipped' ? 'Skipped' : ''));
     const ev = {
       id: 'med-' + medName,
       type: 'med',
@@ -2753,6 +2757,8 @@ function skipMeals(mealKeys) {
     if (!feedingData[dateStr][m]) feedingData[dateStr][m] = '—skipped—';
   });
   save(KEYS.feeding, feedingData);
+  // V-M-70: complete the _refreshTodayMedWithFat contract on every feedingData mutation.
+  if (typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();
   renderHomeMealProgress();
   updateMealSkipButtons();
   showQLToast(mealKeys.map(m => m.charAt(0).toUpperCase() + m.slice(1)).join(' & ') + ' marked as skipped');
@@ -2771,6 +2777,8 @@ function skipSingleMeal(mealKey) {
   if (feedingData[dateStr][mealKey] && feedingData[dateStr][mealKey] !== '—skipped—') return; // already has food
   feedingData[dateStr][mealKey] = '—skipped—';
   save(KEYS.feeding, feedingData);
+  // V-M-70: complete the _refreshTodayMedWithFat contract.
+  if (dateStr === today() && typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();
   const input = document.getElementById('meal-' + mealKey);
   if (input) { input.value = ''; input.placeholder = 'Skipped'; input.disabled = true; }
   const timeInput = document.getElementById('mealtime-' + mealKey);
@@ -2786,6 +2794,8 @@ function unskipSingleMeal(mealKey) {
   if (!feedingData[dateStr]) return;
   feedingData[dateStr][mealKey] = '';
   save(KEYS.feeding, feedingData);
+  // V-M-70: complete the _refreshTodayMedWithFat contract.
+  if (dateStr === today() && typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();
   const input = document.getElementById('meal-' + mealKey);
   if (input) { input.value = ''; input.placeholder = 'Type to search foods...'; input.disabled = false; }
   const timeInput = document.getElementById('mealtime-' + mealKey);

--- a/split/medical.js
+++ b/split/medical.js
@@ -2233,7 +2233,8 @@ function renderMedicalStats() {
     if (dateKey.startsWith('_') || typeof val !== 'object') return;
     if (new Date(dateKey) < weekAgo) return;
     totalDays++;
-    Object.values(val).forEach(s => { if (s.startsWith('done')) givenCount++; });
+    // V-K-66: schema-aware count — handles both legacy string and new object shapes.
+    Object.values(val).forEach(s => { if (medCheckIsDone(s)) givenCount++; });
   });
 
   el.innerHTML = `
@@ -4372,9 +4373,16 @@ function renderMedD3PatternCard() {
   doneDays.forEach(d => { if (d.parsed.fatFood) fatFoodCounts[d.parsed.fatFood] = (fatFoodCounts[d.parsed.fatFood] || 0) + 1; });
   let topFatFood = null, topN = 0;
   Object.keys(fatFoodCounts).forEach(k => { if (fatFoodCounts[k] > topN) { topFatFood = k; topN = fatFoodCounts[k]; } });
-  // Streak: consecutive done-days ending today
+  // Streak: consecutive done-days ending today.
+  // V-M-64: if today is unlogged (parent hasn't tapped Done yet), don't punish the streak —
+  // walk from yesterday and label "through yesterday" so a 30-day perfect run doesn't read as 0.
   let streak = 0;
-  for (let i = days.length - 1; i >= 0; i--) {
+  let streakLabel = 'Current streak';
+  const todayParsed = days[days.length - 1].parsed;
+  const todayResolved = !!(todayParsed && (todayParsed.status === 'done' || todayParsed.status === 'late' || todayParsed.status === 'skipped'));
+  const startIdx = todayResolved ? days.length - 1 : days.length - 2;
+  if (!todayResolved) streakLabel = 'Streak through yesterday';
+  for (let i = startIdx; i >= 0; i--) {
     if (days[i].parsed && (days[i].parsed.status === 'done' || days[i].parsed.status === 'late')) streak++;
     else break;
   }
@@ -4388,7 +4396,7 @@ function renderMedD3PatternCard() {
     summary += `<div class="med-d3-summary-row">${zi('bowl')} <span class="${fatCls}">With-fat rate: ${withFatCount} of ${withFatKnown.length} doses (${fatRate}%)</span></div>`;
   }
   if (topFatFood) summary += `<div class="med-d3-summary-row">${zi('check')} Usually paired with: <strong>${escHtml(topFatFood)}</strong></div>`;
-  if (streak > 0) summary += `<div class="med-d3-summary-row">${zi('trending-flat')} Current streak: <strong>${streak} day${streak === 1 ? '' : 's'}</strong></div>`;
+  if (streak > 0) summary += `<div class="med-d3-summary-row">${zi('trending-flat')} ${streakLabel}: <strong>${streak} day${streak === 1 ? '' : 's'}</strong></div>`;
   if (unloggedDays.length > 0) summary += `<div class="med-d3-summary-row tc-warn">${zi('warn')} ${unloggedDays.length} day${unloggedDays.length === 1 ? '' : 's'} not logged in this window</div>`;
   summary += '</div>';
   // 14-day compact list (most-recent first)
@@ -4402,9 +4410,11 @@ function renderMedD3PatternCard() {
       row = `<span class="tc-warn">Skipped</span>`;
     } else {
       const t = d.parsed.givenAt ? 'Done at ' + escHtml(d.parsed.givenAt) : 'Done';
+      // V-M-61 + V-M-63: only render the "no fat-meal" line on explicit false
+      // (not null/unknown), with softened framing.
       const fat = d.parsed.withFat === true && d.parsed.fatFood
         ? ` <span class="tc-sage">· with ${escHtml(d.parsed.fatFood)}</span>`
-        : (d.parsed.withFat === false ? ` <span class="t-sub">· no fat-meal nearby</span>` : '');
+        : (d.parsed.withFat === false ? ` <span class="t-sub">· no fat-meal logged nearby</span>` : '');
       row = t + fat;
     }
     list += `<div class="med-d3-log-row"><span class="med-d3-log-date">${escHtml(label)}</span><span>${row}</span></div>`;
@@ -9551,9 +9561,10 @@ function computeSupplementAdherence(windowDays) {
       var dow = d.getDay();
 
       var calStatus = 'missed';
-      if (status && status.indexOf('done') === 0) {
-        var timeStr = status.replace('done:', '');
-        if (timeStr === 'late') {
+      // V-K-66: schema-aware status read.
+      var parsedStatus = parseMedCheck(status);
+      if (parsedStatus && (parsedStatus.status === 'done' || parsedStatus.status === 'late')) {
+        if (parsedStatus.status === 'late') {
           lateCount++;
           calStatus = 'late';
           doneCount++; // late still counts as done for adherence
@@ -9561,10 +9572,11 @@ function computeSupplementAdherence(windowDays) {
           doneCount++;
           calStatus = 'done';
           // Parse time
+          var timeStr = parsedStatus.givenAt || '';
           var parsed = _parseSupplementTime(timeStr);
           if (parsed !== null) times.push(parsed);
         }
-      } else if (status === 'skipped') {
+      } else if (parsedStatus && parsedStatus.status === 'skipped') {
         skippedCount++;
         calStatus = 'skipped';
         dayOfWeekMisses[dow]++;

--- a/split/medical.js
+++ b/split/medical.js
@@ -4402,6 +4402,16 @@ function renderMedD3PatternCard() {
     if (eligibleDays[i] && eligibleDays[i].parsed && (eligibleDays[i].parsed.status === 'done' || eligibleDays[i].parsed.status === 'late')) streak++;
     else break;
   }
+  // V-M-74: fresh-install warm-start — when the parent has just installed and hasn't
+  // logged a dose yet, don't slap them with a rose-tier "0/1 days (0%)". Render a
+  // softer "Just getting started" stripe with no aggressive percentile / streak / fat
+  // surfaces yet.
+  if (eligibleDays.length === 1 && doneDays.length === 0 && skippedDays.length === 0) {
+    body.innerHTML = '<div class="med-d3-summary"><div class="med-d3-summary-row">'
+      + zi('clock') + ' Just getting started — log today\'s dose to begin tracking.'
+      + '</div></div>';
+    return;
+  }
   // Build summary lines
   const sigClass = adherence >= 90 ? 'tc-sage' : adherence >= 70 ? 'tc-warn' : 'tc-rose';
   let summary = '<div class="med-d3-summary">';

--- a/split/medical.js
+++ b/split/medical.js
@@ -4324,6 +4324,101 @@ function renderMeds() {
     `;
     list.appendChild(div);
   });
+  // Vit D3 tracking v1: refresh the 14-day pattern card whenever meds re-render.
+  renderMedD3PatternCard();
+}
+
+// Vit D3 tracking v1: 14-day pattern card.
+// Renders adherence %, usual-time band, with-fat rate, top fat pairing, current streak,
+// and a compact 14-day log. Hidden if no active D3 med tracked.
+function renderMedD3PatternCard() {
+  const card = document.getElementById('medD3PatternCard');
+  const body = document.getElementById('medD3PatternBody');
+  if (!card || !body) return;
+  const d3Med = (meds || []).find(m => m.active && m.name && m.name.toLowerCase().indexOf('d3') >= 0);
+  if (!d3Med) { card.style.display = 'none'; return; }
+  card.style.display = '';
+  const todayStr = today();
+  // 14-day window ending today
+  const days = [];
+  for (let i = 13; i >= 0; i--) {
+    const d = new Date();
+    d.setDate(d.getDate() - i);
+    const ds = d.getFullYear() + '-' + String(d.getMonth()+1).padStart(2,'0') + '-' + String(d.getDate()).padStart(2,'0');
+    const parsed = parseMedCheck(medChecks[ds] && medChecks[ds][d3Med.name]);
+    days.push({ date: ds, parsed: parsed });
+  }
+  // Aggregate stats
+  const doneDays = days.filter(d => d.parsed && (d.parsed.status === 'done' || d.parsed.status === 'late'));
+  const skippedDays = days.filter(d => d.parsed && d.parsed.status === 'skipped');
+  const unloggedDays = days.filter(d => !d.parsed);
+  const adherence = days.length > 0 ? Math.round((doneDays.length / days.length) * 100) : 0;
+  // Usual-time band: take givenAt minutes, find central 80% range
+  const mins = doneDays.map(d => _hhmmToMinutes(d.parsed.givenAt)).filter(m => m >= 0).sort((a,b) => a-b);
+  let usualBand = null;
+  if (mins.length >= 3) {
+    const lo = mins[Math.floor(mins.length * 0.1)];
+    const hi = mins[Math.floor(mins.length * 0.9)];
+    usualBand = _minutesToHhmm(lo) + '–' + _minutesToHhmm(hi);
+  } else if (mins.length > 0) {
+    usualBand = _minutesToHhmm(mins[0]) + (mins.length > 1 ? '–' + _minutesToHhmm(mins[mins.length-1]) : '');
+  }
+  // With-fat rate
+  const withFatKnown = doneDays.filter(d => d.parsed.withFat === true || d.parsed.withFat === false);
+  const withFatCount = doneDays.filter(d => d.parsed.withFat === true).length;
+  const fatRate = withFatKnown.length > 0 ? Math.round((withFatCount / withFatKnown.length) * 100) : null;
+  // Top fat food
+  const fatFoodCounts = {};
+  doneDays.forEach(d => { if (d.parsed.fatFood) fatFoodCounts[d.parsed.fatFood] = (fatFoodCounts[d.parsed.fatFood] || 0) + 1; });
+  let topFatFood = null, topN = 0;
+  Object.keys(fatFoodCounts).forEach(k => { if (fatFoodCounts[k] > topN) { topFatFood = k; topN = fatFoodCounts[k]; } });
+  // Streak: consecutive done-days ending today
+  let streak = 0;
+  for (let i = days.length - 1; i >= 0; i--) {
+    if (days[i].parsed && (days[i].parsed.status === 'done' || days[i].parsed.status === 'late')) streak++;
+    else break;
+  }
+  // Build summary lines
+  const sigClass = adherence >= 90 ? 'tc-sage' : adherence >= 70 ? 'tc-warn' : 'tc-rose';
+  let summary = '<div class="med-d3-summary">';
+  summary += `<div class="med-d3-summary-row"><strong class="${sigClass}">Adherence: ${doneDays.length}/${days.length} days (${adherence}%)</strong></div>`;
+  if (usualBand) summary += `<div class="med-d3-summary-row">${zi('clock')} Usual time: ${escHtml(usualBand)}</div>`;
+  if (fatRate !== null) {
+    const fatCls = fatRate >= 70 ? 'tc-sage' : 'tc-warn';
+    summary += `<div class="med-d3-summary-row">${zi('bowl')} <span class="${fatCls}">With-fat rate: ${withFatCount} of ${withFatKnown.length} doses (${fatRate}%)</span></div>`;
+  }
+  if (topFatFood) summary += `<div class="med-d3-summary-row">${zi('check')} Usually paired with: <strong>${escHtml(topFatFood)}</strong></div>`;
+  if (streak > 0) summary += `<div class="med-d3-summary-row">${zi('trending-flat')} Current streak: <strong>${streak} day${streak === 1 ? '' : 's'}</strong></div>`;
+  if (unloggedDays.length > 0) summary += `<div class="med-d3-summary-row tc-warn">${zi('warn')} ${unloggedDays.length} day${unloggedDays.length === 1 ? '' : 's'} not logged in this window</div>`;
+  summary += '</div>';
+  // 14-day compact list (most-recent first)
+  let list = '<div class="med-d3-log">';
+  days.slice().reverse().forEach(d => {
+    const label = d.date === todayStr ? 'Today' : formatDate(d.date);
+    let row;
+    if (!d.parsed) {
+      row = `<span class="tc-warn">Not logged</span>`;
+    } else if (d.parsed.status === 'skipped') {
+      row = `<span class="tc-warn">Skipped</span>`;
+    } else {
+      const t = d.parsed.givenAt ? 'Done at ' + escHtml(d.parsed.givenAt) : 'Done';
+      const fat = d.parsed.withFat === true && d.parsed.fatFood
+        ? ` <span class="tc-sage">· with ${escHtml(d.parsed.fatFood)}</span>`
+        : (d.parsed.withFat === false ? ` <span class="t-sub">· no fat-meal nearby</span>` : '');
+      row = t + fat;
+    }
+    list += `<div class="med-d3-log-row"><span class="med-d3-log-date">${escHtml(label)}</span><span>${row}</span></div>`;
+  });
+  list += '</div>';
+  body.innerHTML = summary + list;
+}
+
+// Helper: HH:MM minutes → "HH:MM" 24h string.
+function _minutesToHhmm(m) {
+  if (typeof m !== 'number' || m < 0) return '';
+  const h = Math.floor(m / 60);
+  const mm = m % 60;
+  return String(h).padStart(2, '0') + ':' + String(mm).padStart(2, '0');
 }
 
 function openMedModal() {

--- a/split/medical.js
+++ b/split/medical.js
@@ -4349,20 +4349,34 @@ function renderMedD3PatternCard() {
     const parsed = parseMedCheck(medChecks[ds] && medChecks[ds][d3Med.name]);
     days.push({ date: ds, parsed: parsed });
   }
-  // Aggregate stats
-  const doneDays = days.filter(d => d.parsed && (d.parsed.status === 'done' || d.parsed.status === 'late'));
-  const skippedDays = days.filter(d => d.parsed && d.parsed.status === 'skipped');
-  const unloggedDays = days.filter(d => !d.parsed);
-  const adherence = days.length > 0 ? Math.round((doneDays.length / days.length) * 100) : 0;
-  // Usual-time band: take givenAt minutes, find central 80% range
+  // CR-6: adherence denominator must respect d3Med.start AND medChecks._trackingSince —
+  // pre-fix divided by the full 14-day window unconditionally, giving wildly different
+  // numbers vs computeSupplementAdherence on the same screen for a recently-activated med.
+  const medStart = d3Med.start || '2025-09-04';
+  const trackStart = medChecks._trackingSince || '0000-00-00';
+  const effectiveStart = medStart > trackStart ? medStart : trackStart;
+  const eligibleDays = days.filter(d => d.date >= effectiveStart);
+  const doneDays = eligibleDays.filter(d => d.parsed && (d.parsed.status === 'done' || d.parsed.status === 'late'));
+  const skippedDays = eligibleDays.filter(d => d.parsed && d.parsed.status === 'skipped');
+  const unloggedDays = eligibleDays.filter(d => !d.parsed);
+  const adherence = eligibleDays.length > 0 ? Math.round((doneDays.length / eligibleDays.length) * 100) : 0;
+  // Usual-time band: take givenAt minutes, find central 80% range.
+  // CR-11: use (N-1)*p indexing instead of N*p (which collapsed to the max for many N
+  // and degraded 'central 80%' into 'min-to-max range') AND require N>=5 for the band
+  // to be statistically meaningful — below that, show honest min-max range with a tag.
   const mins = doneDays.map(d => _hhmmToMinutes(d.parsed.givenAt)).filter(m => m >= 0).sort((a,b) => a-b);
   let usualBand = null;
-  if (mins.length >= 3) {
-    const lo = mins[Math.floor(mins.length * 0.1)];
-    const hi = mins[Math.floor(mins.length * 0.9)];
+  let usualBandLabel = 'Usual time';
+  if (mins.length >= 5) {
+    const lo = mins[Math.floor((mins.length - 1) * 0.1)];
+    const hi = mins[Math.floor((mins.length - 1) * 0.9)];
     usualBand = _minutesToHhmm(lo) + '–' + _minutesToHhmm(hi);
-  } else if (mins.length > 0) {
-    usualBand = _minutesToHhmm(mins[0]) + (mins.length > 1 ? '–' + _minutesToHhmm(mins[mins.length-1]) : '');
+  } else if (mins.length >= 2) {
+    usualBand = _minutesToHhmm(mins[0]) + '–' + _minutesToHhmm(mins[mins.length-1]);
+    usualBandLabel = 'Time range so far';
+  } else if (mins.length === 1) {
+    usualBand = _minutesToHhmm(mins[0]);
+    usualBandLabel = 'Only one timed dose';
   }
   // With-fat rate
   const withFatKnown = doneDays.filter(d => d.parsed.withFat === true || d.parsed.withFat === false);
@@ -4376,21 +4390,27 @@ function renderMedD3PatternCard() {
   // Streak: consecutive done-days ending today.
   // V-M-64: if today is unlogged (parent hasn't tapped Done yet), don't punish the streak —
   // walk from yesterday and label "through yesterday" so a 30-day perfect run doesn't read as 0.
+  // CR-6: walk over eligibleDays (post-medStart) not raw days, so a recently-activated med
+  // doesn't see its streak punished by pre-activation no-data rows.
   let streak = 0;
   let streakLabel = 'Current streak';
-  const todayParsed = days[days.length - 1].parsed;
+  const todayParsed = eligibleDays.length > 0 ? eligibleDays[eligibleDays.length - 1].parsed : null;
   const todayResolved = !!(todayParsed && (todayParsed.status === 'done' || todayParsed.status === 'late' || todayParsed.status === 'skipped'));
-  const startIdx = todayResolved ? days.length - 1 : days.length - 2;
+  const startIdx = todayResolved ? eligibleDays.length - 1 : eligibleDays.length - 2;
   if (!todayResolved) streakLabel = 'Streak through yesterday';
   for (let i = startIdx; i >= 0; i--) {
-    if (days[i].parsed && (days[i].parsed.status === 'done' || days[i].parsed.status === 'late')) streak++;
+    if (eligibleDays[i] && eligibleDays[i].parsed && (eligibleDays[i].parsed.status === 'done' || eligibleDays[i].parsed.status === 'late')) streak++;
     else break;
   }
   // Build summary lines
   const sigClass = adherence >= 90 ? 'tc-sage' : adherence >= 70 ? 'tc-warn' : 'tc-rose';
   let summary = '<div class="med-d3-summary">';
-  summary += `<div class="med-d3-summary-row"><strong class="${sigClass}">Adherence: ${doneDays.length}/${days.length} days (${adherence}%)</strong></div>`;
-  if (usualBand) summary += `<div class="med-d3-summary-row">${zi('clock')} Usual time: ${escHtml(usualBand)}</div>`;
+  summary += `<div class="med-d3-summary-row"><strong class="${sigClass}">Adherence: ${doneDays.length}/${eligibleDays.length} days (${adherence}%)</strong></div>`;
+  // CR-9: render times in 12h for parent-facing display.
+  if (usualBand) {
+    const bandDisplay = usualBand.split('–').map(t => _formatTime12h(t)).join('–');
+    summary += `<div class="med-d3-summary-row">${zi('clock')} ${escHtml(usualBandLabel)}: ${escHtml(bandDisplay)}</div>`;
+  }
   if (fatRate !== null) {
     const fatCls = fatRate >= 70 ? 'tc-sage' : 'tc-warn';
     summary += `<div class="med-d3-summary-row">${zi('bowl')} <span class="${fatCls}">With-fat rate: ${withFatCount} of ${withFatKnown.length} doses (${fatRate}%)</span></div>`;
@@ -4399,19 +4419,25 @@ function renderMedD3PatternCard() {
   if (streak > 0) summary += `<div class="med-d3-summary-row">${zi('trending-flat')} ${streakLabel}: <strong>${streak} day${streak === 1 ? '' : 's'}</strong></div>`;
   if (unloggedDays.length > 0) summary += `<div class="med-d3-summary-row tc-warn">${zi('warn')} ${unloggedDays.length} day${unloggedDays.length === 1 ? '' : 's'} not logged in this window</div>`;
   summary += '</div>';
-  // 14-day compact list (most-recent first)
+  // 14-day compact list (most-recent first) — iterates raw days (so pre-medStart rows
+  // show 'Not tracked yet' rather than vanishing entirely; the adherence math above
+  // uses eligibleDays so the user-visible numbers are correct).
   let list = '<div class="med-d3-log">';
   days.slice().reverse().forEach(d => {
     const label = d.date === todayStr ? 'Today' : formatDate(d.date);
     let row;
-    if (!d.parsed) {
+    if (d.date < effectiveStart) {
+      row = `<span class="t-sub">Not tracked yet</span>`;
+    } else if (!d.parsed) {
       row = `<span class="tc-warn">Not logged</span>`;
     } else if (d.parsed.status === 'skipped') {
       row = `<span class="tc-warn">Skipped</span>`;
     } else {
-      const t = d.parsed.givenAt ? 'Done at ' + escHtml(d.parsed.givenAt) : 'Done';
-      // V-M-61 + V-M-63: only render the "no fat-meal" line on explicit false
-      // (not null/unknown), with softened framing.
+      // CR-9 + CR-15: 12h display, surface 'logged late' marker consistently.
+      const isLate = d.parsed.status === 'late';
+      const t = d.parsed.givenAt
+        ? 'Done at ' + escHtml(_formatTime12h(d.parsed.givenAt)) + (isLate ? ' (late)' : '')
+        : (isLate ? 'Done (logged late)' : 'Done');
       const fat = d.parsed.withFat === true && d.parsed.fatFood
         ? ` <span class="tc-sage">· with ${escHtml(d.parsed.fatFood)}</span>`
         : (d.parsed.withFat === false ? ` <span class="t-sub">· no fat-meal logged nearby</span>` : '');
@@ -9683,14 +9709,23 @@ function computeSupplementAdherence(windowDays) {
 }
 
 function _parseSupplementTime(str) {
-  // Parse 'HH:MM am/pm' or 'HH:MM AM/PM' to minutes since midnight
+  // CR-3: parse BOTH 24h 'HH:MM' (new schema writes via en-GB) AND 12h 'HH:MM am|pm' (legacy)
+  // to minutes since midnight. Pre-CR3 this only accepted the 12h suffixed form, so every
+  // post-v1 24h write returned null and the timing-analysis surface silently died.
   if (!str || str === 'late') return null;
   str = str.trim().toLowerCase();
-  var match = str.match(/^(\d{1,2}):(\d{2})\s*(am|pm)$/);
-  if (!match) return null;
-  var h = parseInt(match[1], 10);
-  var m = parseInt(match[2], 10);
-  var ampm = match[3];
+  var match24 = str.match(/^(\d{1,2}):(\d{2})$/);
+  if (match24) {
+    var h24 = parseInt(match24[1], 10);
+    var m24 = parseInt(match24[2], 10);
+    if (h24 < 0 || h24 > 23 || m24 < 0 || m24 > 59) return null;
+    return h24 * 60 + m24;
+  }
+  var match12 = str.match(/^(\d{1,2}):(\d{2})\s*(am|pm)$/);
+  if (!match12) return null;
+  var h = parseInt(match12[1], 10);
+  var m = parseInt(match12[2], 10);
+  var ampm = match12[3];
   if (ampm === 'pm' && h !== 12) h += 12;
   if (ampm === 'am' && h === 12) h = 0;
   return h * 60 + m;

--- a/split/styles.css
+++ b/split/styles.css
@@ -2314,6 +2314,18 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
   font-size:var(--fs-sm); padding:var(--sp-4) var(--sp-10);
   min-height:auto;
 }
+/* CR-5: skipped-state reminder card variant — distinct from done/missed */
+.supp-alert-skipped {
+  background:var(--amber-light);
+  border-left-color:var(--amber);
+}
+.supp-alert-skipped .supp-alert-title { color:var(--tc-warn); }
+.supp-alert-skipped .supp-alert-detail { color:var(--tc-warn); }
+/* CR-7: openMedAdjust hint when no historical time was captured */
+.supp-adjust-hint {
+  display:inline-block; margin-right:var(--sp-6);
+  font-style:italic;
+}
 .med-d3-summary {
   padding:var(--sp-8) 0; line-height:var(--lh-relaxed);
   font-size:var(--fs-base); color:var(--mid);

--- a/split/styles.css
+++ b/split/styles.css
@@ -2321,10 +2321,13 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
 }
 .supp-alert-skipped .supp-alert-title { color:var(--tc-warn); }
 .supp-alert-skipped .supp-alert-detail { color:var(--tc-warn); }
-/* CR-7: openMedAdjust hint when no historical time was captured */
+/* CR-7: openMedAdjust hint when no historical time was captured.
+   V-V-10: explicit --mid colour so the italic reads as neutral observation rather than
+   inheriting --tc-sage from .supp-alert-done (which read as confirmatory not directive).
+   V-V-11: baked-in fs-sm so the class is self-contained if a future caller forgets t-sm. */
 .supp-adjust-hint {
   display:inline-block; margin-right:var(--sp-6);
-  font-style:italic;
+  font-style:italic; font-size:var(--fs-sm); color:var(--mid);
 }
 .med-d3-summary {
   padding:var(--sp-8) 0; line-height:var(--lh-relaxed);

--- a/split/styles.css
+++ b/split/styles.css
@@ -2261,7 +2261,7 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
 .supp-alert-title { flex:1; font-size:var(--fs-md); font-weight:600; color:var(--text); }
 .supp-alert.done .supp-alert-title { color:var(--tc-sage); }
 .supp-alert.missed .supp-alert-title { color:var(--tc-rose); }
-.supp-alert-action { flex-shrink:0; display:flex; gap:var(--sp-4); align-items:center; }
+.supp-alert-action { flex-shrink:0; display:flex; gap:var(--sp-4); align-items:center; flex-wrap:wrap; justify-content:flex-end; }
 .supp-alert-detail { font-size:var(--fs-base); font-weight:400; color:var(--mid); padding-left:var(--sp-24); line-height:var(--lh-normal); }
 .supp-alert.done .supp-alert-detail { color:var(--tc-sage); }
 .supp-alert.missed .supp-alert-detail { color:var(--tc-rose); }
@@ -2325,9 +2325,11 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
 }
 .med-d3-log-row {
   display:flex; gap:var(--sp-12); padding:var(--sp-2) 0;
+  flex-wrap:nowrap;
 }
+.med-d3-log-row > :last-child { min-width:0; overflow-wrap:break-word; flex:1; }
 .med-d3-log-date {
-  min-width:80px; color:var(--mid); font-weight:400;
+  min-width:64px; color:var(--mid); font-weight:400; flex-shrink:0;
 }
 
 /* ── Home stat pills ── */

--- a/split/styles.css
+++ b/split/styles.css
@@ -2286,6 +2286,50 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
 }
 .supp-skip-btn:hover { border-color:var(--rose); color:var(--rose); background:var(--rose-light); }
 
+/* Vit D3 tracking v1 — done-state card, inline time-edit, and pattern card */
+.supp-alert-done {
+  background:var(--sage-light);
+  border-left-color:var(--sage);
+}
+.supp-alert-done .supp-alert-title { color:var(--tc-sage); }
+.supp-alert-done .supp-alert-detail { color:var(--tc-sage); }
+.supp-check-btn-alt {
+  background:transparent;
+  color:var(--tc-sage);
+  border:1.5px solid var(--sage);
+}
+.supp-check-btn-alt:hover { background:var(--sage-light); }
+.supp-time-input {
+  font-family:'Nunito',sans-serif; font-size:var(--fs-base);
+  padding:var(--sp-6) var(--sp-10); border-radius:var(--r-md);
+  border:1.5px solid var(--border); background:var(--bg);
+  color:var(--text); min-height:40px;
+}
+.supp-fat-badge {
+  display:inline-flex; align-items:center; gap:var(--sp-4);
+  font-size:var(--fs-sm); color:var(--tc-sage); font-weight:600;
+}
+.supp-fat-badge-neutral { color:var(--mid); font-weight:400; }
+.supp-adjust-btn {
+  font-size:var(--fs-sm); padding:var(--sp-4) var(--sp-10);
+  min-height:auto;
+}
+.med-d3-summary {
+  padding:var(--sp-8) 0; line-height:var(--lh-relaxed);
+  font-size:var(--fs-base); color:var(--mid);
+}
+.med-d3-summary-row { padding:var(--sp-2) 0; }
+.med-d3-log {
+  padding-top:var(--sp-6); border-top:1px solid var(--border);
+  font-size:var(--fs-sm); line-height:var(--lh-normal);
+}
+.med-d3-log-row {
+  display:flex; gap:var(--sp-12); padding:var(--sp-2) 0;
+}
+.med-d3-log-date {
+  min-width:80px; color:var(--mid); font-weight:400;
+}
+
 /* ── Home stat pills ── */
 /* ── Stat pills grid — balanced sizing ── */
 .stat-pills-grid {

--- a/split/template.html
+++ b/split/template.html
@@ -721,6 +721,14 @@
         <div class="med-list" id="medList"></div>
       </div>
 
+      <!-- VIT D3 14-DAY PATTERN -->
+      <div class="card card-info col-full" id="medD3PatternCard">
+        <div class="card-header">
+          <div class="card-title"><div class="icon icon-sky"><svg class="zi"><use href="#zi-sun"/></svg></div> Vitamin D3 — 14-day pattern</div>
+        </div>
+        <div id="medD3PatternBody"></div>
+      </div>
+
       <!-- VACCINATION COVERAGE CHECK -->
       <div class="card card-info col-full" id="medVaccCoverage">
         <div class="card-header" data-collapse-target="vaccCoverageBody" data-collapse-chevron="vaccCoverageChevron">

--- a/split/template.html
+++ b/split/template.html
@@ -724,7 +724,7 @@
       <!-- VIT D3 14-DAY PATTERN -->
       <div class="card card-info col-full" id="medD3PatternCard">
         <div class="card-header">
-          <div class="card-title"><div class="icon icon-sky"><svg class="zi"><use href="#zi-sun"/></svg></div> Vitamin D3 — 14-day pattern</div>
+          <div class="card-title"><div class="icon icon-sky"><svg class="zi"><use href="#zi-sun"/></svg></div> Vitamin D3 · 14-day pattern</div>
         </div>
         <div id="medD3PatternBody"></div>
       </div>

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -2,7 +2,7 @@ audit-emoji.sh [default (5 surfaced ranges)]: 0 HR-1 violations across split, in
 audit-icon-text: PASS (0 unannotated `(label|text|reason|detail): (zi|iconText)(` field-assignments)
 audit-resolve-shield: PASS (4 resolve-caller(s) carry the explicit `'Resolve'` btnText shield per V-M-41 doctrine)
 audit-viz-smoke: PASS (4 ids + 5 tokens) across template.html + styles.css
-[bump-version] 2026.05.23-7 → 2026.05.23-8
+[bump-version] 2026.05.23-8 → 2026.05.23-9
 [poop-reference] wrote /home/user/sproutlab/docs/POOP_COLOR_REFERENCE.html
 [careticket-sm] wrote /home/user/sproutlab/docs/CARETICKET_STATE_MACHINE.html — 6 transitions, 0 drift flags
 <!DOCTYPE html>
@@ -17253,7 +17253,7 @@ function _detectFatContextNearTime(timeStr, dateStr, windowMinutes) {
   meals.forEach(function(m) {
     var mTime = day[m + '_time'];
     var mFoods = day[m];
-    if (!mTime || !mFoods || mFoods === '—skipped—' || mFoods === '—skipped—') return;
+    if (!mTime || !mFoods || mFoods === '—skipped—') return;
     var mMin = _hhmmToMinutes(mTime);
     if (mMin < 0) return;
     var delta = mMin - targetMin; // signed: negative = meal before dose

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -1,3 +1,10 @@
+audit-emoji.sh [default (5 surfaced ranges)]: 0 HR-1 violations across split, index.html, sproutlab.html
+audit-icon-text: PASS (0 unannotated `(label|text|reason|detail): (zi|iconText)(` field-assignments)
+audit-resolve-shield: PASS (4 resolve-caller(s) carry the explicit `'Resolve'` btnText shield per V-M-41 doctrine)
+audit-viz-smoke: PASS (4 ids + 5 tokens) across template.html + styles.css
+[bump-version] 2026.05.24-1 → 2026.05.24-2
+[poop-reference] wrote /home/user/sproutlab/docs/POOP_COLOR_REFERENCE.html
+[careticket-sm] wrote /home/user/sproutlab/docs/CARETICKET_STATE_MACHINE.html — 6 transitions, 0 drift flags
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -2328,10 +2335,13 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
 }
 .supp-alert-skipped .supp-alert-title { color:var(--tc-warn); }
 .supp-alert-skipped .supp-alert-detail { color:var(--tc-warn); }
-/* CR-7: openMedAdjust hint when no historical time was captured */
+/* CR-7: openMedAdjust hint when no historical time was captured.
+   V-V-10: explicit --mid colour so the italic reads as neutral observation rather than
+   inheriting --tc-sage from .supp-alert-done (which read as confirmatory not directive).
+   V-V-11: baked-in fs-sm so the class is self-contained if a future caller forgets t-sm. */
 .supp-adjust-hint {
   display:inline-block; margin-right:var(--sp-6);
-  font-style:italic;
+  font-style:italic; font-size:var(--fs-sm); color:var(--mid);
 }
 .med-d3-summary {
   padding:var(--sp-8) 0; line-height:var(--lh-relaxed);
@@ -17187,11 +17197,15 @@ function parseMedCheck(val) {
     // CR-2: accept BOTH 'HH:MM' (24h) AND 'HH:MM am|pm' / 'HH:MM AM|PM' (legacy en-IN 12h).
     // The pre-v1 markMedDone used en-IN locale which produced 12h+suffix strings;
     // those must round-trip through parseMedCheck without losing givenAt.
-    var isHHMM24 = /^\d{1,2}:\d{2}$/.test(t);
+    // V-K-73: tighten range validation — pre-fix, '24:00' / '25:99' passed the structural
+    // regex and stored as givenAt, then _hhmmToMinutes returned out-of-range minutes (1440+).
+    var hhmm24 = t.match(/^(\d{1,2}):(\d{2})$/);
     var ampmMatch = t.match(/^(\d{1,2}):(\d{2})\s*(am|pm)$/i);
     var givenAt = null;
-    if (isHHMM24) {
-      givenAt = t;
+    if (hhmm24) {
+      var h24 = parseInt(hhmm24[1], 10);
+      var m24 = parseInt(hhmm24[2], 10);
+      if (h24 >= 0 && h24 <= 23 && m24 >= 0 && m24 <= 59) givenAt = t;
     } else if (ampmMatch) {
       var h = parseInt(ampmMatch[1], 10);
       var mm = ampmMatch[2];
@@ -17295,7 +17309,10 @@ function _refreshTodayMedWithFat() {
 // CR-9: display formatter — 24h canonical 'HH:MM' → '8:42 AM' / '2:30 PM' for parent-facing surfaces.
 // The schema stores 24h (en-GB canonical) per V-M-60; this formatter renders the Indian-parent 12h convention.
 function _formatTime12h(hhmm) {
-  if (!hhmm || !/^\d{1,2}:\d{2}$/.test(hhmm)) return hhmm || '';
+  // V-M-72: string-only guard at entry so a future render site without an outer
+  // `if (givenAt)` check can't leak literal 'null' / 'undefined' to the parent.
+  if (typeof hhmm !== 'string' || !hhmm) return '';
+  if (!/^\d{1,2}:\d{2}$/.test(hhmm)) return hhmm;
   var parts = hhmm.split(':');
   var h = parseInt(parts[0], 10);
   var m = parts[1];
@@ -17660,6 +17677,7 @@ function init() {
     else if (action === 'cancelMedDoneAt' && typeof cancelMedDoneAt === 'function') cancelMedDoneAt(Number(arg2));
     else if (action === 'openMedAdjust' && typeof openMedAdjust === 'function') openMedAdjust(arg, Number(arg2));
     else if (action === 'confirmMedAdjust' && typeof confirmMedAdjust === 'function') confirmMedAdjust(arg, Number(arg2));
+    else if (action === 'undoMedSkip' && typeof undoMedSkip === 'function') undoMedSkip(arg, Number(arg2));
     else if (action === 'deleteFeedingEntry' && typeof deleteFeedingEntry === 'function') deleteFeedingEntry(arg);
     else if (action === 'switchFoodCatSub' && typeof switchFoodCatSub === 'function') switchFoodCatSub(arg, arg2);
     else if (action === 'expandMilestoneByIdx' && typeof expandMilestoneByIdx === 'function') expandMilestoneByIdx(Number(arg));
@@ -18001,6 +18019,7 @@ function init() {
     else if (action === 'cancelMedDoneAt') cancelMedDoneAt(parseInt(arg2));
     else if (action === 'openMedAdjust') openMedAdjust(arg, parseInt(arg2));
     else if (action === 'confirmMedAdjust') confirmMedAdjust(arg, parseInt(arg2));
+    else if (action === 'undoMedSkip') undoMedSkip(arg, parseInt(arg2));
     else if (action === 'overrideMilestoneStatus') { const args = arg.split(',').map(s=>s.trim().replace(/^'|'$/g,'')); overrideMilestoneStatus(...args); }
     else if (action === 'upcomingToMilestone') { const args = arg.split(',').map(s=>s.trim().replace(/^'|'$/g,'')); upcomingToMilestone(...args); }
     else if (action === 'deleteFoodAndRender') { deleteFood(arg); renderFoodCatSubContent(arg2); }
@@ -23580,20 +23599,22 @@ function renderRemindersAndAlerts() {
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${fatBadge}</div>
       </div>`;
     } else if (isSkipped) {
-      // CR-5: NEW skipped-state render. Pre-fix, the skipped branch produced no card at all
-      // and the 'All medications done for today' banner was removed — the parent got zero
-      // visual acknowledgement of their explicit skip, while _obCheckVitD3 kept flagging
-      // 'Vit D3 pending' on the home overlay, contradicting the just-recorded action.
+      // CR-5: skipped-state render with explicit acknowledgement + Undo affordance.
+      // V-M-68 + V-M-73 fix: Undo no longer calls markMedDone(name, idx) directly (which
+      // silently substituted tap-time as the administration time, exactly the CR-4 class
+      // of bug). Instead Undo clears the skip back to PENDING — the card re-renders with
+      // the standard [Done now] [Done at...] [Skip] buttons, forcing the parent to make
+      // an explicit choice. No fabricated time, no destroyed audit trail.
       html += `
       <div class="supp-alert supp-alert-skipped" id="supp-alert-${idx}">
         <div class="supp-alert-top">
           <div class="supp-alert-icon">${zi('skip-forward')}</div>
           <div class="supp-alert-title">Skipped today — ${escHtml(m.name)}</div>
           <div class="supp-alert-action">
-            <button class="supp-skip-btn supp-adjust-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Undo skip</button>
+            <button class="supp-skip-btn supp-adjust-btn" data-action="undoMedSkip" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Undo skip</button>
           </div>
         </div>
-        <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}Skip recorded — tap Undo to revert and log a dose.</div>
+        <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}Skip recorded — tap Undo to clear and log the dose.</div>
       </div>`;
     }
   });
@@ -23808,6 +23829,22 @@ function confirmMedDoneAt(name, idx) {
   markMedDone(name, idx, picked);
 }
 function cancelMedDoneAt(idx) {
+  renderRemindersAndAlerts();
+  renderHomeContextAlerts();
+}
+
+// V-M-68 + V-M-73: revert a skip back to PENDING (not to "Done at tap-time"). The skip's
+// loggedAt audit trail is dropped — acceptable because the parent's post-Undo intent is
+// "I want to log the dose properly now," not "preserve the misclick." Re-renders so the
+// parent sees the original [Done now] [Done at...] [Skip] choice without a fabricated time.
+function undoMedSkip(name, idx) {
+  const todayStr = today();
+  if (medChecks[todayStr] && medChecks[todayStr][name] !== undefined) {
+    delete medChecks[todayStr][name];
+    save(KEYS.medChecks, medChecks);
+    _tsfMarkDirty();
+    _islMarkDirty('medical');
+  }
   renderRemindersAndAlerts();
   renderHomeContextAlerts();
 }
@@ -29411,9 +29448,11 @@ function renderHistoryPreviews() {
     const ydChecks = medChecks[ydKey] || {};
     const activeMeds = meds.filter(m => m.active);
 
-    // Check yesterday for missed/skipped
-    const ydMissed = activeMeds.filter(m => !ydChecks[m.name]);
-    const ydSkipped = activeMeds.filter(m => ydChecks[m.name] === 'skipped');
+    // Check yesterday for missed/skipped — V-K-74: schema-aware via medCheckSkipped.
+    // Pre-fix `=== 'skipped'` missed the new object shape; parent who skipped yesterday
+    // saw the "Yesterday's meds not logged" danger strip instead of "Skipped yesterday".
+    const ydMissed = activeMeds.filter(m => !ydChecks[m.name] || (!medCheckIsDone(ydChecks[m.name]) && !medCheckSkipped(ydChecks[m.name])));
+    const ydSkipped = activeMeds.filter(m => medCheckSkipped(ydChecks[m.name]));
 
     if (ydMissed.length > 0) {
       medPrev.innerHTML = `<div class="info-strip is-danger">
@@ -35099,6 +35138,10 @@ function _miSetIntake(dateStr, meal, value) {
   feedingData[dateStr][meal + '_intake'] = value;
   save(KEYS.feeding, feedingData);
   _islMarkDirty('diet');
+  // V-M-70: intake adjustment alone doesn't change meal content (so withFat won't flip),
+  // but completes the contract that EVERY feedingData mutation re-evaluates today's
+  // negative-withFat doses. Defensive — harmless when nothing matches.
+  if (dateStr === today() && typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();
 }
 
 function _miLevelFor(value) {
@@ -41182,6 +41225,16 @@ function renderMedD3PatternCard() {
   for (let i = startIdx; i >= 0; i--) {
     if (eligibleDays[i] && eligibleDays[i].parsed && (eligibleDays[i].parsed.status === 'done' || eligibleDays[i].parsed.status === 'late')) streak++;
     else break;
+  }
+  // V-M-74: fresh-install warm-start — when the parent has just installed and hasn't
+  // logged a dose yet, don't slap them with a rose-tier "0/1 days (0%)". Render a
+  // softer "Just getting started" stripe with no aggressive percentile / streak / fat
+  // surfaces yet.
+  if (eligibleDays.length === 1 && doneDays.length === 0 && skippedDays.length === 0) {
+    body.innerHTML = '<div class="med-d3-summary"><div class="med-d3-summary-row">'
+      + zi('clock') + ' Just getting started — log today\'s dose to begin tracking.'
+      + '</div></div>';
+    return;
   }
   // Build summary lines
   const sigClass = adherence >= 90 ? 'tc-sage' : adherence >= 70 ? 'tc-warn' : 'tc-rose';
@@ -58770,7 +58823,11 @@ function _tsfCollectEvents() {
       timeStr = parsed.givenAt;
       displayTime = _tsfFormatTime(parsed.givenAt);
     }
-    const detail = (parsed.status === 'done' || parsed.status === 'late') ? 'Done' : (parsed.status === 'skipped' ? 'Skipped' : '');
+    // V-V-17: chip detail carries the late marker so a half-awake parent reading only the
+    // chip (without tapping to expand) can see retroactive logs at a glance.
+    const detail = parsed.status === 'late' ? 'Done (late)'
+                 : (parsed.status === 'done' ? 'Done'
+                 : (parsed.status === 'skipped' ? 'Skipped' : ''));
     const ev = {
       id: 'med-' + medName,
       type: 'med',
@@ -59636,6 +59693,8 @@ function skipMeals(mealKeys) {
     if (!feedingData[dateStr][m]) feedingData[dateStr][m] = '—skipped—';
   });
   save(KEYS.feeding, feedingData);
+  // V-M-70: complete the _refreshTodayMedWithFat contract on every feedingData mutation.
+  if (typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();
   renderHomeMealProgress();
   updateMealSkipButtons();
   showQLToast(mealKeys.map(m => m.charAt(0).toUpperCase() + m.slice(1)).join(' & ') + ' marked as skipped');
@@ -59654,6 +59713,8 @@ function skipSingleMeal(mealKey) {
   if (feedingData[dateStr][mealKey] && feedingData[dateStr][mealKey] !== '—skipped—') return; // already has food
   feedingData[dateStr][mealKey] = '—skipped—';
   save(KEYS.feeding, feedingData);
+  // V-M-70: complete the _refreshTodayMedWithFat contract.
+  if (dateStr === today() && typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();
   const input = document.getElementById('meal-' + mealKey);
   if (input) { input.value = ''; input.placeholder = 'Skipped'; input.disabled = true; }
   const timeInput = document.getElementById('mealtime-' + mealKey);
@@ -59669,6 +59730,8 @@ function unskipSingleMeal(mealKey) {
   if (!feedingData[dateStr]) return;
   feedingData[dateStr][mealKey] = '';
   save(KEYS.feeding, feedingData);
+  // V-M-70: complete the _refreshTodayMedWithFat contract.
+  if (dateStr === today() && typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();
   const input = document.getElementById('meal-' + mealKey);
   if (input) { input.value = ''; input.placeholder = 'Type to search foods...'; input.disabled = false; }
   const timeInput = document.getElementById('mealtime-' + mealKey);

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -1,3 +1,10 @@
+audit-emoji.sh [default (5 surfaced ranges)]: 0 HR-1 violations across split, index.html, sproutlab.html
+audit-icon-text: PASS (0 unannotated `(label|text|reason|detail): (zi|iconText)(` field-assignments)
+audit-resolve-shield: PASS (4 resolve-caller(s) carry the explicit `'Resolve'` btnText shield per V-M-41 doctrine)
+audit-viz-smoke: PASS (4 ids + 5 tokens) across template.html + styles.css
+[bump-version] 2026.05.23-7 → 2026.05.23-8
+[poop-reference] wrote /home/user/sproutlab/docs/POOP_COLOR_REFERENCE.html
+[careticket-sm] wrote /home/user/sproutlab/docs/CARETICKET_STATE_MACHINE.html — 6 transitions, 0 drift flags
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -2268,7 +2275,7 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
 .supp-alert-title { flex:1; font-size:var(--fs-md); font-weight:600; color:var(--text); }
 .supp-alert.done .supp-alert-title { color:var(--tc-sage); }
 .supp-alert.missed .supp-alert-title { color:var(--tc-rose); }
-.supp-alert-action { flex-shrink:0; display:flex; gap:var(--sp-4); align-items:center; }
+.supp-alert-action { flex-shrink:0; display:flex; gap:var(--sp-4); align-items:center; flex-wrap:wrap; justify-content:flex-end; }
 .supp-alert-detail { font-size:var(--fs-base); font-weight:400; color:var(--mid); padding-left:var(--sp-24); line-height:var(--lh-normal); }
 .supp-alert.done .supp-alert-detail { color:var(--tc-sage); }
 .supp-alert.missed .supp-alert-detail { color:var(--tc-rose); }
@@ -2332,9 +2339,11 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
 }
 .med-d3-log-row {
   display:flex; gap:var(--sp-12); padding:var(--sp-2) 0;
+  flex-wrap:nowrap;
 }
+.med-d3-log-row > :last-child { min-width:0; overflow-wrap:break-word; flex:1; }
 .med-d3-log-date {
-  min-width:80px; color:var(--mid); font-weight:400;
+  min-width:64px; color:var(--mid); font-weight:400; flex-shrink:0;
 }
 
 /* ── Home stat pills ── */
@@ -10498,7 +10507,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
       <!-- VIT D3 14-DAY PATTERN -->
       <div class="card card-info col-full" id="medD3PatternCard">
         <div class="card-header">
-          <div class="card-title"><div class="icon icon-sky"><svg class="zi"><use href="#zi-sun"/></svg></div> Vitamin D3 — 14-day pattern</div>
+          <div class="card-title"><div class="icon icon-sky"><svg class="zi"><use href="#zi-sun"/></svg></div> Vitamin D3 · 14-day pattern</div>
         </div>
         <div id="medD3PatternBody"></div>
       </div>
@@ -17153,6 +17162,8 @@ function save(key, val) {
 // Every reader migrates via parseMedCheck() so writers can emit the new shape unconditionally.
 function parseMedCheck(val) {
   if (!val) return null;
+  // V-K-72: arrays are typeof 'object' but not med-check shapes — reject explicitly.
+  if (Array.isArray(val)) return null;
   if (typeof val === 'object') {
     return {
       status:   val.status || null,
@@ -17224,6 +17235,8 @@ function _hhmmToMinutes(s) {
 
 // Detect whether a fat-bearing food was logged in feedingData near `timeStr` on `dateStr`.
 // Window: ±60min default. Returns { withFat, fatFood, fatDelta } (delta signed: negative = food first).
+// V-K-69: token-equality matching (with _baseFoodName alias normalization) instead of substring
+// `indexOf` — avoids the coconut-water-matches-coconut false-positive.
 function _detectFatContextNearTime(timeStr, dateStr, windowMinutes) {
   var win = (typeof windowMinutes === 'number') ? windowMinutes : 60;
   var result = { withFat:false, fatFood:null, fatDelta:null };
@@ -17233,20 +17246,33 @@ function _detectFatContextNearTime(timeStr, dateStr, windowMinutes) {
   var day = feedingData[dateStr];
   if (!day) return result;
   var fatSet = _getFatBearingFoodNames();
+  var fatLookup = {};
+  for (var fi = 0; fi < fatSet.length; fi++) fatLookup[fatSet[fi]] = true;
   var meals = ['breakfast', 'lunch', 'dinner', 'snack'];
   var best = null;
   meals.forEach(function(m) {
     var mTime = day[m + '_time'];
     var mFoods = day[m];
-    if (!mTime || !mFoods || mFoods === '—skipped—') return;
+    if (!mTime || !mFoods || mFoods === '—skipped—' || mFoods === '—skipped—') return;
     var mMin = _hhmmToMinutes(mTime);
     if (mMin < 0) return;
     var delta = mMin - targetMin; // signed: negative = meal before dose
     if (Math.abs(delta) > win) return;
-    var lower = String(mFoods).toLowerCase();
+    // Tokenize the meal text on comma / " and " / "+" / "&". Trim each token. Empty tokens dropped.
+    var tokens = String(mFoods).toLowerCase().split(/\s*,\s*|\s+and\s+|\s*\+\s*|\s*&\s*/).map(function(s) { return s.trim(); }).filter(Boolean);
     var matched = null;
-    for (var i = 0; i < fatSet.length; i++) {
-      if (lower.indexOf(fatSet[i]) >= 0) { matched = fatSet[i]; break; }
+    for (var ti = 0; ti < tokens.length; ti++) {
+      var tok = tokens[ti];
+      // Try exact token match first.
+      if (fatLookup[tok]) { matched = tok; break; }
+      // V-K-69: if the token is itself a known NUTRITION key but NOT in fatLookup, do NOT attempt
+      // alias normalisation — the parent logged a specific known food that is NOT fat-bearing
+      // (e.g. 'coconut water' is a distinct NUTRITION entry from 'coconut'; _baseFoodName would
+      // strip 'water' as a form-word and incorrectly return 'coconut').
+      if (typeof NUTRITION === 'object' && NUTRITION[tok]) continue;
+      // Otherwise try alias-normalized base name (catches 'yogurt' → 'curd', 'fresh ghee' → 'ghee').
+      var base = (typeof _baseFoodName === 'function') ? _baseFoodName(tok) : tok;
+      if (base !== tok && fatLookup[base]) { matched = base; break; }
     }
     if (matched && (best === null || Math.abs(delta) < Math.abs(best.delta))) {
       best = { food: matched, delta: delta };
@@ -17537,6 +17563,11 @@ function init() {
     else if (action === 'resolveMissedMedSkipped' && typeof resolveMissedMed === 'function') resolveMissedMed(arg, arg2, 'skipped');
     else if (action === 'markMedDone' && typeof markMedDone === 'function') markMedDone(arg, Number(arg2));
     else if (action === 'markMedSkipped' && typeof markMedSkipped === 'function') markMedSkipped(arg, Number(arg2));
+    else if (action === 'openMedDoneAt' && typeof openMedDoneAt === 'function') openMedDoneAt(arg, Number(arg2));
+    else if (action === 'confirmMedDoneAt' && typeof confirmMedDoneAt === 'function') confirmMedDoneAt(arg, Number(arg2));
+    else if (action === 'cancelMedDoneAt' && typeof cancelMedDoneAt === 'function') cancelMedDoneAt(Number(arg2));
+    else if (action === 'openMedAdjust' && typeof openMedAdjust === 'function') openMedAdjust(arg, Number(arg2));
+    else if (action === 'confirmMedAdjust' && typeof confirmMedAdjust === 'function') confirmMedAdjust(arg, Number(arg2));
     else if (action === 'deleteFeedingEntry' && typeof deleteFeedingEntry === 'function') deleteFeedingEntry(arg);
     else if (action === 'switchFoodCatSub' && typeof switchFoodCatSub === 'function') switchFoodCatSub(arg, arg2);
     else if (action === 'expandMilestoneByIdx' && typeof expandMilestoneByIdx === 'function') expandMilestoneByIdx(Number(arg));
@@ -17873,6 +17904,11 @@ function init() {
     else if (action === 'resolveMissedMed') resolveMissedMed(arg, arg2, arg3);
     else if (action === 'markMedDone') markMedDone(arg, parseInt(arg2));
     else if (action === 'markMedSkipped') markMedSkipped(arg, parseInt(arg2));
+    else if (action === 'openMedDoneAt') openMedDoneAt(arg, parseInt(arg2));
+    else if (action === 'confirmMedDoneAt') confirmMedDoneAt(arg, parseInt(arg2));
+    else if (action === 'cancelMedDoneAt') cancelMedDoneAt(parseInt(arg2));
+    else if (action === 'openMedAdjust') openMedAdjust(arg, parseInt(arg2));
+    else if (action === 'confirmMedAdjust') confirmMedAdjust(arg, parseInt(arg2));
     else if (action === 'overrideMilestoneStatus') { const args = arg.split(',').map(s=>s.trim().replace(/^'|'$/g,'')); overrideMilestoneStatus(...args); }
     else if (action === 'upcomingToMilestone') { const args = arg.split(',').map(s=>s.trim().replace(/^'|'$/g,'')); upcomingToMilestone(...args); }
     else if (action === 'deleteFoodAndRender') { deleteFood(arg); renderFoodCatSubContent(arg2); }
@@ -18901,7 +18937,8 @@ function calcMedicalScore() {
       const ds = toDateStr(d);
       const dayChecks = medChecks[ds];
       if (dayChecks) {
-        const anyDone = Object.values(dayChecks).some(v => typeof v === 'string' && v.startsWith('done'));
+        // V-K-68: schema-aware via medCheckIsDone (handles both legacy string + new object).
+        const anyDone = Object.values(dayChecks).some(v => medCheckIsDone(v));
         if (anyDone) daysChecked++;
       }
     }
@@ -23415,7 +23452,7 @@ function renderRemindersAndAlerts() {
           <div class="supp-alert-title">Reminder — ${escHtml(m.name)}</div>
           <div class="supp-alert-action">
             <button class="supp-check-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done now</button>
-            <button class="supp-check-btn supp-check-btn-alt" data-action="openMedDoneAt" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done at...</button>
+            <button class="supp-check-btn supp-check-btn-alt" data-action="openMedDoneAt" data-arg="${escHtml(m.name)}" data-arg2="${idx}">${zi('clock')} Done at...</button>
             <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Skip</button>
           </div>
         </div>
@@ -23423,12 +23460,15 @@ function renderRemindersAndAlerts() {
       </div>`;
     } else if (isDone) {
       const givenAt = parsed && parsed.givenAt ? parsed.givenAt : null;
-      const withFat = parsed && parsed.withFat === true;
       const fatFood = parsed && parsed.fatFood ? parsed.fatFood : null;
       const timeText = givenAt ? 'Done at ' + escHtml(givenAt) : 'Done today';
-      const fatBadge = withFat && fatFood
-        ? `<span class="supp-fat-badge">${zi('check')} with ${escHtml(fatFood)}</span>`
-        : (givenAt && !withFat ? `<span class="supp-fat-badge supp-fat-badge-neutral">no fat-meal nearby</span>` : '');
+      // V-M-61: null withFat (legacy / unknown) renders no badge. V-M-63: softer framing.
+      let fatBadge = '';
+      if (parsed && parsed.withFat === true && fatFood) {
+        fatBadge = `<span class="supp-fat-badge">${zi('check')} with ${escHtml(fatFood)}</span>`;
+      } else if (parsed && parsed.withFat === false && givenAt) {
+        fatBadge = `<span class="supp-fat-badge supp-fat-badge-neutral">no fat-meal logged nearby</span>`;
+      }
       html += `
       <div class="supp-alert supp-alert-done" id="supp-alert-${idx}">
         <div class="supp-alert-top">
@@ -23598,7 +23638,9 @@ function fmtTips(s) {
 function markMedDone(name, idx, givenTime) {
   const todayStr = today();
   const now = new Date();
-  const loggedAt = now.toLocaleTimeString('en-IN', { hour:'2-digit', minute:'2-digit' });
+  // V-M-60: storage uses 24h en-GB (HH:MM). Display layer formats for the user;
+  // the storage layer must be canonical so _hhmmToMinutes parses correctly across AM/PM.
+  const loggedAt = now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
   const givenAt = (typeof givenTime === 'string' && /^\d{1,2}:\d{2}$/.test(givenTime)) ? givenTime : loggedAt;
   const fat = _detectFatContextNearTime(givenAt, todayStr);
   if (!medChecks[todayStr]) medChecks[todayStr] = {};
@@ -23659,10 +23701,11 @@ function adjustMedTime(name, idx, newTime) {
   if (!existing || existing.status === 'skipped') return;
   const fat = _detectFatContextNearTime(newTime, todayStr);
   const now = new Date();
+  // V-M-65: canonical 24h storage (en-GB).
   medChecks[todayStr][name] = {
     status:   existing.status,
     givenAt:  newTime,
-    loggedAt: existing.loggedAt || now.toLocaleTimeString('en-IN', { hour:'2-digit', minute:'2-digit' }),
+    loggedAt: existing.loggedAt || now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' }),
     withFat:  fat.withFat,
     fatFood:  fat.fatFood,
     fatDelta: fat.fatDelta,
@@ -25333,8 +25376,9 @@ function renderMedLog() {
     const [year, mon] = monthKey.split('-');
     const monthLabel = `${monthNames[parseInt(mon) - 1]} ${year}`;
     const monthId = 'ml-' + monthKey;
-    const givenCount = items.filter(e => e.status.startsWith('done')).length;
-    const skippedCount = items.filter(e => e.status === 'skipped').length;
+    // V-K-66: schema-aware filtering — items can carry legacy string status OR new object status.
+    const givenCount = items.filter(e => medCheckIsDone(e.status)).length;
+    const skippedCount = items.filter(e => medCheckSkipped(e.status)).length;
 
     html += `<div class="history-month" id="${monthId}">
       <div class="history-month-header" data-action="toggleHistoryMonth" data-arg="${monthId}" style="background:linear-gradient(135deg,var(--sky-light),var(--sky-light));border-color:rgba(168,207,224,0.4);">
@@ -25362,12 +25406,15 @@ function renderMedLog() {
       html += `<div style=""font-weight:600;font-size:var(--fs-sm);color:var(--tc-sky);margin-bottom:4px;">${dayName}, ${dayNum} ${monthNames[parseInt(mon) - 1]}</div>`;
 
       dayItems.forEach(e => {
-        const isDone = e.status.startsWith('done');
-        const timeStr = isDone ? e.status.replace('done:', '') : '';
+        // V-K-66: schema-aware status read.
+        const parsed = parseMedCheck(e.status);
+        const isDone = !!(parsed && (parsed.status === 'done' || parsed.status === 'late'));
+        const isLate = !!(parsed && parsed.status === 'late');
+        const timeStr = parsed && parsed.givenAt ? parsed.givenAt : '';
         const icon = isDone ? zi('check') : zi('skip-forward');
         const label = isDone ? 'Given' : 'Skipped';
         const color = isDone ? '#3a7060' : '#926030';
-        const timePart = timeStr && timeStr !== 'late' ? ` at ${timeStr}` : timeStr === 'late' ? ' (logged late)' : '';
+        const timePart = isLate ? ' (logged late)' : (timeStr ? ` at ${escHtml(timeStr)}` : '');
 
         html += `
           <div style="display:flex;align-items:center;gap:var(--sp-8);padding:3px 0;font-size:var(--fs-base);">
@@ -29208,7 +29255,8 @@ function renderHistoryPreviews() {
       </div>`;
     } else {
       // Show today's status
-      const todayDone = activeMeds.filter(m => todayChecks[m.name] && todayChecks[m.name].startsWith('done'));
+      // V-K-66: schema-aware via medCheckIsDone.
+      const todayDone = activeMeds.filter(m => medCheckIsDone(todayChecks[m.name]));
       if (todayDone.length === activeMeds.length && activeMeds.length > 0) {
         medPrev.innerHTML = `<div class="info-strip is-sage">
           <span><svg class="zi"><use href="#zi-check"/></svg></span>
@@ -29700,23 +29748,24 @@ function computeBaselines() {
 
   // ── Supplement adherence (D3) ──
   const activeMeds = meds.filter(m => m.active);
+  // V-K-66: schema-aware reads via medCheckIsDone / medCheckSkipped (handles legacy string + new object).
   activeMeds.forEach(m => {
     const mKey = sanitizeAlertKey(m.name);
     let streak = 0;
     for (let i = 0; i < 90; i++) {
       const d = new Date(); d.setDate(d.getDate() - i);
       const ds = toDateStr(d);
-      // Skip today if not yet resolved
-      if (i === 0) {
-        const dayLog = medChecks[ds] || {};
-        const status = dayLog[m.name];
-        if (!status || (!status.startsWith('done:') && status !== 'skipped')) continue;
-        if (status.startsWith('done:')) { streak++; continue; }
-        break; // skipped breaks streak
-      }
       const dayLog = medChecks[ds] || {};
       const status = dayLog[m.name];
-      if (status && status.startsWith('done:')) { streak++; }
+      const isDone = medCheckIsDone(status);
+      const isSkipped = medCheckSkipped(status);
+      // Skip today if not yet resolved (no entry at all)
+      if (i === 0) {
+        if (!isDone && !isSkipped) continue;
+        if (isDone) { streak++; continue; }
+        break; // skipped breaks streak
+      }
+      if (isDone) { streak++; }
       else break;
     }
     b['suppStreak_' + mKey] = streak;
@@ -29731,7 +29780,7 @@ function computeBaselines() {
       if (ds < (m.start || '2025-09-04')) continue;
       total30++;
       const dayLog = medChecks[ds] || {};
-      if (dayLog[m.name] && dayLog[m.name].startsWith('done:')) given30++;
+      if (medCheckIsDone(dayLog[m.name])) given30++;
     }
     b['suppAdherence30_' + mKey] = total30 > 0 ? Math.floor((given30 / total30) * 100) : null;
     b['suppGiven30_' + mKey] = given30;
@@ -30230,7 +30279,10 @@ function computeAlerts() {
     const ydStr = toDateStr(yd);
     const ydLog = medChecks[ydStr] || {};
     const ydStatus = ydLog[m.name];
-    const wasMissedYd = ydStr >= (medChecks._trackingSince || todayStr) && ydStr >= (m.start || '2025-09-04') && (!ydStatus || ydStatus === 'skipped');
+    // V-K-66: schema-aware "yesterday missed" check — handles both string and object shapes.
+    const ydDone = medCheckIsDone(ydStatus);
+    const ydSkipped = medCheckSkipped(ydStatus);
+    const wasMissedYd = ydStr >= (medChecks._trackingSince || todayStr) && ydStr >= (m.start || '2025-09-04') && (!ydDone && (ydSkipped || !ydStatus));
     // Count how long the prior streak was before it broke
     if (wasMissedYd && streak === 0) {
       let priorStreak = 0;
@@ -30238,7 +30290,7 @@ function computeAlerts() {
         const d = new Date(); d.setDate(d.getDate() - i);
         const ds = toDateStr(d);
         const dl = medChecks[ds] || {};
-        if (dl[m.name] && dl[m.name].startsWith('done:')) priorStreak++;
+        if (medCheckIsDone(dl[m.name])) priorStreak++;
         else break;
       }
       if (priorStreak >= 3) {
@@ -31035,13 +31087,24 @@ function renderTodayPlan() {
     });
   }
 
-  // D3 supplement
+  // D3 supplement — V-K-66: schema-aware via parseMedCheck (legacy string + new object both handled).
   const d3Med = meds.find(m => m.active && m.name.toLowerCase().includes('d3'));
   if (d3Med) {
-    const d3Done = medChecks[todayStr] && medChecks[todayStr][d3Med.name] && medChecks[todayStr][d3Med.name].startsWith('done:');
+    const d3Parsed = parseMedCheck(medChecks[todayStr] && medChecks[todayStr][d3Med.name]);
+    const d3Done = !!(d3Parsed && (d3Parsed.status === 'done' || d3Parsed.status === 'late'));
+    const d3Given = d3Parsed && d3Parsed.givenAt ? d3Parsed.givenAt : null;
+    const d3Fat = d3Parsed && d3Parsed.withFat === true && d3Parsed.fatFood ? d3Parsed.fatFood : null;
+    let doneDetail;
+    if (d3Done) {
+      const timePart = d3Given ? ' at ' + escHtml(d3Given) : '';
+      const fatPart = d3Fat ? ' · with ' + escHtml(d3Fat) : '';
+      doneDetail = '<svg class="zi"><use href="#zi-check"/></svg> Done' + timePart + fatPart;
+    } else {
+      doneDetail = d3Med.dose + ' — give with or after a feed for best absorption';
+    }
     items.push({
       time: '9 AM', icon: zi('pill'), title: d3Med.name,
-      detail: d3Done ? '<svg class="zi"><use href="#zi-check"/></svg> Done today' : d3Med.dose + ' — give with or after a feed for best absorption',
+      detail: doneDetail,
       tag: 'med', done: d3Done, htmlDetail: d3Done
     });
   }
@@ -31470,7 +31533,8 @@ function renderTrendChips() {
   const total = Math.max(Object.keys(nutrientDays).length, 5);
   chips.push({ icon:zi('bowl'), label:'Nutrients', value: covered + '/' + total + ' groups', delta: covered >= total ? 'balanced' : 'gaps', cls: covered >= total ? 'tc-good' : 'tc-warn', tab:'diet' });
 
-  // Vitamin D3 — schema-aware (legacy 'done:HH:MM' string + new object shape both handled)
+  // Vitamin D3 — schema-aware (legacy 'done:HH:MM' string + new object shape both handled).
+  // V-M-62 + V-K-70: fatFood comes from parent feedingData input — escape at this render boundary.
   if (d3Med) {
     const todayStr = today();
     const d3Val = medChecks[todayStr] && medChecks[todayStr][d3Med.name];
@@ -31479,8 +31543,8 @@ function renderTrendChips() {
     let valueText, deltaText;
     if (d3Done) {
       const t = d3Parsed.givenAt;
-      const fat = d3Parsed.withFat === true && d3Parsed.fatFood ? ' · with ' + d3Parsed.fatFood : '';
-      valueText = t ? ('Done at ' + t + fat) : 'Done today';
+      const fat = d3Parsed.withFat === true && d3Parsed.fatFood ? ' · with ' + escHtml(d3Parsed.fatFood) : '';
+      valueText = t ? ('Done at ' + escHtml(t) + fat) : 'Done today';
       deltaText = zi('check');
     } else {
       valueText = 'Pending';
@@ -38761,7 +38825,8 @@ function renderMedicalStats() {
     if (dateKey.startsWith('_') || typeof val !== 'object') return;
     if (new Date(dateKey) < weekAgo) return;
     totalDays++;
-    Object.values(val).forEach(s => { if (s.startsWith('done')) givenCount++; });
+    // V-K-66: schema-aware count — handles both legacy string and new object shapes.
+    Object.values(val).forEach(s => { if (medCheckIsDone(s)) givenCount++; });
   });
 
   el.innerHTML = `
@@ -40900,9 +40965,16 @@ function renderMedD3PatternCard() {
   doneDays.forEach(d => { if (d.parsed.fatFood) fatFoodCounts[d.parsed.fatFood] = (fatFoodCounts[d.parsed.fatFood] || 0) + 1; });
   let topFatFood = null, topN = 0;
   Object.keys(fatFoodCounts).forEach(k => { if (fatFoodCounts[k] > topN) { topFatFood = k; topN = fatFoodCounts[k]; } });
-  // Streak: consecutive done-days ending today
+  // Streak: consecutive done-days ending today.
+  // V-M-64: if today is unlogged (parent hasn't tapped Done yet), don't punish the streak —
+  // walk from yesterday and label "through yesterday" so a 30-day perfect run doesn't read as 0.
   let streak = 0;
-  for (let i = days.length - 1; i >= 0; i--) {
+  let streakLabel = 'Current streak';
+  const todayParsed = days[days.length - 1].parsed;
+  const todayResolved = !!(todayParsed && (todayParsed.status === 'done' || todayParsed.status === 'late' || todayParsed.status === 'skipped'));
+  const startIdx = todayResolved ? days.length - 1 : days.length - 2;
+  if (!todayResolved) streakLabel = 'Streak through yesterday';
+  for (let i = startIdx; i >= 0; i--) {
     if (days[i].parsed && (days[i].parsed.status === 'done' || days[i].parsed.status === 'late')) streak++;
     else break;
   }
@@ -40916,7 +40988,7 @@ function renderMedD3PatternCard() {
     summary += `<div class="med-d3-summary-row">${zi('bowl')} <span class="${fatCls}">With-fat rate: ${withFatCount} of ${withFatKnown.length} doses (${fatRate}%)</span></div>`;
   }
   if (topFatFood) summary += `<div class="med-d3-summary-row">${zi('check')} Usually paired with: <strong>${escHtml(topFatFood)}</strong></div>`;
-  if (streak > 0) summary += `<div class="med-d3-summary-row">${zi('trending-flat')} Current streak: <strong>${streak} day${streak === 1 ? '' : 's'}</strong></div>`;
+  if (streak > 0) summary += `<div class="med-d3-summary-row">${zi('trending-flat')} ${streakLabel}: <strong>${streak} day${streak === 1 ? '' : 's'}</strong></div>`;
   if (unloggedDays.length > 0) summary += `<div class="med-d3-summary-row tc-warn">${zi('warn')} ${unloggedDays.length} day${unloggedDays.length === 1 ? '' : 's'} not logged in this window</div>`;
   summary += '</div>';
   // 14-day compact list (most-recent first)
@@ -40930,9 +41002,11 @@ function renderMedD3PatternCard() {
       row = `<span class="tc-warn">Skipped</span>`;
     } else {
       const t = d.parsed.givenAt ? 'Done at ' + escHtml(d.parsed.givenAt) : 'Done';
+      // V-M-61 + V-M-63: only render the "no fat-meal" line on explicit false
+      // (not null/unknown), with softened framing.
       const fat = d.parsed.withFat === true && d.parsed.fatFood
         ? ` <span class="tc-sage">· with ${escHtml(d.parsed.fatFood)}</span>`
-        : (d.parsed.withFat === false ? ` <span class="t-sub">· no fat-meal nearby</span>` : '');
+        : (d.parsed.withFat === false ? ` <span class="t-sub">· no fat-meal logged nearby</span>` : '');
       row = t + fat;
     }
     list += `<div class="med-d3-log-row"><span class="med-d3-log-date">${escHtml(label)}</span><span>${row}</span></div>`;
@@ -46079,9 +46153,10 @@ function computeSupplementAdherence(windowDays) {
       var dow = d.getDay();
 
       var calStatus = 'missed';
-      if (status && status.indexOf('done') === 0) {
-        var timeStr = status.replace('done:', '');
-        if (timeStr === 'late') {
+      // V-K-66: schema-aware status read.
+      var parsedStatus = parseMedCheck(status);
+      if (parsedStatus && (parsedStatus.status === 'done' || parsedStatus.status === 'late')) {
+        if (parsedStatus.status === 'late') {
           lateCount++;
           calStatus = 'late';
           doneCount++; // late still counts as done for adherence
@@ -46089,10 +46164,11 @@ function computeSupplementAdherence(windowDays) {
           doneCount++;
           calStatus = 'done';
           // Parse time
+          var timeStr = parsedStatus.givenAt || '';
           var parsed = _parseSupplementTime(timeStr);
           if (parsed !== null) times.push(parsed);
         }
-      } else if (status === 'skipped') {
+      } else if (parsedStatus && parsedStatus.status === 'skipped') {
         skippedCount++;
         calStatus = 'skipped';
         dayOfWeekMisses[dow]++;
@@ -58447,37 +58523,38 @@ function _tsfCollectEvents() {
   });
 
   // ── Supplements (medChecks) today ──
+  // V-K-67: schema-aware via parseMedCheck — accepts BOTH legacy 'done:HH:MM' strings AND new object shape.
   const todayMedChecks = medChecks[t] || {};
   Object.keys(todayMedChecks).forEach(function(medName) {
     const val = todayMedChecks[medName];
-    if (typeof val !== 'string') return;
+    const parsed = parseMedCheck(val);
+    if (!parsed) return;
     let timeStr = null;
     let timeMin = null;
     let displayTime = '';
-    if (val.startsWith('done:')) {
-      const timePart = val.replace('done:', '').trim();
-      if (timePart !== 'late') {
-        timeMin = _tsfTimeToMinutes(timePart);
-        timeStr = timePart;
-        displayTime = _tsfFormatTime(timePart);
-      }
+    if ((parsed.status === 'done' || parsed.status === 'late') && parsed.givenAt) {
+      timeMin = _tsfTimeToMinutes(parsed.givenAt);
+      timeStr = parsed.givenAt;
+      displayTime = _tsfFormatTime(parsed.givenAt);
     }
+    const detail = (parsed.status === 'done' || parsed.status === 'late') ? 'Done' : (parsed.status === 'skipped' ? 'Skipped' : '');
     const ev = {
       id: 'med-' + medName,
       type: 'med',
       time: timeStr,
       timeMin: timeMin,
       label: medName,
-      detail: val.startsWith('done:') ? 'Done' : val === 'skipped' ? 'Skipped' : '',
+      detail: detail,
       icon: zi('pill'),
       color: 'sky',
       inferred: false,
       displayTime: displayTime,
-      status: val
+      status: val,
+      parsed: parsed
     };
     if (timeMin !== null) {
       events.push(ev);
-    } else if (val !== 'skipped') {
+    } else if (parsed.status !== 'skipped') {
       noTimeEvents.push(ev);
     }
   });
@@ -58513,9 +58590,9 @@ function _tsfGetAnchor() {
     poopData.filter(function(p) { return p.date === d; }).forEach(function() { dayCount++; });
     // Activities
     (activityLog[d] || []).forEach(function() { dayCount++; });
-    // Meds
+    // Meds — V-K-67: schema-aware via medCheckIsDone.
     const mc = medChecks[d] || {};
-    Object.keys(mc).forEach(function(k) { if (mc[k] && mc[k].toString().startsWith('done')) dayCount++; });
+    Object.keys(mc).forEach(function(k) { if (medCheckIsDone(mc[k])) dayCount++; });
     if (dayCount > 0) {
       totalEvents += dayCount;
       daysWithData++;
@@ -58580,11 +58657,11 @@ function _tsfDetectPatterns() {
           }
         });
       } else if (def.type === 'med' && def.medName) {
+        // V-K-67: schema-aware via parseMedCheck.
         const mc = medChecks[d] || {};
-        const val = mc[def.medName];
-        if (val && typeof val === 'string' && val.startsWith('done:')) {
-          const timePart = val.replace('done:', '').trim();
-          const mm = _tsfTimeToMinutes(timePart);
+        const parsed = parseMedCheck(mc[def.medName]);
+        if (parsed && (parsed.status === 'done' || parsed.status === 'late')) {
+          const mm = parsed.givenAt ? _tsfTimeToMinutes(parsed.givenAt) : null;
           found = true;
           if (mm !== null) foundMin = mm;
         }
@@ -58676,8 +58753,9 @@ function _tsfGetNudges() {
         return pm !== null && pm >= pat.windowStart && pm <= pat.windowEnd;
       });
     } else if (pat.type === 'med' && pat.medName) {
+      // V-K-67: schema-aware — handles both legacy string and new object shapes.
       const mc = todayMC[pat.medName];
-      alreadyLogged = mc && typeof mc === 'string' && (mc.startsWith('done') || mc === 'skipped');
+      alreadyLogged = medCheckIsDone(mc) || medCheckSkipped(mc);
     }
 
     if (alreadyLogged) return;
@@ -58729,7 +58807,19 @@ function _tsfRenderEventExpanded(ev) {
     if (ev.duration) html += '<div>Duration: ' + ev.duration + ' min</div>';
     if (ev.domains && ev.domains.length > 0) html += '<div>Domains: ' + escHtml(ev.domains.join(', ')) + '</div>';
   } else if (ev.type === 'med') {
-    if (ev.status) html += '<div>Status: ' + escHtml(ev.status.replace('done:', 'Done at ')) + '</div>';
+    // V-K-67: schema-aware via parseMedCheck (handles both legacy string + new object).
+    const parsedStatus = parseMedCheck(ev.status);
+    if (parsedStatus) {
+      let statusText;
+      if (parsedStatus.status === 'skipped') statusText = 'Skipped';
+      else if (parsedStatus.status === 'late') statusText = 'Done (logged late)';
+      else if (parsedStatus.status === 'done') statusText = parsedStatus.givenAt ? 'Done at ' + parsedStatus.givenAt : 'Done';
+      else statusText = '';
+      if (statusText) html += '<div>Status: ' + escHtml(statusText) + '</div>';
+      if (parsedStatus.withFat === true && parsedStatus.fatFood) {
+        html += '<div>With fat: ' + escHtml(parsedStatus.fatFood) + '</div>';
+      }
+    }
   }
   return html || '<div>No additional details</div>';
 }

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -2293,6 +2293,50 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
 }
 .supp-skip-btn:hover { border-color:var(--rose); color:var(--rose); background:var(--rose-light); }
 
+/* Vit D3 tracking v1 — done-state card, inline time-edit, and pattern card */
+.supp-alert-done {
+  background:var(--sage-light);
+  border-left-color:var(--sage);
+}
+.supp-alert-done .supp-alert-title { color:var(--tc-sage); }
+.supp-alert-done .supp-alert-detail { color:var(--tc-sage); }
+.supp-check-btn-alt {
+  background:transparent;
+  color:var(--tc-sage);
+  border:1.5px solid var(--sage);
+}
+.supp-check-btn-alt:hover { background:var(--sage-light); }
+.supp-time-input {
+  font-family:'Nunito',sans-serif; font-size:var(--fs-base);
+  padding:var(--sp-6) var(--sp-10); border-radius:var(--r-md);
+  border:1.5px solid var(--border); background:var(--bg);
+  color:var(--text); min-height:40px;
+}
+.supp-fat-badge {
+  display:inline-flex; align-items:center; gap:var(--sp-4);
+  font-size:var(--fs-sm); color:var(--tc-sage); font-weight:600;
+}
+.supp-fat-badge-neutral { color:var(--mid); font-weight:400; }
+.supp-adjust-btn {
+  font-size:var(--fs-sm); padding:var(--sp-4) var(--sp-10);
+  min-height:auto;
+}
+.med-d3-summary {
+  padding:var(--sp-8) 0; line-height:var(--lh-relaxed);
+  font-size:var(--fs-base); color:var(--mid);
+}
+.med-d3-summary-row { padding:var(--sp-2) 0; }
+.med-d3-log {
+  padding-top:var(--sp-6); border-top:1px solid var(--border);
+  font-size:var(--fs-sm); line-height:var(--lh-normal);
+}
+.med-d3-log-row {
+  display:flex; gap:var(--sp-12); padding:var(--sp-2) 0;
+}
+.med-d3-log-date {
+  min-width:80px; color:var(--mid); font-weight:400;
+}
+
 /* ── Home stat pills ── */
 /* ── Stat pills grid — balanced sizing ── */
 .stat-pills-grid {
@@ -10451,6 +10495,14 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
         <div class="med-list" id="medList"></div>
       </div>
 
+      <!-- VIT D3 14-DAY PATTERN -->
+      <div class="card card-info col-full" id="medD3PatternCard">
+        <div class="card-header">
+          <div class="card-title"><div class="icon icon-sky"><svg class="zi"><use href="#zi-sun"/></svg></div> Vitamin D3 — 14-day pattern</div>
+        </div>
+        <div id="medD3PatternBody"></div>
+      </div>
+
       <!-- VACCINATION COVERAGE CHECK -->
       <div class="card card-info col-full" id="medVaccCoverage">
         <div class="card-header" data-collapse-target="vaccCoverageBody" data-collapse-chevron="vaccCoverageChevron">
@@ -17093,6 +17145,122 @@ function save(key, val) {
 }
 
 // ─────────────────────────────────────────
+// MED-CHECK SCHEMA HELPERS — v1 Vit D3 tracking
+// ─────────────────────────────────────────
+// medChecks[date][medName] accepts two shapes (backwards-compat, non-destructive migration):
+//   • Legacy string: 'done:HH:MM' | 'done:late' | 'done' | 'skipped'  — HH:MM was tap-time
+//   • New object: { status, givenAt, loggedAt, withFat, fatFood, fatDelta }
+// Every reader migrates via parseMedCheck() so writers can emit the new shape unconditionally.
+function parseMedCheck(val) {
+  if (!val) return null;
+  if (typeof val === 'object') {
+    return {
+      status:   val.status || null,
+      givenAt:  val.givenAt || null,
+      loggedAt: val.loggedAt || null,
+      withFat:  typeof val.withFat === 'boolean' ? val.withFat : null,
+      fatFood:  val.fatFood || null,
+      fatDelta: typeof val.fatDelta === 'number' ? val.fatDelta : null,
+    };
+  }
+  if (typeof val !== 'string') return null;
+  if (val === 'skipped') return { status:'skipped', givenAt:null, loggedAt:null, withFat:null, fatFood:null, fatDelta:null };
+  if (val === 'done:late' || val === 'done') return { status:'late', givenAt:null, loggedAt:null, withFat:null, fatFood:null, fatDelta:null };
+  if (val.indexOf('done:') === 0) {
+    var t = val.slice(5);
+    var isTime = /^\d{1,2}:\d{2}$/.test(t);
+    return {
+      status: isTime ? 'done' : (t === 'late' ? 'late' : 'done'),
+      givenAt: isTime ? t : null,
+      loggedAt: null, // legacy didn't separate; givenAt was actually tap-time but treat as best-known
+      withFat: null,
+      fatFood: null,
+      fatDelta: null,
+    };
+  }
+  return null;
+}
+function medCheckIsDone(val) {
+  var p = parseMedCheck(val);
+  return !!(p && (p.status === 'done' || p.status === 'late'));
+}
+function medCheckSkipped(val) {
+  var p = parseMedCheck(val);
+  return !!(p && p.status === 'skipped');
+}
+function medCheckGivenAt(val) {
+  var p = parseMedCheck(val);
+  return p ? p.givenAt : null;
+}
+
+// Derive fat-bearing food names from NUTRITION (memoised). Computed-not-hardcoded so
+// the C-1.5 factuality work flows through automatically — no second source of truth.
+var _fatBearingFoodNamesCache = null;
+function _getFatBearingFoodNames() {
+  if (_fatBearingFoodNamesCache) return _fatBearingFoodNamesCache;
+  var out = [];
+  if (typeof NUTRITION === 'object' && NUTRITION) {
+    Object.keys(NUTRITION).forEach(function(name) {
+      var e = NUTRITION[name];
+      if (!e) return;
+      var tags = e.tags || [];
+      var nuts = e.nutrients || [];
+      if (tags.indexOf('healthy-fats') >= 0 || nuts.indexOf('healthy fats') >= 0 ||
+          nuts.indexOf('omega-3') >= 0 || nuts.indexOf('MCTs') >= 0) {
+        out.push(name);
+      }
+    });
+  }
+  // Indian-prep augmentation: paratha carries ghee in default preparation.
+  if (out.indexOf('paratha') < 0) out.push('paratha');
+  _fatBearingFoodNamesCache = out;
+  return out;
+}
+function _hhmmToMinutes(s) {
+  if (!s) return -1;
+  var m = String(s).match(/^(\d{1,2}):(\d{2})/);
+  return m ? (parseInt(m[1], 10) * 60 + parseInt(m[2], 10)) : -1;
+}
+
+// Detect whether a fat-bearing food was logged in feedingData near `timeStr` on `dateStr`.
+// Window: ±60min default. Returns { withFat, fatFood, fatDelta } (delta signed: negative = food first).
+function _detectFatContextNearTime(timeStr, dateStr, windowMinutes) {
+  var win = (typeof windowMinutes === 'number') ? windowMinutes : 60;
+  var result = { withFat:false, fatFood:null, fatDelta:null };
+  var targetMin = _hhmmToMinutes(timeStr);
+  if (targetMin < 0) return result;
+  if (typeof feedingData !== 'object' || !feedingData) return result;
+  var day = feedingData[dateStr];
+  if (!day) return result;
+  var fatSet = _getFatBearingFoodNames();
+  var meals = ['breakfast', 'lunch', 'dinner', 'snack'];
+  var best = null;
+  meals.forEach(function(m) {
+    var mTime = day[m + '_time'];
+    var mFoods = day[m];
+    if (!mTime || !mFoods || mFoods === '—skipped—') return;
+    var mMin = _hhmmToMinutes(mTime);
+    if (mMin < 0) return;
+    var delta = mMin - targetMin; // signed: negative = meal before dose
+    if (Math.abs(delta) > win) return;
+    var lower = String(mFoods).toLowerCase();
+    var matched = null;
+    for (var i = 0; i < fatSet.length; i++) {
+      if (lower.indexOf(fatSet[i]) >= 0) { matched = fatSet[i]; break; }
+    }
+    if (matched && (best === null || Math.abs(delta) < Math.abs(best.delta))) {
+      best = { food: matched, delta: delta };
+    }
+  });
+  if (best) {
+    result.withFat = true;
+    result.fatFood = best.food;
+    result.fatDelta = best.delta;
+  }
+  return result;
+}
+
+// ─────────────────────────────────────────
 // DEFAULT DATA (pre-loaded)
 // ─────────────────────────────────────────
 const DOB        = new Date(2025, 8, 4, 17, 9); // Sep 4, 2025 at 17:09 IST
@@ -23226,39 +23394,57 @@ function renderRemindersAndAlerts() {
     </div>`;
   }
 
-  // ── 4. TODAY'S MED REMINDERS — only show unresolved ones ──
+  // ── 4. TODAY'S MED REMINDERS — show pending with two-button + Adjust on done ──
+  // Vit D3 tracking v1: pending state offers "Done now" + "Done at..." + Skip.
+  // Done state renders captured givenAt + with-fat context with a reachable Adjust.
   let allTodayResolved = true;
   activeMeds.forEach((m, idx) => {
     const dayLog = medChecks[todayStr] || {};
     const status = dayLog[m.name];
-    const isDone = status && status.startsWith('done:');
-    const isSkipped = status === 'skipped';
+    const parsed = parseMedCheck(status);
+    const isDone = !!(parsed && (parsed.status === 'done' || parsed.status === 'late'));
+    const isSkipped = !!(parsed && parsed.status === 'skipped');
     const isResolved = isDone || isSkipped;
     if (!isResolved) allTodayResolved = false;
 
     if (!isResolved) {
-      // Only show unresolved meds
       html += `
       <div class="supp-alert" id="supp-alert-${idx}">
         <div class="supp-alert-top">
           <div class="supp-alert-icon">${zi('warn')}</div>
           <div class="supp-alert-title">Reminder — ${escHtml(m.name)}</div>
           <div class="supp-alert-action">
-            <button class="supp-check-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done</button>
+            <button class="supp-check-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done now</button>
+            <button class="supp-check-btn supp-check-btn-alt" data-action="openMedDoneAt" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done at...</button>
             <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Skip</button>
           </div>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${escHtml(m.freq || 'As prescribed')}</div>
       </div>`;
+    } else if (isDone) {
+      const givenAt = parsed && parsed.givenAt ? parsed.givenAt : null;
+      const withFat = parsed && parsed.withFat === true;
+      const fatFood = parsed && parsed.fatFood ? parsed.fatFood : null;
+      const timeText = givenAt ? 'Done at ' + escHtml(givenAt) : 'Done today';
+      const fatBadge = withFat && fatFood
+        ? `<span class="supp-fat-badge">${zi('check')} with ${escHtml(fatFood)}</span>`
+        : (givenAt && !withFat ? `<span class="supp-fat-badge supp-fat-badge-neutral">no fat-meal nearby</span>` : '');
+      html += `
+      <div class="supp-alert supp-alert-done" id="supp-alert-${idx}">
+        <div class="supp-alert-top">
+          <div class="supp-alert-icon">${zi('check')}</div>
+          <div class="supp-alert-title">${timeText} — ${escHtml(m.name)}</div>
+          <div class="supp-alert-action">
+            <button class="supp-skip-btn supp-adjust-btn" data-action="openMedAdjust" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Adjust</button>
+          </div>
+        </div>
+        <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${fatBadge}</div>
+      </div>`;
     }
   });
 
-  // If all today's meds are resolved, show a compact summary instead
-  if (activeMeds.length > 0 && allTodayResolved) {
-    html += `<div style="display:flex;align-items:center;gap:var(--sp-8);padding:8px 12px;border-radius:var(--r-lg);background:var(--sage-light);font-size:var(--fs-base);color:var(--tc-sage);">
-      <span><svg class="zi"><use href="#zi-check"/></svg></span> All medications done for today
-    </div>`;
-  }
+  // Vit D3 tracking v1: the all-resolved banner is redundant now that done-state
+  // cards render their own captured time + with-fat context. Removed.
 
   // v2.3: Store HTML — renderHomeContextAlerts will combine and render both
   window._remindersHTML = html;
@@ -23405,12 +23591,25 @@ function fmtTips(s) {
           .replace(/\{\{NO\}\}/g, '<span class="icon-rose">' + zi('warn') + '</span>');
 }
 
-function markMedDone(name, idx) {
+// Vit D3 tracking v1: markMedDone emits the new object schema with
+// actual administration time (givenAt) + auto-detected fat-meal context.
+// givenTime is optional — defaults to "now" (the "Done now" button path).
+// The "Done at..." flow passes a parent-stated HH:MM string.
+function markMedDone(name, idx, givenTime) {
   const todayStr = today();
   const now = new Date();
-  const timeStr = now.toLocaleTimeString('en-IN', { hour:'2-digit', minute:'2-digit' });
+  const loggedAt = now.toLocaleTimeString('en-IN', { hour:'2-digit', minute:'2-digit' });
+  const givenAt = (typeof givenTime === 'string' && /^\d{1,2}:\d{2}$/.test(givenTime)) ? givenTime : loggedAt;
+  const fat = _detectFatContextNearTime(givenAt, todayStr);
   if (!medChecks[todayStr]) medChecks[todayStr] = {};
-  medChecks[todayStr][name] = 'done:' + timeStr;
+  medChecks[todayStr][name] = {
+    status:   'done',
+    givenAt:  givenAt,
+    loggedAt: loggedAt,
+    withFat:  fat.withFat,
+    fatFood:  fat.fatFood,
+    fatDelta: fat.fatDelta,
+  };
   save(KEYS.medChecks, medChecks);
   _tsfMarkDirty();
   _islMarkDirty('medical');
@@ -23422,6 +23621,77 @@ function markMedDone(name, idx) {
   } else {
     renderRemindersAndAlerts(); renderHomeContextAlerts();
   }
+}
+
+// Open the inline "Done at..." time-edit in the reminder card. Reveals a
+// time-input + Save/Cancel pair inside the card without a modal.
+function openMedDoneAt(name, idx) {
+  const card = document.getElementById('supp-alert-' + idx);
+  if (!card) return;
+  const actionRow = card.querySelector('.supp-alert-action');
+  if (!actionRow || actionRow.dataset.editing === '1') return;
+  actionRow.dataset.editing = '1';
+  const now = new Date();
+  const nowStr = now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' }); // HH:MM 24h for input
+  actionRow.innerHTML =
+    '<input type="time" class="supp-time-input" id="supp-time-' + idx + '" value="' + escAttr(nowStr) + '">' +
+    '<button class="supp-check-btn" data-action="confirmMedDoneAt" data-arg="' + escAttr(name) + '" data-arg2="' + idx + '">Save</button>' +
+    '<button class="supp-skip-btn" data-action="cancelMedDoneAt" data-arg2="' + idx + '">Cancel</button>';
+}
+function confirmMedDoneAt(name, idx) {
+  const input = document.getElementById('supp-time-' + idx);
+  const picked = input && input.value ? input.value : null;
+  markMedDone(name, idx, picked);
+}
+function cancelMedDoneAt(idx) {
+  renderRemindersAndAlerts();
+  renderHomeContextAlerts();
+}
+
+// Adjust the administration time of an already-logged dose. Re-runs with-fat
+// detection on the new givenAt. Works on today's dose (the only adjust surface
+// in v1; past-day adjusts continue to use resolveMissedMed).
+function adjustMedTime(name, idx, newTime) {
+  const todayStr = today();
+  if (!medChecks[todayStr] || !medChecks[todayStr][name]) return;
+  if (!newTime || !/^\d{1,2}:\d{2}$/.test(newTime)) return;
+  const existing = parseMedCheck(medChecks[todayStr][name]);
+  if (!existing || existing.status === 'skipped') return;
+  const fat = _detectFatContextNearTime(newTime, todayStr);
+  const now = new Date();
+  medChecks[todayStr][name] = {
+    status:   existing.status,
+    givenAt:  newTime,
+    loggedAt: existing.loggedAt || now.toLocaleTimeString('en-IN', { hour:'2-digit', minute:'2-digit' }),
+    withFat:  fat.withFat,
+    fatFood:  fat.fatFood,
+    fatDelta: fat.fatDelta,
+  };
+  save(KEYS.medChecks, medChecks);
+  _tsfMarkDirty();
+  _islMarkDirty('medical');
+  renderRemindersAndAlerts();
+  renderHomeContextAlerts();
+}
+function openMedAdjust(name, idx) {
+  const card = document.getElementById('supp-alert-' + idx);
+  if (!card) return;
+  const actionRow = card.querySelector('.supp-alert-action');
+  if (!actionRow || actionRow.dataset.editing === '1') return;
+  actionRow.dataset.editing = '1';
+  const cur = parseMedCheck(medChecks[today()] && medChecks[today()][name]);
+  const curAt = (cur && cur.givenAt) || new Date().toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
+  // Re-format HH:MM (handle "08:42 AM" legacy by stripping any AM/PM tail)
+  const norm = String(curAt).replace(/\s*(AM|PM)\s*$/i, '');
+  actionRow.innerHTML =
+    '<input type="time" class="supp-time-input" id="supp-time-' + idx + '" value="' + escAttr(norm) + '">' +
+    '<button class="supp-check-btn" data-action="confirmMedAdjust" data-arg="' + escAttr(name) + '" data-arg2="' + idx + '">Save</button>' +
+    '<button class="supp-skip-btn" data-action="cancelMedDoneAt" data-arg2="' + idx + '">Cancel</button>';
+}
+function confirmMedAdjust(name, idx) {
+  const input = document.getElementById('supp-time-' + idx);
+  const picked = input && input.value ? input.value : null;
+  adjustMedTime(name, idx, picked);
 }
 
 function markMedSkipped(name, idx) {
@@ -27685,24 +27955,19 @@ function _obIsTeethingActive() {
 }
 
 function _obCheckVitD3() {
-  // Check if Vit D3 hasn't been given today
+  // Returns true if Vit D3 needs attention (not given today or no D3 med tracked).
+  // Schema-aware via medCheckIsDone (handles both legacy 'done:HH:MM' string and new object shape).
   var todayStr = today();
   var dayEntry = medChecks ? medChecks[todayStr] : null;
   if (!dayEntry) return true;
-  // Check all meds for D3
   var d3Given = false;
-  var d3Found = false;
   var activeMeds = (meds || []).filter(function(m) { return m.active; });
   activeMeds.forEach(function(m) {
     if (m.name && m.name.toLowerCase().indexOf('d3') >= 0) {
-      d3Found = true;
-      var status = dayEntry[m.name];
-      if (status && status.indexOf('done') === 0) d3Given = true;
+      if (medCheckIsDone(dayEntry[m.name])) d3Given = true;
     }
   });
-  // If no D3 med tracked, or D3 not given today
-  if (!d3Given) return true;
-  return false;
+  return !d3Given;
 }
 
 function _obGetNextVaccine() {
@@ -31205,11 +31470,23 @@ function renderTrendChips() {
   const total = Math.max(Object.keys(nutrientDays).length, 5);
   chips.push({ icon:zi('bowl'), label:'Nutrients', value: covered + '/' + total + ' groups', delta: covered >= total ? 'balanced' : 'gaps', cls: covered >= total ? 'tc-good' : 'tc-warn', tab:'diet' });
 
-  // Vitamin D3
+  // Vitamin D3 — schema-aware (legacy 'done:HH:MM' string + new object shape both handled)
   if (d3Med) {
     const todayStr = today();
-    const d3Done = medChecks[todayStr] && medChecks[todayStr][d3Med.name] && medChecks[todayStr][d3Med.name].startsWith('done:');
-    chips.push({ icon:zi('sun'), label:'Vitamin D3', value: d3Done ? 'Done today' : 'Pending', delta: d3Done ? zi('check') : 'pending', cls: d3Done ? 'tc-good' : 'tc-warn', tab:'medical' });
+    const d3Val = medChecks[todayStr] && medChecks[todayStr][d3Med.name];
+    const d3Parsed = parseMedCheck(d3Val);
+    const d3Done = !!(d3Parsed && (d3Parsed.status === 'done' || d3Parsed.status === 'late'));
+    let valueText, deltaText;
+    if (d3Done) {
+      const t = d3Parsed.givenAt;
+      const fat = d3Parsed.withFat === true && d3Parsed.fatFood ? ' · with ' + d3Parsed.fatFood : '';
+      valueText = t ? ('Done at ' + t + fat) : 'Done today';
+      deltaText = zi('check');
+    } else {
+      valueText = 'Pending';
+      deltaText = 'pending';
+    }
+    chips.push({ icon:zi('sun'), label:'Vitamin D3', value: valueText, delta: deltaText, cls: d3Done ? 'tc-good' : 'tc-warn', tab:'medical' });
   }
 
   let html = '';
@@ -40575,6 +40852,101 @@ function renderMeds() {
     `;
     list.appendChild(div);
   });
+  // Vit D3 tracking v1: refresh the 14-day pattern card whenever meds re-render.
+  renderMedD3PatternCard();
+}
+
+// Vit D3 tracking v1: 14-day pattern card.
+// Renders adherence %, usual-time band, with-fat rate, top fat pairing, current streak,
+// and a compact 14-day log. Hidden if no active D3 med tracked.
+function renderMedD3PatternCard() {
+  const card = document.getElementById('medD3PatternCard');
+  const body = document.getElementById('medD3PatternBody');
+  if (!card || !body) return;
+  const d3Med = (meds || []).find(m => m.active && m.name && m.name.toLowerCase().indexOf('d3') >= 0);
+  if (!d3Med) { card.style.display = 'none'; return; }
+  card.style.display = '';
+  const todayStr = today();
+  // 14-day window ending today
+  const days = [];
+  for (let i = 13; i >= 0; i--) {
+    const d = new Date();
+    d.setDate(d.getDate() - i);
+    const ds = d.getFullYear() + '-' + String(d.getMonth()+1).padStart(2,'0') + '-' + String(d.getDate()).padStart(2,'0');
+    const parsed = parseMedCheck(medChecks[ds] && medChecks[ds][d3Med.name]);
+    days.push({ date: ds, parsed: parsed });
+  }
+  // Aggregate stats
+  const doneDays = days.filter(d => d.parsed && (d.parsed.status === 'done' || d.parsed.status === 'late'));
+  const skippedDays = days.filter(d => d.parsed && d.parsed.status === 'skipped');
+  const unloggedDays = days.filter(d => !d.parsed);
+  const adherence = days.length > 0 ? Math.round((doneDays.length / days.length) * 100) : 0;
+  // Usual-time band: take givenAt minutes, find central 80% range
+  const mins = doneDays.map(d => _hhmmToMinutes(d.parsed.givenAt)).filter(m => m >= 0).sort((a,b) => a-b);
+  let usualBand = null;
+  if (mins.length >= 3) {
+    const lo = mins[Math.floor(mins.length * 0.1)];
+    const hi = mins[Math.floor(mins.length * 0.9)];
+    usualBand = _minutesToHhmm(lo) + '–' + _minutesToHhmm(hi);
+  } else if (mins.length > 0) {
+    usualBand = _minutesToHhmm(mins[0]) + (mins.length > 1 ? '–' + _minutesToHhmm(mins[mins.length-1]) : '');
+  }
+  // With-fat rate
+  const withFatKnown = doneDays.filter(d => d.parsed.withFat === true || d.parsed.withFat === false);
+  const withFatCount = doneDays.filter(d => d.parsed.withFat === true).length;
+  const fatRate = withFatKnown.length > 0 ? Math.round((withFatCount / withFatKnown.length) * 100) : null;
+  // Top fat food
+  const fatFoodCounts = {};
+  doneDays.forEach(d => { if (d.parsed.fatFood) fatFoodCounts[d.parsed.fatFood] = (fatFoodCounts[d.parsed.fatFood] || 0) + 1; });
+  let topFatFood = null, topN = 0;
+  Object.keys(fatFoodCounts).forEach(k => { if (fatFoodCounts[k] > topN) { topFatFood = k; topN = fatFoodCounts[k]; } });
+  // Streak: consecutive done-days ending today
+  let streak = 0;
+  for (let i = days.length - 1; i >= 0; i--) {
+    if (days[i].parsed && (days[i].parsed.status === 'done' || days[i].parsed.status === 'late')) streak++;
+    else break;
+  }
+  // Build summary lines
+  const sigClass = adherence >= 90 ? 'tc-sage' : adherence >= 70 ? 'tc-warn' : 'tc-rose';
+  let summary = '<div class="med-d3-summary">';
+  summary += `<div class="med-d3-summary-row"><strong class="${sigClass}">Adherence: ${doneDays.length}/${days.length} days (${adherence}%)</strong></div>`;
+  if (usualBand) summary += `<div class="med-d3-summary-row">${zi('clock')} Usual time: ${escHtml(usualBand)}</div>`;
+  if (fatRate !== null) {
+    const fatCls = fatRate >= 70 ? 'tc-sage' : 'tc-warn';
+    summary += `<div class="med-d3-summary-row">${zi('bowl')} <span class="${fatCls}">With-fat rate: ${withFatCount} of ${withFatKnown.length} doses (${fatRate}%)</span></div>`;
+  }
+  if (topFatFood) summary += `<div class="med-d3-summary-row">${zi('check')} Usually paired with: <strong>${escHtml(topFatFood)}</strong></div>`;
+  if (streak > 0) summary += `<div class="med-d3-summary-row">${zi('trending-flat')} Current streak: <strong>${streak} day${streak === 1 ? '' : 's'}</strong></div>`;
+  if (unloggedDays.length > 0) summary += `<div class="med-d3-summary-row tc-warn">${zi('warn')} ${unloggedDays.length} day${unloggedDays.length === 1 ? '' : 's'} not logged in this window</div>`;
+  summary += '</div>';
+  // 14-day compact list (most-recent first)
+  let list = '<div class="med-d3-log">';
+  days.slice().reverse().forEach(d => {
+    const label = d.date === todayStr ? 'Today' : formatDate(d.date);
+    let row;
+    if (!d.parsed) {
+      row = `<span class="tc-warn">Not logged</span>`;
+    } else if (d.parsed.status === 'skipped') {
+      row = `<span class="tc-warn">Skipped</span>`;
+    } else {
+      const t = d.parsed.givenAt ? 'Done at ' + escHtml(d.parsed.givenAt) : 'Done';
+      const fat = d.parsed.withFat === true && d.parsed.fatFood
+        ? ` <span class="tc-sage">· with ${escHtml(d.parsed.fatFood)}</span>`
+        : (d.parsed.withFat === false ? ` <span class="t-sub">· no fat-meal nearby</span>` : '');
+      row = t + fat;
+    }
+    list += `<div class="med-d3-log-row"><span class="med-d3-log-date">${escHtml(label)}</span><span>${row}</span></div>`;
+  });
+  list += '</div>';
+  body.innerHTML = summary + list;
+}
+
+// Helper: HH:MM minutes → "HH:MM" 24h string.
+function _minutesToHhmm(m) {
+  if (typeof m !== 'number' || m < 0) return '';
+  const h = Math.floor(m / 60);
+  const mm = m % 60;
+  return String(h).padStart(2, '0') + ':' + String(mm).padStart(2, '0');
 }
 
 function openMedModal() {
@@ -47278,18 +47650,27 @@ function _islMedicalData(startDate, endDate) {
   var suppTotal = 0;
   var d3Times = [];
 
+  // Vit D3 tracking v1: schema-aware via parseMedCheck (handles legacy string + new object shape).
+  // d3Times now also carries the with-fat context for downstream analysis surfaces.
+  var d3WithFat = 0;
+  var d3WithoutFat = 0;
+  var d3FatFoods = [];
   dates.forEach(function(ds) {
     var dayChecks = medChecks[ds];
     if (dayChecks) {
       var anyDone = false;
       Object.keys(dayChecks).forEach(function(name) {
-        var val = dayChecks[name];
-        if (typeof val === 'string' && val.startsWith('done')) {
+        var parsed = parseMedCheck(dayChecks[name]);
+        if (parsed && (parsed.status === 'done' || parsed.status === 'late')) {
           anyDone = true;
-          // Extract D3 time
           if (/d3|vitamin d/i.test(name)) {
-            var timePart = val.replace('done:', '').replace('done', '');
-            if (timePart) d3Times.push(timePart);
+            if (parsed.givenAt) d3Times.push(parsed.givenAt);
+            if (parsed.withFat === true) {
+              d3WithFat++;
+              if (parsed.fatFood) d3FatFoods.push(parsed.fatFood);
+            } else if (parsed.withFat === false) {
+              d3WithoutFat++;
+            }
           }
         }
       });
@@ -47320,11 +47701,26 @@ function _islMedicalData(startDate, endDate) {
 
   var medScore = calcMedicalScore();
 
+  var d3FatTotal = d3WithFat + d3WithoutFat;
+  var d3FatRate = d3FatTotal > 0 ? Math.round((d3WithFat / d3FatTotal) * 100) : null;
+  // Most-common fat food across the window (Mode of d3FatFoods)
+  var d3FatTopFood = null;
+  if (d3FatFoods.length > 0) {
+    var counts = {};
+    d3FatFoods.forEach(function(f) { counts[f] = (counts[f] || 0) + 1; });
+    var top = null, topN = 0;
+    Object.keys(counts).forEach(function(k) { if (counts[k] > topN) { top = k; topN = counts[k]; } });
+    d3FatTopFood = top;
+  }
   return {
     suppAdherence: suppTotal > 0 ? Math.round((suppDays / suppTotal) * 100) : null,
     suppDays: suppDays,
     suppTotal: suppTotal,
     d3Times: d3Times,
+    d3WithFat: d3WithFat,
+    d3WithoutFat: d3WithoutFat,
+    d3FatRate: d3FatRate,
+    d3FatTopFood: d3FatTopFood,
     vaccCompleted: completed.length,
     vaccUpcoming: upcoming.length > 0 ? upcoming[0] : null,
     growthInRange: rangeGrowth,
@@ -50314,7 +50710,13 @@ function _qaRoutine() {
   if (pp.totalCount > 0) items.push({ text: 'Poop: avg ' + pp.avgPerDay + '/day, mostly ' + (pp.mostCommonConsistency || 'normal'), signal: 'neutral', icon: zi('diaper') });
 
   var md = getDomainData('medical', _offsetDateStr(today(), -6), today());
-  if (md.suppAdherence !== null) items.push({ text: 'Vit D3: ' + md.suppAdherence + '% adherence', signal: md.suppAdherence >= ISL_THRESHOLDS.D3_ADHERENCE_GOOD_PCT ? 'good' : 'warn', icon: zi('pill') });
+  if (md.suppAdherence !== null) {
+    var d3Text = 'Vit D3: ' + md.suppAdherence + '% adherence';
+    if (md.d3FatRate !== null && (md.d3WithFat + md.d3WithoutFat) >= 3) {
+      d3Text += ' · ' + md.d3FatRate + '% with fat';
+    }
+    items.push({ text: d3Text, signal: md.suppAdherence >= ISL_THRESHOLDS.D3_ADHERENCE_GOOD_PCT ? 'good' : 'warn', icon: zi('pill') });
+  }
 
   var age = ageAt();
   return {
@@ -50541,9 +50943,14 @@ function _qaDoctorPrep() {
     items.push({ text: 'Next vaccine: ' + gd.vaccUpcoming.name + (vDays > 0 ? ' in ' + vDays + ' days' : ' \u2014 due now'), signal: vDays <= 3 ? 'action' : 'info' });
   }
 
-  // D3 adherence
+  // D3 adherence + with-fat enrichment (only if we have enough samples to be meaningful)
   if (gd.suppAdherence !== null) {
     items.push({ text: 'D3 adherence (30d): ' + gd.suppAdherence + '%', signal: gd.suppAdherence >= ISL_THRESHOLDS.D3_ADHERENCE_GOOD_PCT ? 'good' : 'warn' });
+    if (gd.d3FatRate !== null && (gd.d3WithFat + gd.d3WithoutFat) >= 5) {
+      var fatText = 'D3 with-fat absorption (30d): ' + gd.d3FatRate + '% of doses';
+      if (gd.d3FatTopFood) fatText += ' · most often ' + gd.d3FatTopFood;
+      items.push({ text: fatText, signal: gd.d3FatRate >= 70 ? 'good' : 'info' });
+    }
   }
 
   // Recent concerns from last 7 days

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -1,10 +1,3 @@
-audit-emoji.sh [default (5 surfaced ranges)]: 0 HR-1 violations across split, index.html, sproutlab.html
-audit-icon-text: PASS (0 unannotated `(label|text|reason|detail): (zi|iconText)(` field-assignments)
-audit-resolve-shield: PASS (4 resolve-caller(s) carry the explicit `'Resolve'` btnText shield per V-M-41 doctrine)
-audit-viz-smoke: PASS (4 ids + 5 tokens) across template.html + styles.css
-[bump-version] 2026.05.23-8 → 2026.05.23-9
-[poop-reference] wrote /home/user/sproutlab/docs/POOP_COLOR_REFERENCE.html
-[careticket-sm] wrote /home/user/sproutlab/docs/CARETICKET_STATE_MACHINE.html — 6 transitions, 0 drift flags
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -2327,6 +2320,18 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
 .supp-adjust-btn {
   font-size:var(--fs-sm); padding:var(--sp-4) var(--sp-10);
   min-height:auto;
+}
+/* CR-5: skipped-state reminder card variant — distinct from done/missed */
+.supp-alert-skipped {
+  background:var(--amber-light);
+  border-left-color:var(--amber);
+}
+.supp-alert-skipped .supp-alert-title { color:var(--tc-warn); }
+.supp-alert-skipped .supp-alert-detail { color:var(--tc-warn); }
+/* CR-7: openMedAdjust hint when no historical time was captured */
+.supp-adjust-hint {
+  display:inline-block; margin-right:var(--sp-6);
+  font-style:italic;
 }
 .med-d3-summary {
   padding:var(--sp-8) 0; line-height:var(--lh-relaxed);
@@ -17179,11 +17184,26 @@ function parseMedCheck(val) {
   if (val === 'done:late' || val === 'done') return { status:'late', givenAt:null, loggedAt:null, withFat:null, fatFood:null, fatDelta:null };
   if (val.indexOf('done:') === 0) {
     var t = val.slice(5);
-    var isTime = /^\d{1,2}:\d{2}$/.test(t);
+    // CR-2: accept BOTH 'HH:MM' (24h) AND 'HH:MM am|pm' / 'HH:MM AM|PM' (legacy en-IN 12h).
+    // The pre-v1 markMedDone used en-IN locale which produced 12h+suffix strings;
+    // those must round-trip through parseMedCheck without losing givenAt.
+    var isHHMM24 = /^\d{1,2}:\d{2}$/.test(t);
+    var ampmMatch = t.match(/^(\d{1,2}):(\d{2})\s*(am|pm)$/i);
+    var givenAt = null;
+    if (isHHMM24) {
+      givenAt = t;
+    } else if (ampmMatch) {
+      var h = parseInt(ampmMatch[1], 10);
+      var mm = ampmMatch[2];
+      var ampm = ampmMatch[3].toLowerCase();
+      if (ampm === 'pm' && h !== 12) h += 12;
+      if (ampm === 'am' && h === 12) h = 0;
+      givenAt = (h < 10 ? '0' + h : String(h)) + ':' + mm;
+    }
     return {
-      status: isTime ? 'done' : (t === 'late' ? 'late' : 'done'),
-      givenAt: isTime ? t : null,
-      loggedAt: null, // legacy didn't separate; givenAt was actually tap-time but treat as best-known
+      status: givenAt !== null ? 'done' : (t === 'late' ? 'late' : 'done'),
+      givenAt: givenAt,
+      loggedAt: null,
       withFat: null,
       fatFood: null,
       fatDelta: null,
@@ -17233,6 +17253,59 @@ function _hhmmToMinutes(s) {
   return m ? (parseInt(m[1], 10) * 60 + parseInt(m[2], 10)) : -1;
 }
 
+// CR-14: re-run with-fat detection on today's dose entries that currently report withFat:false.
+// markMedDone freezes withFat at log-time against the feedingData snapshot; if the parent logs
+// the dose BEFORE typing the breakfast row that accompanied it, withFat stays permanently false
+// unless they tap Adjust. This helper is called from the feedingData save paths to catch the
+// "logged dose first, logged meal second" sequence within the ±60min window.
+// Only flips withFat:false → true (never the reverse — never erases a real positive observation).
+// Returns true if any record was updated.
+function _refreshTodayMedWithFat() {
+  if (typeof medChecks !== 'object' || !medChecks) return false;
+  var t = today();
+  var dayMC = medChecks[t];
+  if (!dayMC) return false;
+  var mutated = false;
+  Object.keys(dayMC).forEach(function(name) {
+    var parsed = parseMedCheck(dayMC[name]);
+    if (!parsed) return;
+    if (parsed.status !== 'done' && parsed.status !== 'late') return;
+    if (!parsed.givenAt) return;
+    if (parsed.withFat !== false) return; // only redetect when previously negative
+    var fresh = _detectFatContextNearTime(parsed.givenAt, t);
+    if (fresh.withFat === true) {
+      // Preserve the rest of the object; only update the fat fields.
+      var cur = (typeof dayMC[name] === 'object' && !Array.isArray(dayMC[name])) ? dayMC[name] : parsed;
+      dayMC[name] = Object.assign({}, cur, {
+        withFat:  true,
+        fatFood:  fresh.fatFood,
+        fatDelta: fresh.fatDelta,
+      });
+      mutated = true;
+    }
+  });
+  if (mutated) {
+    save(KEYS.medChecks, medChecks);
+    if (typeof _tsfMarkDirty === 'function') _tsfMarkDirty();
+    if (typeof _islMarkDirty === 'function') _islMarkDirty('medical');
+  }
+  return mutated;
+}
+
+// CR-9: display formatter — 24h canonical 'HH:MM' → '8:42 AM' / '2:30 PM' for parent-facing surfaces.
+// The schema stores 24h (en-GB canonical) per V-M-60; this formatter renders the Indian-parent 12h convention.
+function _formatTime12h(hhmm) {
+  if (!hhmm || !/^\d{1,2}:\d{2}$/.test(hhmm)) return hhmm || '';
+  var parts = hhmm.split(':');
+  var h = parseInt(parts[0], 10);
+  var m = parts[1];
+  if (isNaN(h) || h < 0 || h > 23) return hhmm;
+  if (h === 0) return '12:' + m + ' AM';
+  if (h === 12) return '12:' + m + ' PM';
+  if (h > 12) return (h - 12) + ':' + m + ' PM';
+  return h + ':' + m + ' AM';
+}
+
 // Detect whether a fat-bearing food was logged in feedingData near `timeStr` on `dateStr`.
 // Window: ±60min default. Returns { withFat, fatFood, fatDelta } (delta signed: negative = food first).
 // V-K-69: token-equality matching (with _baseFoodName alias normalization) instead of substring
@@ -17248,18 +17321,28 @@ function _detectFatContextNearTime(timeStr, dateStr, windowMinutes) {
   var fatSet = _getFatBearingFoodNames();
   var fatLookup = {};
   for (var fi = 0; fi < fatSet.length; fi++) fatLookup[fatSet[fi]] = true;
+  // CR-12: iterate meals in chronological proximity order (closest-to-dose-time first)
+  // instead of the hard-coded ['breakfast','lunch','dinner','snack'] order — eliminates
+  // the meal-name-iteration bias when two meals tie in absolute delta.
   var meals = ['breakfast', 'lunch', 'dinner', 'snack'];
-  var best = null;
+  var mealEntries = [];
   meals.forEach(function(m) {
     var mTime = day[m + '_time'];
     var mFoods = day[m];
     if (!mTime || !mFoods || mFoods === '—skipped—') return;
     var mMin = _hhmmToMinutes(mTime);
     if (mMin < 0) return;
-    var delta = mMin - targetMin; // signed: negative = meal before dose
+    var delta = mMin - targetMin;
     if (Math.abs(delta) > win) return;
+    mealEntries.push({ meal: m, foods: mFoods, min: mMin, delta: delta, abs: Math.abs(delta) });
+  });
+  mealEntries.sort(function(a, b) { return a.abs - b.abs; });
+
+  var best = null;
+  mealEntries.forEach(function(entry) {
+    if (best !== null) return; // already found the closest match
     // Tokenize the meal text on comma / " and " / "+" / "&". Trim each token. Empty tokens dropped.
-    var tokens = String(mFoods).toLowerCase().split(/\s*,\s*|\s+and\s+|\s*\+\s*|\s*&\s*/).map(function(s) { return s.trim(); }).filter(Boolean);
+    var tokens = String(entry.foods).toLowerCase().split(/\s*,\s*|\s+and\s+|\s*\+\s*|\s*&\s*/).map(function(s) { return s.trim(); }).filter(Boolean);
     var matched = null;
     for (var ti = 0; ti < tokens.length; ti++) {
       var tok = tokens[ti];
@@ -17273,9 +17356,18 @@ function _detectFatContextNearTime(timeStr, dateStr, windowMinutes) {
       // Otherwise try alias-normalized base name (catches 'yogurt' → 'curd', 'fresh ghee' → 'ghee').
       var base = (typeof _baseFoodName === 'function') ? _baseFoodName(tok) : tok;
       if (base !== tok && fatLookup[base]) { matched = base; break; }
+      // CR-13: plural/singular drift — NUTRITION is keyed inconsistently ('almonds' plural,
+      // 'walnut' singular). Try both depluralization and pluralization against fatLookup directly.
+      if (tok.length > 3 && tok.charAt(tok.length - 1) === 's') {
+        var singular = tok.slice(0, -1);
+        if (fatLookup[singular]) { matched = singular; break; }
+      } else if (tok.length > 2) {
+        var plural = tok + 's';
+        if (fatLookup[plural]) { matched = plural; break; }
+      }
     }
-    if (matched && (best === null || Math.abs(delta) < Math.abs(best.delta))) {
-      best = { food: matched, delta: delta };
+    if (matched) {
+      best = { food: matched, delta: entry.delta };
     }
   });
   if (best) {
@@ -23461,7 +23553,14 @@ function renderRemindersAndAlerts() {
     } else if (isDone) {
       const givenAt = parsed && parsed.givenAt ? parsed.givenAt : null;
       const fatFood = parsed && parsed.fatFood ? parsed.fatFood : null;
-      const timeText = givenAt ? 'Done at ' + escHtml(givenAt) : 'Done today';
+      const isLate = parsed && parsed.status === 'late';
+      // CR-9: render 12h for parent-facing surfaces. Storage stays 24h en-GB canonical.
+      // CR-15: surface 'logged late' marker on the title here too — was inconsistent
+      // vs the TSF event-detail expansion which always showed it.
+      let timeText;
+      if (givenAt) timeText = 'Done at ' + escHtml(_formatTime12h(givenAt)) + (isLate ? ' (logged late)' : '');
+      else if (isLate) timeText = 'Done — logged late';
+      else timeText = 'Done today';
       // V-M-61: null withFat (legacy / unknown) renders no badge. V-M-63: softer framing.
       let fatBadge = '';
       if (parsed && parsed.withFat === true && fatFood) {
@@ -23479,6 +23578,22 @@ function renderRemindersAndAlerts() {
           </div>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${fatBadge}</div>
+      </div>`;
+    } else if (isSkipped) {
+      // CR-5: NEW skipped-state render. Pre-fix, the skipped branch produced no card at all
+      // and the 'All medications done for today' banner was removed — the parent got zero
+      // visual acknowledgement of their explicit skip, while _obCheckVitD3 kept flagging
+      // 'Vit D3 pending' on the home overlay, contradicting the just-recorded action.
+      html += `
+      <div class="supp-alert supp-alert-skipped" id="supp-alert-${idx}">
+        <div class="supp-alert-top">
+          <div class="supp-alert-icon">${zi('skip-forward')}</div>
+          <div class="supp-alert-title">Skipped today — ${escHtml(m.name)}</div>
+          <div class="supp-alert-action">
+            <button class="supp-skip-btn supp-adjust-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Undo skip</button>
+          </div>
+        </div>
+        <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}Skip recorded — tap Undo to revert and log a dose.</div>
       </div>`;
     }
   });
@@ -23681,8 +23796,15 @@ function openMedDoneAt(name, idx) {
     '<button class="supp-skip-btn" data-action="cancelMedDoneAt" data-arg2="' + idx + '">Cancel</button>';
 }
 function confirmMedDoneAt(name, idx) {
+  // CR-4: validate before falling through to markMedDone — empty / malformed input must
+  // surface an error, not silently substitute tap-time and overwrite the parent's intent.
   const input = document.getElementById('supp-time-' + idx);
   const picked = input && input.value ? input.value : null;
+  if (!picked || !/^\d{1,2}:\d{2}$/.test(picked)) {
+    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Pick a time, or tap Cancel');
+    if (input) { try { input.focus(); } catch(e) {} }
+    return;
+  }
   markMedDone(name, idx, picked);
 }
 function cancelMedDoneAt(idx) {
@@ -23722,26 +23844,50 @@ function openMedAdjust(name, idx) {
   const actionRow = card.querySelector('.supp-alert-action');
   if (!actionRow || actionRow.dataset.editing === '1') return;
   actionRow.dataset.editing = '1';
+  // CR-7: prefill with the captured givenAt if present; if absent (legacy record with no
+  // time captured), leave the input EMPTY rather than substituting the current clock time.
+  // confirmMedAdjust's CR-8 validation will block a save with no time, so the parent must
+  // actively type a value to overwrite the historical record — no accidental clobbers.
   const cur = parseMedCheck(medChecks[today()] && medChecks[today()][name]);
-  const curAt = (cur && cur.givenAt) || new Date().toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
-  // Re-format HH:MM (handle "08:42 AM" legacy by stripping any AM/PM tail)
+  const curAt = cur && cur.givenAt ? cur.givenAt : '';
   const norm = String(curAt).replace(/\s*(AM|PM)\s*$/i, '');
+  const hint = norm ? '' : '<span class="supp-adjust-hint t-sub t-sm">No time captured — enter actual time:</span>';
   actionRow.innerHTML =
+    hint +
     '<input type="time" class="supp-time-input" id="supp-time-' + idx + '" value="' + escAttr(norm) + '">' +
     '<button class="supp-check-btn" data-action="confirmMedAdjust" data-arg="' + escAttr(name) + '" data-arg2="' + idx + '">Save</button>' +
     '<button class="supp-skip-btn" data-action="cancelMedDoneAt" data-arg2="' + idx + '">Cancel</button>';
 }
 function confirmMedAdjust(name, idx) {
+  // CR-8: validate before falling through to adjustMedTime — empty / malformed input
+  // must surface an error and NOT wedge the editor (adjustMedTime's old early-return
+  // left dataset.editing='1' set, blocking reopens).
   const input = document.getElementById('supp-time-' + idx);
   const picked = input && input.value ? input.value : null;
+  if (!picked || !/^\d{1,2}:\d{2}$/.test(picked)) {
+    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Pick a time, or tap Cancel');
+    if (input) { try { input.focus(); } catch(e) {} }
+    return;
+  }
   adjustMedTime(name, idx, picked);
 }
 
 function markMedSkipped(name, idx) {
+  // CR-10: emit new object schema. Skipped doses now carry loggedAt for audit trail.
   const todayStr = today();
+  const now = new Date();
+  const loggedAt = now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
   if (!medChecks[todayStr]) medChecks[todayStr] = {};
-  medChecks[todayStr][name] = 'skipped';
+  medChecks[todayStr][name] = {
+    status:   'skipped',
+    givenAt:  null,
+    loggedAt: loggedAt,
+    withFat:  null,
+    fatFood:  null,
+    fatDelta: null,
+  };
   save(KEYS.medChecks, medChecks);
+  _tsfMarkDirty();
   _islMarkDirty('medical');
 
   const el = document.getElementById('supp-alert-' + idx);
@@ -23754,13 +23900,34 @@ function markMedSkipped(name, idx) {
 }
 
 function resolveMissedMed(name, dateStr, action) {
+  // CR-10: emit new object schema for both retroactive done-mark and retroactive skip.
+  // Retroactive done has no givenAt (no specific administration time was captured) so
+  // with-fat detection is left null — the 14-day card's withFatKnown denominator
+  // correctly excludes records with no time-anchored fat context.
   if (!medChecks[dateStr]) medChecks[dateStr] = {};
+  const now = new Date();
+  const loggedAt = now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
   if (action === 'done') {
-    medChecks[dateStr][name] = 'done:late';
+    medChecks[dateStr][name] = {
+      status:   'late',
+      givenAt:  null,
+      loggedAt: loggedAt,
+      withFat:  null,
+      fatFood:  null,
+      fatDelta: null,
+    };
   } else {
-    medChecks[dateStr][name] = 'skipped';
+    medChecks[dateStr][name] = {
+      status:   'skipped',
+      givenAt:  null,
+      loggedAt: loggedAt,
+      withFat:  null,
+      fatFood:  null,
+      fatDelta: null,
+    };
   }
   save(KEYS.medChecks, medChecks);
+  _tsfMarkDirty();
   _islMarkDirty('medical');
   renderRemindersAndAlerts(); renderHomeContextAlerts();
 }
@@ -25406,7 +25573,8 @@ function renderMedLog() {
       html += `<div style=""font-weight:600;font-size:var(--fs-sm);color:var(--tc-sky);margin-bottom:4px;">${dayName}, ${dayNum} ${monthNames[parseInt(mon) - 1]}</div>`;
 
       dayItems.forEach(e => {
-        // V-K-66: schema-aware status read.
+        // V-K-66: schema-aware status read. CR-9: 12h display for parent-facing time.
+        // CR-15: when both givenAt AND late are present, surface "at HH:MM (late)" — not just "(logged late)".
         const parsed = parseMedCheck(e.status);
         const isDone = !!(parsed && (parsed.status === 'done' || parsed.status === 'late'));
         const isLate = !!(parsed && parsed.status === 'late');
@@ -25414,7 +25582,9 @@ function renderMedLog() {
         const icon = isDone ? zi('check') : zi('skip-forward');
         const label = isDone ? 'Given' : 'Skipped';
         const color = isDone ? '#3a7060' : '#926030';
-        const timePart = isLate ? ' (logged late)' : (timeStr ? ` at ${escHtml(timeStr)}` : '');
+        let timePart = '';
+        if (timeStr) timePart = ' at ' + escHtml(_formatTime12h(timeStr)) + (isLate ? ' (late)' : '');
+        else if (isLate) timePart = ' (logged late)';
 
         html += `
           <div style="display:flex;align-items:center;gap:var(--sp-8);padding:3px 0;font-size:var(--fs-base);">
@@ -28002,19 +28172,23 @@ function _obIsTeethingActive() {
 }
 
 function _obCheckVitD3() {
-  // Returns true if Vit D3 needs attention (not given today or no D3 med tracked).
-  // Schema-aware via medCheckIsDone (handles both legacy 'done:HH:MM' string and new object shape).
+  // Returns true if Vit D3 needs attention.
+  // CR-5: Skipped doses count as RESOLVED — parent explicitly chose to skip and
+  // _obCheckVitD3 must respect that decision, otherwise the home overlay keeps
+  // flagging 'D3 pending' in contradiction to the parent's just-recorded skip.
   var todayStr = today();
   var dayEntry = medChecks ? medChecks[todayStr] : null;
   if (!dayEntry) return true;
-  var d3Given = false;
+  var d3Resolved = false;
   var activeMeds = (meds || []).filter(function(m) { return m.active; });
   activeMeds.forEach(function(m) {
     if (m.name && m.name.toLowerCase().indexOf('d3') >= 0) {
-      if (medCheckIsDone(dayEntry[m.name])) d3Given = true;
+      if (medCheckIsDone(dayEntry[m.name]) || medCheckSkipped(dayEntry[m.name])) {
+        d3Resolved = true;
+      }
     }
   });
-  return !d3Given;
+  return !d3Resolved;
 }
 
 function _obGetNextVaccine() {
@@ -31088,17 +31262,20 @@ function renderTodayPlan() {
   }
 
   // D3 supplement — V-K-66: schema-aware via parseMedCheck (legacy string + new object both handled).
+  // CR-9: 12h display via _formatTime12h. CR-15: surface 'logged late' marker.
   const d3Med = meds.find(m => m.active && m.name.toLowerCase().includes('d3'));
   if (d3Med) {
     const d3Parsed = parseMedCheck(medChecks[todayStr] && medChecks[todayStr][d3Med.name]);
     const d3Done = !!(d3Parsed && (d3Parsed.status === 'done' || d3Parsed.status === 'late'));
+    const d3Late = !!(d3Parsed && d3Parsed.status === 'late');
     const d3Given = d3Parsed && d3Parsed.givenAt ? d3Parsed.givenAt : null;
     const d3Fat = d3Parsed && d3Parsed.withFat === true && d3Parsed.fatFood ? d3Parsed.fatFood : null;
     let doneDetail;
     if (d3Done) {
-      const timePart = d3Given ? ' at ' + escHtml(d3Given) : '';
+      const timePart = d3Given ? ' at ' + escHtml(_formatTime12h(d3Given)) : '';
+      const latePart = d3Late ? ' (logged late)' : '';
       const fatPart = d3Fat ? ' · with ' + escHtml(d3Fat) : '';
-      doneDetail = '<svg class="zi"><use href="#zi-check"/></svg> Done' + timePart + fatPart;
+      doneDetail = '<svg class="zi"><use href="#zi-check"/></svg> Done' + timePart + latePart + fatPart;
     } else {
       doneDetail = d3Med.dose + ' — give with or after a feed for best absorption';
     }
@@ -31535,22 +31712,34 @@ function renderTrendChips() {
 
   // Vitamin D3 — schema-aware (legacy 'done:HH:MM' string + new object shape both handled).
   // V-M-62 + V-K-70: fatFood comes from parent feedingData input — escape at this render boundary.
+  // CR-9: 12h display formatter for parent-facing time.
+  // CR-15: surface 'logged late' marker so chip and event-detail agree on status.
+  // CR-5: also render explicit "Skipped today" rather than "Pending" when status:'skipped'.
   if (d3Med) {
     const todayStr = today();
     const d3Val = medChecks[todayStr] && medChecks[todayStr][d3Med.name];
     const d3Parsed = parseMedCheck(d3Val);
     const d3Done = !!(d3Parsed && (d3Parsed.status === 'done' || d3Parsed.status === 'late'));
-    let valueText, deltaText;
+    const d3Skipped = !!(d3Parsed && d3Parsed.status === 'skipped');
+    const d3Late = !!(d3Parsed && d3Parsed.status === 'late');
+    let valueText, deltaText, cls;
     if (d3Done) {
       const t = d3Parsed.givenAt;
       const fat = d3Parsed.withFat === true && d3Parsed.fatFood ? ' · with ' + escHtml(d3Parsed.fatFood) : '';
-      valueText = t ? ('Done at ' + escHtml(t) + fat) : 'Done today';
+      const lateTag = d3Late ? ' (late)' : '';
+      valueText = t ? ('Done at ' + escHtml(_formatTime12h(t)) + lateTag + fat) : (d3Late ? 'Done — logged late' : 'Done today');
       deltaText = zi('check');
+      cls = 'tc-good';
+    } else if (d3Skipped) {
+      valueText = 'Skipped today';
+      deltaText = 'skipped';
+      cls = 'tc-warn';
     } else {
       valueText = 'Pending';
       deltaText = 'pending';
+      cls = 'tc-warn';
     }
-    chips.push({ icon:zi('sun'), label:'Vitamin D3', value: valueText, delta: deltaText, cls: d3Done ? 'tc-good' : 'tc-warn', tab:'medical' });
+    chips.push({ icon:zi('sun'), label:'Vitamin D3', value: valueText, delta: deltaText, cls: cls, tab:'medical' });
   }
 
   let html = '';
@@ -40941,20 +41130,34 @@ function renderMedD3PatternCard() {
     const parsed = parseMedCheck(medChecks[ds] && medChecks[ds][d3Med.name]);
     days.push({ date: ds, parsed: parsed });
   }
-  // Aggregate stats
-  const doneDays = days.filter(d => d.parsed && (d.parsed.status === 'done' || d.parsed.status === 'late'));
-  const skippedDays = days.filter(d => d.parsed && d.parsed.status === 'skipped');
-  const unloggedDays = days.filter(d => !d.parsed);
-  const adherence = days.length > 0 ? Math.round((doneDays.length / days.length) * 100) : 0;
-  // Usual-time band: take givenAt minutes, find central 80% range
+  // CR-6: adherence denominator must respect d3Med.start AND medChecks._trackingSince —
+  // pre-fix divided by the full 14-day window unconditionally, giving wildly different
+  // numbers vs computeSupplementAdherence on the same screen for a recently-activated med.
+  const medStart = d3Med.start || '2025-09-04';
+  const trackStart = medChecks._trackingSince || '0000-00-00';
+  const effectiveStart = medStart > trackStart ? medStart : trackStart;
+  const eligibleDays = days.filter(d => d.date >= effectiveStart);
+  const doneDays = eligibleDays.filter(d => d.parsed && (d.parsed.status === 'done' || d.parsed.status === 'late'));
+  const skippedDays = eligibleDays.filter(d => d.parsed && d.parsed.status === 'skipped');
+  const unloggedDays = eligibleDays.filter(d => !d.parsed);
+  const adherence = eligibleDays.length > 0 ? Math.round((doneDays.length / eligibleDays.length) * 100) : 0;
+  // Usual-time band: take givenAt minutes, find central 80% range.
+  // CR-11: use (N-1)*p indexing instead of N*p (which collapsed to the max for many N
+  // and degraded 'central 80%' into 'min-to-max range') AND require N>=5 for the band
+  // to be statistically meaningful — below that, show honest min-max range with a tag.
   const mins = doneDays.map(d => _hhmmToMinutes(d.parsed.givenAt)).filter(m => m >= 0).sort((a,b) => a-b);
   let usualBand = null;
-  if (mins.length >= 3) {
-    const lo = mins[Math.floor(mins.length * 0.1)];
-    const hi = mins[Math.floor(mins.length * 0.9)];
+  let usualBandLabel = 'Usual time';
+  if (mins.length >= 5) {
+    const lo = mins[Math.floor((mins.length - 1) * 0.1)];
+    const hi = mins[Math.floor((mins.length - 1) * 0.9)];
     usualBand = _minutesToHhmm(lo) + '–' + _minutesToHhmm(hi);
-  } else if (mins.length > 0) {
-    usualBand = _minutesToHhmm(mins[0]) + (mins.length > 1 ? '–' + _minutesToHhmm(mins[mins.length-1]) : '');
+  } else if (mins.length >= 2) {
+    usualBand = _minutesToHhmm(mins[0]) + '–' + _minutesToHhmm(mins[mins.length-1]);
+    usualBandLabel = 'Time range so far';
+  } else if (mins.length === 1) {
+    usualBand = _minutesToHhmm(mins[0]);
+    usualBandLabel = 'Only one timed dose';
   }
   // With-fat rate
   const withFatKnown = doneDays.filter(d => d.parsed.withFat === true || d.parsed.withFat === false);
@@ -40968,21 +41171,27 @@ function renderMedD3PatternCard() {
   // Streak: consecutive done-days ending today.
   // V-M-64: if today is unlogged (parent hasn't tapped Done yet), don't punish the streak —
   // walk from yesterday and label "through yesterday" so a 30-day perfect run doesn't read as 0.
+  // CR-6: walk over eligibleDays (post-medStart) not raw days, so a recently-activated med
+  // doesn't see its streak punished by pre-activation no-data rows.
   let streak = 0;
   let streakLabel = 'Current streak';
-  const todayParsed = days[days.length - 1].parsed;
+  const todayParsed = eligibleDays.length > 0 ? eligibleDays[eligibleDays.length - 1].parsed : null;
   const todayResolved = !!(todayParsed && (todayParsed.status === 'done' || todayParsed.status === 'late' || todayParsed.status === 'skipped'));
-  const startIdx = todayResolved ? days.length - 1 : days.length - 2;
+  const startIdx = todayResolved ? eligibleDays.length - 1 : eligibleDays.length - 2;
   if (!todayResolved) streakLabel = 'Streak through yesterday';
   for (let i = startIdx; i >= 0; i--) {
-    if (days[i].parsed && (days[i].parsed.status === 'done' || days[i].parsed.status === 'late')) streak++;
+    if (eligibleDays[i] && eligibleDays[i].parsed && (eligibleDays[i].parsed.status === 'done' || eligibleDays[i].parsed.status === 'late')) streak++;
     else break;
   }
   // Build summary lines
   const sigClass = adherence >= 90 ? 'tc-sage' : adherence >= 70 ? 'tc-warn' : 'tc-rose';
   let summary = '<div class="med-d3-summary">';
-  summary += `<div class="med-d3-summary-row"><strong class="${sigClass}">Adherence: ${doneDays.length}/${days.length} days (${adherence}%)</strong></div>`;
-  if (usualBand) summary += `<div class="med-d3-summary-row">${zi('clock')} Usual time: ${escHtml(usualBand)}</div>`;
+  summary += `<div class="med-d3-summary-row"><strong class="${sigClass}">Adherence: ${doneDays.length}/${eligibleDays.length} days (${adherence}%)</strong></div>`;
+  // CR-9: render times in 12h for parent-facing display.
+  if (usualBand) {
+    const bandDisplay = usualBand.split('–').map(t => _formatTime12h(t)).join('–');
+    summary += `<div class="med-d3-summary-row">${zi('clock')} ${escHtml(usualBandLabel)}: ${escHtml(bandDisplay)}</div>`;
+  }
   if (fatRate !== null) {
     const fatCls = fatRate >= 70 ? 'tc-sage' : 'tc-warn';
     summary += `<div class="med-d3-summary-row">${zi('bowl')} <span class="${fatCls}">With-fat rate: ${withFatCount} of ${withFatKnown.length} doses (${fatRate}%)</span></div>`;
@@ -40991,19 +41200,25 @@ function renderMedD3PatternCard() {
   if (streak > 0) summary += `<div class="med-d3-summary-row">${zi('trending-flat')} ${streakLabel}: <strong>${streak} day${streak === 1 ? '' : 's'}</strong></div>`;
   if (unloggedDays.length > 0) summary += `<div class="med-d3-summary-row tc-warn">${zi('warn')} ${unloggedDays.length} day${unloggedDays.length === 1 ? '' : 's'} not logged in this window</div>`;
   summary += '</div>';
-  // 14-day compact list (most-recent first)
+  // 14-day compact list (most-recent first) — iterates raw days (so pre-medStart rows
+  // show 'Not tracked yet' rather than vanishing entirely; the adherence math above
+  // uses eligibleDays so the user-visible numbers are correct).
   let list = '<div class="med-d3-log">';
   days.slice().reverse().forEach(d => {
     const label = d.date === todayStr ? 'Today' : formatDate(d.date);
     let row;
-    if (!d.parsed) {
+    if (d.date < effectiveStart) {
+      row = `<span class="t-sub">Not tracked yet</span>`;
+    } else if (!d.parsed) {
       row = `<span class="tc-warn">Not logged</span>`;
     } else if (d.parsed.status === 'skipped') {
       row = `<span class="tc-warn">Skipped</span>`;
     } else {
-      const t = d.parsed.givenAt ? 'Done at ' + escHtml(d.parsed.givenAt) : 'Done';
-      // V-M-61 + V-M-63: only render the "no fat-meal" line on explicit false
-      // (not null/unknown), with softened framing.
+      // CR-9 + CR-15: 12h display, surface 'logged late' marker consistently.
+      const isLate = d.parsed.status === 'late';
+      const t = d.parsed.givenAt
+        ? 'Done at ' + escHtml(_formatTime12h(d.parsed.givenAt)) + (isLate ? ' (late)' : '')
+        : (isLate ? 'Done (logged late)' : 'Done');
       const fat = d.parsed.withFat === true && d.parsed.fatFood
         ? ` <span class="tc-sage">· with ${escHtml(d.parsed.fatFood)}</span>`
         : (d.parsed.withFat === false ? ` <span class="t-sub">· no fat-meal logged nearby</span>` : '');
@@ -46275,14 +46490,23 @@ function computeSupplementAdherence(windowDays) {
 }
 
 function _parseSupplementTime(str) {
-  // Parse 'HH:MM am/pm' or 'HH:MM AM/PM' to minutes since midnight
+  // CR-3: parse BOTH 24h 'HH:MM' (new schema writes via en-GB) AND 12h 'HH:MM am|pm' (legacy)
+  // to minutes since midnight. Pre-CR3 this only accepted the 12h suffixed form, so every
+  // post-v1 24h write returned null and the timing-analysis surface silently died.
   if (!str || str === 'late') return null;
   str = str.trim().toLowerCase();
-  var match = str.match(/^(\d{1,2}):(\d{2})\s*(am|pm)$/);
-  if (!match) return null;
-  var h = parseInt(match[1], 10);
-  var m = parseInt(match[2], 10);
-  var ampm = match[3];
+  var match24 = str.match(/^(\d{1,2}):(\d{2})$/);
+  if (match24) {
+    var h24 = parseInt(match24[1], 10);
+    var m24 = parseInt(match24[2], 10);
+    if (h24 < 0 || h24 > 23 || m24 < 0 || m24 > 59) return null;
+    return h24 * 60 + m24;
+  }
+  var match12 = str.match(/^(\d{1,2}):(\d{2})\s*(am|pm)$/);
+  if (!match12) return null;
+  var h = parseInt(match12[1], 10);
+  var m = parseInt(match12[2], 10);
+  var ampm = match12[3];
   if (ampm === 'pm' && h !== 12) h += 12;
   if (ampm === 'am' && h === 12) h = 0;
   return h * 60 + m;
@@ -53517,14 +53741,19 @@ function qaAnswerSupplement(intentId) {
         actionItems.push({ text: 'Set extra reminders for ' + s.flaggedDays.join(', '), signal: 'action' });
       }
 
-      // Today's status
+      // Today's status — CR-1: schema-aware via parseMedCheck (handles both legacy string + new object).
       var todayEntry = (medChecks || {})[today()];
       var todayStatus = todayEntry ? todayEntry[s.name] : undefined;
-      if (!todayStatus) {
+      var todayParsed = parseMedCheck(todayStatus);
+      if (!todayParsed) {
         actionItems.push({ text: 'Not given today yet — don\'t forget!', signal: 'action' });
-      } else if (todayStatus.indexOf('done') === 0) {
-        var timeGiven = todayStatus.replace('done:', '');
-        actionItems.push({ text: 'Given today at ' + timeGiven, signal: 'good' });
+      } else if (todayParsed.status === 'done' || todayParsed.status === 'late') {
+        var timeGiven = todayParsed.givenAt ? _formatTime12h(todayParsed.givenAt) : 'unrecorded time';
+        var lateTag = todayParsed.status === 'late' ? ' (logged late)' : '';
+        var fatTag = todayParsed.withFat === true && todayParsed.fatFood ? ' with ' + todayParsed.fatFood : '';
+        actionItems.push({ text: 'Given today at ' + timeGiven + fatTag + lateTag, signal: 'good' });
+      } else if (todayParsed.status === 'skipped') {
+        actionItems.push({ text: 'Skipped today', signal: 'info' });
       }
     });
   } catch(e) {
@@ -56173,6 +56402,8 @@ function saveFeedingDay() {
   save(KEYS.feeding, feedingData);
   _tsfMarkDirty();
   _islMarkDirty('diet');
+  // CR-14: re-evaluate with-fat for today's dose entries that were logged before this meal.
+  if (d === today() && typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();
   // Auto-introduce any new foods from all meal slots
   autoIntroduceFoodsFromDay(d);
   renderFeedingHistory();
@@ -58072,6 +58303,8 @@ function saveQLFeed() {
   _tsfMarkDirty();
 
   _islMarkDirty('diet');
+  // CR-14: re-evaluate with-fat for today's dose entries that were logged before this meal.
+  if (dateStr === today() && typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();
   // Auto-introduce new foods
   autoIntroduceFoodsFromDay(dateStr);
 
@@ -58808,13 +59041,18 @@ function _tsfRenderEventExpanded(ev) {
     if (ev.domains && ev.domains.length > 0) html += '<div>Domains: ' + escHtml(ev.domains.join(', ')) + '</div>';
   } else if (ev.type === 'med') {
     // V-K-67: schema-aware via parseMedCheck (handles both legacy string + new object).
+    // CR-9 + CR-15: 12h display via _formatTime12h, unified late surface ('Done at X (logged late)').
     const parsedStatus = parseMedCheck(ev.status);
     if (parsedStatus) {
       let statusText;
       if (parsedStatus.status === 'skipped') statusText = 'Skipped';
-      else if (parsedStatus.status === 'late') statusText = 'Done (logged late)';
-      else if (parsedStatus.status === 'done') statusText = parsedStatus.givenAt ? 'Done at ' + parsedStatus.givenAt : 'Done';
-      else statusText = '';
+      else if (parsedStatus.status === 'late') {
+        statusText = parsedStatus.givenAt
+          ? 'Done at ' + _formatTime12h(parsedStatus.givenAt) + ' (logged late)'
+          : 'Done (logged late)';
+      } else if (parsedStatus.status === 'done') {
+        statusText = parsedStatus.givenAt ? 'Done at ' + _formatTime12h(parsedStatus.givenAt) : 'Done';
+      } else statusText = '';
       if (statusText) html += '<div>Status: ' + escHtml(statusText) + '</div>';
       if (parsedStatus.withFat === true && parsedStatus.fatFood) {
         html += '<div>With fat: ' + escHtml(parsedStatus.fatFood) + '</div>';

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -2,7 +2,7 @@ audit-emoji.sh [default (5 surfaced ranges)]: 0 HR-1 violations across split, in
 audit-icon-text: PASS (0 unannotated `(label|text|reason|detail): (zi|iconText)(` field-assignments)
 audit-resolve-shield: PASS (4 resolve-caller(s) carry the explicit `'Resolve'` btnText shield per V-M-41 doctrine)
 audit-viz-smoke: PASS (4 ids + 5 tokens) across template.html + styles.css
-[bump-version] 2026.05.24-1 → 2026.05.24-2
+[bump-version] 2026.05.24-3 → 2026.05.24-4
 [poop-reference] wrote /home/user/sproutlab/docs/POOP_COLOR_REFERENCE.html
 [careticket-sm] wrote /home/user/sproutlab/docs/CARETICKET_STATE_MACHINE.html — 6 transitions, 0 drift flags
 <!DOCTYPE html>

--- a/tests/e2e/vit-d3-tracking.spec.ts
+++ b/tests/e2e/vit-d3-tracking.spec.ts
@@ -126,6 +126,100 @@ test('regression-guard-d3-with-fat-no-match: dose with no nearby fat-meal record
   expect(r.fatFood).toBeNull();
 });
 
+test('regression-guard-d3-substring-no-false-positive: coconut water does NOT match coconut in fat set (token-equality)', async ({ page }) => {
+  // V-K-69: parent logs `coconut water` (which is NOT fat-bearing — it's electrolyte water).
+  // The pre-fix substring matcher would have matched `coconut` (which IS fat-bearing).
+  // Token-equality matching means the multi-word `coconut water` token doesn't equal
+  // the single-word `coconut` token, so withFat must be false.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    if (!feedingData[t]) feedingData[t] = {};
+    feedingData[t].breakfast = 'coconut water, banana';
+    feedingData[t].breakfast_time = '08:30';
+    feedingData[t].lunch = '';
+    feedingData[t].lunch_time = '';
+    if (medChecks[t]) delete medChecks[t][d3.name];
+    markMedDone(d3.name, 0, '08:45');
+    const stored = medChecks[t][d3.name];
+    return { withFat: stored && stored.withFat, fatFood: stored && stored.fatFood };
+  });
+
+  expect(r.withFat, 'coconut water (not fat-bearing) must NOT match coconut (fat-bearing)').toBe(false);
+  expect(r.fatFood).toBeNull();
+});
+
+test('regression-guard-d3-parseMedCheck-non-string-non-object: null/undefined/number/array/boolean all return null', async ({ page }) => {
+  // V-K-72: parseMedCheck must be TypeError-safe on any non-string-non-object input.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const fixtures = [null, undefined, 0, 42, [], [1, 2], true, false];
+    return fixtures.map(f => ({ input: JSON.stringify(f) ?? String(f), result: parseMedCheck(f) }));
+  });
+
+  // Every non-string-non-object input must return null.
+  r.forEach(row => {
+    expect(row.result, `parseMedCheck(${row.input}) must return null`).toBeNull();
+  });
+});
+
+test('regression-guard-d3-history-render-no-throw: Med-Log history tab renders without throwing on a v1-shape entry', async ({ page }) => {
+  // V-K-66: Med-Log history previously called e.status.startsWith() — would TypeError on the new object shape.
+  // Test seeds today's medCheck with a v1 object and verifies the renderMedLog path executes without throwing.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    // Seed a v1 object-shape entry
+    if (!medChecks[t]) medChecks[t] = {};
+    medChecks[t][d3.name] = {
+      status: 'done',
+      givenAt: '08:45',
+      loggedAt: '08:50',
+      withFat: true,
+      fatFood: 'ghee',
+      fatDelta: -15,
+    };
+    // Build the items array the history-month iteration consumes — invoke the reader logic directly.
+    // The history-render iterates items.filter(e => medCheckIsDone(e.status)) post-migration.
+    const items = [{ name: d3.name, date: t, status: medChecks[t][d3.name] }];
+    let threw = false;
+    let givenCount = 0;
+    try {
+      givenCount = items.filter(e => medCheckIsDone(e.status)).length;
+    } catch (err) { threw = true; }
+    return { threw, givenCount };
+  });
+
+  expect(r.threw, 'history-render filtering must not throw on v1 object-shape entries').toBe(false);
+  expect(r.givenCount).toBe(1);
+});
+
+test('regression-guard-d3-data-action-delegation: openMedDoneAt is registered in the dispatcher and reachable via DOM click', async ({ page }) => {
+  // V-M-59: the five new data-actions must be wired into the core.js delegation dispatcher.
+  // The regression-guard suite previously called functions directly via page.evaluate, missing the click-path gap.
+  // This test verifies each new action handler is at least defined and discoverable.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const required = ['openMedDoneAt', 'confirmMedDoneAt', 'cancelMedDoneAt', 'openMedAdjust', 'confirmMedAdjust'];
+    return required.map(name => ({ name, defined: typeof window[name] === 'function' }));
+  });
+
+  const missing = r.filter(x => !x.defined).map(x => x.name);
+  expect(missing, 'every new data-action handler must be a function on window scope').toEqual([]);
+});
+
 test('regression-guard-d3-adjust-flow: adjustMedTime updates givenAt AND re-runs with-fat detection on the new time', async ({ page }) => {
   // Mark done at 14:00 with no nearby fat-meal (no breakfast logged) — should be withFat:false.
   // Then adjust to 08:45 which IS near a 08:30 fat-meal — should flip to withFat:true.

--- a/tests/e2e/vit-d3-tracking.spec.ts
+++ b/tests/e2e/vit-d3-tracking.spec.ts
@@ -538,6 +538,140 @@ test('regression-guard-d3-qaSupplement-schema-aware: qaAnswerSupplement reads ne
   expect(r.givenText).toContain('ghee');
 });
 
+test('regression-guard-d3-undoMedSkip-clears-to-pending: Undo skip does NOT silently log at tap-time', async ({ page }) => {
+  // V-M-68 + V-M-73: pre-fix, Undo skip wired to markMedDone(name, idx) with no givenTime,
+  // which silently substituted tap-time. Reintroduced the CR-4 class of bug through a
+  // different door. Fix: Undo clears the entry back to undefined (pending state) so the
+  // parent makes an explicit choice via [Done now] / [Done at...] / [Skip].
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    // First: skip
+    markMedSkipped(d3.name, 0);
+    const afterSkip = medChecks[t][d3.name];
+    // Then: undo
+    undoMedSkip(d3.name, 0);
+    const afterUndo = medChecks[t] ? medChecks[t][d3.name] : undefined;
+    return {
+      skipStatus: afterSkip && afterSkip.status,
+      undoIsCleared: afterUndo === undefined,
+      didNotSilentlyLog: !afterUndo || afterUndo.status !== 'done',
+    };
+  });
+
+  expect(r.skipStatus).toBe('skipped');
+  expect(r.undoIsCleared, 'Undo must clear medChecks entry back to undefined (pending)').toBe(true);
+  expect(r.didNotSilentlyLog, 'Undo must NOT fabricate a "Done at tap-time" record').toBe(true);
+});
+
+test('regression-guard-d3-yesterday-skipped-schema-aware: home medical preview reads new object shape for ydSkipped', async ({ page }) => {
+  // V-K-74: pre-fix, home.js used `ydChecks[m.name] === 'skipped'` strict-equality which
+  // silently missed the new object shape. Parent who skipped yesterday saw the
+  // "Yesterday's meds not logged" danger strip instead of the "Skipped yesterday" warn strip.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const yesterday = _offsetDateStr(today(), -1);
+    if (!medChecks[yesterday]) medChecks[yesterday] = {};
+    medChecks[yesterday][d3.name] = { status:'skipped', givenAt:null, loggedAt:'10:00', withFat:null, fatFood:null, fatDelta:null };
+    return {
+      schemaAwareSkipped: medCheckSkipped(medChecks[yesterday][d3.name]),
+      schemaAwareNotDone: !medCheckIsDone(medChecks[yesterday][d3.name]),
+    };
+  });
+
+  expect(r.schemaAwareSkipped, 'medCheckSkipped must recognise the new object-shape skipped state').toBe(true);
+  expect(r.schemaAwareNotDone, 'object-shape skip must NOT register as done').toBe(true);
+});
+
+test('regression-guard-d3-parseMedCheck-range-validates-24h: out-of-range hour/minute rejected', async ({ page }) => {
+  // V-K-73: pre-fix the 24h regex was purely structural; '24:00' / '25:99' passed and
+  // stored verbatim as givenAt, then _hhmmToMinutes returned 1440+ minutes (out of range).
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    return {
+      ok_valid_morning: parseMedCheck('done:08:42').givenAt,
+      ok_valid_midnight: parseMedCheck('done:00:00').givenAt,
+      ok_valid_23h:    parseMedCheck('done:23:59').givenAt,
+      reject_24h:      parseMedCheck('done:24:00').givenAt,
+      reject_25h:      parseMedCheck('done:25:99').givenAt,
+      reject_99m:      parseMedCheck('done:08:99').givenAt,
+    };
+  });
+
+  expect(r.ok_valid_morning).toBe('08:42');
+  expect(r.ok_valid_midnight).toBe('00:00');
+  expect(r.ok_valid_23h).toBe('23:59');
+  expect(r.reject_24h, '24:00 must be rejected as out-of-range').toBeNull();
+  expect(r.reject_25h, '25:99 must be rejected').toBeNull();
+  expect(r.reject_99m, '08:99 must be rejected (minute >= 60)').toBeNull();
+});
+
+test('regression-guard-d3-formatTime12h-string-guard: non-string inputs return empty string, never literal "null" / "undefined"', async ({ page }) => {
+  // V-M-72: defensive — a future render site that forgets the outer `if (givenAt)` guard
+  // would otherwise leak literal 'null' to the parent. Now the function entry-guards.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    return {
+      onNull:      _formatTime12h(null),
+      onUndefined: _formatTime12h(undefined),
+      onNumber:    _formatTime12h(842),
+      onBoolean:   _formatTime12h(true),
+      onArray:     _formatTime12h([]),
+      onObject:    _formatTime12h({}),
+    };
+  });
+
+  expect(r.onNull).toBe('');
+  expect(r.onUndefined).toBe('');
+  expect(r.onNumber).toBe('');
+  expect(r.onBoolean).toBe('');
+  expect(r.onArray).toBe('');
+  expect(r.onObject).toBe('');
+});
+
+test('regression-guard-d3-refresh-never-flips-true-to-false: positive withFat observation is never erased', async ({ page }) => {
+  // CR-14 invariant verification — _refreshTodayMedWithFat must only flip false→true,
+  // never true→false. A parent who edited the feedingData meal text to remove the fat
+  // food after the dose was logged must NOT see their original positive observation erased.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    feedingData[t] = { breakfast:'chapati, ghee', breakfast_time:'08:30' };
+    if (medChecks[t]) delete medChecks[t][d3.name];
+    markMedDone(d3.name, 0, '08:45');
+    const before = medChecks[t][d3.name];
+    // Now: remove the ghee from the meal text. Re-running refresh must NOT flip true→false.
+    feedingData[t].breakfast = 'chapati, banana';
+    _refreshTodayMedWithFat();
+    const after = medChecks[t][d3.name];
+    return {
+      beforeWithFat: before && before.withFat,
+      afterWithFat:  after && after.withFat,
+      afterFood:     after && after.fatFood,
+    };
+  });
+
+  expect(r.beforeWithFat).toBe(true);
+  expect(r.afterWithFat, 'refresh must NEVER flip true → false').toBe(true);
+  expect(r.afterFood, 'fatFood must be preserved').toBe('ghee');
+});
+
 test('regression-guard-d3-adjust-flow: adjustMedTime updates givenAt AND re-runs with-fat detection on the new time', async ({ page }) => {
   // Mark done at 14:00 with no nearby fat-meal (no breakfast logged) — should be withFat:false.
   // Then adjust to 08:45 which IS near a 08:30 fat-meal — should flip to withFat:true.

--- a/tests/e2e/vit-d3-tracking.spec.ts
+++ b/tests/e2e/vit-d3-tracking.spec.ts
@@ -1,0 +1,166 @@
+import { test, expect } from '@playwright/test';
+
+// Vit D3 Tracking v1 — regression guards.
+// Spec: docs/specs/vit-d3-tracking-v1.md.
+// QA chain canon-cc-008: Maren Mode-1 (primary) + Kael Mode-1 (secondary) parallel
+//                       → Lyra synth → Cipher Edict V.
+
+test('regression-guard-d3-schema-backwards-compat: parseMedCheck normalises legacy strings to canonical object', async ({ page }) => {
+  // Legacy storage shape is a string starting with 'done:' followed by HH:MM tap-time.
+  // parseMedCheck must return the canonical object with givenAt = HH:MM and withFat = null.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const fixtures = [
+      { input: 'done:08:42', expectStatus: 'done', expectGivenAt: '08:42', expectWithFat: null },
+      { input: 'done:late', expectStatus: 'late', expectGivenAt: null, expectWithFat: null },
+      { input: 'skipped', expectStatus: 'skipped', expectGivenAt: null, expectWithFat: null },
+      { input: 'done', expectStatus: 'late', expectGivenAt: null, expectWithFat: null }, // bare 'done' falls into late bucket
+    ];
+    return fixtures.map(f => {
+      const p = parseMedCheck(f.input);
+      return {
+        input: f.input,
+        ok: p && p.status === f.expectStatus && p.givenAt === f.expectGivenAt && p.withFat === f.expectWithFat,
+        actual: p,
+      };
+    }).filter(r => !r.ok);
+  });
+
+  expect(r, 'parseMedCheck must canonicalise legacy string shapes').toEqual([]);
+});
+
+test('regression-guard-d3-write-object-shape: markMedDone emits the new object schema with all six fields', async ({ page }) => {
+  // The "Done now" button path — no givenTime arg, defaults to now. Verify the
+  // persisted value is an object (not a string) with all six schema fields present.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    // Seed: ensure DEFAULT_MEDS has Vit D3
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med in DEFAULT_MEDS' };
+    // Clear any existing today entry
+    const t = today();
+    if (medChecks[t]) delete medChecks[t][d3.name];
+    // Call the write path
+    markMedDone(d3.name, 0);
+    const stored = medChecks[t][d3.name];
+    return {
+      isObject: typeof stored === 'object' && stored !== null,
+      hasStatus: stored && 'status' in stored,
+      hasGivenAt: stored && 'givenAt' in stored,
+      hasLoggedAt: stored && 'loggedAt' in stored,
+      hasWithFat: stored && 'withFat' in stored,
+      hasFatFood: stored && 'fatFood' in stored,
+      hasFatDelta: stored && 'fatDelta' in stored,
+      statusVal: stored && stored.status,
+    };
+  });
+
+  expect(r.isObject, 'write must emit object shape, not legacy string').toBe(true);
+  expect(r.hasStatus && r.hasGivenAt && r.hasLoggedAt && r.hasWithFat && r.hasFatFood && r.hasFatDelta, 'object must carry all six schema fields').toBe(true);
+  expect(r.statusVal).toBe('done');
+});
+
+test('regression-guard-d3-with-fat-auto-detect: a fat-bearing meal logged near the dose time triggers withFat:true', async ({ page }) => {
+  // Seed feedingData with a ghee-containing breakfast at 08:30, then mark D3 done at 08:45.
+  // Verify the auto-detector flagged withFat:true with fatFood matching ghee and fatDelta within window.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    // Seed meal log: breakfast at 08:30 with ghee chapati
+    if (!feedingData[t]) feedingData[t] = {};
+    feedingData[t].breakfast = 'chapati, ghee, banana';
+    feedingData[t].breakfast_time = '08:30';
+    // Clear today's D3
+    if (medChecks[t]) delete medChecks[t][d3.name];
+    // Mark done at 08:45 (15min after the fat-meal)
+    markMedDone(d3.name, 0, '08:45');
+    const stored = medChecks[t][d3.name];
+    return {
+      withFat: stored && stored.withFat,
+      fatFood: stored && stored.fatFood,
+      fatDelta: stored && stored.fatDelta,
+      givenAt: stored && stored.givenAt,
+    };
+  });
+
+  expect(r.withFat, 'fat-bearing meal within ±60min should trigger withFat:true').toBe(true);
+  expect(r.fatFood, 'fatFood should be the matched food name').toBe('ghee');
+  expect(r.givenAt).toBe('08:45');
+  expect(typeof r.fatDelta).toBe('number');
+  expect(Math.abs(r.fatDelta)).toBeLessThanOrEqual(60);
+});
+
+test('regression-guard-d3-with-fat-no-match: dose with no nearby fat-meal records withFat:false', async ({ page }) => {
+  // Seed feedingData with only a non-fat meal (rice + cucumber, no ghee/curd/etc).
+  // Verify the auto-detector returns withFat:false.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    if (!feedingData[t]) feedingData[t] = {};
+    feedingData[t].breakfast = 'rice, cucumber, apple';
+    feedingData[t].breakfast_time = '08:30';
+    feedingData[t].lunch = 'plain dal, rice';
+    feedingData[t].lunch_time = '12:30';
+    if (medChecks[t]) delete medChecks[t][d3.name];
+    markMedDone(d3.name, 0, '08:45');
+    const stored = medChecks[t][d3.name];
+    return {
+      withFat: stored && stored.withFat,
+      fatFood: stored && stored.fatFood,
+    };
+  });
+
+  expect(r.withFat, 'no fat-bearing meal nearby → withFat must be false').toBe(false);
+  expect(r.fatFood).toBeNull();
+});
+
+test('regression-guard-d3-adjust-flow: adjustMedTime updates givenAt AND re-runs with-fat detection on the new time', async ({ page }) => {
+  // Mark done at 14:00 with no nearby fat-meal (no breakfast logged) — should be withFat:false.
+  // Then adjust to 08:45 which IS near a 08:30 fat-meal — should flip to withFat:true.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    if (!feedingData[t]) feedingData[t] = {};
+    // Only a morning fat-meal — afternoon has no meal
+    feedingData[t].breakfast = 'chapati, ghee';
+    feedingData[t].breakfast_time = '08:30';
+    feedingData[t].lunch = '';
+    feedingData[t].lunch_time = '';
+    if (medChecks[t]) delete medChecks[t][d3.name];
+    // First log: 14:00 — no fat-meal in window
+    markMedDone(d3.name, 0, '14:00');
+    const first = medChecks[t][d3.name];
+    // Adjust to 08:45 — should match the breakfast ghee
+    adjustMedTime(d3.name, 0, '08:45');
+    const second = medChecks[t][d3.name];
+    return {
+      firstGivenAt: first && first.givenAt,
+      firstWithFat: first && first.withFat,
+      secondGivenAt: second && second.givenAt,
+      secondWithFat: second && second.withFat,
+      secondFatFood: second && second.fatFood,
+    };
+  });
+
+  expect(r.firstGivenAt).toBe('14:00');
+  expect(r.firstWithFat, 'first log at 14:00 has no fat-meal in window').toBe(false);
+  expect(r.secondGivenAt, 'adjust must update givenAt').toBe('08:45');
+  expect(r.secondWithFat, 'adjust must re-run with-fat detection on the new time').toBe(true);
+  expect(r.secondFatFood).toBe('ghee');
+});

--- a/tests/e2e/vit-d3-tracking.spec.ts
+++ b/tests/e2e/vit-d3-tracking.spec.ts
@@ -220,6 +220,324 @@ test('regression-guard-d3-data-action-delegation: openMedDoneAt is registered in
   expect(missing, 'every new data-action handler must be a function on window scope').toEqual([]);
 });
 
+test('regression-guard-d3-parseMedCheck-legacy-ampm: legacy "done:HH:MM am|pm" strings parse to canonical 24h givenAt', async ({ page }) => {
+  // CR-2: pre-PR markMedDone used en-IN locale which produced 'done:08:42 am' / 'done:02:30 PM'.
+  // parseMedCheck must round-trip these into 24h canonical so the pattern card + Med Log
+  // + Q&A surfaces stop hollowing out historical doses.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const fixtures = [
+      { input: 'done:08:42 am', expectGivenAt: '08:42' },
+      { input: 'done:08:42 AM', expectGivenAt: '08:42' },
+      { input: 'done:02:30 pm', expectGivenAt: '14:30' },
+      { input: 'done:12:00 pm', expectGivenAt: '12:00' },
+      { input: 'done:12:30 am', expectGivenAt: '00:30' },
+      { input: 'done:9:5 am',   expectGivenAt: null   }, // single-digit minute — still rejected (data-quality boundary)
+    ];
+    return fixtures.map(f => {
+      const p = parseMedCheck(f.input);
+      return { input: f.input, ok: p && p.givenAt === f.expectGivenAt, actualGivenAt: p ? p.givenAt : null };
+    }).filter(r => !r.ok);
+  });
+
+  expect(r, 'legacy AM/PM strings must round-trip to 24h canonical via parseMedCheck').toEqual([]);
+});
+
+test('regression-guard-d3-parseSupplementTime-24h: _parseSupplementTime accepts the new 24h HH:MM writes', async ({ page }) => {
+  // CR-3: pre-fix only accepted 12h+suffix; every new 24h write returned null and the
+  // medical-tab adherence card silently dropped to 'No timing data'.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    return {
+      h24_morning:   _parseSupplementTime('08:42'),     // → 522 min
+      h24_evening:   _parseSupplementTime('21:00'),     // → 1260 min
+      h24_midnight:  _parseSupplementTime('00:00'),     // → 0 min
+      h12_morning:   _parseSupplementTime('08:42 am'),  // → 522 min
+      h12_afternoon: _parseSupplementTime('2:30 pm'),   // → 870 min
+      late_marker:   _parseSupplementTime('late'),      // → null
+      invalid_h24:   _parseSupplementTime('25:00'),     // → null (out-of-range)
+      invalid_min:   _parseSupplementTime('08:60'),     // → null (out-of-range minute)
+    };
+  });
+
+  expect(r.h24_morning).toBe(8 * 60 + 42);
+  expect(r.h24_evening).toBe(21 * 60);
+  expect(r.h24_midnight).toBe(0);
+  expect(r.h12_morning).toBe(8 * 60 + 42);
+  expect(r.h12_afternoon).toBe(14 * 60 + 30);
+  expect(r.late_marker).toBeNull();
+  expect(r.invalid_h24).toBeNull();
+  expect(r.invalid_min).toBeNull();
+});
+
+test('regression-guard-d3-formatTime12h: canonical 24h HH:MM renders as 12h with AM/PM at display boundaries', async ({ page }) => {
+  // CR-9: V-M-60 storage is canonical 24h en-GB. Display surfaces must reformat to 12h
+  // for the parent-facing convention.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    return {
+      morning:   _formatTime12h('08:42'),    // 8:42 AM
+      noon:      _formatTime12h('12:00'),    // 12:00 PM
+      afternoon: _formatTime12h('14:30'),    // 2:30 PM
+      midnight:  _formatTime12h('00:30'),    // 12:30 AM
+      empty:     _formatTime12h(''),         // ''
+      malformed: _formatTime12h('not-time'), // 'not-time' (pass-through)
+    };
+  });
+
+  expect(r.morning).toBe('8:42 AM');
+  expect(r.noon).toBe('12:00 PM');
+  expect(r.afternoon).toBe('2:30 PM');
+  expect(r.midnight).toBe('12:30 AM');
+  expect(r.empty).toBe('');
+  expect(r.malformed).toBe('not-time');
+});
+
+test('regression-guard-d3-confirmMedDoneAt-empty-input: empty time-input blocks save (no silent fallback to tap-time)', async ({ page }) => {
+  // CR-4: pre-fix, an empty time-input fell through to markMedDone(null) which silently
+  // substituted tap-time as givenAt — the "Done at..." intent was lost. Now blocks save.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    if (medChecks[t]) delete medChecks[t][d3.name];
+    // Simulate the inline editor: create the input element with an empty value.
+    document.body.insertAdjacentHTML('beforeend', '<div id="supp-alert-99"><input type="time" id="supp-time-99" value=""></div>');
+    confirmMedDoneAt(d3.name, 99);
+    const after = medChecks[t] ? medChecks[t][d3.name] : undefined;
+    document.getElementById('supp-alert-99').remove();
+    return { afterDefined: after !== undefined };
+  });
+
+  expect(r.afterDefined, 'empty input must NOT write a med-check entry').toBe(false);
+});
+
+test('regression-guard-d3-skipped-surface-renders: skipped state renders an explicit card with Undo affordance', async ({ page }) => {
+  // CR-5: pre-fix, skipped doses produced no card AND _obCheckVitD3 still flagged 'pending'.
+  // Parent got zero acknowledgement of their explicit skip + a contradictory overlay.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    markMedSkipped(d3.name, 0);
+    // Force a re-render
+    renderRemindersAndAlerts();
+    const html = window._remindersHTML || '';
+    return {
+      hasSkippedCard: html.indexOf('supp-alert-skipped') >= 0,
+      hasUndoButton: html.indexOf('Undo skip') >= 0,
+      obCheck: _obCheckVitD3(),
+      storedShape: typeof medChecks[today()][d3.name],
+    };
+  });
+
+  expect(r.hasSkippedCard, 'isSkipped state must render its own card').toBe(true);
+  expect(r.hasUndoButton, 'skipped card must surface an Undo affordance').toBe(true);
+  expect(r.obCheck, '_obCheckVitD3 must treat skip as resolved (false = no attention needed)').toBe(false);
+  expect(r.storedShape, 'markMedSkipped must now emit object schema').toBe('object');
+});
+
+test('regression-guard-d3-resolveMissedMed-object-shape: backfill via missed-med flow writes the new object schema', async ({ page }) => {
+  // CR-10: pre-fix, resolveMissedMed still wrote legacy 'done:late' / 'skipped' strings.
+  // Now writes the canonical 6-field object so downstream consumers stay consistent.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const yesterday = _offsetDateStr(today(), -1);
+    if (medChecks[yesterday]) delete medChecks[yesterday][d3.name];
+    resolveMissedMed(d3.name, yesterday, 'done');
+    const doneEntry = medChecks[yesterday][d3.name];
+    resolveMissedMed(d3.name, yesterday, 'skipped');
+    const skipEntry = medChecks[yesterday][d3.name];
+    return {
+      doneShape: typeof doneEntry,
+      doneStatus: doneEntry && doneEntry.status,
+      doneHasLoggedAt: doneEntry && typeof doneEntry.loggedAt === 'string',
+      skipShape: typeof skipEntry,
+      skipStatus: skipEntry && skipEntry.status,
+    };
+  });
+
+  expect(r.doneShape).toBe('object');
+  expect(r.doneStatus).toBe('late');
+  expect(r.doneHasLoggedAt, 'late-backfill must record loggedAt for audit trail').toBe(true);
+  expect(r.skipShape).toBe('object');
+  expect(r.skipStatus).toBe('skipped');
+});
+
+test('regression-guard-d3-coconut-water-still-rejected-after-tie-fix: chronological tie-breaker preserves V-K-69 fix', async ({ page }) => {
+  // CR-12: switched _detectFatContextNearTime iteration order from meal-name to chronological
+  // proximity. Make sure the V-K-69 NUTRITION-known-skip still fires regardless of iteration.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    if (!feedingData[t]) feedingData[t] = {};
+    // Mix of meals — non-fat coconut water at exact dose time should NOT match
+    feedingData[t].breakfast = 'coconut water, banana';
+    feedingData[t].breakfast_time = '08:45'; // exactly at dose time
+    feedingData[t].lunch = '';
+    feedingData[t].lunch_time = '';
+    if (medChecks[t]) delete medChecks[t][d3.name];
+    markMedDone(d3.name, 0, '08:45');
+    const stored = medChecks[t][d3.name];
+    return { withFat: stored && stored.withFat, fatFood: stored && stored.fatFood };
+  });
+
+  expect(r.withFat, 'coconut water (NUTRITION-known non-fat) must not match coconut after tie-fix').toBe(false);
+});
+
+test('regression-guard-d3-plural-singular-drift: parent typing "walnuts" matches "walnut" fat-set entry', async ({ page }) => {
+  // CR-13: NUTRITION is keyed inconsistently ('almonds' plural, 'walnut' singular). Parent
+  // natural typing must work both directions.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    if (!feedingData[t]) feedingData[t] = {};
+    feedingData[t].breakfast = 'walnuts, banana'; // parent typed plural; NUTRITION key is 'walnut' singular
+    feedingData[t].breakfast_time = '08:30';
+    feedingData[t].lunch = '';
+    feedingData[t].lunch_time = '';
+    if (medChecks[t]) delete medChecks[t][d3.name];
+    markMedDone(d3.name, 0, '08:45');
+    const stored1 = medChecks[t][d3.name];
+    // Also test the inverse: 'almond' (singular) → NUTRITION key 'almonds' (plural)
+    feedingData[t].breakfast = 'almond, banana';
+    delete medChecks[t][d3.name];
+    markMedDone(d3.name, 0, '08:45');
+    const stored2 = medChecks[t][d3.name];
+    return {
+      walnuts_withFat: stored1 && stored1.withFat,
+      walnuts_food: stored1 && stored1.fatFood,
+      almond_withFat: stored2 && stored2.withFat,
+    };
+  });
+
+  expect(r.walnuts_withFat, 'parent typing "walnuts" must match "walnut" fat-set entry').toBe(true);
+  expect(r.almond_withFat, 'parent typing "almond" must match "almonds" via alias path').toBe(true);
+});
+
+test('regression-guard-d3-pattern-adherence-respects-medStart: a med activated 3 days ago shows N/3, not N/14', async ({ page }) => {
+  // CR-6: pre-fix divided by 14 always; pattern card disagreed with computeSupplementAdherence
+  // for a recently-activated med. Now restricts the denominator to days post-medStart.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    // Set d3Med.start to 3 days ago. Also set _trackingSince to a much earlier date
+    // so it doesn't dominate the effectiveStart calculation in the fresh-install context.
+    const startDate = _offsetDateStr(today(), -2);
+    d3.start = startDate;
+    medChecks._trackingSince = _offsetDateStr(today(), -30);
+    // Mark all 3 days as done
+    for (let i = 0; i < 3; i++) {
+      const ds = _offsetDateStr(today(), -i);
+      if (!medChecks[ds]) medChecks[ds] = {};
+      medChecks[ds][d3.name] = { status:'done', givenAt:'08:00', loggedAt:'08:00', withFat:false, fatFood:null, fatDelta:null };
+    }
+    // Render the pattern card and read the adherence text
+    renderMedD3PatternCard();
+    const body = document.getElementById('medD3PatternBody');
+    const html = body ? body.innerHTML : '';
+    return {
+      has3of3: html.indexOf('3/3 days') >= 0,
+      has3of14: html.indexOf('3/14 days') >= 0,
+      htmlSample: html.slice(0, 400),
+      medStart: d3.start,
+    };
+  });
+
+  expect(r.has3of3, 'adherence must use eligibleDays.length (= days from medStart) — got HTML: ' + r.htmlSample).toBe(true);
+  expect(r.has3of14, 'must NOT divide by raw 14-day window').toBe(false);
+});
+
+test('regression-guard-d3-snapshot-fat-refresh: logging a fat-meal AFTER the dose flips withFat:false → true', async ({ page }) => {
+  // CR-14: pre-fix, markMedDone froze withFat:false against the snapshot at log-time. If
+  // the parent logged the dose BEFORE the meal, withFat stayed false forever.
+  // Fix: _refreshTodayMedWithFat re-evaluates negative-withFat doses on feedingData save.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    // Clear feedingData and medChecks for today
+    feedingData[t] = {};
+    if (medChecks[t]) delete medChecks[t][d3.name];
+    // First: mark D3 done at 08:45 with NO meal logged yet → withFat:false
+    markMedDone(d3.name, 0, '08:45');
+    const before = medChecks[t][d3.name];
+    // Now: log breakfast with ghee at 08:30
+    feedingData[t].breakfast = 'chapati, ghee';
+    feedingData[t].breakfast_time = '08:30';
+    // Trigger the refresh
+    _refreshTodayMedWithFat();
+    const after = medChecks[t][d3.name];
+    return {
+      beforeWithFat: before && before.withFat,
+      afterWithFat:  after && after.withFat,
+      afterFood:     after && after.fatFood,
+    };
+  });
+
+  expect(r.beforeWithFat, 'dose logged before meal must initially be withFat:false').toBe(false);
+  expect(r.afterWithFat, 'after the meal is logged, refresh must flip withFat to true').toBe(true);
+  expect(r.afterFood).toBe('ghee');
+});
+
+test('regression-guard-d3-qaSupplement-schema-aware: qaAnswerSupplement reads new object shape without try/catch swallowing', async ({ page }) => {
+  // CR-1: pre-fix, qaAnswerSupplement.indexOf('done')/.replace('done:','') threw on the new
+  // object shape. The try/catch swallowed it and returned 'Unable to compute'. Now schema-aware.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    if (!medChecks[t]) medChecks[t] = {};
+    medChecks[t][d3.name] = { status:'done', givenAt:'14:30', loggedAt:'14:30', withFat:true, fatFood:'ghee', fatDelta:-5 };
+    const result = qaAnswerSupplement('supplement');
+    // The 'Given today at X' actionItem confirms the schema-aware read worked.
+    const items = (result.sections || []).reduce((acc, s) => acc.concat(s.items || []), []);
+    const givenLine = items.find(i => i.text && i.text.indexOf('Given today at') === 0);
+    return {
+      headline: result.headline,
+      hasGivenLine: !!givenLine,
+      givenText: givenLine ? givenLine.text : null,
+    };
+  });
+
+  expect(r.headline, 'must NOT return the catch-fallback "Unable to compute"').not.toBe('Unable to compute');
+  expect(r.hasGivenLine, 'today\'s "Given at X" actionItem must surface').toBe(true);
+  expect(r.givenText).toContain('2:30 PM');
+  expect(r.givenText).toContain('ghee');
+});
+
 test('regression-guard-d3-adjust-flow: adjustMedTime updates givenAt AND re-runs with-fat detection on the new time', async ({ page }) => {
   // Mark done at 14:00 with no nearby fat-meal (no breakfast logged) — should be withFat:false.
   // Then adjust to 08:45 which IS near a 08:30 fat-meal — should flip to withFat:true.


### PR DESCRIPTION
## Summary

Vit D3 tracking v1 — turning the "half-hearted" implementation (tap-time only, % adherence as the only intelligence) into a real tracking + analysis surface, then hardened through TWO Governor chains + 15 /code-review findings.

- **Spec:** `docs/specs/vit-d3-tracking-v1.md`
- **Base:** sits on top of PR #115 (food-DB cleanup); rebases cleanly when #115 merges
- **Total diff:** ~2700 LOC across 14 files; 25 regression guards; 5 commits

## Commits

| SHA | Pass |
|-----|------|
| `ea9b7d5` | Initial Vit D3 v1 implementation |
| `90161e8` | Lyra synth #1 — Maren V-M-59..67 + Kael V-K-66..72 + Vela V-V-01..09 binding folds |
| `4f6f945` | Cipher Edict V #1 cosmetic cleanup |
| `e7c8945` | CR-fix synth — closed 15 /code-review findings (CR-1..CR-15) |
| `ff514f1` | Lyra synth #2 — Maren V-M-68..76 + Kael V-K-73..77 + Vela V-V-10..17 binding folds |

## Three concurrent shifts (v1 thesis)

1. **Truth at write time** — capture the actual administration time, not tap-time. Storage canonical 24h (en-GB); display reformats to 12h via `_formatTime12h`.
2. **Context at write time** — auto-detect whether a fat-bearing meal was logged ±60min. Token-equality with NUTRITION-known-skip (V-K-69) + chronological-proximity tie-break (CR-12) + plural/singular drift fallback (CR-13). Auto-refresh on every feedingData mutation (CR-14, V-M-70).
3. **Meaning at read time** — 14-day pattern card (adherence respecting medStart, usual-time band, with-fat rate, top pairing, current streak / "through yesterday", unlogged-days callout, compact log) + Q&A enrichment + cross-surface consistency.

## Schema migration (non-destructive, backwards-compat)

| | Pre | Post |
|---|---|---|
| Shape | `'done:HH:MM' \| 'done:late' \| 'skipped'` string | `{status, givenAt, loggedAt, withFat, fatFood, fatDelta}` object |
| Time | Tap-time, en-IN 12h+suffix | Actual administration time, en-GB 24h canonical |
| Meal context | Not captured | Auto-detected + auto-refreshed on meal save |
| Migration | n/a | `parseMedCheck` normalises both shapes; legacy 'HH:MM am/pm' round-trips via CR-2 |

**Helpers in core.js:** `parseMedCheck` / `medCheckIsDone` / `medCheckSkipped` / `medCheckGivenAt` / `_formatTime12h` / `_refreshTodayMedWithFat` / `_detectFatContextNearTime` / `_getFatBearingFoodNames`.

**Reader sites migrated:** 17+ across home.js / medical.js / intelligence-quicklog.js / intelligence-qa-handlers.js / core.js. Cipher verified zero `.startsWith('done')` / `.indexOf('done')` / `.replace('done:', '')` survivors.

## Write-path UX

- **Pending:** `[Done now]` `[clock Done at...]` `[Skip]` (V-V-01 flex-wrap; V-V-02 clock-icon prefix)
- **Done at...:** inline editor (no modal); validates HH:MM (CR-4); empty input blocks save with toast
- **Done state:** `Done at 8:42 AM — Vitamin D3 Drops [Adjust]` + with-fat badge or "no fat-meal logged nearby" (V-M-61 nil-handling, V-M-63 softer framing); late marker (CR-15 unified)
- **Adjust:** empty prefill for legacy null + "No time captured" hint in neutral mid-tone (V-V-10); validates (CR-8); never wedges editor
- **Skipped state:** amber card with `[Undo skip]` — Undo clears entry to undefined (returns to pending) so the parent makes an explicit choice with no fabricated tap-time (V-M-68 + V-M-73)

## Read-path surface upgrades

- **Today So Far chip:** `"Done at 8:42 AM · with ghee chapati"` (12h, escHtml, late marker)
- **TSF event-list chip:** `"Done (late)"` when retroactive (V-V-17 half-awake fix)
- **TSF event-detail expansion:** `"Status: Done at 8:42 AM (logged late)"` + `"With fat: ghee"`
- **Medical-tab 14-day pattern card:** adherence respects medStart (V-K-74 + CR-6); fresh-install warm-start "Just getting started" stripe (V-M-74); usual-time band uses (N-1)·p indexing with N≥5 threshold (CR-11); 14-day compact log with per-day 12h time + with-fat context + "Not tracked yet" for pre-medStart rows
- **Med-Log history:** schema-aware + 12h + late marker
- **Smart Q&A:** Typical-Day card enriched (D3 with-fat rate when N≥3); 30-day summary D3 with-fat line (when N≥5); qaAnswerSupplement migrated from try/catch-swallowed string read to schema-aware actionItem (CR-1)

## Test plan

- [x] **Build:** clean (HR-1, V-K-10, V-M-41, V-V-01..09, viz-smoke all PASS)
- [x] **E2E:** 158 passed, 1 skipped (pre-existing)
- [x] **25 Vit D3 regression guards** — schema (7), with-fat detector (6), display (3), write-path UX (5), pattern card (1), Q&A (1), yesterday-schema (1), retained legacy (2)

## QA chain (canon-cc-008) — TWO complete cycles + cumulative LGTM

| Pass | Range | Maren | Kael | Vela | Lyra synth | Cipher Edict V |
|------|-------|-------|------|------|-----------|----------------|
| #1 | `ea9b7d5..90161e8` | rejected → folded V-M-59..67 | amended → folded V-K-66..72 | clear-with-notes → folded V-V-01..09 | clean | **LGTM** |
| #2 | `90161e8..ff514f1` | clear-with-notes → folded V-M-68..76 | clear-with-notes → folded V-K-73..77 | clear-with-notes → folded V-V-10..17 | clean | **LGTM** |

**Findings totals across both chains:**
- Maren: 18 findings (V-M-59..76) — all binding folded; V-M-67 (no-D3-distinction), V-M-69 (staged-rollout, canon-tier), V-M-71 (iOS device-matrix) deferred per Maren's own framing
- Kael: 12 findings (V-K-66..77) — all binding folded; V-K-75/76/77 (info/documentation) acknowledged
- Vela: 17 findings (V-V-01..17) — all binding folded; V-V-09 (pre-existing typo), V-V-16 (pre-existing inline style), V-V-13/14/15 (cross-jurisdiction advisory) preserved as deferred
- /code-review: 15 findings (CR-1..CR-15) — all closed

**Doctrinal lineage:** PR #116 is the first SproutLab PR to traverse the full canon-cc-008 chain twice (once for initial v1, once for the CR-fix synth), confirming the post-/code-review re-discharge requirement (CLAUDE.md: "/code-review is a supplement, not a Governor audit, and does not discharge this gate").

## Deferred to v2 (documented)

- Reminder / notification scheduling
- Skip-reason capture (ran-out / forgot / refused categorisation)
- Dose override UI per-dose
- Diarrhoea-malabsorption cross-reference
- CareTicket auto-creation on multi-day gaps
- Age-correlated dose escalation (800 → 1000 IU at 12mo+)
- Multi-tenant family-config
- iOS Safari `<input type="time">` empty-prefill device-matrix verification (V-M-71)
- Staged-rollout legacy-reader compatibility (V-M-69 — canon-tier)
- Pre-existing inline `el.style.transform` cleanup (V-V-16 — backlog)
- Quick-Log save from non-home tab → home reminder refresh deferral (V-V-13 — acceptable v1)

## Note on guard count

Commit `ff514f1`'s body parenthetically says "26 total Vit D3 guards" — actual is 25 (V-V-17's chip late-marker is covered by existing TSF chip rendering paths and has no dedicated test). Cipher flagged this as cosmetic doc drift; does not affect correctness or merge gate.

https://claude.ai/code/session_01KpPmqp3WdSGtKknt4oZhfK