### PR TITLE
Hotfix: reminder card overflow — wrap action row + title min-width:0

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@ audit-emoji.sh [default (5 surfaced ranges)]: 0 HR-1 violations across split, in
 audit-icon-text: PASS (0 unannotated `(label|text|reason|detail): (zi|iconText)(` field-assignments)
 audit-resolve-shield: PASS (4 resolve-caller(s) carry the explicit `'Resolve'` btnText shield per V-M-41 doctrine)
 audit-viz-smoke: PASS (4 ids + 5 tokens) across template.html + styles.css
-[bump-version] 2026.05.24-3 → 2026.05.24-4
+[bump-version] 2026.05.24-4 → 2026.05.24-5
 [poop-reference] wrote /home/user/sproutlab/docs/POOP_COLOR_REFERENCE.html
 [careticket-sm] wrote /home/user/sproutlab/docs/CARETICKET_STATE_MACHINE.html — 6 transitions, 0 drift flags
 <!DOCTYPE html>
@@ -2269,10 +2269,20 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
   border-left-color:var(--tc-danger);
 }
 .supp-alert-top {
-  display:flex; align-items:center; gap:var(--sp-8);
+  /* HF-1: flex-wrap so the 3-button action row drops to its own line below the title
+     when horizontal space is tight, rather than squeezing the title into a vertical stack.
+     Closes Vit D3 v2 backlog item (Vela V-V-01 alternative recommendation, originally
+     deferred). Surfaced live post-PR #116 merge — title was wrapping word-by-word into
+     ~80px residual width while flex-shrink:0 on .supp-alert-action held ~250px. */
+  display:flex; align-items:center; gap:var(--sp-8); flex-wrap:wrap;
 }
 .supp-alert-icon { font-size:var(--icon-md); flex-shrink:0; }
-.supp-alert-title { flex:1; font-size:var(--fs-md); font-weight:600; color:var(--text); }
+.supp-alert-title {
+  /* HF-1: min-width:0 lets the title compress past its longest-word width via normal
+     line-wrapping (flex items default to min-width:auto = longest atom). Pairs with the
+     parent's flex-wrap so the action row drops below before the title is forced to wrap. */
+  flex:1; min-width:0; font-size:var(--fs-md); font-weight:600; color:var(--text);
+}
 .supp-alert.done .supp-alert-title { color:var(--tc-sage); }
 .supp-alert.missed .supp-alert-title { color:var(--tc-rose); }
 .supp-alert-action { flex-shrink:0; display:flex; gap:var(--sp-4); align-items:center; flex-wrap:wrap; justify-content:flex-end; }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.24-4",
+  "version": "2026.05.24-5",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/styles.css
+++ b/split/styles.css
@@ -2255,10 +2255,20 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
   border-left-color:var(--tc-danger);
 }
 .supp-alert-top {
-  display:flex; align-items:center; gap:var(--sp-8);
+  /* HF-1: flex-wrap so the 3-button action row drops to its own line below the title
+     when horizontal space is tight, rather than squeezing the title into a vertical stack.
+     Closes Vit D3 v2 backlog item (Vela V-V-01 alternative recommendation, originally
+     deferred). Surfaced live post-PR #116 merge — title was wrapping word-by-word into
+     ~80px residual width while flex-shrink:0 on .supp-alert-action held ~250px. */
+  display:flex; align-items:center; gap:var(--sp-8); flex-wrap:wrap;
 }
 .supp-alert-icon { font-size:var(--icon-md); flex-shrink:0; }
-.supp-alert-title { flex:1; font-size:var(--fs-md); font-weight:600; color:var(--text); }
+.supp-alert-title {
+  /* HF-1: min-width:0 lets the title compress past its longest-word width via normal
+     line-wrapping (flex items default to min-width:auto = longest atom). Pairs with the
+     parent's flex-wrap so the action row drops below before the title is forced to wrap. */
+  flex:1; min-width:0; font-size:var(--fs-md); font-weight:600; color:var(--text);
+}
 .supp-alert.done .supp-alert-title { color:var(--tc-sage); }
 .supp-alert.missed .supp-alert-title { color:var(--tc-rose); }
 .supp-alert-action { flex-shrink:0; display:flex; gap:var(--sp-4); align-items:center; flex-wrap:wrap; justify-content:flex-end; }

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -2,7 +2,7 @@ audit-emoji.sh [default (5 surfaced ranges)]: 0 HR-1 violations across split, in
 audit-icon-text: PASS (0 unannotated `(label|text|reason|detail): (zi|iconText)(` field-assignments)
 audit-resolve-shield: PASS (4 resolve-caller(s) carry the explicit `'Resolve'` btnText shield per V-M-41 doctrine)
 audit-viz-smoke: PASS (4 ids + 5 tokens) across template.html + styles.css
-[bump-version] 2026.05.24-3 → 2026.05.24-4
+[bump-version] 2026.05.24-4 → 2026.05.24-5
 [poop-reference] wrote /home/user/sproutlab/docs/POOP_COLOR_REFERENCE.html
 [careticket-sm] wrote /home/user/sproutlab/docs/CARETICKET_STATE_MACHINE.html — 6 transitions, 0 drift flags
 <!DOCTYPE html>
@@ -2269,10 +2269,20 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
   border-left-color:var(--tc-danger);
 }
 .supp-alert-top {
-  display:flex; align-items:center; gap:var(--sp-8);
+  /* HF-1: flex-wrap so the 3-button action row drops to its own line below the title
+     when horizontal space is tight, rather than squeezing the title into a vertical stack.
+     Closes Vit D3 v2 backlog item (Vela V-V-01 alternative recommendation, originally
+     deferred). Surfaced live post-PR #116 merge — title was wrapping word-by-word into
+     ~80px residual width while flex-shrink:0 on .supp-alert-action held ~250px. */
+  display:flex; align-items:center; gap:var(--sp-8); flex-wrap:wrap;
 }
 .supp-alert-icon { font-size:var(--icon-md); flex-shrink:0; }
-.supp-alert-title { flex:1; font-size:var(--fs-md); font-weight:600; color:var(--text); }
+.supp-alert-title {
+  /* HF-1: min-width:0 lets the title compress past its longest-word width via normal
+     line-wrapping (flex items default to min-width:auto = longest atom). Pairs with the
+     parent's flex-wrap so the action row drops below before the title is forced to wrap. */
+  flex:1; min-width:0; font-size:var(--fs-md); font-weight:600; color:var(--text);
+}
 .supp-alert.done .supp-alert-title { color:var(--tc-sage); }
 .supp-alert.missed .supp-alert-title { color:var(--tc-rose); }
 .supp-alert-action { flex-shrink:0; display:flex; gap:var(--sp-4); align-items:center; flex-wrap:wrap; justify-content:flex-end; }


### PR DESCRIPTION
## Summary

Live-render hotfix surfaced post-PR #116 merge. Two visual defects on the pending-state Vit D3 reminder card:

1. **Title wrapped vertically** into "Reminder" / "—" / "Vitamin" / "D3 Drops" each on their own line — title's `flex:1` had no `min-width:0`, action row's `flex-shrink:0` held ~250px, title was compressed into ~80px.
2. **"Skip" button clipped at the right edge** — `flex-wrap` on `.supp-alert-action` only wraps individual buttons, not the whole row.

Both stem from Vela's V-V-01 alternative recommendation ("restructure so action row sits on its own line below the title") originally deferred at v1 synth.

## Fix

Two-line CSS at `.supp-alert-top` + `.supp-alert-title`:

```css
.supp-alert-top { flex-wrap: wrap; }    /* action row drops below title when tight */
.supp-alert-title { min-width: 0; }     /* title compresses before wrapping */
```

When horizontal space is tight, the action row wraps to a new line below the title — title stays on one line, all 3 buttons remain visible.

## Files touched

- `split/styles.css` (+10 / -2) — the two-line fix + explanatory comments tying back to V-V-01

That's it. No JS. Build artifacts auto-regenerate.

## Test plan

- [x] `pnpm exec playwright test` — 158/159 pass (1 pre-existing skip)
- [x] `bash split/build.sh` — clean
- [x] Rendered CSS verified in compiled `index.html`

## QA chain (canon-cc-008) — FULLY DISCHARGED

| Governor | Verdict | Notes |
|----------|---------|-------|
| **Vela** (primary; shared-module render) | `clear` | V-V-18..24 confirming; wrap pairing correct; cross-state clean; half-awake test PASS |
| **Maren** (advisory; care semantics) | `clear-with-notes` | Half-awake test PASS; one non-blocking note about 280px landscape-split (below realistic Ziva-parent viewport) |
| **Kael** (advisory; engine non-impact) | `clear` | V-K-78..82 confirm zero engine-tier impact |
| **Lyra synth** | clean — no folds required |
| **Cipher Edict V** | **LGTM** | Scope discipline + HR sweep + cumulative integration + illegal-state check all clean |

Closes one **Tier-2** item from `docs/specs/vit-d3-tracking-v2-backlog.md` (live-surfaced derivative of V-V-01).

https://claude.ai/code/session_01KpPmqp3WdSGtKknt4oZhfK