### PR TITLE
Hotfix-of-hotfix: restructure reminder card — action row sibling of top (HF-2)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2262,19 +2262,18 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
   border-left-color:var(--tc-danger);
 }
 .supp-alert-top {
-  /* HF-1: flex-wrap so the 3-button action row drops to its own line below the title
-     when horizontal space is tight, rather than squeezing the title into a vertical stack.
-     Closes Vit D3 v2 backlog item (Vela V-V-01 alternative recommendation, originally
-     deferred). Surfaced live post-PR #116 merge — title was wrapping word-by-word into
-     ~80px residual width while flex-shrink:0 on .supp-alert-action held ~250px. */
-  display:flex; align-items:center; gap:var(--sp-8); flex-wrap:wrap;
+  /* HF-2: reverts PR #117's flex-wrap (no longer needed). The action row is now a
+     SIBLING of .supp-alert-top, not a child — see home.js render branches. So
+     .supp-alert-top only needs to lay out icon + title on a single row. */
+  display:flex; align-items:center; gap:var(--sp-8);
 }
 .supp-alert-icon { font-size:var(--icon-md); flex-shrink:0; }
 .supp-alert-title {
-  /* HF-1: min-width:0 lets the title compress past its longest-word width via normal
-     line-wrapping (flex items default to min-width:auto = longest atom). Pairs with the
-     parent's flex-wrap so the action row drops below before the title is forced to wrap. */
-  flex:1; min-width:0; font-size:var(--fs-md); font-weight:600; color:var(--text);
+  /* HF-2: reverts PR #117's min-width:0 (no longer needed). With the action row out
+     of .supp-alert-top, the title competes with nothing — it gets the full row width
+     after the icon. flex:1 lets it expand to fill; default min-width:auto lets long
+     unbroken words break naturally if ever wider than the card. */
+  flex:1; font-size:var(--fs-md); font-weight:600; color:var(--text);
 }
 .supp-alert.done .supp-alert-title { color:var(--tc-sage); }
 .supp-alert.missed .supp-alert-title { color:var(--tc-rose); }
@@ -23559,16 +23558,22 @@ function renderRemindersAndAlerts() {
     if (!isResolved) allTodayResolved = false;
 
     if (!isResolved) {
+      // HF-2: action row is now a SIBLING of .supp-alert-top (not a child) so it never
+      // competes with the title for horizontal space. Parent .supp-alert is column-flex,
+      // so the action row stacks below title naturally. Closes Vit D3 v2 backlog item
+      // (Vela V-V-01 original structural recommendation; PR #117 attempted a CSS-only
+      // wrap fix that backfired — min-width:0 let the title shrink past its content and
+      // the parent never triggered wrap).
       html += `
       <div class="supp-alert" id="supp-alert-${idx}">
         <div class="supp-alert-top">
           <div class="supp-alert-icon">${zi('warn')}</div>
           <div class="supp-alert-title">Reminder — ${escHtml(m.name)}</div>
-          <div class="supp-alert-action">
-            <button class="supp-check-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done now</button>
-            <button class="supp-check-btn supp-check-btn-alt" data-action="openMedDoneAt" data-arg="${escHtml(m.name)}" data-arg2="${idx}">${zi('clock')} Done at...</button>
-            <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Skip</button>
-          </div>
+        </div>
+        <div class="supp-alert-action">
+          <button class="supp-check-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done now</button>
+          <button class="supp-check-btn supp-check-btn-alt" data-action="openMedDoneAt" data-arg="${escHtml(m.name)}" data-arg2="${idx}">${zi('clock')} Done at...</button>
+          <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Skip</button>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${escHtml(m.freq || 'As prescribed')}</div>
       </div>`;
@@ -23590,14 +23595,15 @@ function renderRemindersAndAlerts() {
       } else if (parsed && parsed.withFat === false && givenAt) {
         fatBadge = `<span class="supp-fat-badge supp-fat-badge-neutral">no fat-meal logged nearby</span>`;
       }
+      // HF-2: action row sibling of top, same as pending.
       html += `
       <div class="supp-alert supp-alert-done" id="supp-alert-${idx}">
         <div class="supp-alert-top">
           <div class="supp-alert-icon">${zi('check')}</div>
           <div class="supp-alert-title">${timeText} — ${escHtml(m.name)}</div>
-          <div class="supp-alert-action">
-            <button class="supp-skip-btn supp-adjust-btn" data-action="openMedAdjust" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Adjust</button>
-          </div>
+        </div>
+        <div class="supp-alert-action">
+          <button class="supp-skip-btn supp-adjust-btn" data-action="openMedAdjust" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Adjust</button>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${fatBadge}</div>
       </div>`;
@@ -23608,14 +23614,15 @@ function renderRemindersAndAlerts() {
       // of bug). Instead Undo clears the skip back to PENDING — the card re-renders with
       // the standard [Done now] [Done at...] [Skip] buttons, forcing the parent to make
       // an explicit choice. No fabricated time, no destroyed audit trail.
+      // HF-2: action row sibling of top, same as pending/done.
       html += `
       <div class="supp-alert supp-alert-skipped" id="supp-alert-${idx}">
         <div class="supp-alert-top">
           <div class="supp-alert-icon">${zi('skip-forward')}</div>
           <div class="supp-alert-title">Skipped today — ${escHtml(m.name)}</div>
-          <div class="supp-alert-action">
-            <button class="supp-skip-btn supp-adjust-btn" data-action="undoMedSkip" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Undo skip</button>
-          </div>
+        </div>
+        <div class="supp-alert-action">
+          <button class="supp-skip-btn supp-adjust-btn" data-action="undoMedSkip" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Undo skip</button>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}Skip recorded — tap Undo to clear and log the dose.</div>
       </div>`;

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.24-6",
+  "version": "2026.05.24-7",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/home.js
+++ b/split/home.js
@@ -704,16 +704,22 @@ function renderRemindersAndAlerts() {
     if (!isResolved) allTodayResolved = false;
 
     if (!isResolved) {
+      // HF-2: action row is now a SIBLING of .supp-alert-top (not a child) so it never
+      // competes with the title for horizontal space. Parent .supp-alert is column-flex,
+      // so the action row stacks below title naturally. Closes Vit D3 v2 backlog item
+      // (Vela V-V-01 original structural recommendation; PR #117 attempted a CSS-only
+      // wrap fix that backfired — min-width:0 let the title shrink past its content and
+      // the parent never triggered wrap).
       html += `
       <div class="supp-alert" id="supp-alert-${idx}">
         <div class="supp-alert-top">
           <div class="supp-alert-icon">${zi('warn')}</div>
           <div class="supp-alert-title">Reminder — ${escHtml(m.name)}</div>
-          <div class="supp-alert-action">
-            <button class="supp-check-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done now</button>
-            <button class="supp-check-btn supp-check-btn-alt" data-action="openMedDoneAt" data-arg="${escHtml(m.name)}" data-arg2="${idx}">${zi('clock')} Done at...</button>
-            <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Skip</button>
-          </div>
+        </div>
+        <div class="supp-alert-action">
+          <button class="supp-check-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done now</button>
+          <button class="supp-check-btn supp-check-btn-alt" data-action="openMedDoneAt" data-arg="${escHtml(m.name)}" data-arg2="${idx}">${zi('clock')} Done at...</button>
+          <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Skip</button>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${escHtml(m.freq || 'As prescribed')}</div>
       </div>`;
@@ -735,14 +741,15 @@ function renderRemindersAndAlerts() {
       } else if (parsed && parsed.withFat === false && givenAt) {
         fatBadge = `<span class="supp-fat-badge supp-fat-badge-neutral">no fat-meal logged nearby</span>`;
       }
+      // HF-2: action row sibling of top, same as pending.
       html += `
       <div class="supp-alert supp-alert-done" id="supp-alert-${idx}">
         <div class="supp-alert-top">
           <div class="supp-alert-icon">${zi('check')}</div>
           <div class="supp-alert-title">${timeText} — ${escHtml(m.name)}</div>
-          <div class="supp-alert-action">
-            <button class="supp-skip-btn supp-adjust-btn" data-action="openMedAdjust" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Adjust</button>
-          </div>
+        </div>
+        <div class="supp-alert-action">
+          <button class="supp-skip-btn supp-adjust-btn" data-action="openMedAdjust" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Adjust</button>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${fatBadge}</div>
       </div>`;
@@ -753,14 +760,15 @@ function renderRemindersAndAlerts() {
       // of bug). Instead Undo clears the skip back to PENDING — the card re-renders with
       // the standard [Done now] [Done at...] [Skip] buttons, forcing the parent to make
       // an explicit choice. No fabricated time, no destroyed audit trail.
+      // HF-2: action row sibling of top, same as pending/done.
       html += `
       <div class="supp-alert supp-alert-skipped" id="supp-alert-${idx}">
         <div class="supp-alert-top">
           <div class="supp-alert-icon">${zi('skip-forward')}</div>
           <div class="supp-alert-title">Skipped today — ${escHtml(m.name)}</div>
-          <div class="supp-alert-action">
-            <button class="supp-skip-btn supp-adjust-btn" data-action="undoMedSkip" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Undo skip</button>
-          </div>
+        </div>
+        <div class="supp-alert-action">
+          <button class="supp-skip-btn supp-adjust-btn" data-action="undoMedSkip" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Undo skip</button>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}Skip recorded — tap Undo to clear and log the dose.</div>
       </div>`;

--- a/split/styles.css
+++ b/split/styles.css
@@ -2255,19 +2255,18 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
   border-left-color:var(--tc-danger);
 }
 .supp-alert-top {
-  /* HF-1: flex-wrap so the 3-button action row drops to its own line below the title
-     when horizontal space is tight, rather than squeezing the title into a vertical stack.
-     Closes Vit D3 v2 backlog item (Vela V-V-01 alternative recommendation, originally
-     deferred). Surfaced live post-PR #116 merge — title was wrapping word-by-word into
-     ~80px residual width while flex-shrink:0 on .supp-alert-action held ~250px. */
-  display:flex; align-items:center; gap:var(--sp-8); flex-wrap:wrap;
+  /* HF-2: reverts PR #117's flex-wrap (no longer needed). The action row is now a
+     SIBLING of .supp-alert-top, not a child — see home.js render branches. So
+     .supp-alert-top only needs to lay out icon + title on a single row. */
+  display:flex; align-items:center; gap:var(--sp-8);
 }
 .supp-alert-icon { font-size:var(--icon-md); flex-shrink:0; }
 .supp-alert-title {
-  /* HF-1: min-width:0 lets the title compress past its longest-word width via normal
-     line-wrapping (flex items default to min-width:auto = longest atom). Pairs with the
-     parent's flex-wrap so the action row drops below before the title is forced to wrap. */
-  flex:1; min-width:0; font-size:var(--fs-md); font-weight:600; color:var(--text);
+  /* HF-2: reverts PR #117's min-width:0 (no longer needed). With the action row out
+     of .supp-alert-top, the title competes with nothing — it gets the full row width
+     after the icon. flex:1 lets it expand to fill; default min-width:auto lets long
+     unbroken words break naturally if ever wider than the card. */
+  flex:1; font-size:var(--fs-md); font-weight:600; color:var(--text);
 }
 .supp-alert.done .supp-alert-title { color:var(--tc-sage); }
 .supp-alert.missed .supp-alert-title { color:var(--tc-rose); }

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -2262,19 +2262,18 @@ input:checked + .toggle-track::before { transform:translateX(20px); }
   border-left-color:var(--tc-danger);
 }
 .supp-alert-top {
-  /* HF-1: flex-wrap so the 3-button action row drops to its own line below the title
-     when horizontal space is tight, rather than squeezing the title into a vertical stack.
-     Closes Vit D3 v2 backlog item (Vela V-V-01 alternative recommendation, originally
-     deferred). Surfaced live post-PR #116 merge — title was wrapping word-by-word into
-     ~80px residual width while flex-shrink:0 on .supp-alert-action held ~250px. */
-  display:flex; align-items:center; gap:var(--sp-8); flex-wrap:wrap;
+  /* HF-2: reverts PR #117's flex-wrap (no longer needed). The action row is now a
+     SIBLING of .supp-alert-top, not a child — see home.js render branches. So
+     .supp-alert-top only needs to lay out icon + title on a single row. */
+  display:flex; align-items:center; gap:var(--sp-8);
 }
 .supp-alert-icon { font-size:var(--icon-md); flex-shrink:0; }
 .supp-alert-title {
-  /* HF-1: min-width:0 lets the title compress past its longest-word width via normal
-     line-wrapping (flex items default to min-width:auto = longest atom). Pairs with the
-     parent's flex-wrap so the action row drops below before the title is forced to wrap. */
-  flex:1; min-width:0; font-size:var(--fs-md); font-weight:600; color:var(--text);
+  /* HF-2: reverts PR #117's min-width:0 (no longer needed). With the action row out
+     of .supp-alert-top, the title competes with nothing — it gets the full row width
+     after the icon. flex:1 lets it expand to fill; default min-width:auto lets long
+     unbroken words break naturally if ever wider than the card. */
+  flex:1; font-size:var(--fs-md); font-weight:600; color:var(--text);
 }
 .supp-alert.done .supp-alert-title { color:var(--tc-sage); }
 .supp-alert.missed .supp-alert-title { color:var(--tc-rose); }
@@ -23559,16 +23558,22 @@ function renderRemindersAndAlerts() {
     if (!isResolved) allTodayResolved = false;
 
     if (!isResolved) {
+      // HF-2: action row is now a SIBLING of .supp-alert-top (not a child) so it never
+      // competes with the title for horizontal space. Parent .supp-alert is column-flex,
+      // so the action row stacks below title naturally. Closes Vit D3 v2 backlog item
+      // (Vela V-V-01 original structural recommendation; PR #117 attempted a CSS-only
+      // wrap fix that backfired — min-width:0 let the title shrink past its content and
+      // the parent never triggered wrap).
       html += `
       <div class="supp-alert" id="supp-alert-${idx}">
         <div class="supp-alert-top">
           <div class="supp-alert-icon">${zi('warn')}</div>
           <div class="supp-alert-title">Reminder — ${escHtml(m.name)}</div>
-          <div class="supp-alert-action">
-            <button class="supp-check-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done now</button>
-            <button class="supp-check-btn supp-check-btn-alt" data-action="openMedDoneAt" data-arg="${escHtml(m.name)}" data-arg2="${idx}">${zi('clock')} Done at...</button>
-            <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Skip</button>
-          </div>
+        </div>
+        <div class="supp-alert-action">
+          <button class="supp-check-btn" data-action="markMedDone" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Done now</button>
+          <button class="supp-check-btn supp-check-btn-alt" data-action="openMedDoneAt" data-arg="${escHtml(m.name)}" data-arg2="${idx}">${zi('clock')} Done at...</button>
+          <button class="supp-skip-btn" data-action="markMedSkipped" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Skip</button>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${escHtml(m.freq || 'As prescribed')}</div>
       </div>`;
@@ -23590,14 +23595,15 @@ function renderRemindersAndAlerts() {
       } else if (parsed && parsed.withFat === false && givenAt) {
         fatBadge = `<span class="supp-fat-badge supp-fat-badge-neutral">no fat-meal logged nearby</span>`;
       }
+      // HF-2: action row sibling of top, same as pending.
       html += `
       <div class="supp-alert supp-alert-done" id="supp-alert-${idx}">
         <div class="supp-alert-top">
           <div class="supp-alert-icon">${zi('check')}</div>
           <div class="supp-alert-title">${timeText} — ${escHtml(m.name)}</div>
-          <div class="supp-alert-action">
-            <button class="supp-skip-btn supp-adjust-btn" data-action="openMedAdjust" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Adjust</button>
-          </div>
+        </div>
+        <div class="supp-alert-action">
+          <button class="supp-skip-btn supp-adjust-btn" data-action="openMedAdjust" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Adjust</button>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}${fatBadge}</div>
       </div>`;
@@ -23608,14 +23614,15 @@ function renderRemindersAndAlerts() {
       // of bug). Instead Undo clears the skip back to PENDING — the card re-renders with
       // the standard [Done now] [Done at...] [Skip] buttons, forcing the parent to make
       // an explicit choice. No fabricated time, no destroyed audit trail.
+      // HF-2: action row sibling of top, same as pending/done.
       html += `
       <div class="supp-alert supp-alert-skipped" id="supp-alert-${idx}">
         <div class="supp-alert-top">
           <div class="supp-alert-icon">${zi('skip-forward')}</div>
           <div class="supp-alert-title">Skipped today — ${escHtml(m.name)}</div>
-          <div class="supp-alert-action">
-            <button class="supp-skip-btn supp-adjust-btn" data-action="undoMedSkip" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Undo skip</button>
-          </div>
+        </div>
+        <div class="supp-alert-action">
+          <button class="supp-skip-btn supp-adjust-btn" data-action="undoMedSkip" data-arg="${escHtml(m.name)}" data-arg2="${idx}">Undo skip</button>
         </div>
         <div class="supp-alert-detail">${m.dose ? escHtml(m.dose) + ' · ' : ''}Skip recorded — tap Undo to clear and log the dose.</div>
       </div>`;


### PR DESCRIPTION
## Summary

PR #117's CSS-only fix to the reminder card overflow defect didn't work as intended on the live PWA. Architect surfaced post-merge screenshot showing the title still wrapping vertically into "Reminder" / "—" / "Vitan" / "D3" / "Drops" with "Vitamin" clipped by the overlapping Done now button.

**Root cause:** `min-width:0` on `.supp-alert-title` made the title willing to shrink to zero width. The flex algorithm then always thought everything "fit" on row 1 and never triggered the parent's `flex-wrap`. Action row stayed alongside title; title squeezed into ~80px and wrapped word-by-word.

**This fix:** structural change Vela originally pointed at in V-V-01 ("restructure so the action row sits on its own line below the title"). Move `.supp-alert-action` OUT of `.supp-alert-top` to be a **sibling** in the parent `.supp-alert` column flex. Action row becomes its own row naturally — zero flex-wrap gymnastics, zero horizontal-space competition with title.

## Result on narrow phones

```
Row 1: [icon] Reminder — Vitamin D3 Drops      ← full row, never squeezed
Row 2: [Done now] [Done at...] [Skip]         ← right-clustered, no overlap
Row 3: 0.5 ml · 800 IU · Once daily            ← detail unchanged
```

## Files touched

- `split/home.js` (+13 / -10) — all 3 render branches (pending, done, skipped) restructure: action div moves out of `.supp-alert-top`
- `split/styles.css` (+8 / -8) — revert PR #117's `flex-wrap:wrap` + `min-width:0` (both no-ops now that action is sibling)

Inline-editor selectors (`openMedDoneAt` + `openMedAdjust` use `card.querySelector('.supp-alert-action')`) still resolve — `querySelector` is descendant-search, works regardless of nesting depth.

## Test plan

- [x] `pnpm exec playwright test tests/e2e/vit-d3-tracking.spec.ts` — 25/25 pass
- [x] `bash split/build.sh` — clean, `<!DOCTYPE html>` first line
- [ ] Architect eyeball on Vercel preview at narrow viewport (will be live ~30s after push)

## QA chain (canon-cc-008) status

Touches `home.js` (Maren primary) + `styles.css` (shared module → triple-Gov). Awaiting Architect's choice — full chain or waiver given this is the third attempt at the same overflow and the fix mechanism is mechanically simple + locally reversible.

https://claude.ai/code/session_01KpPmqp3WdSGtKknt4oZhfK

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpPmqp3WdSGtKknt4oZhfK)_