### PR TITLE
Build safety: build-safe.sh wrapper + output validation (closes PR #118 class)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,9 +33,13 @@ Three PWA projects sharing a common architectural pattern: split-file HTML conca
 # Codex (self-copying)
 cd split && bash build.sh
 
-# SproutLab (stdout redirect + manual copy)
-cd split && bash build.sh > sproutlab.html
-cp sproutlab.html ../index.html && cp sproutlab.html ../sproutlab.html
+# SproutLab — canonical (post-PR #120):
+pnpm build
+# This calls split/build-safe.sh which (a) invokes build.sh with correct
+# STDOUT/STDERR redirection, (b) validates <!DOCTYPE html>…</html> bookends
+# and size, (c) mirrors sproutlab.html → index.html. NEVER use
+# `bash split/build.sh > out.html 2>&1` — the 2>&1 captures STDERR into the
+# output file and corrupts the HTML (PR #117/#118 incident).
 
 # SEP Invoicing (stdout redirect + manual copy)
 cd split && bash build.sh > ../sep-invoicing.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,16 +122,36 @@ split/
 
 ### Build
 
+**Canonical invocation (use this):**
+
 ```bash
-cd ~/storage/shared/SproutLab/split
-bash build.sh > sproutlab.html
-# Then sync to serve paths:
-cp sproutlab.html ../index.html
-cp sproutlab.html ../sproutlab.html
+pnpm build
+# Then commit and push:
 git add -A && git commit -m "description" && git --no-pager push
 ```
 
-**NEVER use raw cat.** Always build.sh. The split-file build is NOT a simple concatenation — it injects DOCTYPE, style tags, script tags, and Chart.js CDN link.
+`pnpm build` calls `split/build-safe.sh` which (a) invokes `build.sh` with
+correct STDOUT/STDERR redirection, (b) validates the output starts with
+`<!DOCTYPE html>` and is > 100KB, and (c) mirrors `sproutlab.html` →
+`index.html`. **Use this, not direct `bash split/build.sh` invocations.**
+
+**Why the wrapper exists** (PR #118 incident, ratified in PR #120):
+`build.sh` writes HTML to STDOUT and audit gates to STDERR. A caller
+invoking `bash build.sh > out.html 2>&1` will have the `2>&1` merge STDERR
+into STDOUT *after* STDOUT has been redirected to the file — audit text
+gets prepended to the HTML and pollutes the rendered page. `build-safe.sh`
+enforces the correct redirection (`> $OUT 2> $LOG`) and validates the
+output before declaring success.
+
+**Direct `bash build.sh` invocation is supported but ad-hoc**: if you
+must invoke `build.sh` manually (e.g. inside a script that needs the raw
+STDOUT), use `bash build.sh > out.html 2> /tmp/build.log` (STDERR to a
+separate file, never `2>&1`). Then validate: `head -1 out.html` must equal
+`<!DOCTYPE html>`.
+
+**NEVER use raw cat.** Always `pnpm build` (or `build.sh` via the wrapper).
+The split-file build is NOT a simple concatenation — it injects DOCTYPE,
+style tags, script tags, and Chart.js CDN link.
 
 ## Hard Rules (HR-1 through HR-12)
 

--- a/docs/SPROUTLAB_QUICK_REFERENCE.md
+++ b/docs/SPROUTLAB_QUICK_REFERENCE.md
@@ -41,7 +41,7 @@ pnpm build              # bumps manifest version + builds sproutlab.html + copie
 git add -A && git commit -m "message" && git push
 ```
 
-`pnpm build` is the canonical entry; `bash split/build.sh > sproutlab.html && cp sproutlab.html index.html` is the same steps written out (PR-8 wired the script + made build.sh self-locating so `pnpm build` works from any cwd). The manifest version bump runs first (`split/bump-version.mjs`); errors go to stderr so the stdout HTML stream stays clean.
+`pnpm build` is the canonical entry — calls `split/build-safe.sh` which wraps `bash build.sh > sproutlab.html 2> /tmp/build.log`, validates the output starts with `<!DOCTYPE html>`, ends with `</html>`, and is > 100KB, then mirrors to `index.html`. (Post-PR #120; closes the PR #117/#118 STDERR-leak class.) The manifest version bump runs inside `build.sh` (`split/bump-version.mjs`); audit gates + version bump + doc-generator output go to stderr so the stdout HTML stream stays clean. `build-safe.sh` captures stderr to a log and tails it back to the caller for visibility. **NEVER invoke `bash split/build.sh > out.html 2>&1` directly** — the `2>&1` captures STDERR into the output file and corrupts the HTML.
 
 ---
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.24-10",
+  "version": "2026.05.24-13",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.24-7",
+  "version": "2026.05.24-10",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "Dev-only test harness + build script for SproutLab. Production artifact (sproutlab.html / index.html) is built by `pnpm build`; this package.json itself is not part of the runtime bundle.",
   "scripts": {
-    "build": "bash split/build.sh > sproutlab.html && cp sproutlab.html index.html",
+    "build": "bash split/build-safe.sh",
     "test:e2e": "playwright test",
     "test:e2e:stress": "playwright test --repeat-each=5",
     "test:e2e:ci": "CI=1 playwright test --repeat-each=5",

--- a/split/build-safe.sh
+++ b/split/build-safe.sh
@@ -19,7 +19,10 @@ ROOT="$(cd .. && pwd)"
 OUT="$ROOT/sproutlab.html"
 INDEX="$ROOT/index.html"
 LOG="$(mktemp -t sl-build.XXXXXX.log)"
-trap "rm -f $LOG" EXIT
+# V-K-86 (Kael synth): single-quoted trap body — `$LOG` expands at exit time
+# rather than registration time. Stylistic robustness against future refactors
+# that might reassign LOG between trap and exit.
+trap 'rm -f "$LOG"' EXIT
 
 # Run build.sh with proper redirection: STDOUT → file, STDERR → log.
 # `set -e` will trip if build.sh exits non-zero.
@@ -45,7 +48,24 @@ if [ "$FIRST" != "<!DOCTYPE html>" ]; then
   exit 1
 fi
 
+# V-K-84 (Kael synth): also assert the document ends with </html>. Bounds the
+# corruption surface at both ends — catches a class of leak where STDERR text
+# arrives AFTER the DOCTYPE line (the first-line check above wouldn't see it)
+# but lands somewhere inside the body or after the closing tag.
+LAST="$(tail -1 "$OUT")"
+if [ "$LAST" != "</html>" ]; then
+  echo "BUILD CORRUPTED — $OUT does not end with </html>." >&2
+  echo "Last line was: $LAST" >&2
+  echo "" >&2
+  echo "Last 10 lines of output (for diagnosis):" >&2
+  tail -10 "$OUT" >&2
+  exit 1
+fi
+
 # Validate size: a truncated build would be < 100KB. Real builds are several MB.
+# Per Maren advisory: this is belt-and-braces alongside the DOCTYPE/closing-tag
+# checks above — the structural checks are the primary corruption guard; size
+# catches gross truncation that somehow preserves the bookends.
 SIZE="$(wc -c < "$OUT")"
 if [ "$SIZE" -lt 102400 ]; then
   echo "BUILD CORRUPTED — $OUT is suspiciously small ($SIZE bytes; expected > 100KB)." >&2

--- a/split/build-safe.sh
+++ b/split/build-safe.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# build-safe.sh — canonical safe invocation of build.sh.
+#
+# Why this exists: build.sh writes the HTML payload to STDOUT and audit/log
+# output to STDERR. When a caller invokes it with the WRONG redirection
+# order — e.g. `bash build.sh > out.html 2>&1` — the `2>&1` merges STDERR
+# into STDOUT *after* STDOUT has already been redirected to the file, so
+# audit text gets prepended to the HTML and pollutes the rendered page.
+# This was the live-production bug behind PR #118.
+#
+# This wrapper enforces the correct redirection pattern AND validates the
+# output before declaring the build successful. Use `pnpm build` (which
+# calls this script) instead of invoking build.sh directly.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+ROOT="$(cd .. && pwd)"
+OUT="$ROOT/sproutlab.html"
+INDEX="$ROOT/index.html"
+LOG="$(mktemp -t sl-build.XXXXXX.log)"
+trap "rm -f $LOG" EXIT
+
+# Run build.sh with proper redirection: STDOUT → file, STDERR → log.
+# `set -e` will trip if build.sh exits non-zero.
+if ! bash build.sh > "$OUT" 2> "$LOG"; then
+  echo "BUILD FAILED — build.sh exited non-zero. Tail of build log:" >&2
+  tail -20 "$LOG" >&2
+  exit 1
+fi
+
+# Validate output: must start with <!DOCTYPE html>.
+# Catches the STDERR-leak class of bugs (PR #118) plus any future case
+# where build.sh's STDOUT gets corrupted.
+FIRST="$(head -1 "$OUT")"
+if [ "$FIRST" != "<!DOCTYPE html>" ]; then
+  echo "BUILD CORRUPTED — $OUT does not start with <!DOCTYPE html>." >&2
+  echo "First line was: $FIRST" >&2
+  echo "" >&2
+  echo "First 10 lines of corrupted output:" >&2
+  head -10 "$OUT" >&2
+  echo "" >&2
+  echo "Last 20 lines of build log (for diagnosis):" >&2
+  tail -20 "$LOG" >&2
+  exit 1
+fi
+
+# Validate size: a truncated build would be < 100KB. Real builds are several MB.
+SIZE="$(wc -c < "$OUT")"
+if [ "$SIZE" -lt 102400 ]; then
+  echo "BUILD CORRUPTED — $OUT is suspiciously small ($SIZE bytes; expected > 100KB)." >&2
+  exit 1
+fi
+
+# Mirror to index.html (the served path).
+cp "$OUT" "$INDEX"
+
+# Surface the audit-gate output (it was on STDERR, captured to log).
+# Show the tail so the parent sees PASS lines without re-running the suite.
+tail -10 "$LOG" >&2
+
+echo "Build OK: $OUT ($SIZE bytes); mirrored to $INDEX." >&2


### PR DESCRIPTION
## Summary

Hardens the build pipeline against the redirection-misordering class of bugs (PR #117 → PR #118 incident). The wrapper enforces correct STDOUT/STDERR redirection and validates output at both ends (`<!DOCTYPE html>` head + `</html>` tail + 100KB size floor).

## What changes

| File | Change |
|------|--------|
| `split/build-safe.sh` | **NEW** — canonical wrapper. Correct redirection (`> $OUT 2> $LOG`, never `2>&1`), three-prong validation, audit-gate surfacing, idempotent recovery |
| `package.json` | `pnpm build` → `bash split/build-safe.sh` |
| `CLAUDE.md` §Build | Recommend `pnpm build` canonical; explain why (PR #118 incident); warn against `2>&1` if direct `build.sh` is needed |
| `AGENTS.md` §Build Commands | Doc-sync to canonical pattern + same `2>&1` warning |
| `docs/SPROUTLAB_QUICK_REFERENCE.md` | Doc-sync to canonical pattern + same warning |
| `split/build.sh` | **UNCHANGED** — interface preserved |

## Verify

- [x] `pnpm build` — OK, all audit gates PASS, output 3310995 bytes
- [x] Negative test (STDERR leak prepended) — caught by `<!DOCTYPE html>` head check
- [x] Negative test (junk appended) — caught by `</html>` tail check (V-K-84 fold-in)
- [x] `pnpm exec playwright test tests/e2e/vit-d3-tracking.spec.ts` — 25/25 pass

## QA chain (canon-cc-008) — FULLY DISCHARGED

| Pass | Verdict | Notes |
|------|---------|-------|
| **Kael Mode-1** (primary — engine-adjacent infra) | `clear-with-notes` | V-K-83..87. Synth folded V-K-83 (doc-sync), V-K-84 (tail check), V-K-86 (single-quote trap). V-K-85 (CRLF/BOM) + V-K-87 (audit-gate visibility) deferred non-blocking. |
| **Maren Mode-1** (advisory — care fail-closed posture) | `clear-with-notes` | Synth folded size-floor rationale inline-doc; post-cp `index.html` validation deferred non-blocking. |
| **Vela Mode-1** (advisory — visible-text invariant) | `clear-with-notes` | DOCTYPE case-sensitivity acceptable as strictness. |
| **Lyra synth** (`9040c67`) | clean | 3 fold-ins applied, 4 non-blocking notes documented |
| **Cipher Edict V** | **LGTM** | HR sweep clean; scope disciplined; illegal-state-blocked; doc-sync cross-verified; cross-cutting integration clean |

https://claude.ai/code/session_01KpPmqp3WdSGtKknt4oZhfK