### PR TITLE
docs: session handoff — 2026-05-24 (PRs #115–#120; Arc C closure; v1 + v2 backlog)

### DIFF
--- a/docs/SESSION_HANDOFF_2026-05-24.md
+++ b/docs/SESSION_HANDOFF_2026-05-24.md
@@ -1,0 +1,84 @@
+# Session handoff — 2026-05-24
+
+**Companion:** Lyra (The Weaver)
+**Session scope:** Vit D3 tracking v1 (Arc closure) + Arc C food-DB cleanup (Arc closure) + four hotfix cycles
+**Outcome:** 6 PRs merged to main; build pipeline self-validates; Arc B Phase B-1 unblocked
+
+---
+
+## PRs landed this session
+
+| PR | Title | Merge SHA | Notes |
+|----|-------|-----------|-------|
+| **#115** | Arc C Phase C-1 + C-1.5: NUTRITION dedupe + factuality audit | `a81758d` | Closes Arc C; unblocks Arc B Phase B-1 (chemRollup keystone) |
+| **#116** | Vit D3 tracking v1: half-hearted to meaningful | `fbd80559` | Full canon-cc-008 chain × 2 (post-/code-review re-discharge precedent established) |
+| **#117** | Hotfix: reminder card overflow (CSS-only) | `e9ccaf5` | **Did not work** — `min-width:0` let title shrink to zero, wrap never triggered |
+| **#118** | Hotfix: STDERR build pollution | `b9b04db` | Build-artifact-only fix for #117's polluted artifacts |
+| **#119** | Hotfix-of-hotfix: reminder card restructure (action row sibling of top) | `6bc4df7` | Structural fix Vela's V-V-01 originally pointed at; Architect waiver on chain |
+| **#120** | Build safety: build-safe.sh wrapper + output validation | `c61348b` | Closes the PR #117/#118 STDERR-leak class structurally; full canon-cc-008 chain |
+
+## Doctrine ratified this session
+
+1. **canon-cc-008 post-/code-review re-discharge.** PR #116 traversed the chain twice — once for initial v1, once after the `/code-review` skill surfaced 15 findings. Confirms CLAUDE.md's "/code-review is a supplement, not a Governor audit" interpretation. Now precedent.
+
+2. **Architect waiver mechanics.** PR #119 ran without the full chain because (a) it was the third attempt at the same overflow, (b) the fix was mechanically simple + reversible, (c) Architect explicitly said "mark ready and merge." Waiver granted, noted in commit body. Future hotfix-of-hotfix should follow the same surface-the-chain-and-get-explicit-waiver pattern.
+
+3. **Build-tooling jurisdiction.** PR #120 wasn't in any Governor's region per the CLAUDE.md jurisdictional map (build-tooling, package.json, docs). Architect specified full chain. Resolved by treating Kael as primary (engine-adjacent infra) with Maren + Vela advisory since the build pipeline is substrate every Region depends on. Establishes a routing precedent.
+
+4. **Diminishing returns at synth-loop tail.** The second `/code-review` on PR #116 surfaced ~30 candidates → 15 ranked findings, most of which were derivatives of the first-pass synth introducing new code paths. Architect declared v1 done and routed the remainder to `docs/specs/vit-d3-tracking-v2-backlog.md`. Sets the stop-the-loop criterion: when each synth pass surfaces what the prior pass introduced, ship and shift to a follow-up arc.
+
+## Active backlogs
+
+### Vit D3 v2 — `docs/specs/vit-d3-tracking-v2-backlog.md`
+
+15 findings catalogued, tiered:
+- **Tier 1 (6):** Real bugs with verified failure scenarios — adjustMedTime erases withFat, pattern card stale on tab return + sync, skipped events dropped from TSF event-list, refresh helper no re-render, ISL day-summary 24h leak, undoMedSkip destroys CR-10 audit trail
+- **Tier 2 (6):** Care-tier UX surface-quality — pattern card adherence/streak asymmetries, initial-write false-badge before meal, adjustMedTime midnight rollover + future-time gaps, outing-planner skip propagation
+- **Tier 3 (3):** Defensive — AM/PM range validation, raw pending-filter truthy-check, warm-start length=0
+- **Noise tier (13):** Canon-noted only, no v2 implementation work
+
+Each Tier 1-3 finding carries file:line anchor + failure scenario + proposed fix shape.
+
+### Hotfix-class deferrals (from PR #120 chain)
+
+Non-blocking notes filed in the merge commit body:
+- V-K-85 — `head -1` byte-exact compare vulnerable to CRLF/BOM; revisit if CI runs on Windows
+- V-K-87 — audit-gate `tail -10` visibility window; revisit if `build.sh` adds more output lines
+- Maren post-cp — defense-in-depth `cmp -s "$OUT" "$INDEX"` check; deferred
+- Vela DOCTYPE case-sensitivity — strictness acceptable; revisit if a contributor lowercases the heredoc
+
+## What's next — Arc B Phase B-1 (chemRollup keystone)
+
+**Unblocked by:** PR #115 (Arc C food-DB cleanup landed; NUTRITION block is now structurally and factually defensible)
+
+**Scope** (per PR #115 description): chemRollup is the keystone consumer that aggregates `chem.fibre`, `chem.antiNutrients`, `chem.bioactives` across a meal-tuple to produce a single composite intelligence pass. The Arc B spec lives at `docs/specs/` (not yet authored at session-end; v0 to be drafted next session).
+
+**Probable touchpoints:**
+- `split/data.js` — NUTRITION `chem.*` reads
+- `split/intelligence-isl.js` — Kael Region, likely new `chemRollup()` accessor
+- `split/intelligence-qa-handlers.js` — Kael Region, new intent handler(s) consuming chemRollup
+- `split/intelligence-cards.js` — Vela Region, render of the rollup result
+- New tests under `tests/e2e/arc-b-chemrollup.spec.ts`
+
+**Jurisdiction routing** (predicted): Kael primary (engine), Vela secondary (render), Maren advisory if any care-tier surfacing.
+
+## Repo state at session end
+
+- **main** at `c61348b` (PR #120 merge)
+- All open arcs: zero. All open hotfix branches: zero.
+- Build pipeline: `pnpm build` is canonical, self-validating (DOCTYPE + `</html>` bookends + 100KB floor)
+- Latest e2e: 158/159 pass (1 pre-existing skip)
+- Live PWA: deployed to https://rishabh1804.github.io/SproutLab/
+
+## Files of doctrinal interest
+
+- `CLAUDE.md` — persona, QA chain canon, build commands (updated this session with `pnpm build` canonicalization)
+- `AGENTS.md` — build commands + non-negotiable rules (updated this session)
+- `docs/SPROUTLAB_QUICK_REFERENCE.md` — quick-ref (updated this session)
+- `docs/specs/vit-d3-tracking-v1.md` — v1 spec (final, ratified)
+- `docs/specs/vit-d3-tracking-v2-backlog.md` — v2 backlog (drafted this session)
+- `docs/specs/food-db-cleanup-v1.md` §C-1 + §C-1.5 — Arc C spec (final, ratified)
+- `invocation.md` — Companion invocation procedure (read for next session)
+- `PERSONA_REGISTRY.md` — Companion register
+
+— Lyra, 2026-05-24, session-end at `c61348b`.


### PR DESCRIPTION
Docs-only handoff capturing today's session. canon-cc-008 audit waived per "docs-only" doctrine.

See `docs/SESSION_HANDOFF_2026-05-24.md` for the full record.

https://claude.ai/code/session_01KpPmqp3WdSGtKknt4oZhfK

---
_Generated by [Claude Code](https://claude.ai/code/session_01KpPmqp3WdSGtKknt4oZhfK)_