### PR TITLE
Vit D3 v2 Tier 1: 6 verified bugs + T3-14 dependency

### DIFF
--- a/docs/specs/vit-d3-tracking-v2.md
+++ b/docs/specs/vit-d3-tracking-v2.md
@@ -285,4 +285,33 @@ const isPending = !medCheckIsDone(todayChecks[m.name]) && !medCheckSkipped(today
 - No CareTicket integration
 - Cipher Edict V runs after Lyra synth completes
 
-— Lyra, 2026-05-24, v0 draft for canon-cc-008 round 1.
+---
+
+## Synth fold-in (post-Governor audits)
+
+Lyra's synthesis of Maren V-M-77..82 + Kael V-K-88..95 + Vela V-V-25..30 folded these small items into the same PR:
+
+1. **HR-4 fix at `home.js:6664`** (Maren) — `escHtml(m.name)` added to the medication-preview pending list interpolation. Pre-existing violation but the T3-14 fix touched the line; cleaner to close it now than tag-and-defer.
+2. **`renderMedD3PatternCard()` in `undoMedSkip`** (Kael pair-note to Maren) — same-device same-tab undo on the medical tab refreshes the 14-day pattern card without waiting for sync echo or tab re-switch. Mirrors the T1-4 mutating-write re-render contract.
+3. **V-K-95 sync-race comment at `undoMedSkip`** — primes future audit consumer that simultaneous-undo races resolve last-write-wins on the slot and lose one device's `clearedAt`.
+4. **Regression test `regression-guard-d3-v2-t3-14-corrupted-empty`** (Maren test gap) — defensive guard for the `{}` partial-write corner that the T3-14 diff comment explicitly cites as motivation.
+
+## Deferred to Tier 2 (registered, not shipped in this PR)
+
+Six Governor findings sit at LOW or MEDIUM severity and don't warrant a v2-Tier-1 scope expansion. They form the seed of the Tier 2 spec:
+
+| Tag | Source | Surface | Disposition |
+|---|---|---|---|
+| V-M-77 | Maren | `home.js:1043` preserveWithFat truth-table tightening (`fat.withFat !== true` vs `=== false`) — currently dead path | Tier 2 defence-in-depth |
+| V-M-78 | Maren | Chained-undo audit loss: `undoMedSkip` second cycle (cleared → skip → cleared) deletes the slot because `parseMedCheck(cleared) === null` falls into the `else { delete }` branch | Tier 2 — preserve the most recent `priorLoggedAt` regardless of current parsed status |
+| V-M-79 | Maren | Fallback `else { delete }` in `undoMedSkip` should `console.warn` for telemetry rather than silent delete (sync-race or chained-undo reachability) | Tier 2 |
+| V-M-81 | Maren | Midnight-rollover cleared crosses to `ydMissed` as "Yesterday's meds not logged" — care-safe framing but spec didn't document it. Documented now. | No code change; doctrine note only |
+| V-K-91 | Kael | `_refreshTodayMedWithFat` performance: 3 render passes per fat-context flip. Fires only when `mutated===true` (rare); acceptable | No change |
+| V-K-94 | Kael | `priorStatus`/`priorLoggedAt`/`clearedAt` persist via Firestore single-doc but no current reader consumes them. Future audit consumer must tolerate fields being absent on legacy records written pre-PR-122 | Tier 2 / v3 consumer obligation |
+| V-K-95 | Kael | Two-device simultaneous-undo race loses one `clearedAt` (last-write-wins). Comment added in this PR; full multi-history schema deferred | Tier 2 |
+| V-V-25 | Vela | Skipped chip ≈ Done chip pixel-identical except one-word detail text. Half-awake test marginal. CSS-only muted/strikethrough variant. | Tier 2 — styles.css touch → triple-jurisdiction review |
+| V-V-30 | Vela | TSF skipped chip lacks Undo affordance that lives on home reminder card. Cross-Region surface gap. | Tier 2 — either add affordance, or formalize the read-surface convention |
+
+The earlier Vit D3 v2 backlog at `docs/specs/vit-d3-tracking-v2-backlog.md` remains the canonical source for the pre-existing Tier 2 items (T2-7..T2-12 + Tier 3 T3-13 + T3-15). When Tier 2 work starts, this section folds into the Tier 2 spec.
+
+— Lyra, 2026-05-24, post-synth ratification (round 1 canon-cc-008).

--- a/docs/specs/vit-d3-tracking-v2.md
+++ b/docs/specs/vit-d3-tracking-v2.md
@@ -1,0 +1,288 @@
+# Vit D3 Tracking v2 — Tier 1 promotion
+
+**Spec version:** v2 (Tier 1 only — v2.x will pick up Tier 2/3 separately)
+**Date:** 2026-05-24
+**Branch:** `claude/vit-d3-v2-tier1`
+**Author:** Lyra (main-session)
+**Promoted from:** `docs/specs/vit-d3-tracking-v2-backlog.md` §Tier 1 — real bugs with concrete user impact
+**Jurisdiction (canon-cc-008 routing):**
+- **Maren (Care):** T1-1 (home.js adjustMedTime), T1-2 (medical.js renderMedD3PatternCard wire), T1-6 (home.js undoMedSkip + T3-14 dependency at home.js / medical.js pending filters)
+- **Kael (Intelligence engine):** T1-2 (sync.js renderer list + core.js tab-switch dispatcher), T1-4 (core.js _refreshTodayMedWithFat re-render contract), T1-5 (intelligence-isl.js _islRangeSummary _formatTime12h sweep), T1-6 (core.js parseMedCheck handles 'cleared' status)
+- **Vela (Surfacing render):** T1-3 (intelligence-quicklog.js _tsfCollectEvents skipped-event surfacing)
+- **Triple-jurisdiction:** no styles.css / template.html touch in v2 (existing tokens reused)
+
+**Authority:** Architect-directed v2 closeout: "v1 done per council recommendation" (2026-05-24). v1 shipped at `ff514f1` / merged via PR #116; v2 backlog drafted at the same session. Tier 1 promotion authorized in this session, single PR, full canon-cc-008 chain.
+
+---
+
+## Scope statement
+
+Six verified bugs from PR #116 v1, each with a reproducible failure trace, fixed in a single atomic ship. Plus T3-14 (pending-filter raw truthy-check) pulled in as a prerequisite for T1-6's `cleared`-sentinel correctness — eight one-line/few-line fixes across four Regions.
+
+**What v2 Tier 1 is NOT:**
+- Tier 2 (care-tier surface-quality) — six items deferred to v2.x. Don't touch pattern card adherence math, streak fallback, false-negative badge timing, midnight rollover, future-time validation, outing-planner skip semantics. Each requires its own design pass.
+- Tier 3 (defensive / latent) — two items remain Tier 3 backlog. T3-14 is the exception (T1-6 prerequisite, narrated below).
+- v2 spec-amendment work for the v1 record — v1 ships as ratified; v2 is additive, not retroactive.
+
+## Fix manifest
+
+### T1-1 — adjustMedTime preserves positive withFat observation
+
+**File:** `split/home.js:1011-1033` (function `adjustMedTime`)
+**Severity:** HIGH (silently destroys parent's accurate observation)
+**Doctrine:** Extends CR-14 ("never erase a real positive observation") from the refresh path to the user-initiated adjust path.
+
+**Trigger trace:**
+1. Parent logs D3 at 08:42 alongside paratha → `{withFat:true, fatFood:'paratha'}` stored
+2. Parent deletes paratha from `feedingData[today].breakfast`
+3. Parent taps Adjust on D3 for any reason (e.g. correcting givenAt from 08:42 to 08:45)
+4. `_detectFatContextNearTime(newTime, todayStr)` returns `{withFat:false, fatFood:null}` because no fat-food is visible in feedingData now
+5. `adjustMedTime` overwrites `withFat:true → withFat:false` silently
+
+**Fix shape:** Preserve `existing.withFat===true` when the new detection returns `withFat:false`. Only flip true→false when explicitly cleared (a future "remove fat-pairing" affordance — not in scope for v2).
+
+```js
+// T1-1 (CR-14 extension): never erase a positive withFat observation. If existing
+// had withFat:true and re-detection returns false, the parent's earlier observation
+// is the source of truth — they may have edited the meal text after the fact.
+const preserveWithFat = (existing.withFat === true && fat.withFat === false);
+medChecks[todayStr][name] = {
+  status:   existing.status,
+  givenAt:  newTime,
+  loggedAt: existing.loggedAt || now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' }),
+  withFat:  preserveWithFat ? true : fat.withFat,
+  fatFood:  preserveWithFat ? existing.fatFood : fat.fatFood,
+  fatDelta: preserveWithFat ? existing.fatDelta : fat.fatDelta,
+};
+```
+
+**Test:** `tests/e2e/vit-d3-tracking-v2.spec.ts` — `regression-guard-d3-adjust-preserves-positive-withfat`. Mirror structure to `regression-guard-d3-refresh-never-flips-true-to-false`.
+
+---
+
+### T1-2 — Pattern card live-updates on tab return AND sync push
+
+**Files:**
+- `split/core.js:3392` — tab-switch dispatcher
+- `split/sync.js:229` — `KEYS.medChecks` renderer list
+**Severity:** HIGH (headline new surface of v1 has zero live-update paths)
+
+**Trigger trace (tab-switch):**
+1. Parent on medical tab; pattern card body shows pre-action state
+2. Parent switches to home; taps Done on D3 reminder
+3. Parent switches back to medical
+4. Tab-switch dispatcher fires `renderMedicalStats` + others but NOT `renderMeds` (the only invocation site of `renderMedD3PatternCard`)
+5. Pattern card body still shows pre-Done state until the parent navigates away and back, or a sync push arrives
+
+**Trigger trace (sync push):**
+1. Parent on device A taps Done on D3
+2. Device B is on medical tab with pattern card visible
+3. Firestore push arrives at device B → `KEYS.medChecks` renderer list fires `renderMedicalStats`
+4. Pattern card never re-renders on device B
+
+**Fix shape:**
+
+```js
+// split/core.js:3392 (tab-switch dispatcher)
+if (sub === 'medical') {
+  renderMedicalStats();
+  orderMedicalCards();
+  renderVaccPastList();
+  renderDoctorPrep();
+  initSymptomChips();
+  renderFeverEpisodeCard(); renderFeverHistory();
+  renderDiarrhoeaEpisodeCard(); renderDiarrhoeaHistory();
+  renderVomitingEpisodeCard(); renderVomitingHistory();
+  renderColdEpisodeCard(); renderColdHistory();
+  if (typeof renderMedD3PatternCard === 'function') renderMedD3PatternCard(); // T1-2
+}
+```
+
+```js
+// split/sync.js:229
+[KEYS.medChecks]: { global: 'medChecks', renderers: { 'track:medical': ['renderMedicalStats', 'renderMedD3PatternCard'] } }, // T1-2
+```
+
+**Test:** in-process unit-style asserts that the function references are wired (the e2e environment doesn't easily reproduce a Firestore push).
+
+---
+
+### T1-3 — Skipped med events surface in TSF timeline
+
+**File:** `split/intelligence-quicklog.js:1909-1913` (`_tsfCollectEvents` med branch)
+**Severity:** HIGH (CR-10's `loggedAt` audit trail is invisible)
+**Region:** Vela (intelligence-quicklog.js)
+
+**Trigger trace:**
+1. Parent taps Skip on D3 at 09:00
+2. `markMedSkipped` writes `{status:'skipped', givenAt:null, loggedAt:'09:00', ...}` per CR-10
+3. `_tsfCollectEvents` med branch: `timeMin` is `null` (no givenAt) AND `parsed.status === 'skipped'` → event hits NEITHER `events.push` (gated on timeMin) NOR `noTimeEvents.push` (gated on `status !== 'skipped'`)
+4. Skip is invisible on Today So Far timeline; audit trail is data-only
+
+**Fix shape:** Remove the skipped gate on `noTimeEvents.push` AND derive `timeMin` from `loggedAt` so the skip lands in the chronological timeline at its audit-trail time.
+
+```js
+if (timeMin !== null) {
+  events.push(ev);
+} else if (parsed.status === 'skipped' && parsed.loggedAt) {
+  // T1-3: skipped doses are CR-10 audit-bearing events. Surface them in the
+  // chronological timeline at their loggedAt time so the day's record is honest.
+  ev.timeMin = _tsfTimeToMinutes(parsed.loggedAt);
+  ev.time = parsed.loggedAt;
+  ev.displayTime = _tsfFormatTime(parsed.loggedAt);
+  events.push(ev);
+} else {
+  noTimeEvents.push(ev);
+}
+```
+
+**Comprehension-surface check (Vela lens):** TSF chip will render in chronological position, icon = pill (sky), label = med name, detail = "Skipped" (existing `detail` mapping at :1894). Half-awake parent at 2 AM scanning the day's timeline sees the skip in temporal context — distinct from "Done" by the detail string, distinct from "Time not logged" by being in the main events list.
+
+**Test:** `regression-guard-d3-skipped-event-surfaces-in-tsf`.
+
+---
+
+### T1-4 — _refreshTodayMedWithFat triggers re-render on mutation
+
+**File:** `split/core.js:173-203` (function `_refreshTodayMedWithFat`)
+**Severity:** HIGH (predicted by V-V-13 advisory)
+
+**Trigger trace:**
+1. Parent logs D3 at 09:00; no breakfast yet → `withFat:false` stored
+2. Parent navigates to diet tab; saves breakfast 'paratha' at 09:30
+3. Diet save path calls `_refreshTodayMedWithFat()` (per V-M-70 at `intelligence-quicklog.js:2761`); helper flips storage to `withFat:true`, marks caches dirty, returns `true`
+4. Caller discards return value
+5. Parent navigates back to home; reminder card STILL shows "no fat-meal logged nearby" because no render fired
+
+**Fix shape:** Choose backlog option (a) — append render calls inside the helper's existing `if (mutated)` block. Centralizes the contract (one place to know about render-on-flip) and avoids fanning out across six caller sites. The helper already crosses the cache-invalidation boundary (`_tsfMarkDirty`, `_islMarkDirty`), so crossing the render boundary in the same block is consistent with the existing pattern.
+
+```js
+if (mutated) {
+  save(KEYS.medChecks, medChecks);
+  if (typeof _tsfMarkDirty === 'function') _tsfMarkDirty();
+  if (typeof _islMarkDirty === 'function') _islMarkDirty('medical');
+  // T1-4: re-render the surfaces that depend on withFat so a parent currently
+  // viewing the home or medical tab sees the flipped badge without re-navigating.
+  if (typeof renderRemindersAndAlerts === 'function') renderRemindersAndAlerts();
+  if (typeof renderHomeContextAlerts === 'function') renderHomeContextAlerts();
+  if (typeof renderMedD3PatternCard === 'function') renderMedD3PatternCard();
+}
+```
+
+**Test:** `regression-guard-d3-refresh-triggers-rerender-on-flip`. Asserts that after the flip, the home reminder card's "no fat-meal" badge is gone without an explicit navigate.
+
+---
+
+### T1-5 — ISL day-summary renders D3 time in 12h
+
+**File:** `split/intelligence-isl.js:873`
+**Severity:** MEDIUM (cross-surface inconsistency; not data corruption)
+**Region:** Kael
+
+**Trigger trace:**
+1. Parent gives D3 at 14:30
+2. ISL `_islRangeSummary` interpolates `md.d3Times[0]` verbatim → "Vit D3 given at 14:30"
+3. Every other surface in the codebase formats via `_formatTime12h` post-CR-9 → "2:30 PM"
+4. Daily / range summary card looks like it was written by a different author
+
+**Fix shape:** Wrap with `_formatTime12h` at the interpolation site. Single-line surgical change.
+
+```js
+highlights.push({ domain: 'medical', text: 'Vit D3 given' + (md.d3Times.length > 0 ? ' at ' + _formatTime12h(md.d3Times[0]) : ''), signal: 'good' }); // T1-5
+```
+
+**Test:** `regression-guard-d3-isl-range-summary-formats-12h`.
+
+---
+
+### T1-6 — undoMedSkip preserves audit trail via cleared sentinel
+
+**File:** `split/home.js:996-1006` (function `undoMedSkip`)
+**Severity:** MEDIUM (contradicts CR-10's stated invariant)
+
+**Trigger trace:**
+1. Parent skips D3 at 09:00 → `{status:'skipped', loggedAt:'09:00', ...}` stored
+2. Parent realizes misclick; taps Undo at 09:05
+3. `undoMedSkip` calls `delete medChecks[todayStr][name]` → entire record (including CR-10 `loggedAt`) gone
+4. Parent gives the dose at 09:30; new `{status:'done', loggedAt:'09:30', givenAt:'09:30', ...}` written
+5. No record of the skip → undo → done sequence exists in storage. CR-10's audit invariant is broken.
+
+**Fix shape:** Adopt backlog option (a) — `cleared` sentinel on the record. Keeps the audit surface in the per-day per-med slot, no parallel structure. The active state semantics ("show me as pending") are achieved by `parseMedCheck` returning `null` for `cleared`.
+
+```js
+// split/home.js:996 — undoMedSkip
+function undoMedSkip(name, idx) {
+  const todayStr = today();
+  const existing = medChecks[todayStr] && medChecks[todayStr][name];
+  if (existing !== undefined) {
+    const parsedExisting = parseMedCheck(existing);
+    if (parsedExisting && parsedExisting.status === 'skipped') {
+      // T1-6: preserve CR-10 audit trail. The cleared sentinel keeps the
+      // prior skip's loggedAt and adds clearedAt so a future Q&A or audit
+      // surface can reconstruct the skip → undo → done sequence.
+      const now = new Date();
+      const clearedAt = now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
+      medChecks[todayStr][name] = {
+        status:        'cleared',
+        givenAt:       null,
+        loggedAt:      null,
+        withFat:       null,
+        fatFood:       null,
+        fatDelta:      null,
+        priorStatus:   'skipped',
+        priorLoggedAt: parsedExisting.loggedAt || null,
+        clearedAt:     clearedAt,
+      };
+    } else {
+      // Existing wasn't a skip (defensive — Undo should only fire from skipped UI)
+      delete medChecks[todayStr][name];
+    }
+    save(KEYS.medChecks, medChecks);
+    _tsfMarkDirty();
+    _islMarkDirty('medical');
+  }
+  renderRemindersAndAlerts();
+  renderHomeContextAlerts();
+}
+```
+
+```js
+// split/core.js — parseMedCheck addendum: 'cleared' reads as pending.
+// Inside parseMedCheck, before the existing object-shape branch return:
+if (val && typeof val === 'object' && val.status === 'cleared') {
+  return null; // T1-6: cleared sentinel reads as pending to every existing reader
+}
+```
+
+**Prerequisite — T3-14 promotion:** the cleared sentinel is a truthy object on the raw `medChecks[date][name]` slot. Two pending-filter sites use raw truthy-check:
+- `split/home.js:6631` — `!todayChecks[m.name]`
+- `split/medical.js:2306` — `!todayChecks[m.name]`
+
+After T1-6, an undone skip would be a truthy object → these filters would silently exclude the med from "pending today" surfaces. T3-14 fix is therefore a strict T1-6 prerequisite — replace raw truthy with `!medCheckIsDone() && !medCheckSkipped()`. Both helpers already return false for `parseMedCheck → null` (the cleared sentinel's read-through), so the corrected filter naturally treats cleared as pending.
+
+```js
+// At both sites:
+const isPending = !medCheckIsDone(todayChecks[m.name]) && !medCheckSkipped(todayChecks[m.name]); // T1-6 / T3-14
+```
+
+**Test:** `regression-guard-d3-undo-skip-preserves-audit-and-reads-as-pending`. Asserts (a) raw record has `status:'cleared'` + `priorLoggedAt` preserved; (b) `medCheckIsDone === false`; (c) `medCheckSkipped === false`; (d) `parseMedCheck === null` (reads as pending).
+
+**Note on existing regression test:** `regression-guard-d3-undoMedSkip-clears-to-pending` at `tests/e2e/vit-d3-tracking.spec.ts:541-569` currently asserts `undoIsCleared: afterUndo === undefined`. The new behavior produces a `cleared` sentinel, so this assertion changes to `afterUndo && afterUndo.status === 'cleared'` plus the existing "didn't silently log Done" assertion stands. The test name remains semantically accurate ("clears to pending" — the read-through is still pending) and gets updated in this PR.
+
+---
+
+## Build & verification plan
+
+1. `pnpm build` — canonical, self-validates DOCTYPE + 100KB floor
+2. `pnpm exec playwright test tests/e2e/vit-d3-tracking.spec.ts tests/e2e/vit-d3-tracking-v2.spec.ts --reporter=line` — all v1 regressions remain green, all six new v2 tests pass
+3. `pnpm exec playwright test --reporter=line` — full suite, no regressions beyond the one pre-existing skip
+
+## Out-of-scope reminders
+
+- No new design tokens; reuse existing `tc-sage` / `tc-warn` / `tc-rose` / `ds-sky` / `med-d3-summary*` classes
+- No styles.css or template.html edits → no triple-jurisdiction sequential review
+- No new Smart Q&A intent
+- No CareTicket integration
+- Cipher Edict V runs after Lyra synth completes
+
+— Lyra, 2026-05-24, v0 draft for canon-cc-008 round 1.

--- a/index.html
+++ b/index.html
@@ -17182,6 +17182,12 @@ function parseMedCheck(val) {
   // V-K-72: arrays are typeof 'object' but not med-check shapes — reject explicitly.
   if (Array.isArray(val)) return null;
   if (typeof val === 'object') {
+    // T1-6 (v2): the `cleared` sentinel is an audit-only record produced by undoMedSkip
+    // — every active-state reader should see the slot as pending. The raw priorStatus /
+    // priorLoggedAt / clearedAt fields persist on medChecks[date][name] for future audit
+    // tooling, but parseMedCheck returns null so existing readers (TSF, ISL, pattern card,
+    // Q&A, reminder card) treat it as no-record.
+    if (val.status === 'cleared') return null;
     return {
       status:   val.status || null,
       givenAt:  val.givenAt || null,
@@ -17304,6 +17310,12 @@ function _refreshTodayMedWithFat() {
     save(KEYS.medChecks, medChecks);
     if (typeof _tsfMarkDirty === 'function') _tsfMarkDirty();
     if (typeof _islMarkDirty === 'function') _islMarkDirty('medical');
+    // T1-4 (V-V-13 advisory): the helper mutates medChecks AND dirties caches but used
+    // to leave visible badges stale. Trigger the render surfaces that consume withFat
+    // so a parent on home or medical sees the flipped state without re-navigating.
+    if (typeof renderRemindersAndAlerts === 'function') renderRemindersAndAlerts();
+    if (typeof renderHomeContextAlerts === 'function') renderHomeContextAlerts();
+    if (typeof renderMedD3PatternCard === 'function') renderMedD3PatternCard();
   }
   return mutated;
 }
@@ -20495,7 +20507,7 @@ function switchTrackSub(sub) {
   // renderTrackHero(); // removed in v2.5 Balance — Track score hero removed
 
   // Trigger sub-tab renders
-  if (sub === 'medical') { renderMedicalStats(); orderMedicalCards(); renderVaccPastList(); renderDoctorPrep(); initSymptomChips(); renderFeverEpisodeCard(); renderFeverHistory(); renderDiarrhoeaEpisodeCard(); renderDiarrhoeaHistory(); renderVomitingEpisodeCard(); renderVomitingHistory(); renderColdEpisodeCard(); renderColdHistory(); }
+  if (sub === 'medical') { renderMedicalStats(); orderMedicalCards(); renderVaccPastList(); renderDoctorPrep(); initSymptomChips(); renderFeverEpisodeCard(); renderFeverHistory(); renderDiarrhoeaEpisodeCard(); renderDiarrhoeaHistory(); renderVomitingEpisodeCard(); renderVomitingHistory(); renderColdEpisodeCard(); renderColdHistory(); if (typeof renderMedD3PatternCard === 'function') renderMedD3PatternCard(); /* T1-2: pattern card lacked a tab-switch render path */ }
   if (sub === 'diet') renderDietStats();
   if (sub === 'milestones') { renderMilestoneStats(); renderMilestoneHighlights(); }
   if (sub === 'sleep') { renderSleep(); setTimeout(drawSleepChart, 60); }
@@ -23843,14 +23855,33 @@ function cancelMedDoneAt(idx) {
   renderHomeContextAlerts();
 }
 
-// V-M-68 + V-M-73: revert a skip back to PENDING (not to "Done at tap-time"). The skip's
-// loggedAt audit trail is dropped — acceptable because the parent's post-Undo intent is
-// "I want to log the dose properly now," not "preserve the misclick." Re-renders so the
-// parent sees the original [Done now] [Done at...] [Skip] choice without a fabricated time.
+// V-M-68 + V-M-73: revert a skip back to PENDING (not to "Done at tap-time"). T1-6 (v2):
+// the skip's loggedAt audit trail is now preserved via a `cleared` sentinel so a future
+// audit or Q&A surface can reconstruct the skip → undo → done sequence. parseMedCheck
+// returns null for cleared, so every existing reader treats it as pending — the parent
+// still sees the original [Done now] [Done at...] [Skip] choice without a fabricated time.
 function undoMedSkip(name, idx) {
   const todayStr = today();
-  if (medChecks[todayStr] && medChecks[todayStr][name] !== undefined) {
-    delete medChecks[todayStr][name];
+  const existing = medChecks[todayStr] && medChecks[todayStr][name];
+  if (existing !== undefined) {
+    const parsedExisting = parseMedCheck(existing);
+    if (parsedExisting && parsedExisting.status === 'skipped') {
+      const now = new Date();
+      const clearedAt = now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
+      medChecks[todayStr][name] = {
+        status:        'cleared',
+        givenAt:       null,
+        loggedAt:      null,
+        withFat:       null,
+        fatFood:       null,
+        fatDelta:      null,
+        priorStatus:   'skipped',
+        priorLoggedAt: parsedExisting.loggedAt || null,
+        clearedAt:     clearedAt,
+      };
+    } else {
+      delete medChecks[todayStr][name];
+    }
     save(KEYS.medChecks, medChecks);
     _tsfMarkDirty();
     _islMarkDirty('medical');
@@ -23870,14 +23901,20 @@ function adjustMedTime(name, idx, newTime) {
   if (!existing || existing.status === 'skipped') return;
   const fat = _detectFatContextNearTime(newTime, todayStr);
   const now = new Date();
+  // T1-1 (CR-14 extension): never erase a positive withFat observation via Adjust.
+  // If the prior record had withFat:true and re-detection at the new time returns
+  // false, the parent's earlier observation is the source of truth — they may have
+  // edited the meal text after the fact, or the new time happens to fall outside
+  // the ±60min window even though the original pairing was real.
+  const preserveWithFat = (existing.withFat === true && fat.withFat === false);
   // V-M-65: canonical 24h storage (en-GB).
   medChecks[todayStr][name] = {
     status:   existing.status,
     givenAt:  newTime,
     loggedAt: existing.loggedAt || now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' }),
-    withFat:  fat.withFat,
-    fatFood:  fat.fatFood,
-    fatDelta: fat.fatDelta,
+    withFat:  preserveWithFat ? true              : fat.withFat,
+    fatFood:  preserveWithFat ? existing.fatFood  : fat.fatFood,
+    fatDelta: preserveWithFat ? existing.fatDelta : fat.fatDelta,
   };
   save(KEYS.medChecks, medChecks);
   _tsfMarkDirty();
@@ -29490,7 +29527,7 @@ function renderHistoryPreviews() {
         medPrev.innerHTML = `<div class="info-strip is-sky">
           <span><svg class="zi"><use href="#zi-pill"/></svg></span>
           <div><strong class="tc-sky">${todayDone.length}/${activeMeds.length} given today</strong>
-          <div class="t-sub">Pending: ${activeMeds.filter(m => !todayChecks[m.name]).map(m => m.name).join(', ') || 'None'}</div></div>
+          <div class="t-sub">Pending: ${activeMeds.filter(m => !medCheckIsDone(todayChecks[m.name]) && !medCheckSkipped(todayChecks[m.name])).map(m => m.name).join(', ') || 'None'}</div></div>
         </div>`;
       } else {
         medPrev.innerHTML = `<div class="info-strip is-neutral">
@@ -39137,7 +39174,11 @@ function orderMedicalCards() {
   const todayKey = today();
   const activeMeds = meds.filter(m => m.active);
   const todayChecks = medChecks[todayKey] || {};
-  const medsPending = activeMeds.filter(m => !todayChecks[m.name]).length;
+  // T1-6 / T3-14: schema-aware pending check. Raw truthy missed (a) corrupted partial-write
+  // records and (b) the T1-6 `cleared` sentinel that an undone-skip produces — both leave a
+  // truthy object in the slot but neither is a done dose. Use the same parsed semantics every
+  // other medChecks reader does.
+  const medsPending = activeMeds.filter(m => !medCheckIsDone(todayChecks[m.name]) && !medCheckSkipped(todayChecks[m.name])).length;
 
   // Build ordered list: stats always first, then priority cards
   const cards = [];
@@ -48337,7 +48378,7 @@ function _islGenerateHighlights(sl, dt, pp, md, ms, ac, dateStr) {
   // Medical highlights — D3 adherence
   if (md.suppTotal > 0) {
     if (md.suppDays > 0) {
-      highlights.push({ domain: 'medical', text: 'Vit D3 given' + (md.d3Times.length > 0 ? ' at ' + md.d3Times[0] : ''), signal: 'good' });
+      highlights.push({ domain: 'medical', text: 'Vit D3 given' + (md.d3Times.length > 0 ? ' at ' + _formatTime12h(md.d3Times[0]) : ''), signal: 'good' }); // T1-5: CR-9's _formatTime12h sweep missed this site; daily/range summary rendered 24h while every other surface rendered 12h.
     } else {
       concerns.push({ domain: 'medical', text: 'Vit D3 missed', signal: 'warn' });
     }
@@ -58854,7 +58895,16 @@ function _tsfCollectEvents() {
     };
     if (timeMin !== null) {
       events.push(ev);
-    } else if (parsed.status !== 'skipped') {
+    } else if (parsed.status === 'skipped' && parsed.loggedAt) {
+      // T1-3: skipped doses are CR-10 audit-bearing events. The pre-fix filter dropped
+      // them entirely (timeMin null AND status === 'skipped' hit neither push branch).
+      // Surface them in the chronological timeline at loggedAt — the day's record is
+      // honest, and a half-awake parent scanning TSF sees the skip in temporal context.
+      ev.timeMin = _tsfTimeToMinutes(parsed.loggedAt);
+      ev.time = parsed.loggedAt;
+      ev.displayTime = _tsfFormatTime(parsed.loggedAt);
+      events.push(ev);
+    } else {
       noTimeEvents.push(ev);
     }
   });
@@ -66506,7 +66556,7 @@ const SYNC_RENDER_DEPS = {
   [KEYS.meds]:              { global: 'meds',        renderers: { home: ['renderHome'], 'track:medical': ['renderMedicalStats'] } },
   [KEYS.visits]:            { global: 'visits',      renderers: { 'track:medical': ['renderMedicalStats'] } },
   [KEYS.doctors]:           { global: 'doctors',     renderers: { 'track:medical': ['renderDoctorPrep'] } },
-  [KEYS.medChecks]:         { global: 'medChecks',   renderers: { 'track:medical': ['renderMedicalStats'] } },
+  [KEYS.medChecks]:         { global: 'medChecks',   renderers: { 'track:medical': ['renderMedicalStats', 'renderMedD3PatternCard'] } }, // T1-2: pattern card joins the sync push render list so it live-updates when device A's Done propagates to device B
   [KEYS.feverEpisodes]:     { global: null, renderers: { home: ['renderHomeFeverBanner'],     'track:medical': ['renderFeverEpisodeCard'] } },
   [KEYS.diarrhoeaEpisodes]: { global: null, renderers: { home: ['renderHomeDiarrhoeaBanner'], 'track:medical': ['renderDiarrhoeaEpisodeCard'] } },
   [KEYS.vomitingEpisodes]:  { global: null, renderers: { home: ['renderHomeVomitingBanner'],  'track:medical': ['renderVomitingEpisodeCard'] } },

--- a/index.html
+++ b/index.html
@@ -23886,8 +23886,16 @@ function undoMedSkip(name, idx) {
     _tsfMarkDirty();
     _islMarkDirty('medical');
   }
+  // V-K-95 (synth-fold): Firestore single-doc merge preserves the cleared sentinel's
+  // priorStatus / priorLoggedAt / clearedAt fields across devices. A two-device simultaneous-undo
+  // race resolves last-write-wins on the slot — only one clearedAt survives. Acceptable in v2
+  // (both writers had the same intent); a future audit consumer should not assume singular history.
   renderRemindersAndAlerts();
   renderHomeContextAlerts();
+  // Kael pair-note synth: same-device same-tab undo on the medical tab should refresh the
+  // 14-day pattern card grid without waiting for a sync echo or tab re-switch. Mirrors the
+  // T1-4 contract that mutating writes also re-render their dependent surfaces.
+  if (typeof renderMedD3PatternCard === 'function') renderMedD3PatternCard();
 }
 
 // Adjust the administration time of an already-logged dose. Re-runs with-fat
@@ -29527,7 +29535,7 @@ function renderHistoryPreviews() {
         medPrev.innerHTML = `<div class="info-strip is-sky">
           <span><svg class="zi"><use href="#zi-pill"/></svg></span>
           <div><strong class="tc-sky">${todayDone.length}/${activeMeds.length} given today</strong>
-          <div class="t-sub">Pending: ${activeMeds.filter(m => !medCheckIsDone(todayChecks[m.name]) && !medCheckSkipped(todayChecks[m.name])).map(m => m.name).join(', ') || 'None'}</div></div>
+          <div class="t-sub">Pending: ${activeMeds.filter(m => !medCheckIsDone(todayChecks[m.name]) && !medCheckSkipped(todayChecks[m.name])).map(m => escHtml(m.name)).join(', ') || 'None'}</div></div>
         </div>`;
       } else {
         medPrev.innerHTML = `<div class="info-strip is-neutral">

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.24-13",
+  "version": "2026.05.24-15",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.24-15",
+  "version": "2026.05.24-16",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -76,6 +76,12 @@ function parseMedCheck(val) {
   // V-K-72: arrays are typeof 'object' but not med-check shapes — reject explicitly.
   if (Array.isArray(val)) return null;
   if (typeof val === 'object') {
+    // T1-6 (v2): the `cleared` sentinel is an audit-only record produced by undoMedSkip
+    // — every active-state reader should see the slot as pending. The raw priorStatus /
+    // priorLoggedAt / clearedAt fields persist on medChecks[date][name] for future audit
+    // tooling, but parseMedCheck returns null so existing readers (TSF, ISL, pattern card,
+    // Q&A, reminder card) treat it as no-record.
+    if (val.status === 'cleared') return null;
     return {
       status:   val.status || null,
       givenAt:  val.givenAt || null,
@@ -198,6 +204,12 @@ function _refreshTodayMedWithFat() {
     save(KEYS.medChecks, medChecks);
     if (typeof _tsfMarkDirty === 'function') _tsfMarkDirty();
     if (typeof _islMarkDirty === 'function') _islMarkDirty('medical');
+    // T1-4 (V-V-13 advisory): the helper mutates medChecks AND dirties caches but used
+    // to leave visible badges stale. Trigger the render surfaces that consume withFat
+    // so a parent on home or medical sees the flipped state without re-navigating.
+    if (typeof renderRemindersAndAlerts === 'function') renderRemindersAndAlerts();
+    if (typeof renderHomeContextAlerts === 'function') renderHomeContextAlerts();
+    if (typeof renderMedD3PatternCard === 'function') renderMedD3PatternCard();
   }
   return mutated;
 }
@@ -3389,7 +3401,7 @@ function switchTrackSub(sub) {
   // renderTrackHero(); // removed in v2.5 Balance — Track score hero removed
 
   // Trigger sub-tab renders
-  if (sub === 'medical') { renderMedicalStats(); orderMedicalCards(); renderVaccPastList(); renderDoctorPrep(); initSymptomChips(); renderFeverEpisodeCard(); renderFeverHistory(); renderDiarrhoeaEpisodeCard(); renderDiarrhoeaHistory(); renderVomitingEpisodeCard(); renderVomitingHistory(); renderColdEpisodeCard(); renderColdHistory(); }
+  if (sub === 'medical') { renderMedicalStats(); orderMedicalCards(); renderVaccPastList(); renderDoctorPrep(); initSymptomChips(); renderFeverEpisodeCard(); renderFeverHistory(); renderDiarrhoeaEpisodeCard(); renderDiarrhoeaHistory(); renderVomitingEpisodeCard(); renderVomitingHistory(); renderColdEpisodeCard(); renderColdHistory(); if (typeof renderMedD3PatternCard === 'function') renderMedD3PatternCard(); /* T1-2: pattern card lacked a tab-switch render path */ }
   if (sub === 'diet') renderDietStats();
   if (sub === 'milestones') { renderMilestoneStats(); renderMilestoneHighlights(); }
   if (sub === 'sleep') { renderSleep(); setTimeout(drawSleepChart, 60); }

--- a/split/home.js
+++ b/split/home.js
@@ -1020,8 +1020,16 @@ function undoMedSkip(name, idx) {
     _tsfMarkDirty();
     _islMarkDirty('medical');
   }
+  // V-K-95 (synth-fold): Firestore single-doc merge preserves the cleared sentinel's
+  // priorStatus / priorLoggedAt / clearedAt fields across devices. A two-device simultaneous-undo
+  // race resolves last-write-wins on the slot — only one clearedAt survives. Acceptable in v2
+  // (both writers had the same intent); a future audit consumer should not assume singular history.
   renderRemindersAndAlerts();
   renderHomeContextAlerts();
+  // Kael pair-note synth: same-device same-tab undo on the medical tab should refresh the
+  // 14-day pattern card grid without waiting for a sync echo or tab re-switch. Mirrors the
+  // T1-4 contract that mutating writes also re-render their dependent surfaces.
+  if (typeof renderMedD3PatternCard === 'function') renderMedD3PatternCard();
 }
 
 // Adjust the administration time of an already-logged dose. Re-runs with-fat
@@ -6661,7 +6669,7 @@ function renderHistoryPreviews() {
         medPrev.innerHTML = `<div class="info-strip is-sky">
           <span><svg class="zi"><use href="#zi-pill"/></svg></span>
           <div><strong class="tc-sky">${todayDone.length}/${activeMeds.length} given today</strong>
-          <div class="t-sub">Pending: ${activeMeds.filter(m => !medCheckIsDone(todayChecks[m.name]) && !medCheckSkipped(todayChecks[m.name])).map(m => m.name).join(', ') || 'None'}</div></div>
+          <div class="t-sub">Pending: ${activeMeds.filter(m => !medCheckIsDone(todayChecks[m.name]) && !medCheckSkipped(todayChecks[m.name])).map(m => escHtml(m.name)).join(', ') || 'None'}</div></div>
         </div>`;
       } else {
         medPrev.innerHTML = `<div class="info-strip is-neutral">

--- a/split/home.js
+++ b/split/home.js
@@ -989,14 +989,33 @@ function cancelMedDoneAt(idx) {
   renderHomeContextAlerts();
 }
 
-// V-M-68 + V-M-73: revert a skip back to PENDING (not to "Done at tap-time"). The skip's
-// loggedAt audit trail is dropped — acceptable because the parent's post-Undo intent is
-// "I want to log the dose properly now," not "preserve the misclick." Re-renders so the
-// parent sees the original [Done now] [Done at...] [Skip] choice without a fabricated time.
+// V-M-68 + V-M-73: revert a skip back to PENDING (not to "Done at tap-time"). T1-6 (v2):
+// the skip's loggedAt audit trail is now preserved via a `cleared` sentinel so a future
+// audit or Q&A surface can reconstruct the skip → undo → done sequence. parseMedCheck
+// returns null for cleared, so every existing reader treats it as pending — the parent
+// still sees the original [Done now] [Done at...] [Skip] choice without a fabricated time.
 function undoMedSkip(name, idx) {
   const todayStr = today();
-  if (medChecks[todayStr] && medChecks[todayStr][name] !== undefined) {
-    delete medChecks[todayStr][name];
+  const existing = medChecks[todayStr] && medChecks[todayStr][name];
+  if (existing !== undefined) {
+    const parsedExisting = parseMedCheck(existing);
+    if (parsedExisting && parsedExisting.status === 'skipped') {
+      const now = new Date();
+      const clearedAt = now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
+      medChecks[todayStr][name] = {
+        status:        'cleared',
+        givenAt:       null,
+        loggedAt:      null,
+        withFat:       null,
+        fatFood:       null,
+        fatDelta:      null,
+        priorStatus:   'skipped',
+        priorLoggedAt: parsedExisting.loggedAt || null,
+        clearedAt:     clearedAt,
+      };
+    } else {
+      delete medChecks[todayStr][name];
+    }
     save(KEYS.medChecks, medChecks);
     _tsfMarkDirty();
     _islMarkDirty('medical');
@@ -1016,14 +1035,20 @@ function adjustMedTime(name, idx, newTime) {
   if (!existing || existing.status === 'skipped') return;
   const fat = _detectFatContextNearTime(newTime, todayStr);
   const now = new Date();
+  // T1-1 (CR-14 extension): never erase a positive withFat observation via Adjust.
+  // If the prior record had withFat:true and re-detection at the new time returns
+  // false, the parent's earlier observation is the source of truth — they may have
+  // edited the meal text after the fact, or the new time happens to fall outside
+  // the ±60min window even though the original pairing was real.
+  const preserveWithFat = (existing.withFat === true && fat.withFat === false);
   // V-M-65: canonical 24h storage (en-GB).
   medChecks[todayStr][name] = {
     status:   existing.status,
     givenAt:  newTime,
     loggedAt: existing.loggedAt || now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' }),
-    withFat:  fat.withFat,
-    fatFood:  fat.fatFood,
-    fatDelta: fat.fatDelta,
+    withFat:  preserveWithFat ? true              : fat.withFat,
+    fatFood:  preserveWithFat ? existing.fatFood  : fat.fatFood,
+    fatDelta: preserveWithFat ? existing.fatDelta : fat.fatDelta,
   };
   save(KEYS.medChecks, medChecks);
   _tsfMarkDirty();
@@ -6636,7 +6661,7 @@ function renderHistoryPreviews() {
         medPrev.innerHTML = `<div class="info-strip is-sky">
           <span><svg class="zi"><use href="#zi-pill"/></svg></span>
           <div><strong class="tc-sky">${todayDone.length}/${activeMeds.length} given today</strong>
-          <div class="t-sub">Pending: ${activeMeds.filter(m => !todayChecks[m.name]).map(m => m.name).join(', ') || 'None'}</div></div>
+          <div class="t-sub">Pending: ${activeMeds.filter(m => !medCheckIsDone(todayChecks[m.name]) && !medCheckSkipped(todayChecks[m.name])).map(m => m.name).join(', ') || 'None'}</div></div>
         </div>`;
       } else {
         medPrev.innerHTML = `<div class="info-strip is-neutral">

--- a/split/intelligence-isl.js
+++ b/split/intelligence-isl.js
@@ -870,7 +870,7 @@ function _islGenerateHighlights(sl, dt, pp, md, ms, ac, dateStr) {
   // Medical highlights — D3 adherence
   if (md.suppTotal > 0) {
     if (md.suppDays > 0) {
-      highlights.push({ domain: 'medical', text: 'Vit D3 given' + (md.d3Times.length > 0 ? ' at ' + md.d3Times[0] : ''), signal: 'good' });
+      highlights.push({ domain: 'medical', text: 'Vit D3 given' + (md.d3Times.length > 0 ? ' at ' + _formatTime12h(md.d3Times[0]) : ''), signal: 'good' }); // T1-5: CR-9's _formatTime12h sweep missed this site; daily/range summary rendered 24h while every other surface rendered 12h.
     } else {
       concerns.push({ domain: 'medical', text: 'Vit D3 missed', signal: 'warn' });
     }

--- a/split/intelligence-quicklog.js
+++ b/split/intelligence-quicklog.js
@@ -1908,7 +1908,16 @@ function _tsfCollectEvents() {
     };
     if (timeMin !== null) {
       events.push(ev);
-    } else if (parsed.status !== 'skipped') {
+    } else if (parsed.status === 'skipped' && parsed.loggedAt) {
+      // T1-3: skipped doses are CR-10 audit-bearing events. The pre-fix filter dropped
+      // them entirely (timeMin null AND status === 'skipped' hit neither push branch).
+      // Surface them in the chronological timeline at loggedAt — the day's record is
+      // honest, and a half-awake parent scanning TSF sees the skip in temporal context.
+      ev.timeMin = _tsfTimeToMinutes(parsed.loggedAt);
+      ev.time = parsed.loggedAt;
+      ev.displayTime = _tsfFormatTime(parsed.loggedAt);
+      events.push(ev);
+    } else {
       noTimeEvents.push(ev);
     }
   });

--- a/split/medical.js
+++ b/split/medical.js
@@ -2303,7 +2303,11 @@ function orderMedicalCards() {
   const todayKey = today();
   const activeMeds = meds.filter(m => m.active);
   const todayChecks = medChecks[todayKey] || {};
-  const medsPending = activeMeds.filter(m => !todayChecks[m.name]).length;
+  // T1-6 / T3-14: schema-aware pending check. Raw truthy missed (a) corrupted partial-write
+  // records and (b) the T1-6 `cleared` sentinel that an undone-skip produces — both leave a
+  // truthy object in the slot but neither is a done dose. Use the same parsed semantics every
+  // other medChecks reader does.
+  const medsPending = activeMeds.filter(m => !medCheckIsDone(todayChecks[m.name]) && !medCheckSkipped(todayChecks[m.name])).length;
 
   // Build ordered list: stats always first, then priority cards
   const cards = [];

--- a/split/sync.js
+++ b/split/sync.js
@@ -226,7 +226,7 @@ const SYNC_RENDER_DEPS = {
   [KEYS.meds]:              { global: 'meds',        renderers: { home: ['renderHome'], 'track:medical': ['renderMedicalStats'] } },
   [KEYS.visits]:            { global: 'visits',      renderers: { 'track:medical': ['renderMedicalStats'] } },
   [KEYS.doctors]:           { global: 'doctors',     renderers: { 'track:medical': ['renderDoctorPrep'] } },
-  [KEYS.medChecks]:         { global: 'medChecks',   renderers: { 'track:medical': ['renderMedicalStats'] } },
+  [KEYS.medChecks]:         { global: 'medChecks',   renderers: { 'track:medical': ['renderMedicalStats', 'renderMedD3PatternCard'] } }, // T1-2: pattern card joins the sync push render list so it live-updates when device A's Done propagates to device B
   [KEYS.feverEpisodes]:     { global: null, renderers: { home: ['renderHomeFeverBanner'],     'track:medical': ['renderFeverEpisodeCard'] } },
   [KEYS.diarrhoeaEpisodes]: { global: null, renderers: { home: ['renderHomeDiarrhoeaBanner'], 'track:medical': ['renderDiarrhoeaEpisodeCard'] } },
   [KEYS.vomitingEpisodes]:  { global: null, renderers: { home: ['renderHomeVomitingBanner'],  'track:medical': ['renderVomitingEpisodeCard'] } },

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -17182,6 +17182,12 @@ function parseMedCheck(val) {
   // V-K-72: arrays are typeof 'object' but not med-check shapes — reject explicitly.
   if (Array.isArray(val)) return null;
   if (typeof val === 'object') {
+    // T1-6 (v2): the `cleared` sentinel is an audit-only record produced by undoMedSkip
+    // — every active-state reader should see the slot as pending. The raw priorStatus /
+    // priorLoggedAt / clearedAt fields persist on medChecks[date][name] for future audit
+    // tooling, but parseMedCheck returns null so existing readers (TSF, ISL, pattern card,
+    // Q&A, reminder card) treat it as no-record.
+    if (val.status === 'cleared') return null;
     return {
       status:   val.status || null,
       givenAt:  val.givenAt || null,
@@ -17304,6 +17310,12 @@ function _refreshTodayMedWithFat() {
     save(KEYS.medChecks, medChecks);
     if (typeof _tsfMarkDirty === 'function') _tsfMarkDirty();
     if (typeof _islMarkDirty === 'function') _islMarkDirty('medical');
+    // T1-4 (V-V-13 advisory): the helper mutates medChecks AND dirties caches but used
+    // to leave visible badges stale. Trigger the render surfaces that consume withFat
+    // so a parent on home or medical sees the flipped state without re-navigating.
+    if (typeof renderRemindersAndAlerts === 'function') renderRemindersAndAlerts();
+    if (typeof renderHomeContextAlerts === 'function') renderHomeContextAlerts();
+    if (typeof renderMedD3PatternCard === 'function') renderMedD3PatternCard();
   }
   return mutated;
 }
@@ -20495,7 +20507,7 @@ function switchTrackSub(sub) {
   // renderTrackHero(); // removed in v2.5 Balance — Track score hero removed
 
   // Trigger sub-tab renders
-  if (sub === 'medical') { renderMedicalStats(); orderMedicalCards(); renderVaccPastList(); renderDoctorPrep(); initSymptomChips(); renderFeverEpisodeCard(); renderFeverHistory(); renderDiarrhoeaEpisodeCard(); renderDiarrhoeaHistory(); renderVomitingEpisodeCard(); renderVomitingHistory(); renderColdEpisodeCard(); renderColdHistory(); }
+  if (sub === 'medical') { renderMedicalStats(); orderMedicalCards(); renderVaccPastList(); renderDoctorPrep(); initSymptomChips(); renderFeverEpisodeCard(); renderFeverHistory(); renderDiarrhoeaEpisodeCard(); renderDiarrhoeaHistory(); renderVomitingEpisodeCard(); renderVomitingHistory(); renderColdEpisodeCard(); renderColdHistory(); if (typeof renderMedD3PatternCard === 'function') renderMedD3PatternCard(); /* T1-2: pattern card lacked a tab-switch render path */ }
   if (sub === 'diet') renderDietStats();
   if (sub === 'milestones') { renderMilestoneStats(); renderMilestoneHighlights(); }
   if (sub === 'sleep') { renderSleep(); setTimeout(drawSleepChart, 60); }
@@ -23843,14 +23855,33 @@ function cancelMedDoneAt(idx) {
   renderHomeContextAlerts();
 }
 
-// V-M-68 + V-M-73: revert a skip back to PENDING (not to "Done at tap-time"). The skip's
-// loggedAt audit trail is dropped — acceptable because the parent's post-Undo intent is
-// "I want to log the dose properly now," not "preserve the misclick." Re-renders so the
-// parent sees the original [Done now] [Done at...] [Skip] choice without a fabricated time.
+// V-M-68 + V-M-73: revert a skip back to PENDING (not to "Done at tap-time"). T1-6 (v2):
+// the skip's loggedAt audit trail is now preserved via a `cleared` sentinel so a future
+// audit or Q&A surface can reconstruct the skip → undo → done sequence. parseMedCheck
+// returns null for cleared, so every existing reader treats it as pending — the parent
+// still sees the original [Done now] [Done at...] [Skip] choice without a fabricated time.
 function undoMedSkip(name, idx) {
   const todayStr = today();
-  if (medChecks[todayStr] && medChecks[todayStr][name] !== undefined) {
-    delete medChecks[todayStr][name];
+  const existing = medChecks[todayStr] && medChecks[todayStr][name];
+  if (existing !== undefined) {
+    const parsedExisting = parseMedCheck(existing);
+    if (parsedExisting && parsedExisting.status === 'skipped') {
+      const now = new Date();
+      const clearedAt = now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
+      medChecks[todayStr][name] = {
+        status:        'cleared',
+        givenAt:       null,
+        loggedAt:      null,
+        withFat:       null,
+        fatFood:       null,
+        fatDelta:      null,
+        priorStatus:   'skipped',
+        priorLoggedAt: parsedExisting.loggedAt || null,
+        clearedAt:     clearedAt,
+      };
+    } else {
+      delete medChecks[todayStr][name];
+    }
     save(KEYS.medChecks, medChecks);
     _tsfMarkDirty();
     _islMarkDirty('medical');
@@ -23870,14 +23901,20 @@ function adjustMedTime(name, idx, newTime) {
   if (!existing || existing.status === 'skipped') return;
   const fat = _detectFatContextNearTime(newTime, todayStr);
   const now = new Date();
+  // T1-1 (CR-14 extension): never erase a positive withFat observation via Adjust.
+  // If the prior record had withFat:true and re-detection at the new time returns
+  // false, the parent's earlier observation is the source of truth — they may have
+  // edited the meal text after the fact, or the new time happens to fall outside
+  // the ±60min window even though the original pairing was real.
+  const preserveWithFat = (existing.withFat === true && fat.withFat === false);
   // V-M-65: canonical 24h storage (en-GB).
   medChecks[todayStr][name] = {
     status:   existing.status,
     givenAt:  newTime,
     loggedAt: existing.loggedAt || now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' }),
-    withFat:  fat.withFat,
-    fatFood:  fat.fatFood,
-    fatDelta: fat.fatDelta,
+    withFat:  preserveWithFat ? true              : fat.withFat,
+    fatFood:  preserveWithFat ? existing.fatFood  : fat.fatFood,
+    fatDelta: preserveWithFat ? existing.fatDelta : fat.fatDelta,
   };
   save(KEYS.medChecks, medChecks);
   _tsfMarkDirty();
@@ -29490,7 +29527,7 @@ function renderHistoryPreviews() {
         medPrev.innerHTML = `<div class="info-strip is-sky">
           <span><svg class="zi"><use href="#zi-pill"/></svg></span>
           <div><strong class="tc-sky">${todayDone.length}/${activeMeds.length} given today</strong>
-          <div class="t-sub">Pending: ${activeMeds.filter(m => !todayChecks[m.name]).map(m => m.name).join(', ') || 'None'}</div></div>
+          <div class="t-sub">Pending: ${activeMeds.filter(m => !medCheckIsDone(todayChecks[m.name]) && !medCheckSkipped(todayChecks[m.name])).map(m => m.name).join(', ') || 'None'}</div></div>
         </div>`;
       } else {
         medPrev.innerHTML = `<div class="info-strip is-neutral">
@@ -39137,7 +39174,11 @@ function orderMedicalCards() {
   const todayKey = today();
   const activeMeds = meds.filter(m => m.active);
   const todayChecks = medChecks[todayKey] || {};
-  const medsPending = activeMeds.filter(m => !todayChecks[m.name]).length;
+  // T1-6 / T3-14: schema-aware pending check. Raw truthy missed (a) corrupted partial-write
+  // records and (b) the T1-6 `cleared` sentinel that an undone-skip produces — both leave a
+  // truthy object in the slot but neither is a done dose. Use the same parsed semantics every
+  // other medChecks reader does.
+  const medsPending = activeMeds.filter(m => !medCheckIsDone(todayChecks[m.name]) && !medCheckSkipped(todayChecks[m.name])).length;
 
   // Build ordered list: stats always first, then priority cards
   const cards = [];
@@ -48337,7 +48378,7 @@ function _islGenerateHighlights(sl, dt, pp, md, ms, ac, dateStr) {
   // Medical highlights — D3 adherence
   if (md.suppTotal > 0) {
     if (md.suppDays > 0) {
-      highlights.push({ domain: 'medical', text: 'Vit D3 given' + (md.d3Times.length > 0 ? ' at ' + md.d3Times[0] : ''), signal: 'good' });
+      highlights.push({ domain: 'medical', text: 'Vit D3 given' + (md.d3Times.length > 0 ? ' at ' + _formatTime12h(md.d3Times[0]) : ''), signal: 'good' }); // T1-5: CR-9's _formatTime12h sweep missed this site; daily/range summary rendered 24h while every other surface rendered 12h.
     } else {
       concerns.push({ domain: 'medical', text: 'Vit D3 missed', signal: 'warn' });
     }
@@ -58854,7 +58895,16 @@ function _tsfCollectEvents() {
     };
     if (timeMin !== null) {
       events.push(ev);
-    } else if (parsed.status !== 'skipped') {
+    } else if (parsed.status === 'skipped' && parsed.loggedAt) {
+      // T1-3: skipped doses are CR-10 audit-bearing events. The pre-fix filter dropped
+      // them entirely (timeMin null AND status === 'skipped' hit neither push branch).
+      // Surface them in the chronological timeline at loggedAt — the day's record is
+      // honest, and a half-awake parent scanning TSF sees the skip in temporal context.
+      ev.timeMin = _tsfTimeToMinutes(parsed.loggedAt);
+      ev.time = parsed.loggedAt;
+      ev.displayTime = _tsfFormatTime(parsed.loggedAt);
+      events.push(ev);
+    } else {
       noTimeEvents.push(ev);
     }
   });
@@ -66506,7 +66556,7 @@ const SYNC_RENDER_DEPS = {
   [KEYS.meds]:              { global: 'meds',        renderers: { home: ['renderHome'], 'track:medical': ['renderMedicalStats'] } },
   [KEYS.visits]:            { global: 'visits',      renderers: { 'track:medical': ['renderMedicalStats'] } },
   [KEYS.doctors]:           { global: 'doctors',     renderers: { 'track:medical': ['renderDoctorPrep'] } },
-  [KEYS.medChecks]:         { global: 'medChecks',   renderers: { 'track:medical': ['renderMedicalStats'] } },
+  [KEYS.medChecks]:         { global: 'medChecks',   renderers: { 'track:medical': ['renderMedicalStats', 'renderMedD3PatternCard'] } }, // T1-2: pattern card joins the sync push render list so it live-updates when device A's Done propagates to device B
   [KEYS.feverEpisodes]:     { global: null, renderers: { home: ['renderHomeFeverBanner'],     'track:medical': ['renderFeverEpisodeCard'] } },
   [KEYS.diarrhoeaEpisodes]: { global: null, renderers: { home: ['renderHomeDiarrhoeaBanner'], 'track:medical': ['renderDiarrhoeaEpisodeCard'] } },
   [KEYS.vomitingEpisodes]:  { global: null, renderers: { home: ['renderHomeVomitingBanner'],  'track:medical': ['renderVomitingEpisodeCard'] } },

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -23886,8 +23886,16 @@ function undoMedSkip(name, idx) {
     _tsfMarkDirty();
     _islMarkDirty('medical');
   }
+  // V-K-95 (synth-fold): Firestore single-doc merge preserves the cleared sentinel's
+  // priorStatus / priorLoggedAt / clearedAt fields across devices. A two-device simultaneous-undo
+  // race resolves last-write-wins on the slot — only one clearedAt survives. Acceptable in v2
+  // (both writers had the same intent); a future audit consumer should not assume singular history.
   renderRemindersAndAlerts();
   renderHomeContextAlerts();
+  // Kael pair-note synth: same-device same-tab undo on the medical tab should refresh the
+  // 14-day pattern card grid without waiting for a sync echo or tab re-switch. Mirrors the
+  // T1-4 contract that mutating writes also re-render their dependent surfaces.
+  if (typeof renderMedD3PatternCard === 'function') renderMedD3PatternCard();
 }
 
 // Adjust the administration time of an already-logged dose. Re-runs with-fat
@@ -29527,7 +29535,7 @@ function renderHistoryPreviews() {
         medPrev.innerHTML = `<div class="info-strip is-sky">
           <span><svg class="zi"><use href="#zi-pill"/></svg></span>
           <div><strong class="tc-sky">${todayDone.length}/${activeMeds.length} given today</strong>
-          <div class="t-sub">Pending: ${activeMeds.filter(m => !medCheckIsDone(todayChecks[m.name]) && !medCheckSkipped(todayChecks[m.name])).map(m => m.name).join(', ') || 'None'}</div></div>
+          <div class="t-sub">Pending: ${activeMeds.filter(m => !medCheckIsDone(todayChecks[m.name]) && !medCheckSkipped(todayChecks[m.name])).map(m => escHtml(m.name)).join(', ') || 'None'}</div></div>
         </div>`;
       } else {
         medPrev.innerHTML = `<div class="info-strip is-neutral">

--- a/tests/e2e/vit-d3-tracking-v2.spec.ts
+++ b/tests/e2e/vit-d3-tracking-v2.spec.ts
@@ -1,0 +1,256 @@
+import { test, expect } from '@playwright/test';
+
+// Vit D3 Tracking v2 — Tier 1 regression guards.
+// Spec: docs/specs/vit-d3-tracking-v2.md.
+// Backlog: docs/specs/vit-d3-tracking-v2-backlog.md §Tier 1.
+// QA chain canon-cc-008: Maren + Kael + Vela Mode-1 parallel → Lyra synth → Cipher Edict V.
+
+// ── T1-1 ─────────────────────────────────────────────────────────────────────
+test('regression-guard-d3-v2-t1-1: adjustMedTime preserves positive withFat across time edits', async ({ page }) => {
+  // Trigger: parent logs at 08:45 with paratha (withFat:true). Later deletes the paratha
+  // from feedingData. Taps Adjust on the dose for any reason. The pre-T1-1 path overwrites
+  // withFat:true → false because re-detection at the new time sees no fat-food.
+  // T1-1 extends CR-14 ("never erase a positive observation") to the user-initiated path.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    if (!feedingData[t]) feedingData[t] = {};
+    feedingData[t].breakfast = 'paratha';
+    feedingData[t].breakfast_time = '08:30';
+    feedingData[t].lunch = '';
+    feedingData[t].lunch_time = '';
+    if (medChecks[t]) delete medChecks[t][d3.name];
+    // Log at 08:45 — should detect paratha as fat pairing.
+    markMedDone(d3.name, 0, '08:45');
+    const before = medChecks[t][d3.name];
+    // Parent deletes the meal text. Then taps Adjust (changing time to 08:50, say).
+    feedingData[t].breakfast = '';
+    feedingData[t].breakfast_time = '';
+    adjustMedTime(d3.name, 0, '08:50');
+    const after = medChecks[t][d3.name];
+    return {
+      beforeWithFat: before && before.withFat,
+      beforeFood:    before && before.fatFood,
+      afterGivenAt:  after && after.givenAt,
+      afterWithFat:  after && after.withFat,
+      afterFood:     after && after.fatFood,
+    };
+  });
+
+  expect(r.beforeWithFat).toBe(true);
+  expect(r.beforeFood).toBe('paratha');
+  expect(r.afterGivenAt, 'Adjust must update givenAt').toBe('08:50');
+  expect(r.afterWithFat, 'T1-1: Adjust must NOT erase a positive withFat observation').toBe(true);
+  expect(r.afterFood, 'T1-1: original fatFood must be preserved').toBe('paratha');
+});
+
+// ── T1-2 ─────────────────────────────────────────────────────────────────────
+test('regression-guard-d3-v2-t1-2-sync: medChecks renderer list includes renderMedD3PatternCard', async ({ page }) => {
+  // The sync push for medChecks pre-fix fired only renderMedicalStats; pattern card stayed
+  // stale on device B when device A pushed an updated dose. T1-2 adds the pattern card to
+  // the renderers list at sync.js:229.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const reg = (typeof SYNC_RENDER_DEPS === 'object') ? SYNC_RENDER_DEPS : null;
+    if (!reg) return { skipped: 'SYNC_RENDER_DEPS not exposed' };
+    const entry = reg[KEYS.medChecks];
+    return {
+      hasEntry: !!entry,
+      renderersList: entry && entry.renderers && entry.renderers['track:medical'],
+      hasStats:   entry && entry.renderers && entry.renderers['track:medical'] && entry.renderers['track:medical'].includes('renderMedicalStats'),
+      hasPattern: entry && entry.renderers && entry.renderers['track:medical'] && entry.renderers['track:medical'].includes('renderMedD3PatternCard'),
+    };
+  });
+
+  if ((r as any).skipped) {
+    test.skip(true, (r as any).skipped);
+    return;
+  }
+  expect(r.hasEntry).toBe(true);
+  expect(r.hasStats, 'renderMedicalStats must remain in the renderers list').toBe(true);
+  expect(r.hasPattern, 'T1-2: renderMedD3PatternCard must be added to the renderers list').toBe(true);
+});
+
+test('regression-guard-d3-v2-t1-2-tabswitch: medical tab dispatcher calls renderMedD3PatternCard', async ({ page }) => {
+  // Pre-T1-2, the medical tab-switch dispatcher fired renderMedicalStats but NOT renderMeds,
+  // and renderMedD3PatternCard's only invocation site was inside renderMeds. Tab-switching
+  // back to medical after taking action elsewhere left the pattern card body stale.
+  // T1-2 adds an explicit renderMedD3PatternCard() call to the medical sub-tab dispatcher.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    // Spy on renderMedD3PatternCard. switchTab('medical') redirects to track-tab then
+    // invokes switchTrackSub('medical') which contains the T1-2 dispatcher call.
+    let callCount = 0;
+    const original = (window as any).renderMedD3PatternCard;
+    (window as any).renderMedD3PatternCard = function() { callCount++; return original ? original.apply(this, arguments) : undefined; };
+    if (typeof switchTab === 'function') switchTab('medical');
+    const result = { callCount };
+    (window as any).renderMedD3PatternCard = original;
+    return result;
+  });
+
+  expect(r.callCount, 'T1-2: medical tab dispatcher must invoke renderMedD3PatternCard at least once').toBeGreaterThanOrEqual(1);
+});
+
+// ── T1-3 ─────────────────────────────────────────────────────────────────────
+test('regression-guard-d3-v2-t1-3: skipped med events surface in TSF timeline at loggedAt', async ({ page }) => {
+  // Pre-fix: _tsfCollectEvents pushed only when timeMin !== null (events branch) OR
+  // status !== 'skipped' (noTimeEvents branch). Skipped doses (timeMin null AND status
+  // skipped) hit neither — CR-10's loggedAt audit trail was invisible on TSF.
+  // T1-3 routes skipped-with-loggedAt to the events branch at its loggedAt time.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    if (!medChecks[t]) medChecks[t] = {};
+    // Directly seed a skipped record with a specific loggedAt so the assertion is deterministic.
+    medChecks[t][d3.name] = { status:'skipped', givenAt:null, loggedAt:'09:15', withFat:null, fatFood:null, fatDelta:null };
+    if (typeof _tsfMarkDirty === 'function') _tsfMarkDirty();
+    const collected = _tsfCollectEvents();
+    const medEv = collected.events.find(e => e.type === 'med' && e.label === d3.name);
+    const medNoTime = collected.noTimeEvents.find(e => e.type === 'med' && e.label === d3.name);
+    return {
+      eventsHasMed: !!medEv,
+      noTimeHasMed: !!medNoTime,
+      medEvTimeMin: medEv && medEv.timeMin,
+      medEvTime: medEv && medEv.time,
+      medEvDetail: medEv && medEv.detail,
+    };
+  });
+
+  expect(r.eventsHasMed, 'T1-3: skipped med must appear in the chronological events list').toBe(true);
+  expect(r.noTimeHasMed, 'T1-3: skipped med must NOT appear in the noTimeEvents fallback').toBeFalsy();
+  expect(r.medEvTimeMin, 'T1-3: timeMin derived from loggedAt 09:15').toBe(9 * 60 + 15);
+  expect(r.medEvTime, 'T1-3: time derived from loggedAt').toBe('09:15');
+  expect(r.medEvDetail, 'T1-3: detail string remains "Skipped" (the pre-existing chip label)').toBe('Skipped');
+});
+
+// ── T1-4 ─────────────────────────────────────────────────────────────────────
+test('regression-guard-d3-v2-t1-4: _refreshTodayMedWithFat triggers re-renders on mutation', async ({ page }) => {
+  // V-V-13 advisory: helper mutates medChecks AND dirties caches but used to skip render.
+  // T1-4 appends render calls inside the `if (mutated)` block.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    // No fat-food yet → markMedDone records withFat:false.
+    if (!feedingData[t]) feedingData[t] = {};
+    feedingData[t].breakfast = '';
+    feedingData[t].breakfast_time = '';
+    if (medChecks[t]) delete medChecks[t][d3.name];
+    markMedDone(d3.name, 0, '09:00');
+    const before = medChecks[t][d3.name];
+    // Add ghee breakfast retroactively. Spy on the render functions before the flip.
+    feedingData[t].breakfast = 'chapati, ghee';
+    feedingData[t].breakfast_time = '09:15';
+    let reminderCalls = 0, contextCalls = 0, patternCalls = 0;
+    const orig1 = (window as any).renderRemindersAndAlerts;
+    const orig2 = (window as any).renderHomeContextAlerts;
+    const orig3 = (window as any).renderMedD3PatternCard;
+    (window as any).renderRemindersAndAlerts  = function() { reminderCalls++; };
+    (window as any).renderHomeContextAlerts   = function() { contextCalls++; };
+    (window as any).renderMedD3PatternCard    = function() { patternCalls++; };
+    const mutated = _refreshTodayMedWithFat();
+    (window as any).renderRemindersAndAlerts  = orig1;
+    (window as any).renderHomeContextAlerts   = orig2;
+    (window as any).renderMedD3PatternCard    = orig3;
+    const after = medChecks[t][d3.name];
+    return {
+      beforeWithFat: before && before.withFat,
+      mutated:       mutated,
+      afterWithFat:  after && after.withFat,
+      reminderCalls, contextCalls, patternCalls,
+    };
+  });
+
+  expect(r.beforeWithFat).toBe(false);
+  expect(r.mutated, 'helper must report mutation').toBe(true);
+  expect(r.afterWithFat, 'flip false → true on retroactive fat-meal').toBe(true);
+  expect(r.reminderCalls, 'T1-4: renderRemindersAndAlerts fires on flip').toBeGreaterThanOrEqual(1);
+  expect(r.contextCalls,  'T1-4: renderHomeContextAlerts fires on flip').toBeGreaterThanOrEqual(1);
+  expect(r.patternCalls,  'T1-4: renderMedD3PatternCard fires on flip').toBeGreaterThanOrEqual(1);
+});
+
+// ── T1-5 ─────────────────────────────────────────────────────────────────────
+test('regression-guard-d3-v2-t1-5: ISL range summary formats D3 time in 12h', async ({ page }) => {
+  // Pre-fix: _islRangeSummary interpolated md.d3Times[0] verbatim ("Vit D3 given at 14:30").
+  // CR-9's _formatTime12h sweep missed this site. Every other surface renders "2:30 PM".
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    if (!medChecks[t]) medChecks[t] = {};
+    medChecks[t][d3.name] = { status:'done', givenAt:'14:30', loggedAt:'14:32', withFat:false, fatFood:null, fatDelta:null };
+    if (typeof _islMarkDirty === 'function') _islMarkDirty('medical');
+    // _islGenerateHighlights is the patched site; _islBuildDaySummary is its caller.
+    const summary = (typeof _islBuildDaySummary === 'function') ? _islBuildDaySummary(t) : null;
+    let medText = null;
+    if (summary && summary.highlights) {
+      const h = summary.highlights.find(x => x.domain === 'medical');
+      medText = h && h.text;
+    }
+    return { medText };
+  });
+
+  expect(r.medText, 'medical highlight must exist').toBeTruthy();
+  expect(r.medText, 'T1-5: time must render in 12h, not 24h').toContain('PM');
+  expect(r.medText, 'T1-5: 14:30 → 2:30 PM').toContain('2:30');
+  expect(r.medText, 'T1-5: 24h leak guard').not.toContain('14:30');
+});
+
+// ── T1-6 ─────────────────────────────────────────────────────────────────────
+// Note: the existing v1 test `regression-guard-d3-undoMedSkip-reads-as-pending` covers
+// the round-trip skip → undo → cleared-sentinel + parseMedCheck-returns-null assertion.
+// This v2 test covers the T3-14 prerequisite: pending-filter sites must read cleared as
+// pending (the raw truthy-check would otherwise silently exclude undone-skips from the
+// today-pending list and the medsPending count).
+test('regression-guard-d3-v2-t1-6-t3-14: pending filters treat cleared sentinel as pending', async ({ page }) => {
+  // After T1-6, an undone skip leaves a `cleared` sentinel (truthy object) in medChecks.
+  // home.js:6664 (pending list display) and medical.js:2306 (medsPending count) used raw
+  // truthy-check (`!todayChecks[m.name]`) which would have silently excluded the med. The
+  // T3-14 fix replaces with `!medCheckIsDone() && !medCheckSkipped()` — both helpers
+  // route through parseMedCheck which returns null for cleared, so the negation is true.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    if (!medChecks[t]) medChecks[t] = {};
+    // Seed a cleared sentinel directly (as undoMedSkip would have left it).
+    medChecks[t][d3.name] = {
+      status:'cleared', givenAt:null, loggedAt:null, withFat:null, fatFood:null, fatDelta:null,
+      priorStatus:'skipped', priorLoggedAt:'09:00', clearedAt:'09:05',
+    };
+    return {
+      isDone:    medCheckIsDone(medChecks[t][d3.name]),
+      isSkipped: medCheckSkipped(medChecks[t][d3.name]),
+      parsedIsNull: parseMedCheck(medChecks[t][d3.name]) === null,
+      // The helper combination used at home.js:6664 and medical.js:2306 post-T3-14
+      readsAsPending: !medCheckIsDone(medChecks[t][d3.name]) && !medCheckSkipped(medChecks[t][d3.name]),
+    };
+  });
+
+  expect(r.isDone, 'cleared is not done').toBe(false);
+  expect(r.isSkipped, 'cleared is not skipped (parent undid it)').toBe(false);
+  expect(r.parsedIsNull, 'parseMedCheck returns null for cleared').toBe(true);
+  expect(r.readsAsPending, 'T3-14: combined helper check correctly classifies cleared as pending').toBe(true);
+});

--- a/tests/e2e/vit-d3-tracking-v2.spec.ts
+++ b/tests/e2e/vit-d3-tracking-v2.spec.ts
@@ -254,3 +254,30 @@ test('regression-guard-d3-v2-t1-6-t3-14: pending filters treat cleared sentinel 
   expect(r.parsedIsNull, 'parseMedCheck returns null for cleared').toBe(true);
   expect(r.readsAsPending, 'T3-14: combined helper check correctly classifies cleared as pending').toBe(true);
 });
+
+// ── T3-14 corrupted-empty-object corner (Maren synth-fold) ───────────────────
+test('regression-guard-d3-v2-t3-14-corrupted-empty: empty-object partial-write reads as pending', async ({ page }) => {
+  // The T3-14 fix's diff comment explicitly cites "corrupted partial-write records" as
+  // motivation. This regression guards the empty-object {} case — an interrupted Firestore
+  // partial-write or a legacy migration leftover — does not silently exclude the med from
+  // pending surfaces (which the raw truthy-check used to do).
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    if (!medChecks[t]) medChecks[t] = {};
+    medChecks[t][d3.name] = {}; // corrupted partial-write
+    return {
+      isDone:    medCheckIsDone(medChecks[t][d3.name]),
+      isSkipped: medCheckSkipped(medChecks[t][d3.name]),
+      readsAsPending: !medCheckIsDone(medChecks[t][d3.name]) && !medCheckSkipped(medChecks[t][d3.name]),
+    };
+  });
+
+  expect(r.isDone, 'empty object is not done').toBe(false);
+  expect(r.isSkipped, 'empty object is not skipped').toBe(false);
+  expect(r.readsAsPending, 'T3-14: corrupted {} must surface as pending so parent re-logs').toBe(true);
+});

--- a/tests/e2e/vit-d3-tracking.spec.ts
+++ b/tests/e2e/vit-d3-tracking.spec.ts
@@ -538,11 +538,12 @@ test('regression-guard-d3-qaSupplement-schema-aware: qaAnswerSupplement reads ne
   expect(r.givenText).toContain('ghee');
 });
 
-test('regression-guard-d3-undoMedSkip-clears-to-pending: Undo skip does NOT silently log at tap-time', async ({ page }) => {
-  // V-M-68 + V-M-73: pre-fix, Undo skip wired to markMedDone(name, idx) with no givenTime,
-  // which silently substituted tap-time. Reintroduced the CR-4 class of bug through a
-  // different door. Fix: Undo clears the entry back to undefined (pending state) so the
-  // parent makes an explicit choice via [Done now] / [Done at...] / [Skip].
+test('regression-guard-d3-undoMedSkip-reads-as-pending: Undo skip does NOT silently log at tap-time AND preserves CR-10 audit trail', async ({ page }) => {
+  // V-M-68 + V-M-73 + T1-6 (v2): Undo skip must NOT fabricate a "Done at tap-time" record
+  // (the CR-4 class of bug). T1-6 (v2) refines V-M-68's `delete` to a `cleared` sentinel
+  // that preserves CR-10's loggedAt audit trail. parseMedCheck returns null for cleared,
+  // so every existing reader treats the slot as pending — the reminder card still offers
+  // the [Done now] / [Done at...] / [Skip] choice without a fabricated time.
   await page.goto('/index.html?nosync');
   await page.waitForTimeout(700);
 
@@ -550,22 +551,32 @@ test('regression-guard-d3-undoMedSkip-clears-to-pending: Undo skip does NOT sile
     const d3 = (meds || []).find(m => m.name && m.name.toLowerCase().includes('d3'));
     if (!d3) return { skipped: 'no D3 med' };
     const t = today();
-    // First: skip
+    // First: skip — produces {status:'skipped', loggedAt:'HH:MM', ...}
     markMedSkipped(d3.name, 0);
     const afterSkip = medChecks[t][d3.name];
-    // Then: undo
+    const skipLoggedAt = afterSkip && afterSkip.loggedAt;
+    // Then: undo — T1-6 preserves audit via cleared sentinel
     undoMedSkip(d3.name, 0);
-    const afterUndo = medChecks[t] ? medChecks[t][d3.name] : undefined;
+    const afterUndo = medChecks[t] && medChecks[t][d3.name];
     return {
-      skipStatus: afterSkip && afterSkip.status,
-      undoIsCleared: afterUndo === undefined,
-      didNotSilentlyLog: !afterUndo || afterUndo.status !== 'done',
+      skipStatus:         afterSkip && afterSkip.status,
+      skipLoggedAt:       skipLoggedAt,
+      didNotSilentlyLog:  !afterUndo || afterUndo.status !== 'done',
+      afterUndoStatus:    afterUndo && afterUndo.status,
+      afterUndoPriorLoggedAt: afterUndo && afterUndo.priorLoggedAt,
+      readsAsPending:     parseMedCheck(afterUndo) === null,
+      notDoneViaHelper:   !medCheckIsDone(afterUndo),
+      notSkippedViaHelper: !medCheckSkipped(afterUndo),
     };
   });
 
   expect(r.skipStatus).toBe('skipped');
-  expect(r.undoIsCleared, 'Undo must clear medChecks entry back to undefined (pending)').toBe(true);
   expect(r.didNotSilentlyLog, 'Undo must NOT fabricate a "Done at tap-time" record').toBe(true);
+  expect(r.afterUndoStatus, 'T1-6: undo writes a cleared sentinel').toBe('cleared');
+  expect(r.afterUndoPriorLoggedAt, 'T1-6: cleared sentinel preserves CR-10 loggedAt audit trail').toBe(r.skipLoggedAt);
+  expect(r.readsAsPending, 'T1-6: parseMedCheck returns null for cleared so readers see pending').toBe(true);
+  expect(r.notDoneViaHelper, 'cleared must read as not-done').toBe(true);
+  expect(r.notSkippedViaHelper, 'cleared must read as not-skipped (parent undid it)').toBe(true);
 });
 
 test('regression-guard-d3-yesterday-skipped-schema-aware: home medical preview reads new object shape for ydSkipped', async ({ page }) => {


### PR DESCRIPTION
## Summary

Promotes `docs/specs/vit-d3-tracking-v2-backlog.md` §Tier 1 to a real spec at `docs/specs/vit-d3-tracking-v2.md` and lands the six fixes in one atomic PR. **T3-14 ships as a T1-6 prerequisite** because the cleared sentinel is a truthy object on `medChecks[date][name]` — the two raw truthy-check sites would otherwise silently exclude undone-skips from the pending list.

## Fix manifest

| ID | File | Region | Fix |
|----|------|--------|-----|
| T1-1 | `home.js` `adjustMedTime` | Maren | Preserve withFat:true when Adjust re-detection returns false (CR-14 extension to user-initiated path) |
| T1-2 | `sync.js` :229 + `core.js` :3404 | Kael | Pattern card wired into sync renderer list AND medical sub-tab dispatcher |
| T1-3 | `intelligence-quicklog.js` `_tsfCollectEvents` | Vela | Skipped doses with loggedAt surface in TSF timeline at audit-trail time |
| T1-4 | `core.js` `_refreshTodayMedWithFat` | Kael | Mutation triggers `renderRemindersAndAlerts` + `renderHomeContextAlerts` + `renderMedD3PatternCard` (V-V-13 advisory closed) |
| T1-5 | `intelligence-isl.js` `_islGenerateHighlights` | Kael | `_formatTime12h` wraps `md.d3Times[0]` (CR-9 sweep close-out) |
| T1-6 | `home.js` `undoMedSkip` | Maren | Cleared sentinel preserves `priorStatus` / `priorLoggedAt` / `clearedAt`. `parseMedCheck` returns null for cleared so every existing reader naturally treats slot as pending |
| T3-14 dep | `home.js` :6664, `medical.js` :2310 | Maren | Raw truthy-check → `!medCheckIsDone && !medCheckSkipped` (required for T1-6 cleared correctness) |

## canon-cc-008 chain — discharged

| Stage | Status |
|---|---|
| Build & self-check | ✓ clean — 4 audit gates pass, DOCTYPE + 100KB floor + version bump |
| Maren Mode-1 (Care) | ✓ clear-with-notes — V-M-77..82 |
| Kael Mode-1 (Intelligence engine) | ✓ clear-with-notes — V-K-88..95 |
| Vela Mode-1 (Surfacing render) | ✓ clear-with-notes — V-V-25..30 |
| Lyra synth-fold (`5e5819a`) | ✓ 4 fold-ins + 9 Tier 2 deferrals registered |
| Cipher Edict V final-pass | ✓ **LGTM (merge-ready)** |

### Synth fold-ins (`5e5819a`)

1. `escHtml(m.name)` at `home.js:6664` (Maren HR-4 pre-existing on the line we touched)
2. `renderMedD3PatternCard()` in `undoMedSkip` (Kael pair-note: closes same-device same-tab stale grid)
3. V-K-95 sync-race comment at `undoMedSkip` (primes future audit consumer)
4. New test `regression-guard-d3-v2-t3-14-corrupted-empty` (defensive guard for `{}` partial-write)

### Deferred to Tier 2 (registered in spec)

V-M-77 (preserveWithFat truth-table), V-M-78 (chained-undo audit), V-M-79 (fallback delete telemetry), V-K-91 (refresh-helper perf), V-K-94 (schema-drift consumer), V-K-95 (sync-race multi-history), V-V-25 (chip discriminator CSS), V-V-30 (TSF Undo affordance). Full register at `docs/specs/vit-d3-tracking-v2.md` §Deferred to Tier 2.

## Test plan

- [x] Spec drafted at `docs/specs/vit-d3-tracking-v2.md` with full trigger-trace + fix-shape + jurisdiction routing per T1 item
- [x] `pnpm build` clean (self-validating)
- [x] 8 new v2 regression guards at `tests/e2e/vit-d3-tracking-v2.spec.ts` — all pass
- [x] Existing `regression-guard-d3-undoMedSkip-clears-to-pending` renamed → `regression-guard-d3-undoMedSkip-reads-as-pending`
- [x] Full e2e: 165/166 pass. The one failure (`smoke.spec.ts:723 Build script contract`) is **pre-existing** — PR #120's `build-safe.sh` shift predates this PR. Out of scope.

## Out of scope (deferred)

- Tier 2 (six care-tier UX items + new register above) — own v2.x spec when picked up
- Tier 3 (T3-13 AM/PM range, T3-15 fresh-install warm-start)
- Pre-existing `smoke.spec.ts:723` build-script-contract failure

https://claude.ai/code/session_017kQ4Wt7chrqgHyMQ1ZrT5P