### PR TITLE
Vit D3 v2 Tier 2 Phase 2-A: pattern card boundary + skipped chip discriminator

### DIFF
--- a/docs/CARETICKET_STATE_MACHINE.html
+++ b/docs/CARETICKET_STATE_MACHINE.html
@@ -91,7 +91,7 @@ code { font-family: var(--mono); font-size: 12px; color: var(--ink); }
 </head>
 <body>
 <h1>CareTicket State Machine</h1>
-<p class="subtitle">SproutLab — 6-transition lifecycle, spec vs implementation. Generated <code>2026-05-24</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on transition-layout snapshots</strong>; <code>CARETICKETS_SPEC_v5.md</code> wins on transition rationale; CLAUDE.md wins on rules, HRs, build commands, persona.</p>
+<p class="subtitle">SproutLab — 6-transition lifecycle, spec vs implementation. Generated <code>2026-05-25</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on transition-layout snapshots</strong>; <code>CARETICKETS_SPEC_v5.md</code> wins on transition rationale; CLAUDE.md wins on rules, HRs, build commands, persona.</p>
 
 <div class="diagram-wrap">
 <svg viewBox="0 0 520 420" width="520" height="420">

--- a/docs/POOP_COLOR_REFERENCE.html
+++ b/docs/POOP_COLOR_REFERENCE.html
@@ -108,7 +108,7 @@ code { font-family: var(--mono); font-size: 12px; color: var(--ink-soft); }
 </head>
 <body>
 <h1>Poop-Color Reference</h1>
-<p class="subtitle">SproutLab — token + render + contrast + lexicon snapshot. Generated <code>2026-05-24</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on token-value snapshots</strong>; CLAUDE.md wins on usage rules.</p>
+<p class="subtitle">SproutLab — token + render + contrast + lexicon snapshot. Generated <code>2026-05-25</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on token-value snapshots</strong>; CLAUDE.md wins on usage rules.</p>
 
 <div class="meta-bar">
   <span>light <code>--warm</code> <code>#fef6f0</code></span>

--- a/index.html
+++ b/index.html
@@ -7903,9 +7903,21 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
    ("Skipped" vs "Done") — half-awake parents at 2 AM can miss it. Strikethrough the
    label, warn-color the time slot, fade the icon. Token-only: --tc-warn for the
    strike color + time slot, --light for the dimmed label. The chip wrapper carries
-   data-state="skipped" set by _tsfRenderEvent in intelligence-quicklog.js. */
+   data-state="skipped" set by _tsfRenderEvent in intelligence-quicklog.js.
+   V-V-32 (Vela synth-fold): dark-theme variant intentionally absent — --tc-warn and
+   --light cascade theme-aware via [data-theme="dark"] overrides further down this file,
+   so the strikethrough + dimmed label reads correctly in both themes without explicit
+   override. Future Governors: do not mistake the absence for an oversight.
+   V-V-31 (Vela synth-fold): if a future event type ever carries BOTH
+   tsf-event-inferred AND data-state="skipped" on the same chip, the time-slot rule
+   below collides with .tsf-event-inferred .tsf-event-time (italic + opacity 0.7).
+   Impossible today (inferred is set only on meal-time fallback, never on med events;
+   only meds can be skipped) — re-evaluate if that boundary shifts. */
 .tsf-event[data-state="skipped"] .tsf-event-label { text-decoration:line-through; text-decoration-color:var(--tc-warn); color:var(--light); }
 .tsf-event[data-state="skipped"] .tsf-event-time  { color:var(--tc-warn); opacity:0.7; }
+/* V-M-86 (Maren synth-fold, triple-jurisdiction round 2): the icon selector is deliberately
+   tightened from spec's bare `.icon` to `.tsf-event-icon .icon`, mirroring the parent
+   rule at line 7886 — prevents bleed if `.icon` ever appears bare elsewhere inside a chip. */
 .tsf-event[data-state="skipped"] .tsf-event-icon .icon { opacity:0.6; }
 .tsf-event-expanded-detail { padding:var(--sp-4) var(--sp-4) var(--sp-8) calc(var(--sp-32) + var(--sp-8) + var(--sp-24) + var(--sp-8) + var(--sp-4)); font-size:var(--fs-xs); color:var(--mid); line-height:1.5; border-top:1px solid var(--glass-strong); margin-top:0; }
 .tsf-show-earlier { text-align:center; font-size:var(--fs-xs); color:var(--tc-indigo); padding:var(--sp-6) 0; cursor:pointer; font-weight:600; }

--- a/index.html
+++ b/index.html
@@ -41255,7 +41255,12 @@ function renderMedD3PatternCard() {
   // "13/14 (93%) · streak through yesterday 13 · 1 day not logged" for a perfect-streak parent.
   const todayParsed = eligibleDays.length > 0 ? eligibleDays[eligibleDays.length - 1].parsed : null;
   const lastDayIsToday = eligibleDays.length > 0 && eligibleDays[eligibleDays.length - 1].date === todayStr;
-  const excludeToday = !todayParsed && lastDayIsToday;
+  // V-M-83 (Maren synth-fold, Phase 2-A): mirror T2-A.2's todayIsSkippedOrUnlogged.
+  // A legitimately-skipped today should be excluded from adherence on the same boundary
+  // that excludes it from the streak walk — otherwise the card reads "Adherence: 13/14
+  // (93%)" beside "Streak through yesterday: 13 days," reproducing the very three-line
+  // incoherence T2-A.1 was authored to eliminate, just at a different boundary.
+  const excludeToday = (!todayParsed || todayParsed.status === 'skipped') && lastDayIsToday;
   const adherenceWindow = excludeToday ? eligibleDays.slice(0, -1) : eligibleDays;
   const doneDays = eligibleDays.filter(d => d.parsed && (d.parsed.status === 'done' || d.parsed.status === 'late'));
   const skippedDays = eligibleDays.filter(d => d.parsed && d.parsed.status === 'skipped');

--- a/index.html
+++ b/index.html
@@ -7898,6 +7898,15 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 .tsf-event-live .tsf-event-detail { animation:tsfPulse 2s ease-in-out infinite; }
 .tsf-event-live[data-calm="true"] .tsf-event-detail { animation:none; }
 @keyframes tsfPulse { 0%,100%{ opacity:1; } 50%{ opacity:0.5; } }
+/* T2-A.3 (V-V-25): skipped-chip discriminator. Post-T1-3 a Skipped chip and a Done
+   chip in the TSF timeline are pixel-identical except for the one-word detail string
+   ("Skipped" vs "Done") — half-awake parents at 2 AM can miss it. Strikethrough the
+   label, warn-color the time slot, fade the icon. Token-only: --tc-warn for the
+   strike color + time slot, --light for the dimmed label. The chip wrapper carries
+   data-state="skipped" set by _tsfRenderEvent in intelligence-quicklog.js. */
+.tsf-event[data-state="skipped"] .tsf-event-label { text-decoration:line-through; text-decoration-color:var(--tc-warn); color:var(--light); }
+.tsf-event[data-state="skipped"] .tsf-event-time  { color:var(--tc-warn); opacity:0.7; }
+.tsf-event[data-state="skipped"] .tsf-event-icon .icon { opacity:0.6; }
 .tsf-event-expanded-detail { padding:var(--sp-4) var(--sp-4) var(--sp-8) calc(var(--sp-32) + var(--sp-8) + var(--sp-24) + var(--sp-8) + var(--sp-4)); font-size:var(--fs-xs); color:var(--mid); line-height:1.5; border-top:1px solid var(--glass-strong); margin-top:0; }
 .tsf-show-earlier { text-align:center; font-size:var(--fs-xs); color:var(--tc-indigo); padding:var(--sp-6) 0; cursor:pointer; font-weight:600; }
 .tsf-show-earlier:active { opacity:0.6; }
@@ -41239,10 +41248,20 @@ function renderMedD3PatternCard() {
   const trackStart = medChecks._trackingSince || '0000-00-00';
   const effectiveStart = medStart > trackStart ? medStart : trackStart;
   const eligibleDays = days.filter(d => d.date >= effectiveStart);
+  // T2-A.1: when today is unlogged (parent hasn't tapped Done yet — e.g. 8 AM pre-dose),
+  // exclude it from adherence + unloggedDays. The V-M-64 streak fallback already excludes
+  // today via startIdx = len-2; the adherence math + warn-tier "N days not logged" surface
+  // follow suit so all three card lines agree at the boundary instead of reading
+  // "13/14 (93%) · streak through yesterday 13 · 1 day not logged" for a perfect-streak parent.
+  const todayParsed = eligibleDays.length > 0 ? eligibleDays[eligibleDays.length - 1].parsed : null;
+  const lastDayIsToday = eligibleDays.length > 0 && eligibleDays[eligibleDays.length - 1].date === todayStr;
+  const excludeToday = !todayParsed && lastDayIsToday;
+  const adherenceWindow = excludeToday ? eligibleDays.slice(0, -1) : eligibleDays;
   const doneDays = eligibleDays.filter(d => d.parsed && (d.parsed.status === 'done' || d.parsed.status === 'late'));
   const skippedDays = eligibleDays.filter(d => d.parsed && d.parsed.status === 'skipped');
-  const unloggedDays = eligibleDays.filter(d => !d.parsed);
-  const adherence = eligibleDays.length > 0 ? Math.round((doneDays.length / eligibleDays.length) * 100) : 0;
+  const adherenceDone = adherenceWindow.filter(d => d.parsed && (d.parsed.status === 'done' || d.parsed.status === 'late'));
+  const unloggedDays = adherenceWindow.filter(d => !d.parsed);
+  const adherence = adherenceWindow.length > 0 ? Math.round((adherenceDone.length / adherenceWindow.length) * 100) : 0;
   // Usual-time band: take givenAt minutes, find central 80% range.
   // CR-11: use (N-1)*p indexing instead of N*p (which collapsed to the max for many N
   // and degraded 'central 80%' into 'min-to-max range') AND require N>=5 for the band
@@ -41271,16 +41290,18 @@ function renderMedD3PatternCard() {
   let topFatFood = null, topN = 0;
   Object.keys(fatFoodCounts).forEach(k => { if (fatFoodCounts[k] > topN) { topFatFood = k; topN = fatFoodCounts[k]; } });
   // Streak: consecutive done-days ending today.
-  // V-M-64: if today is unlogged (parent hasn't tapped Done yet), don't punish the streak —
-  // walk from yesterday and label "through yesterday" so a 30-day perfect run doesn't read as 0.
+  // V-M-64: if today is unlogged (parent hasn't tapped Done yet), walk from yesterday and
+  // label "through yesterday" so a 30-day perfect run doesn't read as 0.
+  // T2-A.2: extend the same fallback to status:'skipped'. A legitimate skip (sick,
+  // dose-form change, doctor advice) shouldn't zero out the historical streak — the
+  // parent's prior run is intact in spirit and the card should reflect that.
   // CR-6: walk over eligibleDays (post-medStart) not raw days, so a recently-activated med
   // doesn't see its streak punished by pre-activation no-data rows.
   let streak = 0;
   let streakLabel = 'Current streak';
-  const todayParsed = eligibleDays.length > 0 ? eligibleDays[eligibleDays.length - 1].parsed : null;
-  const todayResolved = !!(todayParsed && (todayParsed.status === 'done' || todayParsed.status === 'late' || todayParsed.status === 'skipped'));
-  const startIdx = todayResolved ? eligibleDays.length - 1 : eligibleDays.length - 2;
-  if (!todayResolved) streakLabel = 'Streak through yesterday';
+  const todayIsSkippedOrUnlogged = !todayParsed || todayParsed.status === 'skipped';
+  const startIdx = todayIsSkippedOrUnlogged ? eligibleDays.length - 2 : eligibleDays.length - 1;
+  if (todayIsSkippedOrUnlogged) streakLabel = 'Streak through yesterday';
   for (let i = startIdx; i >= 0; i--) {
     if (eligibleDays[i] && eligibleDays[i].parsed && (eligibleDays[i].parsed.status === 'done' || eligibleDays[i].parsed.status === 'late')) streak++;
     else break;
@@ -41298,7 +41319,7 @@ function renderMedD3PatternCard() {
   // Build summary lines
   const sigClass = adherence >= 90 ? 'tc-sage' : adherence >= 70 ? 'tc-warn' : 'tc-rose';
   let summary = '<div class="med-d3-summary">';
-  summary += `<div class="med-d3-summary-row"><strong class="${sigClass}">Adherence: ${doneDays.length}/${eligibleDays.length} days (${adherence}%)</strong></div>`;
+  summary += `<div class="med-d3-summary-row"><strong class="${sigClass}">Adherence: ${adherenceDone.length}/${adherenceWindow.length} days (${adherence}%)</strong></div>`;
   // CR-9: render times in 12h for parent-facing display.
   if (usualBand) {
     const bandDisplay = usualBand.split('–').map(t => _formatTime12h(t)).join('–');
@@ -59283,9 +59304,15 @@ function renderTodaySoFar() {
     const liveClass = ev.isLive ? ' tsf-event-live' : '';
     const expandedClass = isExpanded ? ' tsf-event-expanded' : '';
     const calmAttr = ev.isCalm ? ' data-calm="true"' : '';
+    // T2-A.3 (V-V-25): data-state discriminator for the half-awake test. Post-T1-3 a
+    // skipped chip and a Done chip are pixel-identical except for the detail string.
+    // The CSS .tsf-event[data-state="skipped"] variant in styles.css strikes through
+    // the label, warn-colors the time slot, and fades the icon — distinguishable at
+    // a glance. Phase 2-C TSF Undo affordance will land on the same chip family.
+    const stateAttr = (ev.parsed && ev.parsed.status === 'skipped') ? ' data-state="skipped"' : '';
 
     html += '<div class="tsf-event-wrap' + expandedClass + '">';
-    html += '<div class="tsf-event' + inferredClass + liveClass + '" data-action="tsfToggleEvent" data-arg="' + escHtml(ev.id) + '"' + calmAttr + '>';
+    html += '<div class="tsf-event' + inferredClass + liveClass + '"' + stateAttr + ' data-action="tsfToggleEvent" data-arg="' + escHtml(ev.id) + '"' + calmAttr + '>';
     html += '<div class="tsf-event-time">' + escHtml(ev.displayTime || '') + '</div>';
 
     // Icon with domain color
@@ -59322,8 +59349,11 @@ function renderTodaySoFar() {
       const isExpanded = _tsfExpandedId === ev.id;
       const expandedClass = isExpanded ? ' tsf-event-expanded' : '';
       const iconColorClass = ev.color === 'amber' ? 'icon-amber' : ev.color === 'sage' ? 'icon-sage' : ev.color === 'sky' ? 'icon-sky' : 'icon-indigo';
+      // T2-A.3: parity with the timed-events branch — legacy 'skipped' strings (no loggedAt)
+      // still hit this no-time fallback; the discriminator must apply here too.
+      const stateAttr = (ev.parsed && ev.parsed.status === 'skipped') ? ' data-state="skipped"' : '';
       html += '<div class="tsf-event-wrap' + expandedClass + '">';
-      html += '<div class="tsf-event" data-action="tsfToggleEvent" data-arg="' + escHtml(ev.id) + '">';
+      html += '<div class="tsf-event"' + stateAttr + ' data-action="tsfToggleEvent" data-arg="' + escHtml(ev.id) + '">';
       html += '<div class="tsf-event-time"></div>';
       html += '<div class="tsf-event-icon"><div class="icon ' + iconColorClass + '">' + ev.icon + '</div></div>';
       html += '<div class="tsf-event-body">';

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.24-16",
+  "version": "2026.05.25-1",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.25-2",
+  "version": "2026.05.25-3",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.25-1",
+  "version": "2026.05.25-2",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/intelligence-quicklog.js
+++ b/split/intelligence-quicklog.js
@@ -2288,9 +2288,15 @@ function renderTodaySoFar() {
     const liveClass = ev.isLive ? ' tsf-event-live' : '';
     const expandedClass = isExpanded ? ' tsf-event-expanded' : '';
     const calmAttr = ev.isCalm ? ' data-calm="true"' : '';
+    // T2-A.3 (V-V-25): data-state discriminator for the half-awake test. Post-T1-3 a
+    // skipped chip and a Done chip are pixel-identical except for the detail string.
+    // The CSS .tsf-event[data-state="skipped"] variant in styles.css strikes through
+    // the label, warn-colors the time slot, and fades the icon — distinguishable at
+    // a glance. Phase 2-C TSF Undo affordance will land on the same chip family.
+    const stateAttr = (ev.parsed && ev.parsed.status === 'skipped') ? ' data-state="skipped"' : '';
 
     html += '<div class="tsf-event-wrap' + expandedClass + '">';
-    html += '<div class="tsf-event' + inferredClass + liveClass + '" data-action="tsfToggleEvent" data-arg="' + escHtml(ev.id) + '"' + calmAttr + '>';
+    html += '<div class="tsf-event' + inferredClass + liveClass + '"' + stateAttr + ' data-action="tsfToggleEvent" data-arg="' + escHtml(ev.id) + '"' + calmAttr + '>';
     html += '<div class="tsf-event-time">' + escHtml(ev.displayTime || '') + '</div>';
 
     // Icon with domain color
@@ -2327,8 +2333,11 @@ function renderTodaySoFar() {
       const isExpanded = _tsfExpandedId === ev.id;
       const expandedClass = isExpanded ? ' tsf-event-expanded' : '';
       const iconColorClass = ev.color === 'amber' ? 'icon-amber' : ev.color === 'sage' ? 'icon-sage' : ev.color === 'sky' ? 'icon-sky' : 'icon-indigo';
+      // T2-A.3: parity with the timed-events branch — legacy 'skipped' strings (no loggedAt)
+      // still hit this no-time fallback; the discriminator must apply here too.
+      const stateAttr = (ev.parsed && ev.parsed.status === 'skipped') ? ' data-state="skipped"' : '';
       html += '<div class="tsf-event-wrap' + expandedClass + '">';
-      html += '<div class="tsf-event" data-action="tsfToggleEvent" data-arg="' + escHtml(ev.id) + '">';
+      html += '<div class="tsf-event"' + stateAttr + ' data-action="tsfToggleEvent" data-arg="' + escHtml(ev.id) + '">';
       html += '<div class="tsf-event-time"></div>';
       html += '<div class="tsf-event-icon"><div class="icon ' + iconColorClass + '">' + ev.icon + '</div></div>';
       html += '<div class="tsf-event-body">';

--- a/split/medical.js
+++ b/split/medical.js
@@ -4367,7 +4367,12 @@ function renderMedD3PatternCard() {
   // "13/14 (93%) · streak through yesterday 13 · 1 day not logged" for a perfect-streak parent.
   const todayParsed = eligibleDays.length > 0 ? eligibleDays[eligibleDays.length - 1].parsed : null;
   const lastDayIsToday = eligibleDays.length > 0 && eligibleDays[eligibleDays.length - 1].date === todayStr;
-  const excludeToday = !todayParsed && lastDayIsToday;
+  // V-M-83 (Maren synth-fold, Phase 2-A): mirror T2-A.2's todayIsSkippedOrUnlogged.
+  // A legitimately-skipped today should be excluded from adherence on the same boundary
+  // that excludes it from the streak walk — otherwise the card reads "Adherence: 13/14
+  // (93%)" beside "Streak through yesterday: 13 days," reproducing the very three-line
+  // incoherence T2-A.1 was authored to eliminate, just at a different boundary.
+  const excludeToday = (!todayParsed || todayParsed.status === 'skipped') && lastDayIsToday;
   const adherenceWindow = excludeToday ? eligibleDays.slice(0, -1) : eligibleDays;
   const doneDays = eligibleDays.filter(d => d.parsed && (d.parsed.status === 'done' || d.parsed.status === 'late'));
   const skippedDays = eligibleDays.filter(d => d.parsed && d.parsed.status === 'skipped');

--- a/split/medical.js
+++ b/split/medical.js
@@ -4360,10 +4360,20 @@ function renderMedD3PatternCard() {
   const trackStart = medChecks._trackingSince || '0000-00-00';
   const effectiveStart = medStart > trackStart ? medStart : trackStart;
   const eligibleDays = days.filter(d => d.date >= effectiveStart);
+  // T2-A.1: when today is unlogged (parent hasn't tapped Done yet — e.g. 8 AM pre-dose),
+  // exclude it from adherence + unloggedDays. The V-M-64 streak fallback already excludes
+  // today via startIdx = len-2; the adherence math + warn-tier "N days not logged" surface
+  // follow suit so all three card lines agree at the boundary instead of reading
+  // "13/14 (93%) · streak through yesterday 13 · 1 day not logged" for a perfect-streak parent.
+  const todayParsed = eligibleDays.length > 0 ? eligibleDays[eligibleDays.length - 1].parsed : null;
+  const lastDayIsToday = eligibleDays.length > 0 && eligibleDays[eligibleDays.length - 1].date === todayStr;
+  const excludeToday = !todayParsed && lastDayIsToday;
+  const adherenceWindow = excludeToday ? eligibleDays.slice(0, -1) : eligibleDays;
   const doneDays = eligibleDays.filter(d => d.parsed && (d.parsed.status === 'done' || d.parsed.status === 'late'));
   const skippedDays = eligibleDays.filter(d => d.parsed && d.parsed.status === 'skipped');
-  const unloggedDays = eligibleDays.filter(d => !d.parsed);
-  const adherence = eligibleDays.length > 0 ? Math.round((doneDays.length / eligibleDays.length) * 100) : 0;
+  const adherenceDone = adherenceWindow.filter(d => d.parsed && (d.parsed.status === 'done' || d.parsed.status === 'late'));
+  const unloggedDays = adherenceWindow.filter(d => !d.parsed);
+  const adherence = adherenceWindow.length > 0 ? Math.round((adherenceDone.length / adherenceWindow.length) * 100) : 0;
   // Usual-time band: take givenAt minutes, find central 80% range.
   // CR-11: use (N-1)*p indexing instead of N*p (which collapsed to the max for many N
   // and degraded 'central 80%' into 'min-to-max range') AND require N>=5 for the band
@@ -4392,16 +4402,18 @@ function renderMedD3PatternCard() {
   let topFatFood = null, topN = 0;
   Object.keys(fatFoodCounts).forEach(k => { if (fatFoodCounts[k] > topN) { topFatFood = k; topN = fatFoodCounts[k]; } });
   // Streak: consecutive done-days ending today.
-  // V-M-64: if today is unlogged (parent hasn't tapped Done yet), don't punish the streak —
-  // walk from yesterday and label "through yesterday" so a 30-day perfect run doesn't read as 0.
+  // V-M-64: if today is unlogged (parent hasn't tapped Done yet), walk from yesterday and
+  // label "through yesterday" so a 30-day perfect run doesn't read as 0.
+  // T2-A.2: extend the same fallback to status:'skipped'. A legitimate skip (sick,
+  // dose-form change, doctor advice) shouldn't zero out the historical streak — the
+  // parent's prior run is intact in spirit and the card should reflect that.
   // CR-6: walk over eligibleDays (post-medStart) not raw days, so a recently-activated med
   // doesn't see its streak punished by pre-activation no-data rows.
   let streak = 0;
   let streakLabel = 'Current streak';
-  const todayParsed = eligibleDays.length > 0 ? eligibleDays[eligibleDays.length - 1].parsed : null;
-  const todayResolved = !!(todayParsed && (todayParsed.status === 'done' || todayParsed.status === 'late' || todayParsed.status === 'skipped'));
-  const startIdx = todayResolved ? eligibleDays.length - 1 : eligibleDays.length - 2;
-  if (!todayResolved) streakLabel = 'Streak through yesterday';
+  const todayIsSkippedOrUnlogged = !todayParsed || todayParsed.status === 'skipped';
+  const startIdx = todayIsSkippedOrUnlogged ? eligibleDays.length - 2 : eligibleDays.length - 1;
+  if (todayIsSkippedOrUnlogged) streakLabel = 'Streak through yesterday';
   for (let i = startIdx; i >= 0; i--) {
     if (eligibleDays[i] && eligibleDays[i].parsed && (eligibleDays[i].parsed.status === 'done' || eligibleDays[i].parsed.status === 'late')) streak++;
     else break;
@@ -4419,7 +4431,7 @@ function renderMedD3PatternCard() {
   // Build summary lines
   const sigClass = adherence >= 90 ? 'tc-sage' : adherence >= 70 ? 'tc-warn' : 'tc-rose';
   let summary = '<div class="med-d3-summary">';
-  summary += `<div class="med-d3-summary-row"><strong class="${sigClass}">Adherence: ${doneDays.length}/${eligibleDays.length} days (${adherence}%)</strong></div>`;
+  summary += `<div class="med-d3-summary-row"><strong class="${sigClass}">Adherence: ${adherenceDone.length}/${adherenceWindow.length} days (${adherence}%)</strong></div>`;
   // CR-9: render times in 12h for parent-facing display.
   if (usualBand) {
     const bandDisplay = usualBand.split('–').map(t => _formatTime12h(t)).join('–');

--- a/split/styles.css
+++ b/split/styles.css
@@ -7896,9 +7896,21 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
    ("Skipped" vs "Done") — half-awake parents at 2 AM can miss it. Strikethrough the
    label, warn-color the time slot, fade the icon. Token-only: --tc-warn for the
    strike color + time slot, --light for the dimmed label. The chip wrapper carries
-   data-state="skipped" set by _tsfRenderEvent in intelligence-quicklog.js. */
+   data-state="skipped" set by _tsfRenderEvent in intelligence-quicklog.js.
+   V-V-32 (Vela synth-fold): dark-theme variant intentionally absent — --tc-warn and
+   --light cascade theme-aware via [data-theme="dark"] overrides further down this file,
+   so the strikethrough + dimmed label reads correctly in both themes without explicit
+   override. Future Governors: do not mistake the absence for an oversight.
+   V-V-31 (Vela synth-fold): if a future event type ever carries BOTH
+   tsf-event-inferred AND data-state="skipped" on the same chip, the time-slot rule
+   below collides with .tsf-event-inferred .tsf-event-time (italic + opacity 0.7).
+   Impossible today (inferred is set only on meal-time fallback, never on med events;
+   only meds can be skipped) — re-evaluate if that boundary shifts. */
 .tsf-event[data-state="skipped"] .tsf-event-label { text-decoration:line-through; text-decoration-color:var(--tc-warn); color:var(--light); }
 .tsf-event[data-state="skipped"] .tsf-event-time  { color:var(--tc-warn); opacity:0.7; }
+/* V-M-86 (Maren synth-fold, triple-jurisdiction round 2): the icon selector is deliberately
+   tightened from spec's bare `.icon` to `.tsf-event-icon .icon`, mirroring the parent
+   rule at line 7886 — prevents bleed if `.icon` ever appears bare elsewhere inside a chip. */
 .tsf-event[data-state="skipped"] .tsf-event-icon .icon { opacity:0.6; }
 .tsf-event-expanded-detail { padding:var(--sp-4) var(--sp-4) var(--sp-8) calc(var(--sp-32) + var(--sp-8) + var(--sp-24) + var(--sp-8) + var(--sp-4)); font-size:var(--fs-xs); color:var(--mid); line-height:1.5; border-top:1px solid var(--glass-strong); margin-top:0; }
 .tsf-show-earlier { text-align:center; font-size:var(--fs-xs); color:var(--tc-indigo); padding:var(--sp-6) 0; cursor:pointer; font-weight:600; }

--- a/split/styles.css
+++ b/split/styles.css
@@ -7891,6 +7891,15 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 .tsf-event-live .tsf-event-detail { animation:tsfPulse 2s ease-in-out infinite; }
 .tsf-event-live[data-calm="true"] .tsf-event-detail { animation:none; }
 @keyframes tsfPulse { 0%,100%{ opacity:1; } 50%{ opacity:0.5; } }
+/* T2-A.3 (V-V-25): skipped-chip discriminator. Post-T1-3 a Skipped chip and a Done
+   chip in the TSF timeline are pixel-identical except for the one-word detail string
+   ("Skipped" vs "Done") — half-awake parents at 2 AM can miss it. Strikethrough the
+   label, warn-color the time slot, fade the icon. Token-only: --tc-warn for the
+   strike color + time slot, --light for the dimmed label. The chip wrapper carries
+   data-state="skipped" set by _tsfRenderEvent in intelligence-quicklog.js. */
+.tsf-event[data-state="skipped"] .tsf-event-label { text-decoration:line-through; text-decoration-color:var(--tc-warn); color:var(--light); }
+.tsf-event[data-state="skipped"] .tsf-event-time  { color:var(--tc-warn); opacity:0.7; }
+.tsf-event[data-state="skipped"] .tsf-event-icon .icon { opacity:0.6; }
 .tsf-event-expanded-detail { padding:var(--sp-4) var(--sp-4) var(--sp-8) calc(var(--sp-32) + var(--sp-8) + var(--sp-24) + var(--sp-8) + var(--sp-4)); font-size:var(--fs-xs); color:var(--mid); line-height:1.5; border-top:1px solid var(--glass-strong); margin-top:0; }
 .tsf-show-earlier { text-align:center; font-size:var(--fs-xs); color:var(--tc-indigo); padding:var(--sp-6) 0; cursor:pointer; font-weight:600; }
 .tsf-show-earlier:active { opacity:0.6; }

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -7903,9 +7903,21 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
    ("Skipped" vs "Done") — half-awake parents at 2 AM can miss it. Strikethrough the
    label, warn-color the time slot, fade the icon. Token-only: --tc-warn for the
    strike color + time slot, --light for the dimmed label. The chip wrapper carries
-   data-state="skipped" set by _tsfRenderEvent in intelligence-quicklog.js. */
+   data-state="skipped" set by _tsfRenderEvent in intelligence-quicklog.js.
+   V-V-32 (Vela synth-fold): dark-theme variant intentionally absent — --tc-warn and
+   --light cascade theme-aware via [data-theme="dark"] overrides further down this file,
+   so the strikethrough + dimmed label reads correctly in both themes without explicit
+   override. Future Governors: do not mistake the absence for an oversight.
+   V-V-31 (Vela synth-fold): if a future event type ever carries BOTH
+   tsf-event-inferred AND data-state="skipped" on the same chip, the time-slot rule
+   below collides with .tsf-event-inferred .tsf-event-time (italic + opacity 0.7).
+   Impossible today (inferred is set only on meal-time fallback, never on med events;
+   only meds can be skipped) — re-evaluate if that boundary shifts. */
 .tsf-event[data-state="skipped"] .tsf-event-label { text-decoration:line-through; text-decoration-color:var(--tc-warn); color:var(--light); }
 .tsf-event[data-state="skipped"] .tsf-event-time  { color:var(--tc-warn); opacity:0.7; }
+/* V-M-86 (Maren synth-fold, triple-jurisdiction round 2): the icon selector is deliberately
+   tightened from spec's bare `.icon` to `.tsf-event-icon .icon`, mirroring the parent
+   rule at line 7886 — prevents bleed if `.icon` ever appears bare elsewhere inside a chip. */
 .tsf-event[data-state="skipped"] .tsf-event-icon .icon { opacity:0.6; }
 .tsf-event-expanded-detail { padding:var(--sp-4) var(--sp-4) var(--sp-8) calc(var(--sp-32) + var(--sp-8) + var(--sp-24) + var(--sp-8) + var(--sp-4)); font-size:var(--fs-xs); color:var(--mid); line-height:1.5; border-top:1px solid var(--glass-strong); margin-top:0; }
 .tsf-show-earlier { text-align:center; font-size:var(--fs-xs); color:var(--tc-indigo); padding:var(--sp-6) 0; cursor:pointer; font-weight:600; }

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -41255,7 +41255,12 @@ function renderMedD3PatternCard() {
   // "13/14 (93%) · streak through yesterday 13 · 1 day not logged" for a perfect-streak parent.
   const todayParsed = eligibleDays.length > 0 ? eligibleDays[eligibleDays.length - 1].parsed : null;
   const lastDayIsToday = eligibleDays.length > 0 && eligibleDays[eligibleDays.length - 1].date === todayStr;
-  const excludeToday = !todayParsed && lastDayIsToday;
+  // V-M-83 (Maren synth-fold, Phase 2-A): mirror T2-A.2's todayIsSkippedOrUnlogged.
+  // A legitimately-skipped today should be excluded from adherence on the same boundary
+  // that excludes it from the streak walk — otherwise the card reads "Adherence: 13/14
+  // (93%)" beside "Streak through yesterday: 13 days," reproducing the very three-line
+  // incoherence T2-A.1 was authored to eliminate, just at a different boundary.
+  const excludeToday = (!todayParsed || todayParsed.status === 'skipped') && lastDayIsToday;
   const adherenceWindow = excludeToday ? eligibleDays.slice(0, -1) : eligibleDays;
   const doneDays = eligibleDays.filter(d => d.parsed && (d.parsed.status === 'done' || d.parsed.status === 'late'));
   const skippedDays = eligibleDays.filter(d => d.parsed && d.parsed.status === 'skipped');

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -7898,6 +7898,15 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 .tsf-event-live .tsf-event-detail { animation:tsfPulse 2s ease-in-out infinite; }
 .tsf-event-live[data-calm="true"] .tsf-event-detail { animation:none; }
 @keyframes tsfPulse { 0%,100%{ opacity:1; } 50%{ opacity:0.5; } }
+/* T2-A.3 (V-V-25): skipped-chip discriminator. Post-T1-3 a Skipped chip and a Done
+   chip in the TSF timeline are pixel-identical except for the one-word detail string
+   ("Skipped" vs "Done") — half-awake parents at 2 AM can miss it. Strikethrough the
+   label, warn-color the time slot, fade the icon. Token-only: --tc-warn for the
+   strike color + time slot, --light for the dimmed label. The chip wrapper carries
+   data-state="skipped" set by _tsfRenderEvent in intelligence-quicklog.js. */
+.tsf-event[data-state="skipped"] .tsf-event-label { text-decoration:line-through; text-decoration-color:var(--tc-warn); color:var(--light); }
+.tsf-event[data-state="skipped"] .tsf-event-time  { color:var(--tc-warn); opacity:0.7; }
+.tsf-event[data-state="skipped"] .tsf-event-icon .icon { opacity:0.6; }
 .tsf-event-expanded-detail { padding:var(--sp-4) var(--sp-4) var(--sp-8) calc(var(--sp-32) + var(--sp-8) + var(--sp-24) + var(--sp-8) + var(--sp-4)); font-size:var(--fs-xs); color:var(--mid); line-height:1.5; border-top:1px solid var(--glass-strong); margin-top:0; }
 .tsf-show-earlier { text-align:center; font-size:var(--fs-xs); color:var(--tc-indigo); padding:var(--sp-6) 0; cursor:pointer; font-weight:600; }
 .tsf-show-earlier:active { opacity:0.6; }
@@ -41239,10 +41248,20 @@ function renderMedD3PatternCard() {
   const trackStart = medChecks._trackingSince || '0000-00-00';
   const effectiveStart = medStart > trackStart ? medStart : trackStart;
   const eligibleDays = days.filter(d => d.date >= effectiveStart);
+  // T2-A.1: when today is unlogged (parent hasn't tapped Done yet — e.g. 8 AM pre-dose),
+  // exclude it from adherence + unloggedDays. The V-M-64 streak fallback already excludes
+  // today via startIdx = len-2; the adherence math + warn-tier "N days not logged" surface
+  // follow suit so all three card lines agree at the boundary instead of reading
+  // "13/14 (93%) · streak through yesterday 13 · 1 day not logged" for a perfect-streak parent.
+  const todayParsed = eligibleDays.length > 0 ? eligibleDays[eligibleDays.length - 1].parsed : null;
+  const lastDayIsToday = eligibleDays.length > 0 && eligibleDays[eligibleDays.length - 1].date === todayStr;
+  const excludeToday = !todayParsed && lastDayIsToday;
+  const adherenceWindow = excludeToday ? eligibleDays.slice(0, -1) : eligibleDays;
   const doneDays = eligibleDays.filter(d => d.parsed && (d.parsed.status === 'done' || d.parsed.status === 'late'));
   const skippedDays = eligibleDays.filter(d => d.parsed && d.parsed.status === 'skipped');
-  const unloggedDays = eligibleDays.filter(d => !d.parsed);
-  const adherence = eligibleDays.length > 0 ? Math.round((doneDays.length / eligibleDays.length) * 100) : 0;
+  const adherenceDone = adherenceWindow.filter(d => d.parsed && (d.parsed.status === 'done' || d.parsed.status === 'late'));
+  const unloggedDays = adherenceWindow.filter(d => !d.parsed);
+  const adherence = adherenceWindow.length > 0 ? Math.round((adherenceDone.length / adherenceWindow.length) * 100) : 0;
   // Usual-time band: take givenAt minutes, find central 80% range.
   // CR-11: use (N-1)*p indexing instead of N*p (which collapsed to the max for many N
   // and degraded 'central 80%' into 'min-to-max range') AND require N>=5 for the band
@@ -41271,16 +41290,18 @@ function renderMedD3PatternCard() {
   let topFatFood = null, topN = 0;
   Object.keys(fatFoodCounts).forEach(k => { if (fatFoodCounts[k] > topN) { topFatFood = k; topN = fatFoodCounts[k]; } });
   // Streak: consecutive done-days ending today.
-  // V-M-64: if today is unlogged (parent hasn't tapped Done yet), don't punish the streak —
-  // walk from yesterday and label "through yesterday" so a 30-day perfect run doesn't read as 0.
+  // V-M-64: if today is unlogged (parent hasn't tapped Done yet), walk from yesterday and
+  // label "through yesterday" so a 30-day perfect run doesn't read as 0.
+  // T2-A.2: extend the same fallback to status:'skipped'. A legitimate skip (sick,
+  // dose-form change, doctor advice) shouldn't zero out the historical streak — the
+  // parent's prior run is intact in spirit and the card should reflect that.
   // CR-6: walk over eligibleDays (post-medStart) not raw days, so a recently-activated med
   // doesn't see its streak punished by pre-activation no-data rows.
   let streak = 0;
   let streakLabel = 'Current streak';
-  const todayParsed = eligibleDays.length > 0 ? eligibleDays[eligibleDays.length - 1].parsed : null;
-  const todayResolved = !!(todayParsed && (todayParsed.status === 'done' || todayParsed.status === 'late' || todayParsed.status === 'skipped'));
-  const startIdx = todayResolved ? eligibleDays.length - 1 : eligibleDays.length - 2;
-  if (!todayResolved) streakLabel = 'Streak through yesterday';
+  const todayIsSkippedOrUnlogged = !todayParsed || todayParsed.status === 'skipped';
+  const startIdx = todayIsSkippedOrUnlogged ? eligibleDays.length - 2 : eligibleDays.length - 1;
+  if (todayIsSkippedOrUnlogged) streakLabel = 'Streak through yesterday';
   for (let i = startIdx; i >= 0; i--) {
     if (eligibleDays[i] && eligibleDays[i].parsed && (eligibleDays[i].parsed.status === 'done' || eligibleDays[i].parsed.status === 'late')) streak++;
     else break;
@@ -41298,7 +41319,7 @@ function renderMedD3PatternCard() {
   // Build summary lines
   const sigClass = adherence >= 90 ? 'tc-sage' : adherence >= 70 ? 'tc-warn' : 'tc-rose';
   let summary = '<div class="med-d3-summary">';
-  summary += `<div class="med-d3-summary-row"><strong class="${sigClass}">Adherence: ${doneDays.length}/${eligibleDays.length} days (${adherence}%)</strong></div>`;
+  summary += `<div class="med-d3-summary-row"><strong class="${sigClass}">Adherence: ${adherenceDone.length}/${adherenceWindow.length} days (${adherence}%)</strong></div>`;
   // CR-9: render times in 12h for parent-facing display.
   if (usualBand) {
     const bandDisplay = usualBand.split('–').map(t => _formatTime12h(t)).join('–');
@@ -59283,9 +59304,15 @@ function renderTodaySoFar() {
     const liveClass = ev.isLive ? ' tsf-event-live' : '';
     const expandedClass = isExpanded ? ' tsf-event-expanded' : '';
     const calmAttr = ev.isCalm ? ' data-calm="true"' : '';
+    // T2-A.3 (V-V-25): data-state discriminator for the half-awake test. Post-T1-3 a
+    // skipped chip and a Done chip are pixel-identical except for the detail string.
+    // The CSS .tsf-event[data-state="skipped"] variant in styles.css strikes through
+    // the label, warn-colors the time slot, and fades the icon — distinguishable at
+    // a glance. Phase 2-C TSF Undo affordance will land on the same chip family.
+    const stateAttr = (ev.parsed && ev.parsed.status === 'skipped') ? ' data-state="skipped"' : '';
 
     html += '<div class="tsf-event-wrap' + expandedClass + '">';
-    html += '<div class="tsf-event' + inferredClass + liveClass + '" data-action="tsfToggleEvent" data-arg="' + escHtml(ev.id) + '"' + calmAttr + '>';
+    html += '<div class="tsf-event' + inferredClass + liveClass + '"' + stateAttr + ' data-action="tsfToggleEvent" data-arg="' + escHtml(ev.id) + '"' + calmAttr + '>';
     html += '<div class="tsf-event-time">' + escHtml(ev.displayTime || '') + '</div>';
 
     // Icon with domain color
@@ -59322,8 +59349,11 @@ function renderTodaySoFar() {
       const isExpanded = _tsfExpandedId === ev.id;
       const expandedClass = isExpanded ? ' tsf-event-expanded' : '';
       const iconColorClass = ev.color === 'amber' ? 'icon-amber' : ev.color === 'sage' ? 'icon-sage' : ev.color === 'sky' ? 'icon-sky' : 'icon-indigo';
+      // T2-A.3: parity with the timed-events branch — legacy 'skipped' strings (no loggedAt)
+      // still hit this no-time fallback; the discriminator must apply here too.
+      const stateAttr = (ev.parsed && ev.parsed.status === 'skipped') ? ' data-state="skipped"' : '';
       html += '<div class="tsf-event-wrap' + expandedClass + '">';
-      html += '<div class="tsf-event" data-action="tsfToggleEvent" data-arg="' + escHtml(ev.id) + '">';
+      html += '<div class="tsf-event"' + stateAttr + ' data-action="tsfToggleEvent" data-arg="' + escHtml(ev.id) + '">';
       html += '<div class="tsf-event-time"></div>';
       html += '<div class="tsf-event-icon"><div class="icon ' + iconColorClass + '">' + ev.icon + '</div></div>';
       html += '<div class="tsf-event-body">';

--- a/tests/e2e/vit-d3-tracking-v2-tier-2-a.spec.ts
+++ b/tests/e2e/vit-d3-tracking-v2-tier-2-a.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect } from '@playwright/test';
+
+// Vit D3 Tracking v2 — Tier 2 Phase 2-A regression guards.
+// Spec: docs/specs/vit-d3-tracking-v2-tier-2.md §Phase 2-A.
+// QA chain canon-cc-008: Maren (medical.js) + Vela (intelligence-quicklog.js render
+// + comprehension-surface lens on the CSS) Mode-1 parallel; triple-jurisdiction
+// sequential review on styles.css (Maren → Kael → Vela, first by heaviest-touched
+// Region = Vela); Lyra synth; Cipher Edict V.
+
+// ── T2-A.1 ───────────────────────────────────────────────────────────────────
+test('regression-guard-d3-v2-t2-a-1: pattern card excludes today from adherence + unloggedDays on unlogged morning', async ({ page }) => {
+  // Trigger: Day 14 of a perfect streak at 8 AM (today not yet logged). Pre-fix card read
+  //   "Adherence: 13/14 days (93%)"  +  "1 day not logged in this window"  +  "Streak through yesterday: 13 days".
+  // Three contradictory lines. V-M-64 fixed the streak label; T2-A.1 makes adherence +
+  // unloggedDays exclude today on the same boundary so all three lines agree.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.active && m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    // Seed 13 perfect prior days; ensure today is empty (unlogged morning).
+    if (!medChecks[t]) medChecks[t] = {};
+    delete medChecks[t][d3.name];
+    // Seed days t-1 .. t-13 as done. Use a tiny helper to step a yyyy-mm-dd date back.
+    function back(n) {
+      const d = new Date(t + 'T12:00:00');
+      d.setDate(d.getDate() - n);
+      const y = d.getFullYear(), m = String(d.getMonth()+1).padStart(2,'0'), dd = String(d.getDate()).padStart(2,'0');
+      return y + '-' + m + '-' + dd;
+    }
+    for (let i = 1; i <= 13; i++) {
+      const ds = back(i);
+      if (!medChecks[ds]) medChecks[ds] = {};
+      medChecks[ds][d3.name] = { status:'done', givenAt:'08:30', loggedAt:'08:32', withFat:true, fatFood:'paratha', fatDelta:5 };
+    }
+    // Pin trackingSince so the 14-day window is fully eligible.
+    medChecks._trackingSince = back(13);
+    // Render the card and read the summary text.
+    if (typeof renderMedD3PatternCard === 'function') renderMedD3PatternCard();
+    const body = document.getElementById('medD3PatternBody');
+    const text = body ? body.textContent || '' : '';
+    return { text };
+  });
+
+  if ((r as any).skipped) {
+    test.skip(true, (r as any).skipped);
+    return;
+  }
+  // After T2-A.1: today is excluded from the denominator → 13/13 (100%), no "not logged" stripe.
+  // Pre-fix would have read "Adherence: 13/14 days (93%)" + "1 day not logged".
+  expect(r.text, 'T2-A.1: denominator must exclude today (13/13, not 13/14)').toContain('Adherence: 13/13 days (100%)');
+  expect(r.text, 'T2-A.1: warn stripe "N days not logged" must NOT fire for an unlogged morning').not.toContain('not logged in this window');
+});
+
+// ── T2-A.2 ───────────────────────────────────────────────────────────────────
+test('regression-guard-d3-v2-t2-a-2: pattern card preserves through-yesterday streak on legitimate skip today', async ({ page }) => {
+  // Trigger: parent legitimately skips today (sick, dose-form change, doctor advice).
+  // Pre-fix the streak walk treats skipped as a resolved status → startIdx = len-1 → first
+  // iteration breaks (status not in done/late) → streak=0. Card reads "Current streak: 0 days"
+  // and historical context is erased. T2-A.2 extends V-M-64's exclude-today fallback to skip.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.active && m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    if (!medChecks[t]) medChecks[t] = {};
+    // Skip today (loggedAt-only — schema per CR-10).
+    medChecks[t][d3.name] = { status:'skipped', givenAt:null, loggedAt:'09:00', withFat:null, fatFood:null, fatDelta:null };
+    // 13 perfect prior days.
+    function back(n) {
+      const d = new Date(t + 'T12:00:00');
+      d.setDate(d.getDate() - n);
+      const y = d.getFullYear(), m = String(d.getMonth()+1).padStart(2,'0'), dd = String(d.getDate()).padStart(2,'0');
+      return y + '-' + m + '-' + dd;
+    }
+    for (let i = 1; i <= 13; i++) {
+      const ds = back(i);
+      if (!medChecks[ds]) medChecks[ds] = {};
+      medChecks[ds][d3.name] = { status:'done', givenAt:'08:30', loggedAt:'08:32', withFat:true, fatFood:'paratha', fatDelta:5 };
+    }
+    medChecks._trackingSince = back(13);
+    if (typeof renderMedD3PatternCard === 'function') renderMedD3PatternCard();
+    const body = document.getElementById('medD3PatternBody');
+    const text = body ? body.textContent || '' : '';
+    return { text };
+  });
+
+  if ((r as any).skipped) {
+    test.skip(true, (r as any).skipped);
+    return;
+  }
+  // After T2-A.2: skipped today walks from yesterday → 13-day through-yesterday streak preserved.
+  expect(r.text, 'T2-A.2: streak label must read "through yesterday" on legitimate skip').toContain('Streak through yesterday');
+  expect(r.text, 'T2-A.2: 13-day prior streak must be preserved (not zeroed)').toContain('13 days');
+  expect(r.text, 'T2-A.2: must NOT show the "Current streak: 0" regression').not.toContain('Current streak');
+});
+
+// ── T2-A.3 ───────────────────────────────────────────────────────────────────
+test('regression-guard-d3-v2-t2-a-3: skipped TSF chip has data-state attr and strikethrough CSS', async ({ page }) => {
+  // Trigger: post-T1-3 the skipped chip surfaces in TSF at loggedAt time, but the chip is
+  // pixel-identical to a Done chip (icon = pill, label = med name; only the detail string
+  // differs by one word). T2-A.3 (V-V-25) adds a data-state="skipped" attr on the chip
+  // wrapper + a CSS variant in styles.css: strikethrough label + warn-color time slot +
+  // faded icon. Half-awake-readable distinction.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.active && m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    if (!medChecks[t]) medChecks[t] = {};
+    medChecks[t][d3.name] = { status:'skipped', givenAt:null, loggedAt:'09:15', withFat:null, fatFood:null, fatDelta:null };
+    if (typeof _tsfMarkDirty === 'function') _tsfMarkDirty();
+    // Switch to home (TSF lives there) and render.
+    if (typeof switchTab === 'function') switchTab('home');
+    if (typeof renderTodaySoFar === 'function') renderTodaySoFar();
+    // Query the chip wrapper. Med chip id is 'med-<name>'.
+    const chip = document.querySelector('.tsf-event[data-state="skipped"]') as HTMLElement | null;
+    if (!chip) return { found: false };
+    const label = chip.querySelector('.tsf-event-label') as HTMLElement | null;
+    const time  = chip.querySelector('.tsf-event-time')  as HTMLElement | null;
+    const icon  = chip.querySelector('.tsf-event-icon .icon') as HTMLElement | null;
+    const labelStyle = label ? getComputedStyle(label) : null;
+    const timeStyle  = time  ? getComputedStyle(time)  : null;
+    const iconStyle  = icon  ? getComputedStyle(icon)  : null;
+    return {
+      found: true,
+      labelText: label ? label.textContent : '',
+      labelDecoration: labelStyle ? labelStyle.textDecorationLine : '',
+      timeOpacity: timeStyle ? parseFloat(timeStyle.opacity) : null,
+      iconOpacity: iconStyle ? parseFloat(iconStyle.opacity) : null,
+    };
+  });
+
+  if ((r as any).skipped) {
+    test.skip(true, (r as any).skipped);
+    return;
+  }
+  expect(r.found, 'T2-A.3: chip wrapper must carry data-state="skipped"').toBe(true);
+  expect(r.labelDecoration, 'T2-A.3: skipped label must render strikethrough').toContain('line-through');
+  expect(r.timeOpacity, 'T2-A.3: time slot must be faded (warn-color + opacity 0.7)').toBeLessThanOrEqual(0.8);
+  expect(r.iconOpacity, 'T2-A.3: icon must be faded (opacity 0.6)').toBeLessThanOrEqual(0.7);
+});

--- a/tests/e2e/vit-d3-tracking-v2-tier-2-a.spec.ts
+++ b/tests/e2e/vit-d3-tracking-v2-tier-2-a.spec.ts
@@ -97,6 +97,11 @@ test('regression-guard-d3-v2-t2-a-2: pattern card preserves through-yesterday st
   expect(r.text, 'T2-A.2: streak label must read "through yesterday" on legitimate skip').toContain('Streak through yesterday');
   expect(r.text, 'T2-A.2: 13-day prior streak must be preserved (not zeroed)').toContain('13 days');
   expect(r.text, 'T2-A.2: must NOT show the "Current streak: 0" regression').not.toContain('Current streak');
+  // V-M-85 (Maren synth-fold): T2-A.1 boundary mirrored at the skipped-today case via V-M-83.
+  // Skipped today must be excluded from adherence denominator on the same boundary that
+  // excludes it from the streak walk — otherwise the card renders "13/14 (93%)" beside
+  // "Streak through yesterday: 13" (the three-line incoherence T2-A.1 was authored to fix).
+  expect(r.text, 'V-M-83: skipped today must be excluded from adherence (13/13 not 13/14)').toContain('Adherence: 13/13 days (100%)');
 });
 
 // ── T2-A.3 ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Implements three items from [`docs/specs/vit-d3-tracking-v2-tier-2.md` §Phase 2-A](../blob/main/docs/specs/vit-d3-tracking-v2-tier-2.md) — the smallest of the three Tier 2 phases, recommended-first because it exercises the triple-jurisdiction `styles.css` flow and validates the chip-discriminator CSS pattern before Phase 2-C's TSF Undo affordance lands on the same chip family.

## Items shipped

### T2-A.1 — Pattern card adherence + unloggedDays exclude today on unlogged morning (`split/medical.js`)

Pre-fix the card read three contradictory lines on Day 14 of a perfect streak at 8 AM (today not yet logged): "Adherence: 13/14 days (93%)" + "1 day not logged in this window" + "Streak through yesterday: 13 days." V-M-64 fixed the streak label; T2-A.1 introduces `excludeToday` + `adherenceWindow` so all three lines agree at the boundary. Refactor lifts `todayParsed` out of the streak block to share with the adherence compute (used by T2-A.2 below).

### T2-A.2 — Streak preserves through-yesterday on legitimate skip today (`split/medical.js`)

Extends V-M-64's exclude-today fallback to `status:'skipped'` — `todayIsSkippedOrUnlogged` walks from yesterday and labels "Streak through yesterday" so a 30-day prior streak isn't zeroed by a single legitimate skip (sick, dose-form change, doctor advice).

### T2-A.3 (V-V-25) — Skipped TSF chip CSS discriminator (`split/intelligence-quicklog.js` + `split/styles.css`)

Adds `data-state="skipped"` attribute on the chip wrapper (both timed and no-time render branches — covers post-T1-3 skipped-with-loggedAt path AND legacy `'skipped'` string records without `loggedAt`) + new `.tsf-event[data-state="skipped"]` CSS variant: strikethrough label (warn-color underline + dimmed text), warn-color time slot at 0.7 opacity, faded icon at 0.6 opacity. Tokens-only (`--tc-warn`, `--light`); dark-theme cascade verified.

## Tests

New file `tests/e2e/vit-d3-tracking-v2-tier-2-a.spec.ts` per spec test plan:
- `regression-guard-d3-v2-t2-a-1` — pattern card excludes today from adherence + unloggedDays on unlogged morning
- `regression-guard-d3-v2-t2-a-2` — pattern card preserves through-yesterday streak on legitimate skip today (strengthened with the V-M-85 "Adherence: 13/13 (100%)" assertion post-synth)
- `regression-guard-d3-v2-t2-a-3` — skipped TSF chip has data-state attr and strikethrough CSS

All three pass; all 33 pre-existing v1+v2 vit-d3 tests stay green. Full e2e suite: **168 passed, 1 skipped, 1 pre-existing failure** (`smoke.spec.ts:723 Build script contract` — out of scope per handoff, from PR #120's build-safe.sh shift).

## canon-cc-008 chain — discharged

**Round 1 (parallel):**
- **Maren Mode-1 on `medical.js`** → `clear-with-notes`
- **Vela Mode-1 on `intelligence-quicklog.js` + first-Governor pass on `styles.css`** → `clear-with-notes`

**Round 2 (sequential triple-jurisdiction on `styles.css`, second-Governor):**
- **Maren on `styles.css`** → `clear-with-notes`

**Round 3 (sequential triple-jurisdiction on `styles.css`, third-Governor):**
- **Kael on `styles.css` + data→render pair-touch on `intelligence-quicklog.js` + `core.js`** → `clear-with-notes`

**Cipher Edict V** → **LGTM, zero findings.**

### Synth fold-in (folded by Lyra, commits e18829c + a41a086)

| Tag | Origin | Fold | File |
|---|---|---|---|
| V-M-83 | Maren R1 | Widen `excludeToday` to also fire on `todayParsed.status === 'skipped'` — mirrors T2-A.2's `todayIsSkippedOrUnlogged` so the skipped-today boundary doesn't reproduce the same three-line incoherence T2-A.1 fixed at the unlogged-morning boundary | `medical.js` |
| V-M-85 | Maren R1 | Strengthen t2-a-2 test with `expect(r.text).toContain('Adherence: 13/13 days (100%)')` to guard the V-M-83 boundary | test file |
| V-V-31 | Vela R1 | CSS doctrine comment — inferred+skipped collision impossible today (inferred:true only on meal-time fallback; only meds can be skipped). Re-evaluate if event-type matrix shifts | `styles.css` |
| V-V-32 | Vela R1 | CSS doctrine comment — dark-theme variant deliberately absent; `--tc-warn` and `--light` cascade theme-aware via `[data-theme="dark"]` overrides at `styles.css:5113, 5137` | `styles.css` |
| V-M-86 | Maren R2 | CSS doctrine comment — spec→impl selector tightening from bare `.icon` to `.tsf-event-icon .icon` is intentional, mirrors parent rule at line 7886 to prevent bleed | `styles.css` |

### Deferred (registered, not folded — carried into Phase 2-B/2-C ledger)

| Tag | Origin | Disposition | Future home |
|---|---|---|---|
| V-M-84 | Maren R1 | Empty-window guard hardening — pre-existing latent path, not parent-facing today | Phase 2-B / opportunistic at next medical.js touch |
| V-M-87 | Maren R2 | Severity-register misread risk: warn-color strikethrough may read as "system error" without an intent-anchor button on the chip | **Phase 2-C** — clusters naturally with V-V-30 (TSF Undo affordance, which provides the intent anchor on the same chip family) |
| V-K-96 | Kael R3 | Sync-push on `KEYS.medChecks` doesn't fire `_tsfMarkDirty()` — device B's TSF chip stays Done-styled on remote skip while pattern card correctly shows skip. Pre-existing path, no new staleness opened by this PR (Cipher verified) | **Phase 2-C** — clusters with V-V-30 + V-K-94/95 (sync-schema doctrine) |

### Doctrine ledger corrections

- **V-K-97** (Kael R3): supersedes Vela's V-V-33 "dead code today" framing on the no-time render branch's `stateAttr`. Legacy `'skipped'` strings (parseMedCheck:95 emits `loggedAt:null`) DO route through the no-time branch — they fail T1-3's `parsed.loggedAt`-bearing else-if and fall through to `noTimeEvents.push(ev)`. The author's inline comment at `intelligence-quicklog.js:2336` ("legacy 'skipped' strings (no loggedAt) still hit this no-time fallback") is canonical.

## Out of scope (registered for later phases)

- **Phase 2-B** (Maren-primary `home.js` write-path defence): T2-B.1..T2-B.5
- **Phase 2-C** (cross-cutting audit/sync integrity + TSF Undo affordance): T2-C.1..T2-C.5 + V-M-87 / V-K-96 from this PR's deferrals

## Build hygiene

- `pnpm build` canonical, self-validating (`build-safe.sh` per PR #120)
- No `--no-verify`, no force-push, no destructive ops
- No model-identifier leakage in commits or PR body