### PR TITLE
Vit D3 v2 Tier 2 Phase 2-B: write-path defence (markMedDone null schema, adjust rollover, future-time gate, outing-intent semantics, preserveWithFat tightening)

### DIFF
--- a/index.html
+++ b/index.html
@@ -17314,7 +17314,14 @@ function _refreshTodayMedWithFat() {
     if (!parsed) return;
     if (parsed.status !== 'done' && parsed.status !== 'late') return;
     if (!parsed.givenAt) return;
-    if (parsed.withFat !== false) return; // only redetect when previously negative
+    // T2-B.1 (Phase 2-B) extension of CR-14: redetect for any non-true prior observation,
+    // not just === false. The three-state schema introduced by T2-B.1 at markMedDone writes
+    // withFat:null when no meals were logged at dose-time (an "unknown" state, not a
+    // "negative" state). The same self-resolving contract applies — the parent's later meal
+    // save should flip null → true the same way it flips false → true. Also closes a small
+    // legacy-record gap: pre-CR-10 strings parse to withFat:null and were never redetected;
+    // post-fix they flip to true on the first qualifying meal save like any other record.
+    if (parsed.withFat === true) return; // already positive — never erase a real observation
     var fresh = _detectFatContextNearTime(parsed.givenAt, t);
     if (fresh.withFat === true) {
       // Preserve the rest of the object; only update the fat fields.
@@ -23822,12 +23829,25 @@ function markMedDone(name, idx, givenTime) {
   const loggedAt = now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
   const givenAt = (typeof givenTime === 'string' && /^\d{1,2}:\d{2}$/.test(givenTime)) ? givenTime : loggedAt;
   const fat = _detectFatContextNearTime(givenAt, todayStr);
+  // T2-B.1: half-awake morning. Parent gives D3 at 7:55 AM BEFORE logging breakfast.
+  // _detectFatContextNearTime finds no meal in window → returns withFat:false. The
+  // reminder card would immediately show "no fat-meal logged nearby" — false negative
+  // because the parent simply hasn't logged the meal YET. Three-state schema: when
+  // detection finds no fat AND zero meals logged today AT ALL, write withFat:null
+  // (unknown) instead of withFat:false. The render side already gates the badge on
+  // `withFat === false` (line ~742), so null naturally suppresses the badge. The
+  // refresh helper at core.js _refreshTodayMedWithFat flips null/false → true on the
+  // first qualifying meal save (per CR-14 + T1-1 doctrine), so the unknown state
+  // self-resolves once the parent logs breakfast.
+  const dayFeed = feedingData[todayStr] || {};
+  const noMealsLoggedToday = !['breakfast','lunch','dinner','snack'].some(function(m) { return dayFeed[m] && String(dayFeed[m]).trim(); });
+  const writeWithFat = (fat.withFat === false && noMealsLoggedToday) ? null : fat.withFat;
   if (!medChecks[todayStr]) medChecks[todayStr] = {};
   medChecks[todayStr][name] = {
     status:   'done',
     givenAt:  givenAt,
     loggedAt: loggedAt,
-    withFat:  fat.withFat,
+    withFat:  writeWithFat,
     fatFood:  fat.fatFood,
     fatDelta: fat.fatDelta,
   };
@@ -23869,7 +23889,19 @@ function confirmMedDoneAt(name, idx) {
     if (input) { try { input.focus(); } catch(e) {} }
     return;
   }
+  // T2-B.3: reject future times. A mistyped 23:00 (meant 11:00) would stamp the future,
+  // re-run detection at an empty window, and silently corrupt withFat. Block at the editor.
+  if (_hhmmToMinutes(picked) > _hhmmToMinutes(_currentHHMM())) {
+    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Time must be in the past');
+    if (input) { try { input.focus(); } catch(e) {} }
+    return;
+  }
   markMedDone(name, idx, picked);
+}
+// T2-B.3 helper: canonical 24h HH:MM for current wall-clock, matching the en-GB storage
+// convention (V-M-60). Used by the future-time gate in confirmMedDoneAt + confirmMedAdjust.
+function _currentHHMM() {
+  return new Date().toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
 }
 function cancelMedDoneAt(idx) {
   renderRemindersAndAlerts();
@@ -23922,8 +23954,20 @@ function undoMedSkip(name, idx) {
 // Adjust the administration time of an already-logged dose. Re-runs with-fat
 // detection on the new givenAt. Works on today's dose (the only adjust surface
 // in v1; past-day adjusts continue to use resolveMissedMed).
-function adjustMedTime(name, idx, newTime) {
-  const todayStr = today();
+function adjustMedTime(name, idx, newTime, dayStr) {
+  // T2-B.2: dayStr is the captured-at-open day. Defaults to today() for legacy callers.
+  // If today() has rolled past the captured day (parent opened editor at 23:58, saved at
+  // 00:01), don't silently write a record on the new day's empty slot — toast and abort
+  // so the parent knows why Save didn't take effect. Pre-fix the function would no-op
+  // silently because medChecks[newToday][name] was undefined, leaving the editor wedged
+  // in the now-empty new-date slot.
+  const todayStr = dayStr || today();
+  if (todayStr !== today()) {
+    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Date changed — please re-open Adjust on yesterday\'s record');
+    renderRemindersAndAlerts();
+    renderHomeContextAlerts();
+    return;
+  }
   if (!medChecks[todayStr] || !medChecks[todayStr][name]) return;
   if (!newTime || !/^\d{1,2}:\d{2}$/.test(newTime)) return;
   const existing = parseMedCheck(medChecks[todayStr][name]);
@@ -23935,7 +23979,12 @@ function adjustMedTime(name, idx, newTime) {
   // false, the parent's earlier observation is the source of truth — they may have
   // edited the meal text after the fact, or the new time happens to fall outside
   // the ±60min window even though the original pairing was real.
-  const preserveWithFat = (existing.withFat === true && fat.withFat === false);
+  // T2-B.5 (V-M-77): tighten the truth-table from `=== false` to `!== true` so a future
+  // _detectFatContextNearTime that legitimately returns withFat:null (unknown) doesn't
+  // accidentally erase a positive observation. Currently dead path (detector always
+  // returns boolean per core.js:_detectFatContextNearTime) — doctrine-cleaner for the
+  // T2-B.1 three-state schema that introduces withFat:null at the markMedDone path.
+  const preserveWithFat = (existing.withFat === true && fat.withFat !== true);
   // V-M-65: canonical 24h storage (en-GB).
   medChecks[todayStr][name] = {
     status:   existing.status,
@@ -23965,9 +24014,12 @@ function openMedAdjust(name, idx) {
   const curAt = cur && cur.givenAt ? cur.givenAt : '';
   const norm = String(curAt).replace(/\s*(AM|PM)\s*$/i, '');
   const hint = norm ? '' : '<span class="supp-adjust-hint t-sub t-sm">No time captured — enter actual time:</span>';
+  // T2-B.2: capture today() at editor-open time and thread via data-captured-day so
+  // confirmMedAdjust can detect midnight rollover before writing to the wrong slot.
+  const capturedToday = today();
   actionRow.innerHTML =
     hint +
-    '<input type="time" class="supp-time-input" id="supp-time-' + idx + '" value="' + escAttr(norm) + '">' +
+    '<input type="time" class="supp-time-input" id="supp-time-' + idx + '" value="' + escAttr(norm) + '" data-captured-day="' + escAttr(capturedToday) + '">' +
     '<button class="supp-check-btn" data-action="confirmMedAdjust" data-arg="' + escAttr(name) + '" data-arg2="' + idx + '">Save</button>' +
     '<button class="supp-skip-btn" data-action="cancelMedDoneAt" data-arg2="' + idx + '">Cancel</button>';
 }
@@ -23982,7 +24034,18 @@ function confirmMedAdjust(name, idx) {
     if (input) { try { input.focus(); } catch(e) {} }
     return;
   }
-  adjustMedTime(name, idx, picked);
+  // T2-B.3: reject future times. Parent mistypes 23:00 when they meant 11:00 →
+  // adjustMedTime stamps the future stamp, re-runs detection (no fat-meal at 23:00),
+  // withFat may flip true→false. Block at the editor so the parent can correct without
+  // wedging the slot.
+  if (_hhmmToMinutes(picked) > _hhmmToMinutes(_currentHHMM())) {
+    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Time must be in the past');
+    if (input) { try { input.focus(); } catch(e) {} }
+    return;
+  }
+  // T2-B.2: pass the captured day to adjustMedTime so it can detect midnight rollover.
+  const capturedDay = input && input.dataset ? input.dataset.capturedDay : null;
+  adjustMedTime(name, idx, picked, capturedDay);
 }
 
 function markMedSkipped(name, idx) {
@@ -28029,8 +28092,9 @@ function _obGetPackList(wx, ageM) {
     items.push('Extra outfit (#2)');
   }
 
-  // Medical context
-  var vitD3Needed = _obCheckVitD3();
+  // Medical context — T2-B.4: outing-pack intent, skip != resolved (parent might undo
+  // or the morning skip might not preclude bringing the bottle on an afternoon outing).
+  var vitD3Needed = _obCheckVitD3Needed('outing-pack');
   if (vitD3Needed) items.push('Vitamin D3 drops');
 
   if (_obIsTeethingActive() && !items.some(function(i) { return i.indexOf('Teething') >= 0; })) {
@@ -28232,8 +28296,10 @@ function _obRenderActivity(outing) {
 function _obRenderMedical() {
   var items = [];
 
-  // Vit D3 check
-  var vitD3 = _obCheckVitD3();
+  // Vit D3 check — T2-B.4: outing-give intent, skip != resolved (still surface as a
+  // checkable item on the outing checklist; parent may have skipped this morning for a
+  // reason that doesn't apply to the outing itself, e.g. brand swap pending).
+  var vitD3 = _obCheckVitD3Needed('outing-give');
   if (vitD3) {
     items.push({ icon: 'pill', color: 'sky', text: 'Give Vit D3 before leaving (if not already given today)' });
   }
@@ -28284,24 +28350,26 @@ function _obIsTeethingActive() {
   });
 }
 
-function _obCheckVitD3() {
-  // Returns true if Vit D3 needs attention.
-  // CR-5: Skipped doses count as RESOLVED — parent explicitly chose to skip and
-  // _obCheckVitD3 must respect that decision, otherwise the home overlay keeps
-  // flagging 'D3 pending' in contradiction to the parent's just-recorded skip.
+// T2-B.4: intent-aware D3 surfacing. V-M-67/74's original "skip counts as resolved"
+// doctrine was correct for the home overlay (parent sees the dose as handled, don't nag).
+// The same helper services the outing-planner packing list + outing give-list, where
+// skip != resolved — a 7 AM misclick-skip would silently suppress D3 from packing for an
+// afternoon outing. Route the semantic by intent:
+//   'overlay'      — skip counts as resolved (parent decided; don't keep flagging)
+//   'outing-pack'  — skip != resolved (still pack the bottle; parent may undo or re-give)
+//   'outing-give'  — skip != resolved (still surface as checkable on the outing)
+// 'done' is universally resolved across all intents.
+function _obCheckVitD3Needed(intent) {
   var todayStr = today();
   var dayEntry = medChecks ? medChecks[todayStr] : null;
-  if (!dayEntry) return true;
-  var d3Resolved = false;
   var activeMeds = (meds || []).filter(function(m) { return m.active; });
-  activeMeds.forEach(function(m) {
-    if (m.name && m.name.toLowerCase().indexOf('d3') >= 0) {
-      if (medCheckIsDone(dayEntry[m.name]) || medCheckSkipped(dayEntry[m.name])) {
-        d3Resolved = true;
-      }
-    }
-  });
-  return !d3Resolved;
+  var d3 = null;
+  activeMeds.forEach(function(m) { if (m.name && m.name.toLowerCase().indexOf('d3') >= 0) d3 = m; });
+  if (!d3) return false;
+  var todayCheck = dayEntry ? dayEntry[d3.name] : null;
+  if (medCheckIsDone(todayCheck)) return false;
+  if (intent === 'overlay' && medCheckSkipped(todayCheck)) return false;
+  return true;
 }
 
 function _obGetNextVaccine() {

--- a/index.html
+++ b/index.html
@@ -17321,6 +17321,9 @@ function _refreshTodayMedWithFat() {
     // save should flip null → true the same way it flips false → true. Also closes a small
     // legacy-record gap: pre-CR-10 strings parse to withFat:null and were never redetected;
     // post-fix they flip to true on the first qualifying meal save like any other record.
+    // V-K-99 (Kael synth-fold): CR-14 invariant proof site. `parsed.withFat === true`
+    // short-circuits here, so a true observation is never overwritten by this helper —
+    // future Censors tracing CR-14 land on this line.
     if (parsed.withFat === true) return; // already positive — never erase a real observation
     var fresh = _detectFatContextNearTime(parsed.givenAt, t);
     if (fresh.withFat === true) {
@@ -23840,7 +23843,14 @@ function markMedDone(name, idx, givenTime) {
   // first qualifying meal save (per CR-14 + T1-1 doctrine), so the unknown state
   // self-resolves once the parent logs breakfast.
   const dayFeed = feedingData[todayStr] || {};
-  const noMealsLoggedToday = !['breakfast','lunch','dinner','snack'].some(function(m) { return dayFeed[m] && String(dayFeed[m]).trim(); });
+  // V-M-89 (Maren synth-fold): defensive against legacy installs where a meal field was
+  // stored as the literal string 'null' or 'undefined' (pre-CR-10 corner). Without the
+  // explicit guards a truthy-non-empty 'null' string would short-circuit noMealsLoggedToday
+  // → withFat:false written → false "no fat-meal" badge fires on a 7:55 AM dose.
+  const noMealsLoggedToday = !['breakfast','lunch','dinner','snack'].some(function(m) {
+    var v = dayFeed[m];
+    return v && String(v).trim() && v !== 'null' && v !== 'undefined';
+  });
   const writeWithFat = (fat.withFat === false && noMealsLoggedToday) ? null : fat.withFat;
   if (!medChecks[todayStr]) medChecks[todayStr] = {};
   medChecks[todayStr][name] = {
@@ -23891,6 +23901,9 @@ function confirmMedDoneAt(name, idx) {
   }
   // T2-B.3: reject future times. A mistyped 23:00 (meant 11:00) would stamp the future,
   // re-run detection at an empty window, and silently corrupt withFat. Block at the editor.
+  // V-M-90 (Maren synth-fold): strict `>` — same-minute picks are accepted as "just now"
+  // (parent logs within the wall-clock minute the dose was actually given). `>=` would
+  // forbid the most common case of "I just gave it" within the current minute.
   if (_hhmmToMinutes(picked) > _hhmmToMinutes(_currentHHMM())) {
     if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Time must be in the past');
     if (input) { try { input.focus(); } catch(e) {} }
@@ -23963,7 +23976,11 @@ function adjustMedTime(name, idx, newTime, dayStr) {
   // in the now-empty new-date slot.
   const todayStr = dayStr || today();
   if (todayStr !== today()) {
-    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Date changed — please re-open Adjust on yesterday\'s record');
+    // V-M-88 (Maren synth-fold): soften toast — no past-day Adjust UI exists in v1
+    // (the spec confirms past-day adjusts continue to use resolveMissedMed). A tired
+    // parent at 00:01 reading "please re-open Adjust on yesterday's record" would tap
+    // around looking for a button that isn't there. Reassure that the prior save stands.
+    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Date changed at midnight — yesterday\'s dose is already saved');
     renderRemindersAndAlerts();
     renderHomeContextAlerts();
     return;
@@ -24037,7 +24054,7 @@ function confirmMedAdjust(name, idx) {
   // T2-B.3: reject future times. Parent mistypes 23:00 when they meant 11:00 →
   // adjustMedTime stamps the future stamp, re-runs detection (no fat-meal at 23:00),
   // withFat may flip true→false. Block at the editor so the parent can correct without
-  // wedging the slot.
+  // wedging the slot. Strict `>` per V-M-90 — same-minute picks pass (see confirmMedDoneAt).
   if (_hhmmToMinutes(picked) > _hhmmToMinutes(_currentHHMM())) {
     if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Time must be in the past');
     if (input) { try { input.focus(); } catch(e) {} }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.25-5",
+  "version": "2026.05.25-6",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.25-3",
+  "version": "2026.05.25-5",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -187,7 +187,14 @@ function _refreshTodayMedWithFat() {
     if (!parsed) return;
     if (parsed.status !== 'done' && parsed.status !== 'late') return;
     if (!parsed.givenAt) return;
-    if (parsed.withFat !== false) return; // only redetect when previously negative
+    // T2-B.1 (Phase 2-B) extension of CR-14: redetect for any non-true prior observation,
+    // not just === false. The three-state schema introduced by T2-B.1 at markMedDone writes
+    // withFat:null when no meals were logged at dose-time (an "unknown" state, not a
+    // "negative" state). The same self-resolving contract applies — the parent's later meal
+    // save should flip null → true the same way it flips false → true. Also closes a small
+    // legacy-record gap: pre-CR-10 strings parse to withFat:null and were never redetected;
+    // post-fix they flip to true on the first qualifying meal save like any other record.
+    if (parsed.withFat === true) return; // already positive — never erase a real observation
     var fresh = _detectFatContextNearTime(parsed.givenAt, t);
     if (fresh.withFat === true) {
       // Preserve the rest of the object; only update the fat fields.

--- a/split/core.js
+++ b/split/core.js
@@ -194,6 +194,9 @@ function _refreshTodayMedWithFat() {
     // save should flip null → true the same way it flips false → true. Also closes a small
     // legacy-record gap: pre-CR-10 strings parse to withFat:null and were never redetected;
     // post-fix they flip to true on the first qualifying meal save like any other record.
+    // V-K-99 (Kael synth-fold): CR-14 invariant proof site. `parsed.withFat === true`
+    // short-circuits here, so a true observation is never overwritten by this helper —
+    // future Censors tracing CR-14 land on this line.
     if (parsed.withFat === true) return; // already positive — never erase a real observation
     var fresh = _detectFatContextNearTime(parsed.givenAt, t);
     if (fresh.withFat === true) {

--- a/split/home.js
+++ b/split/home.js
@@ -946,7 +946,14 @@ function markMedDone(name, idx, givenTime) {
   // first qualifying meal save (per CR-14 + T1-1 doctrine), so the unknown state
   // self-resolves once the parent logs breakfast.
   const dayFeed = feedingData[todayStr] || {};
-  const noMealsLoggedToday = !['breakfast','lunch','dinner','snack'].some(function(m) { return dayFeed[m] && String(dayFeed[m]).trim(); });
+  // V-M-89 (Maren synth-fold): defensive against legacy installs where a meal field was
+  // stored as the literal string 'null' or 'undefined' (pre-CR-10 corner). Without the
+  // explicit guards a truthy-non-empty 'null' string would short-circuit noMealsLoggedToday
+  // → withFat:false written → false "no fat-meal" badge fires on a 7:55 AM dose.
+  const noMealsLoggedToday = !['breakfast','lunch','dinner','snack'].some(function(m) {
+    var v = dayFeed[m];
+    return v && String(v).trim() && v !== 'null' && v !== 'undefined';
+  });
   const writeWithFat = (fat.withFat === false && noMealsLoggedToday) ? null : fat.withFat;
   if (!medChecks[todayStr]) medChecks[todayStr] = {};
   medChecks[todayStr][name] = {
@@ -997,6 +1004,9 @@ function confirmMedDoneAt(name, idx) {
   }
   // T2-B.3: reject future times. A mistyped 23:00 (meant 11:00) would stamp the future,
   // re-run detection at an empty window, and silently corrupt withFat. Block at the editor.
+  // V-M-90 (Maren synth-fold): strict `>` — same-minute picks are accepted as "just now"
+  // (parent logs within the wall-clock minute the dose was actually given). `>=` would
+  // forbid the most common case of "I just gave it" within the current minute.
   if (_hhmmToMinutes(picked) > _hhmmToMinutes(_currentHHMM())) {
     if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Time must be in the past');
     if (input) { try { input.focus(); } catch(e) {} }
@@ -1069,7 +1079,11 @@ function adjustMedTime(name, idx, newTime, dayStr) {
   // in the now-empty new-date slot.
   const todayStr = dayStr || today();
   if (todayStr !== today()) {
-    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Date changed — please re-open Adjust on yesterday\'s record');
+    // V-M-88 (Maren synth-fold): soften toast — no past-day Adjust UI exists in v1
+    // (the spec confirms past-day adjusts continue to use resolveMissedMed). A tired
+    // parent at 00:01 reading "please re-open Adjust on yesterday's record" would tap
+    // around looking for a button that isn't there. Reassure that the prior save stands.
+    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Date changed at midnight — yesterday\'s dose is already saved');
     renderRemindersAndAlerts();
     renderHomeContextAlerts();
     return;
@@ -1143,7 +1157,7 @@ function confirmMedAdjust(name, idx) {
   // T2-B.3: reject future times. Parent mistypes 23:00 when they meant 11:00 →
   // adjustMedTime stamps the future stamp, re-runs detection (no fat-meal at 23:00),
   // withFat may flip true→false. Block at the editor so the parent can correct without
-  // wedging the slot.
+  // wedging the slot. Strict `>` per V-M-90 — same-minute picks pass (see confirmMedDoneAt).
   if (_hhmmToMinutes(picked) > _hhmmToMinutes(_currentHHMM())) {
     if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Time must be in the past');
     if (input) { try { input.focus(); } catch(e) {} }

--- a/split/home.js
+++ b/split/home.js
@@ -935,12 +935,25 @@ function markMedDone(name, idx, givenTime) {
   const loggedAt = now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
   const givenAt = (typeof givenTime === 'string' && /^\d{1,2}:\d{2}$/.test(givenTime)) ? givenTime : loggedAt;
   const fat = _detectFatContextNearTime(givenAt, todayStr);
+  // T2-B.1: half-awake morning. Parent gives D3 at 7:55 AM BEFORE logging breakfast.
+  // _detectFatContextNearTime finds no meal in window → returns withFat:false. The
+  // reminder card would immediately show "no fat-meal logged nearby" — false negative
+  // because the parent simply hasn't logged the meal YET. Three-state schema: when
+  // detection finds no fat AND zero meals logged today AT ALL, write withFat:null
+  // (unknown) instead of withFat:false. The render side already gates the badge on
+  // `withFat === false` (line ~742), so null naturally suppresses the badge. The
+  // refresh helper at core.js _refreshTodayMedWithFat flips null/false → true on the
+  // first qualifying meal save (per CR-14 + T1-1 doctrine), so the unknown state
+  // self-resolves once the parent logs breakfast.
+  const dayFeed = feedingData[todayStr] || {};
+  const noMealsLoggedToday = !['breakfast','lunch','dinner','snack'].some(function(m) { return dayFeed[m] && String(dayFeed[m]).trim(); });
+  const writeWithFat = (fat.withFat === false && noMealsLoggedToday) ? null : fat.withFat;
   if (!medChecks[todayStr]) medChecks[todayStr] = {};
   medChecks[todayStr][name] = {
     status:   'done',
     givenAt:  givenAt,
     loggedAt: loggedAt,
-    withFat:  fat.withFat,
+    withFat:  writeWithFat,
     fatFood:  fat.fatFood,
     fatDelta: fat.fatDelta,
   };
@@ -982,7 +995,19 @@ function confirmMedDoneAt(name, idx) {
     if (input) { try { input.focus(); } catch(e) {} }
     return;
   }
+  // T2-B.3: reject future times. A mistyped 23:00 (meant 11:00) would stamp the future,
+  // re-run detection at an empty window, and silently corrupt withFat. Block at the editor.
+  if (_hhmmToMinutes(picked) > _hhmmToMinutes(_currentHHMM())) {
+    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Time must be in the past');
+    if (input) { try { input.focus(); } catch(e) {} }
+    return;
+  }
   markMedDone(name, idx, picked);
+}
+// T2-B.3 helper: canonical 24h HH:MM for current wall-clock, matching the en-GB storage
+// convention (V-M-60). Used by the future-time gate in confirmMedDoneAt + confirmMedAdjust.
+function _currentHHMM() {
+  return new Date().toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
 }
 function cancelMedDoneAt(idx) {
   renderRemindersAndAlerts();
@@ -1035,8 +1060,20 @@ function undoMedSkip(name, idx) {
 // Adjust the administration time of an already-logged dose. Re-runs with-fat
 // detection on the new givenAt. Works on today's dose (the only adjust surface
 // in v1; past-day adjusts continue to use resolveMissedMed).
-function adjustMedTime(name, idx, newTime) {
-  const todayStr = today();
+function adjustMedTime(name, idx, newTime, dayStr) {
+  // T2-B.2: dayStr is the captured-at-open day. Defaults to today() for legacy callers.
+  // If today() has rolled past the captured day (parent opened editor at 23:58, saved at
+  // 00:01), don't silently write a record on the new day's empty slot — toast and abort
+  // so the parent knows why Save didn't take effect. Pre-fix the function would no-op
+  // silently because medChecks[newToday][name] was undefined, leaving the editor wedged
+  // in the now-empty new-date slot.
+  const todayStr = dayStr || today();
+  if (todayStr !== today()) {
+    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Date changed — please re-open Adjust on yesterday\'s record');
+    renderRemindersAndAlerts();
+    renderHomeContextAlerts();
+    return;
+  }
   if (!medChecks[todayStr] || !medChecks[todayStr][name]) return;
   if (!newTime || !/^\d{1,2}:\d{2}$/.test(newTime)) return;
   const existing = parseMedCheck(medChecks[todayStr][name]);
@@ -1048,7 +1085,12 @@ function adjustMedTime(name, idx, newTime) {
   // false, the parent's earlier observation is the source of truth — they may have
   // edited the meal text after the fact, or the new time happens to fall outside
   // the ±60min window even though the original pairing was real.
-  const preserveWithFat = (existing.withFat === true && fat.withFat === false);
+  // T2-B.5 (V-M-77): tighten the truth-table from `=== false` to `!== true` so a future
+  // _detectFatContextNearTime that legitimately returns withFat:null (unknown) doesn't
+  // accidentally erase a positive observation. Currently dead path (detector always
+  // returns boolean per core.js:_detectFatContextNearTime) — doctrine-cleaner for the
+  // T2-B.1 three-state schema that introduces withFat:null at the markMedDone path.
+  const preserveWithFat = (existing.withFat === true && fat.withFat !== true);
   // V-M-65: canonical 24h storage (en-GB).
   medChecks[todayStr][name] = {
     status:   existing.status,
@@ -1078,9 +1120,12 @@ function openMedAdjust(name, idx) {
   const curAt = cur && cur.givenAt ? cur.givenAt : '';
   const norm = String(curAt).replace(/\s*(AM|PM)\s*$/i, '');
   const hint = norm ? '' : '<span class="supp-adjust-hint t-sub t-sm">No time captured — enter actual time:</span>';
+  // T2-B.2: capture today() at editor-open time and thread via data-captured-day so
+  // confirmMedAdjust can detect midnight rollover before writing to the wrong slot.
+  const capturedToday = today();
   actionRow.innerHTML =
     hint +
-    '<input type="time" class="supp-time-input" id="supp-time-' + idx + '" value="' + escAttr(norm) + '">' +
+    '<input type="time" class="supp-time-input" id="supp-time-' + idx + '" value="' + escAttr(norm) + '" data-captured-day="' + escAttr(capturedToday) + '">' +
     '<button class="supp-check-btn" data-action="confirmMedAdjust" data-arg="' + escAttr(name) + '" data-arg2="' + idx + '">Save</button>' +
     '<button class="supp-skip-btn" data-action="cancelMedDoneAt" data-arg2="' + idx + '">Cancel</button>';
 }
@@ -1095,7 +1140,18 @@ function confirmMedAdjust(name, idx) {
     if (input) { try { input.focus(); } catch(e) {} }
     return;
   }
-  adjustMedTime(name, idx, picked);
+  // T2-B.3: reject future times. Parent mistypes 23:00 when they meant 11:00 →
+  // adjustMedTime stamps the future stamp, re-runs detection (no fat-meal at 23:00),
+  // withFat may flip true→false. Block at the editor so the parent can correct without
+  // wedging the slot.
+  if (_hhmmToMinutes(picked) > _hhmmToMinutes(_currentHHMM())) {
+    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Time must be in the past');
+    if (input) { try { input.focus(); } catch(e) {} }
+    return;
+  }
+  // T2-B.2: pass the captured day to adjustMedTime so it can detect midnight rollover.
+  const capturedDay = input && input.dataset ? input.dataset.capturedDay : null;
+  adjustMedTime(name, idx, picked, capturedDay);
 }
 
 function markMedSkipped(name, idx) {
@@ -5142,8 +5198,9 @@ function _obGetPackList(wx, ageM) {
     items.push('Extra outfit (#2)');
   }
 
-  // Medical context
-  var vitD3Needed = _obCheckVitD3();
+  // Medical context — T2-B.4: outing-pack intent, skip != resolved (parent might undo
+  // or the morning skip might not preclude bringing the bottle on an afternoon outing).
+  var vitD3Needed = _obCheckVitD3Needed('outing-pack');
   if (vitD3Needed) items.push('Vitamin D3 drops');
 
   if (_obIsTeethingActive() && !items.some(function(i) { return i.indexOf('Teething') >= 0; })) {
@@ -5345,8 +5402,10 @@ function _obRenderActivity(outing) {
 function _obRenderMedical() {
   var items = [];
 
-  // Vit D3 check
-  var vitD3 = _obCheckVitD3();
+  // Vit D3 check — T2-B.4: outing-give intent, skip != resolved (still surface as a
+  // checkable item on the outing checklist; parent may have skipped this morning for a
+  // reason that doesn't apply to the outing itself, e.g. brand swap pending).
+  var vitD3 = _obCheckVitD3Needed('outing-give');
   if (vitD3) {
     items.push({ icon: 'pill', color: 'sky', text: 'Give Vit D3 before leaving (if not already given today)' });
   }
@@ -5397,24 +5456,26 @@ function _obIsTeethingActive() {
   });
 }
 
-function _obCheckVitD3() {
-  // Returns true if Vit D3 needs attention.
-  // CR-5: Skipped doses count as RESOLVED — parent explicitly chose to skip and
-  // _obCheckVitD3 must respect that decision, otherwise the home overlay keeps
-  // flagging 'D3 pending' in contradiction to the parent's just-recorded skip.
+// T2-B.4: intent-aware D3 surfacing. V-M-67/74's original "skip counts as resolved"
+// doctrine was correct for the home overlay (parent sees the dose as handled, don't nag).
+// The same helper services the outing-planner packing list + outing give-list, where
+// skip != resolved — a 7 AM misclick-skip would silently suppress D3 from packing for an
+// afternoon outing. Route the semantic by intent:
+//   'overlay'      — skip counts as resolved (parent decided; don't keep flagging)
+//   'outing-pack'  — skip != resolved (still pack the bottle; parent may undo or re-give)
+//   'outing-give'  — skip != resolved (still surface as checkable on the outing)
+// 'done' is universally resolved across all intents.
+function _obCheckVitD3Needed(intent) {
   var todayStr = today();
   var dayEntry = medChecks ? medChecks[todayStr] : null;
-  if (!dayEntry) return true;
-  var d3Resolved = false;
   var activeMeds = (meds || []).filter(function(m) { return m.active; });
-  activeMeds.forEach(function(m) {
-    if (m.name && m.name.toLowerCase().indexOf('d3') >= 0) {
-      if (medCheckIsDone(dayEntry[m.name]) || medCheckSkipped(dayEntry[m.name])) {
-        d3Resolved = true;
-      }
-    }
-  });
-  return !d3Resolved;
+  var d3 = null;
+  activeMeds.forEach(function(m) { if (m.name && m.name.toLowerCase().indexOf('d3') >= 0) d3 = m; });
+  if (!d3) return false;
+  var todayCheck = dayEntry ? dayEntry[d3.name] : null;
+  if (medCheckIsDone(todayCheck)) return false;
+  if (intent === 'overlay' && medCheckSkipped(todayCheck)) return false;
+  return true;
 }
 
 function _obGetNextVaccine() {

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -17314,7 +17314,14 @@ function _refreshTodayMedWithFat() {
     if (!parsed) return;
     if (parsed.status !== 'done' && parsed.status !== 'late') return;
     if (!parsed.givenAt) return;
-    if (parsed.withFat !== false) return; // only redetect when previously negative
+    // T2-B.1 (Phase 2-B) extension of CR-14: redetect for any non-true prior observation,
+    // not just === false. The three-state schema introduced by T2-B.1 at markMedDone writes
+    // withFat:null when no meals were logged at dose-time (an "unknown" state, not a
+    // "negative" state). The same self-resolving contract applies — the parent's later meal
+    // save should flip null → true the same way it flips false → true. Also closes a small
+    // legacy-record gap: pre-CR-10 strings parse to withFat:null and were never redetected;
+    // post-fix they flip to true on the first qualifying meal save like any other record.
+    if (parsed.withFat === true) return; // already positive — never erase a real observation
     var fresh = _detectFatContextNearTime(parsed.givenAt, t);
     if (fresh.withFat === true) {
       // Preserve the rest of the object; only update the fat fields.
@@ -23822,12 +23829,25 @@ function markMedDone(name, idx, givenTime) {
   const loggedAt = now.toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
   const givenAt = (typeof givenTime === 'string' && /^\d{1,2}:\d{2}$/.test(givenTime)) ? givenTime : loggedAt;
   const fat = _detectFatContextNearTime(givenAt, todayStr);
+  // T2-B.1: half-awake morning. Parent gives D3 at 7:55 AM BEFORE logging breakfast.
+  // _detectFatContextNearTime finds no meal in window → returns withFat:false. The
+  // reminder card would immediately show "no fat-meal logged nearby" — false negative
+  // because the parent simply hasn't logged the meal YET. Three-state schema: when
+  // detection finds no fat AND zero meals logged today AT ALL, write withFat:null
+  // (unknown) instead of withFat:false. The render side already gates the badge on
+  // `withFat === false` (line ~742), so null naturally suppresses the badge. The
+  // refresh helper at core.js _refreshTodayMedWithFat flips null/false → true on the
+  // first qualifying meal save (per CR-14 + T1-1 doctrine), so the unknown state
+  // self-resolves once the parent logs breakfast.
+  const dayFeed = feedingData[todayStr] || {};
+  const noMealsLoggedToday = !['breakfast','lunch','dinner','snack'].some(function(m) { return dayFeed[m] && String(dayFeed[m]).trim(); });
+  const writeWithFat = (fat.withFat === false && noMealsLoggedToday) ? null : fat.withFat;
   if (!medChecks[todayStr]) medChecks[todayStr] = {};
   medChecks[todayStr][name] = {
     status:   'done',
     givenAt:  givenAt,
     loggedAt: loggedAt,
-    withFat:  fat.withFat,
+    withFat:  writeWithFat,
     fatFood:  fat.fatFood,
     fatDelta: fat.fatDelta,
   };
@@ -23869,7 +23889,19 @@ function confirmMedDoneAt(name, idx) {
     if (input) { try { input.focus(); } catch(e) {} }
     return;
   }
+  // T2-B.3: reject future times. A mistyped 23:00 (meant 11:00) would stamp the future,
+  // re-run detection at an empty window, and silently corrupt withFat. Block at the editor.
+  if (_hhmmToMinutes(picked) > _hhmmToMinutes(_currentHHMM())) {
+    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Time must be in the past');
+    if (input) { try { input.focus(); } catch(e) {} }
+    return;
+  }
   markMedDone(name, idx, picked);
+}
+// T2-B.3 helper: canonical 24h HH:MM for current wall-clock, matching the en-GB storage
+// convention (V-M-60). Used by the future-time gate in confirmMedDoneAt + confirmMedAdjust.
+function _currentHHMM() {
+  return new Date().toLocaleTimeString('en-GB', { hour:'2-digit', minute:'2-digit' });
 }
 function cancelMedDoneAt(idx) {
   renderRemindersAndAlerts();
@@ -23922,8 +23954,20 @@ function undoMedSkip(name, idx) {
 // Adjust the administration time of an already-logged dose. Re-runs with-fat
 // detection on the new givenAt. Works on today's dose (the only adjust surface
 // in v1; past-day adjusts continue to use resolveMissedMed).
-function adjustMedTime(name, idx, newTime) {
-  const todayStr = today();
+function adjustMedTime(name, idx, newTime, dayStr) {
+  // T2-B.2: dayStr is the captured-at-open day. Defaults to today() for legacy callers.
+  // If today() has rolled past the captured day (parent opened editor at 23:58, saved at
+  // 00:01), don't silently write a record on the new day's empty slot — toast and abort
+  // so the parent knows why Save didn't take effect. Pre-fix the function would no-op
+  // silently because medChecks[newToday][name] was undefined, leaving the editor wedged
+  // in the now-empty new-date slot.
+  const todayStr = dayStr || today();
+  if (todayStr !== today()) {
+    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Date changed — please re-open Adjust on yesterday\'s record');
+    renderRemindersAndAlerts();
+    renderHomeContextAlerts();
+    return;
+  }
   if (!medChecks[todayStr] || !medChecks[todayStr][name]) return;
   if (!newTime || !/^\d{1,2}:\d{2}$/.test(newTime)) return;
   const existing = parseMedCheck(medChecks[todayStr][name]);
@@ -23935,7 +23979,12 @@ function adjustMedTime(name, idx, newTime) {
   // false, the parent's earlier observation is the source of truth — they may have
   // edited the meal text after the fact, or the new time happens to fall outside
   // the ±60min window even though the original pairing was real.
-  const preserveWithFat = (existing.withFat === true && fat.withFat === false);
+  // T2-B.5 (V-M-77): tighten the truth-table from `=== false` to `!== true` so a future
+  // _detectFatContextNearTime that legitimately returns withFat:null (unknown) doesn't
+  // accidentally erase a positive observation. Currently dead path (detector always
+  // returns boolean per core.js:_detectFatContextNearTime) — doctrine-cleaner for the
+  // T2-B.1 three-state schema that introduces withFat:null at the markMedDone path.
+  const preserveWithFat = (existing.withFat === true && fat.withFat !== true);
   // V-M-65: canonical 24h storage (en-GB).
   medChecks[todayStr][name] = {
     status:   existing.status,
@@ -23965,9 +24014,12 @@ function openMedAdjust(name, idx) {
   const curAt = cur && cur.givenAt ? cur.givenAt : '';
   const norm = String(curAt).replace(/\s*(AM|PM)\s*$/i, '');
   const hint = norm ? '' : '<span class="supp-adjust-hint t-sub t-sm">No time captured — enter actual time:</span>';
+  // T2-B.2: capture today() at editor-open time and thread via data-captured-day so
+  // confirmMedAdjust can detect midnight rollover before writing to the wrong slot.
+  const capturedToday = today();
   actionRow.innerHTML =
     hint +
-    '<input type="time" class="supp-time-input" id="supp-time-' + idx + '" value="' + escAttr(norm) + '">' +
+    '<input type="time" class="supp-time-input" id="supp-time-' + idx + '" value="' + escAttr(norm) + '" data-captured-day="' + escAttr(capturedToday) + '">' +
     '<button class="supp-check-btn" data-action="confirmMedAdjust" data-arg="' + escAttr(name) + '" data-arg2="' + idx + '">Save</button>' +
     '<button class="supp-skip-btn" data-action="cancelMedDoneAt" data-arg2="' + idx + '">Cancel</button>';
 }
@@ -23982,7 +24034,18 @@ function confirmMedAdjust(name, idx) {
     if (input) { try { input.focus(); } catch(e) {} }
     return;
   }
-  adjustMedTime(name, idx, picked);
+  // T2-B.3: reject future times. Parent mistypes 23:00 when they meant 11:00 →
+  // adjustMedTime stamps the future stamp, re-runs detection (no fat-meal at 23:00),
+  // withFat may flip true→false. Block at the editor so the parent can correct without
+  // wedging the slot.
+  if (_hhmmToMinutes(picked) > _hhmmToMinutes(_currentHHMM())) {
+    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Time must be in the past');
+    if (input) { try { input.focus(); } catch(e) {} }
+    return;
+  }
+  // T2-B.2: pass the captured day to adjustMedTime so it can detect midnight rollover.
+  const capturedDay = input && input.dataset ? input.dataset.capturedDay : null;
+  adjustMedTime(name, idx, picked, capturedDay);
 }
 
 function markMedSkipped(name, idx) {
@@ -28029,8 +28092,9 @@ function _obGetPackList(wx, ageM) {
     items.push('Extra outfit (#2)');
   }
 
-  // Medical context
-  var vitD3Needed = _obCheckVitD3();
+  // Medical context — T2-B.4: outing-pack intent, skip != resolved (parent might undo
+  // or the morning skip might not preclude bringing the bottle on an afternoon outing).
+  var vitD3Needed = _obCheckVitD3Needed('outing-pack');
   if (vitD3Needed) items.push('Vitamin D3 drops');
 
   if (_obIsTeethingActive() && !items.some(function(i) { return i.indexOf('Teething') >= 0; })) {
@@ -28232,8 +28296,10 @@ function _obRenderActivity(outing) {
 function _obRenderMedical() {
   var items = [];
 
-  // Vit D3 check
-  var vitD3 = _obCheckVitD3();
+  // Vit D3 check — T2-B.4: outing-give intent, skip != resolved (still surface as a
+  // checkable item on the outing checklist; parent may have skipped this morning for a
+  // reason that doesn't apply to the outing itself, e.g. brand swap pending).
+  var vitD3 = _obCheckVitD3Needed('outing-give');
   if (vitD3) {
     items.push({ icon: 'pill', color: 'sky', text: 'Give Vit D3 before leaving (if not already given today)' });
   }
@@ -28284,24 +28350,26 @@ function _obIsTeethingActive() {
   });
 }
 
-function _obCheckVitD3() {
-  // Returns true if Vit D3 needs attention.
-  // CR-5: Skipped doses count as RESOLVED — parent explicitly chose to skip and
-  // _obCheckVitD3 must respect that decision, otherwise the home overlay keeps
-  // flagging 'D3 pending' in contradiction to the parent's just-recorded skip.
+// T2-B.4: intent-aware D3 surfacing. V-M-67/74's original "skip counts as resolved"
+// doctrine was correct for the home overlay (parent sees the dose as handled, don't nag).
+// The same helper services the outing-planner packing list + outing give-list, where
+// skip != resolved — a 7 AM misclick-skip would silently suppress D3 from packing for an
+// afternoon outing. Route the semantic by intent:
+//   'overlay'      — skip counts as resolved (parent decided; don't keep flagging)
+//   'outing-pack'  — skip != resolved (still pack the bottle; parent may undo or re-give)
+//   'outing-give'  — skip != resolved (still surface as checkable on the outing)
+// 'done' is universally resolved across all intents.
+function _obCheckVitD3Needed(intent) {
   var todayStr = today();
   var dayEntry = medChecks ? medChecks[todayStr] : null;
-  if (!dayEntry) return true;
-  var d3Resolved = false;
   var activeMeds = (meds || []).filter(function(m) { return m.active; });
-  activeMeds.forEach(function(m) {
-    if (m.name && m.name.toLowerCase().indexOf('d3') >= 0) {
-      if (medCheckIsDone(dayEntry[m.name]) || medCheckSkipped(dayEntry[m.name])) {
-        d3Resolved = true;
-      }
-    }
-  });
-  return !d3Resolved;
+  var d3 = null;
+  activeMeds.forEach(function(m) { if (m.name && m.name.toLowerCase().indexOf('d3') >= 0) d3 = m; });
+  if (!d3) return false;
+  var todayCheck = dayEntry ? dayEntry[d3.name] : null;
+  if (medCheckIsDone(todayCheck)) return false;
+  if (intent === 'overlay' && medCheckSkipped(todayCheck)) return false;
+  return true;
 }
 
 function _obGetNextVaccine() {

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -17321,6 +17321,9 @@ function _refreshTodayMedWithFat() {
     // save should flip null → true the same way it flips false → true. Also closes a small
     // legacy-record gap: pre-CR-10 strings parse to withFat:null and were never redetected;
     // post-fix they flip to true on the first qualifying meal save like any other record.
+    // V-K-99 (Kael synth-fold): CR-14 invariant proof site. `parsed.withFat === true`
+    // short-circuits here, so a true observation is never overwritten by this helper —
+    // future Censors tracing CR-14 land on this line.
     if (parsed.withFat === true) return; // already positive — never erase a real observation
     var fresh = _detectFatContextNearTime(parsed.givenAt, t);
     if (fresh.withFat === true) {
@@ -23840,7 +23843,14 @@ function markMedDone(name, idx, givenTime) {
   // first qualifying meal save (per CR-14 + T1-1 doctrine), so the unknown state
   // self-resolves once the parent logs breakfast.
   const dayFeed = feedingData[todayStr] || {};
-  const noMealsLoggedToday = !['breakfast','lunch','dinner','snack'].some(function(m) { return dayFeed[m] && String(dayFeed[m]).trim(); });
+  // V-M-89 (Maren synth-fold): defensive against legacy installs where a meal field was
+  // stored as the literal string 'null' or 'undefined' (pre-CR-10 corner). Without the
+  // explicit guards a truthy-non-empty 'null' string would short-circuit noMealsLoggedToday
+  // → withFat:false written → false "no fat-meal" badge fires on a 7:55 AM dose.
+  const noMealsLoggedToday = !['breakfast','lunch','dinner','snack'].some(function(m) {
+    var v = dayFeed[m];
+    return v && String(v).trim() && v !== 'null' && v !== 'undefined';
+  });
   const writeWithFat = (fat.withFat === false && noMealsLoggedToday) ? null : fat.withFat;
   if (!medChecks[todayStr]) medChecks[todayStr] = {};
   medChecks[todayStr][name] = {
@@ -23891,6 +23901,9 @@ function confirmMedDoneAt(name, idx) {
   }
   // T2-B.3: reject future times. A mistyped 23:00 (meant 11:00) would stamp the future,
   // re-run detection at an empty window, and silently corrupt withFat. Block at the editor.
+  // V-M-90 (Maren synth-fold): strict `>` — same-minute picks are accepted as "just now"
+  // (parent logs within the wall-clock minute the dose was actually given). `>=` would
+  // forbid the most common case of "I just gave it" within the current minute.
   if (_hhmmToMinutes(picked) > _hhmmToMinutes(_currentHHMM())) {
     if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Time must be in the past');
     if (input) { try { input.focus(); } catch(e) {} }
@@ -23963,7 +23976,11 @@ function adjustMedTime(name, idx, newTime, dayStr) {
   // in the now-empty new-date slot.
   const todayStr = dayStr || today();
   if (todayStr !== today()) {
-    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Date changed — please re-open Adjust on yesterday\'s record');
+    // V-M-88 (Maren synth-fold): soften toast — no past-day Adjust UI exists in v1
+    // (the spec confirms past-day adjusts continue to use resolveMissedMed). A tired
+    // parent at 00:01 reading "please re-open Adjust on yesterday's record" would tap
+    // around looking for a button that isn't there. Reassure that the prior save stands.
+    if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Date changed at midnight — yesterday\'s dose is already saved');
     renderRemindersAndAlerts();
     renderHomeContextAlerts();
     return;
@@ -24037,7 +24054,7 @@ function confirmMedAdjust(name, idx) {
   // T2-B.3: reject future times. Parent mistypes 23:00 when they meant 11:00 →
   // adjustMedTime stamps the future stamp, re-runs detection (no fat-meal at 23:00),
   // withFat may flip true→false. Block at the editor so the parent can correct without
-  // wedging the slot.
+  // wedging the slot. Strict `>` per V-M-90 — same-minute picks pass (see confirmMedDoneAt).
   if (_hhmmToMinutes(picked) > _hhmmToMinutes(_currentHHMM())) {
     if (typeof showQLToast === 'function') showQLToast(zi('warn') + ' Time must be in the past');
     if (input) { try { input.focus(); } catch(e) {} }

--- a/tests/e2e/vit-d3-tracking-v2-tier-2-b.spec.ts
+++ b/tests/e2e/vit-d3-tracking-v2-tier-2-b.spec.ts
@@ -1,0 +1,231 @@
+import { test, expect } from '@playwright/test';
+
+// Vit D3 Tracking v2 — Tier 2 Phase 2-B regression guards.
+// Spec: docs/specs/vit-d3-tracking-v2-tier-2.md §Phase 2-B.
+// QA chain canon-cc-008: Maren Mode-1 on home.js (sole jurisdiction touched).
+// No styles.css / template.html touch → no triple-jurisdiction review.
+// No intelligence-* touch → no Kael / Vela invocation.
+
+// ── T2-B.1 ───────────────────────────────────────────────────────────────────
+test('regression-guard-d3-v2-t2-b-1: markMedDone before any meal writes withFat:null (not false)', async ({ page }) => {
+  // Trigger: half-awake morning. Parent gives D3 at 07:55 BEFORE logging breakfast.
+  // _detectFatContextNearTime finds no meal in window → withFat:false. Pre-fix the
+  // reminder card immediately shows "no fat-meal logged nearby" badge — a false negative
+  // because the parent simply hasn't logged the meal YET. T2-B.1 writes withFat:null
+  // (unknown) when no meals logged today AT ALL; the refresh helper flips null → true
+  // when the parent later saves breakfast.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.active && m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    // Zero meals logged today.
+    if (!feedingData[t]) feedingData[t] = {};
+    feedingData[t].breakfast = ''; feedingData[t].breakfast_time = '';
+    feedingData[t].lunch     = ''; feedingData[t].lunch_time     = '';
+    feedingData[t].dinner    = ''; feedingData[t].dinner_time    = '';
+    feedingData[t].snack     = ''; feedingData[t].snack_time     = '';
+    if (medChecks[t]) delete medChecks[t][d3.name];
+    markMedDone(d3.name, 0, '07:55');
+    const after = medChecks[t][d3.name];
+    // Sanity comparison: log a second dose with breakfast already in feedingData →
+    // should write withFat:false (true negative, not unknown) since meals exist but
+    // none in window.
+    feedingData[t].breakfast = 'plain idli';
+    feedingData[t].breakfast_time = '06:00'; // outside ±60min of 07:55 (delta 115min)
+    delete medChecks[t][d3.name];
+    markMedDone(d3.name, 0, '07:55');
+    const afterWithMeal = medChecks[t][d3.name];
+    return {
+      noMeals_withFat: after && after.withFat,
+      withMeal_withFat: afterWithMeal && afterWithMeal.withFat,
+    };
+  });
+
+  if ((r as any).skipped) {
+    test.skip(true, (r as any).skipped);
+    return;
+  }
+  expect(r.noMeals_withFat, 'T2-B.1: zero-meals path must write withFat:null (unknown), not false').toBeNull();
+  expect(r.withMeal_withFat, 'T2-B.1: meals-exist-but-none-in-window path stays withFat:false (true negative)').toBe(false);
+});
+
+// ── T2-B.2 ───────────────────────────────────────────────────────────────────
+test('regression-guard-d3-v2-t2-b-2: adjustMedTime midnight rollover toasts and no-ops cleanly', async ({ page }) => {
+  // Trigger: parent opens Adjust at 23:58, taps Save at 00:01. today() returns the NEW
+  // date; the record is on the prior date's key. Pre-fix adjustMedTime silently no-ops
+  // (medChecks[newToday][name] === undefined) leaving the editor wedged in the now-empty
+  // new-date slot. T2-B.2 captures the day at editor-open and threads it through; if
+  // today() has rolled past the captured day, toast + return without writing.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.active && m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    if (!medChecks[t]) medChecks[t] = {};
+    medChecks[t][d3.name] = { status:'done', givenAt:'08:00', loggedAt:'08:02', withFat:true, fatFood:'paratha', fatDelta:5 };
+    // Simulate the rollover: pass a stale dayStr (yesterday — i.e. before today())
+    // so todayStr !== today() inside adjustMedTime.
+    function back(n) {
+      const d = new Date(t + 'T12:00:00');
+      d.setDate(d.getDate() - n);
+      const y = d.getFullYear(), m = String(d.getMonth()+1).padStart(2,'0'), dd = String(d.getDate()).padStart(2,'0');
+      return y + '-' + m + '-' + dd;
+    }
+    const before = JSON.parse(JSON.stringify(medChecks[t][d3.name]));
+    // Spy on the toast.
+    let toastMsg: string | null = null;
+    const origToast = (window as any).showQLToast;
+    (window as any).showQLToast = function(msg: string) { toastMsg = msg; };
+    adjustMedTime(d3.name, 0, '08:30', back(1)); // captured-day = yesterday
+    (window as any).showQLToast = origToast;
+    const after = medChecks[t][d3.name];
+    return {
+      toastFired: !!toastMsg,
+      toastContent: toastMsg,
+      recordUnchanged: JSON.stringify(after) === JSON.stringify(before),
+    };
+  });
+
+  if ((r as any).skipped) {
+    test.skip(true, (r as any).skipped);
+    return;
+  }
+  expect(r.toastFired, 'T2-B.2: toast must fire on midnight rollover').toBe(true);
+  expect(r.toastContent, 'T2-B.2: toast names the issue').toContain('Date changed');
+  expect(r.recordUnchanged, 'T2-B.2: the existing record must be untouched on rollover').toBe(true);
+});
+
+// ── T2-B.3 ───────────────────────────────────────────────────────────────────
+test('regression-guard-d3-v2-t2-b-3: confirmMedDoneAt + confirmMedAdjust reject future times', async ({ page }) => {
+  // Trigger: parent mistypes 23:00 when they meant 11:00. Pre-fix adjustMedTime stamps
+  // the future time, re-runs detection (no fat-meal at 23:00), corrupts withFat:true→false
+  // silently. T2-B.3 gates both confirmers on a past-time check.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.active && m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    if (!medChecks[t]) medChecks[t] = {};
+    medChecks[t][d3.name] = { status:'done', givenAt:'08:00', loggedAt:'08:02', withFat:true, fatFood:'paratha', fatDelta:5 };
+    // Build a DOM stub so confirmMedAdjust can find the input.
+    const tmp = document.createElement('div');
+    tmp.innerHTML = '<input type="time" id="supp-time-0" value="23:59" data-captured-day="' + t + '">';
+    document.body.appendChild(tmp);
+    const before = JSON.parse(JSON.stringify(medChecks[t][d3.name]));
+    let toastMsg: string | null = null;
+    const origToast = (window as any).showQLToast;
+    (window as any).showQLToast = function(msg: string) { toastMsg = msg; };
+    // 23:59 is almost certainly in the future for any test-run wall-clock; if the harness
+    // somehow runs at 23:59:xx we accept either outcome (test is best-effort on that boundary).
+    const now = new Date();
+    const nowMin = now.getHours() * 60 + now.getMinutes();
+    const pickedMin = 23 * 60 + 59;
+    confirmMedAdjust(d3.name, 0);
+    (window as any).showQLToast = origToast;
+    const after = medChecks[t][d3.name];
+    document.body.removeChild(tmp);
+    return {
+      nowMin,
+      pickedIsFuture: pickedMin > nowMin,
+      toastContent: toastMsg,
+      recordUnchanged: JSON.stringify(after) === JSON.stringify(before),
+    };
+  });
+
+  if ((r as any).skipped) {
+    test.skip(true, (r as any).skipped);
+    return;
+  }
+  if (!r.pickedIsFuture) {
+    test.skip(true, 'wall-clock happens to be at 23:59 — future-time boundary not exercisable');
+    return;
+  }
+  expect(r.toastContent, 'T2-B.3: future-time toast must fire').toContain('must be in the past');
+  expect(r.recordUnchanged, 'T2-B.3: the record must NOT be mutated when future-time is rejected').toBe(true);
+});
+
+// ── T2-B.4 ───────────────────────────────────────────────────────────────────
+test('regression-guard-d3-v2-t2-b-4: outing-planner intents — skip-today still surfaces D3 for outing-pack + outing-give', async ({ page }) => {
+  // Trigger: V-M-67/74's "skip counts as resolved" doctrine was authored for the home
+  // overlay. The same helper services outing-planner. A 7 AM misclick-skip silently
+  // suppresses D3 from packing/give surfaces for an afternoon outing. T2-B.4 routes by
+  // intent: 'overlay' keeps the original behavior; 'outing-pack' and 'outing-give'
+  // treat skip != resolved.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.active && m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    if (!medChecks[t]) medChecks[t] = {};
+    // Seed skipped today.
+    medChecks[t][d3.name] = { status:'skipped', givenAt:null, loggedAt:'07:00', withFat:null, fatFood:null, fatDelta:null };
+    const overlay   = _obCheckVitD3Needed('overlay');
+    const outPack   = _obCheckVitD3Needed('outing-pack');
+    const outGive   = _obCheckVitD3Needed('outing-give');
+    // Sanity contrast: done suppresses everywhere.
+    medChecks[t][d3.name] = { status:'done', givenAt:'08:00', loggedAt:'08:02', withFat:true, fatFood:'paratha', fatDelta:5 };
+    const overlayDone = _obCheckVitD3Needed('overlay');
+    const packDone    = _obCheckVitD3Needed('outing-pack');
+    const giveDone    = _obCheckVitD3Needed('outing-give');
+    return { overlay, outPack, outGive, overlayDone, packDone, giveDone };
+  });
+
+  if ((r as any).skipped) {
+    test.skip(true, (r as any).skipped);
+    return;
+  }
+  // Skip today:
+  expect(r.overlay,  'T2-B.4: overlay intent treats skip as resolved (V-M-67/74)').toBe(false);
+  expect(r.outPack,  'T2-B.4: outing-pack intent must STILL surface D3 after a morning skip').toBe(true);
+  expect(r.outGive,  'T2-B.4: outing-give intent must STILL surface D3 after a morning skip').toBe(true);
+  // Done today:
+  expect(r.overlayDone, 'T2-B.4: done is universally resolved (overlay)').toBe(false);
+  expect(r.packDone,    'T2-B.4: done is universally resolved (outing-pack)').toBe(false);
+  expect(r.giveDone,    'T2-B.4: done is universally resolved (outing-give)').toBe(false);
+});
+
+// ── T2-B.5 ───────────────────────────────────────────────────────────────────
+test('regression-guard-d3-v2-t2-b-5: adjustMedTime preserves withFat:true against a null re-detection', async ({ page }) => {
+  // Trigger: currently dead path (_detectFatContextNearTime always returns boolean per
+  // core.js). Doctrine-cleaner: if a future detector legitimately returns withFat:null
+  // (e.g. T2-B.1's three-state schema spreads to detection), the existing `=== false`
+  // check would NOT preserve a prior positive observation. The `!== true` widen does.
+  await page.goto('/index.html?nosync');
+  await page.waitForTimeout(700);
+
+  const r = await page.evaluate(() => {
+    const d3 = (meds || []).find(m => m.active && m.name && m.name.toLowerCase().includes('d3'));
+    if (!d3) return { skipped: 'no D3 med' };
+    const t = today();
+    if (!medChecks[t]) medChecks[t] = {};
+    medChecks[t][d3.name] = { status:'done', givenAt:'08:45', loggedAt:'08:46', withFat:true, fatFood:'paratha', fatDelta:5 };
+    // Stub _detectFatContextNearTime to return withFat:null for the duration of the test.
+    const origDetect = (window as any)._detectFatContextNearTime;
+    (window as any)._detectFatContextNearTime = function() { return { withFat:null, fatFood:null, fatDelta:null }; };
+    adjustMedTime(d3.name, 0, '08:50');
+    (window as any)._detectFatContextNearTime = origDetect;
+    const after = medChecks[t][d3.name];
+    return {
+      afterGivenAt: after && after.givenAt,
+      afterWithFat: after && after.withFat,
+      afterFood:    after && after.fatFood,
+    };
+  });
+
+  if ((r as any).skipped) {
+    test.skip(true, (r as any).skipped);
+    return;
+  }
+  expect(r.afterGivenAt, 'T2-B.5: Adjust still updates givenAt').toBe('08:50');
+  expect(r.afterWithFat, 'T2-B.5 (V-M-77): null detection must NOT erase a prior true (preserve path)').toBe(true);
+  expect(r.afterFood,    'T2-B.5: prior fatFood preserved when preserveWithFat triggers').toBe('paratha');
+});

--- a/tests/e2e/vit-d3-tracking-v2.spec.ts
+++ b/tests/e2e/vit-d3-tracking-v2.spec.ts
@@ -177,9 +177,12 @@ test('regression-guard-d3-v2-t1-4: _refreshTodayMedWithFat triggers re-renders o
     };
   });
 
-  expect(r.beforeWithFat).toBe(false);
+  // T2-B.1 (Phase 2-B): markMedDone with no meals logged AT ALL writes withFat:null
+  // instead of withFat:false. The refresh helper's new `=== true` gate accepts both null
+  // and false as redetection candidates, preserving T1-4's flip contract for both shapes.
+  expect(r.beforeWithFat, 'dose logged before any meal must initially be a non-true observation (null or false)').not.toBe(true);
   expect(r.mutated, 'helper must report mutation').toBe(true);
-  expect(r.afterWithFat, 'flip false → true on retroactive fat-meal').toBe(true);
+  expect(r.afterWithFat, 'flip non-true → true on retroactive fat-meal').toBe(true);
   expect(r.reminderCalls, 'T1-4: renderRemindersAndAlerts fires on flip').toBeGreaterThanOrEqual(1);
   expect(r.contextCalls,  'T1-4: renderHomeContextAlerts fires on flip').toBeGreaterThanOrEqual(1);
   expect(r.patternCalls,  'T1-4: renderMedD3PatternCard fires on flip').toBeGreaterThanOrEqual(1);

--- a/tests/e2e/vit-d3-tracking.spec.ts
+++ b/tests/e2e/vit-d3-tracking.spec.ts
@@ -334,17 +334,20 @@ test('regression-guard-d3-skipped-surface-renders: skipped state renders an expl
     // Force a re-render
     renderRemindersAndAlerts();
     const html = window._remindersHTML || '';
+    // T2-B.4 (Phase 2-B): _obCheckVitD3 renamed to _obCheckVitD3Needed(intent). The
+    // home-overlay invocation pattern uses 'overlay' intent which preserves the original
+    // V-M-67/74 "skip counts as resolved" doctrine.
     return {
       hasSkippedCard: html.indexOf('supp-alert-skipped') >= 0,
       hasUndoButton: html.indexOf('Undo skip') >= 0,
-      obCheck: _obCheckVitD3(),
+      obCheck: _obCheckVitD3Needed('overlay'),
       storedShape: typeof medChecks[today()][d3.name],
     };
   });
 
   expect(r.hasSkippedCard, 'isSkipped state must render its own card').toBe(true);
   expect(r.hasUndoButton, 'skipped card must surface an Undo affordance').toBe(true);
-  expect(r.obCheck, '_obCheckVitD3 must treat skip as resolved (false = no attention needed)').toBe(false);
+  expect(r.obCheck, '_obCheckVitD3Needed(overlay) must treat skip as resolved (false = no attention needed)').toBe(false);
   expect(r.storedShape, 'markMedSkipped must now emit object schema').toBe('object');
 });
 
@@ -504,7 +507,12 @@ test('regression-guard-d3-snapshot-fat-refresh: logging a fat-meal AFTER the dos
     };
   });
 
-  expect(r.beforeWithFat, 'dose logged before meal must initially be withFat:false').toBe(false);
+  // T2-B.1 (Phase 2-B): markMedDone with feedingData[t] empty (no meals AT ALL logged today)
+  // now writes withFat:null instead of withFat:false — "unknown" not "negative." The refresh
+  // helper at _refreshTodayMedWithFat redetects on `withFat !== true` post-T2-B.1 so the
+  // null state self-resolves to true the same way false used to. Accept either negative
+  // start state; what matters is the flip to true after the meal save.
+  expect(r.beforeWithFat, 'dose logged before any meal must initially be a non-true observation (null or false)').not.toBe(true);
   expect(r.afterWithFat, 'after the meal is logged, refresh must flip withFat to true').toBe(true);
   expect(r.afterFood).toBe('ghee');
 });


### PR DESCRIPTION
Implements five items from [`docs/specs/vit-d3-tracking-v2-tier-2.md` §Phase 2-B](../blob/main/docs/specs/vit-d3-tracking-v2-tier-2.md) — write-path defence-in-depth for the home.js D3 surface. Second of three Tier 2 phases.

## Items shipped

### T2-B.1 — markMedDone three-state withFat schema (`split/home.js` + `split/core.js`)

Pre-fix the half-awake morning broke the badge: parent gives D3 at 7:55 BEFORE logging breakfast → `_detectFatContextNearTime` finds no meal → `withFat:false` → reminder shows "no fat-meal logged nearby" as a false negative. T2-B.1 writes `withFat:null` (unknown) when no meals AT ALL logged today; the existing badge gate at `home.js:742` (`=== false`) suppresses for null naturally.

**`core.js` fold** (Kael-jurisdiction): spec stated the refresh helper "already flips null/false → true" but the live gate at `core.js:190` was `withFat !== false` (strict) — null records were never redetected. One-line widen to `withFat === true` (skip-when-already-positive) closes the spec-implementation drift AND a small legacy-record gap (pre-CR-10 strings parse to `withFat:null` and were never redetected; post-fix they flip to true on the first qualifying meal save like any other record).

### T2-B.2 — adjustMedTime midnight rollover (`split/home.js`)

Capture `today()` at `openMedAdjust` via `data-captured-day`; thread through `confirmMedAdjust` → `adjustMedTime` new `dayStr` 4th arg; toast + abort cleanly if the captured day mismatches current `today()`. V-M-88 softened the toast wording — no past-day Adjust UI exists in v1.

### T2-B.3 — Future-time rejection (`split/home.js`)

Both `confirmMedDoneAt` + `confirmMedAdjust` gate on `_hhmmToMinutes(picked) > _hhmmToMinutes(_currentHHMM())`. New `_currentHHMM()` helper in home.js keeps the chain Maren-only. V-M-90 documents the strict `>` doctrine inline (same-minute picks accepted as "just now").

### T2-B.4 — Outing-planner intent-aware skip semantics (`split/home.js`)

Rename `_obCheckVitD3` → `_obCheckVitD3Needed(intent)`. `'overlay'` preserves V-M-67/74; `'outing-pack'` + `'outing-give'` treat skip ≠ resolved. Two live callers updated.

### T2-B.5 (V-M-77) — preserveWithFat truth-table tightening (`split/home.js`)

One-character delta `fat.withFat === false` → `fat.withFat !== true`. Doctrine-aligned with T2-B.1's three-state contract.

## Tests

New file `tests/e2e/vit-d3-tracking-v2-tier-2-b.spec.ts` — 5 regression guards (t2-b-1..t2-b-5). All 41 vit-d3 surface tests green; full e2e 173/175 (1 skip + 1 pre-existing `smoke.spec.ts:723 Build script contract` failure from PR #120, out of scope).

**Two pre-existing tests updated** to align with the new schemas:
- `vit-d3-tracking.spec.ts skipped-surface-renders` — uses renamed `_obCheckVitD3Needed('overlay')`
- `vit-d3-tracking.spec.ts snapshot-fat-refresh` + `vit-d3-tracking-v2.spec.ts t1-4` — assert `beforeWithFat.not.toBe(true)` instead of strict `=== false` (covers both null and false negative observations under the T2-B.1 schema)

## canon-cc-008 chain — discharged

**Round 1 (parallel):**
- **Maren Mode-1 on `split/home.js`** → `clear-with-notes`
- **Kael Mode-1 on `split/core.js`** → `clear-with-notes`

No Vela invocation (no intelligence-*.js touch). No triple-jurisdiction (no styles.css / template.html touch).

**Cipher Edict V** → **LGTM, zero blocking findings** (2 cipher-N nits: both register-already; no action).

### Synth fold-in (folded by Lyra, commits 016ebcd + 89ca4ae)

| Tag | Origin | Fold | File |
|---|---|---|---|
| V-M-88 | Maren | Toast wording softened from "please re-open Adjust on yesterday's record" → "Date changed at midnight — yesterday's dose is already saved." No past-day Adjust UI exists in v1 | `home.js` |
| V-M-89 | Maren | `noMealsLoggedToday` predicate hardened against legacy `'null'` / `'undefined'` string values in feedingData meal fields (pre-CR-10 corner) | `home.js` |
| V-M-90 | Maren | Inline doctrine comments on both confirmers documenting the strict `>` future-time gate (same-minute picks accepted as "just now") | `home.js` |
| V-K-99 | Kael | CR-14 invariant proof comment at the new core.js refresh-helper gate — future Censors tracing CR-14 land on this line | `core.js` |
| V-K-98 | Kael | Verify-before-merge: grep confirmed no existing test asserts "legacy record withFat stays null after meal save" — closed informational, no code change | — |

### Deferred (registered, not folded — carried into Phase 2-C ledger)

| Tag | Origin | Disposition | Future home |
|---|---|---|---|
| V-M-91 | Maren | Wrap `'overlay'` / `'outing-pack'` / `'outing-give'` in a const enum. Current typo routes through `return true` fallback (safer direction) | **Phase 2-C** — clusters with audit-schema cleanup |
| V-M-92 | Maren | Integration test covering T2-B.1 + T2-B.5 cross-item trace (dose-before-meal → refresh → Adjust). Individual tests cover each in isolation | **Phase 2-C** or noise tier |

## Phase 2-C deferred ledger (cumulative across PRs #125 + #126)

After this PR merges, Phase 2-C inherits **four items** beyond its spec scope: V-M-87 (severity-register copy from #125), V-K-96 (sync→TSF rerender gap from #125), V-M-91 (intent-enum cleanup from #126), V-M-92 (integration test from #126). Per Cipher's `cipher-2` ledger nit: manageable within a single 2-C arc; surface to Architect if a fifth item lands before 2-C opens.

## Build hygiene

- `pnpm build` canonical, self-validating
- No `--no-verify`, no force-push, no destructive ops
- No model-identifier leakage in commits or PR body