### PR TITLE
milestones-tab-v1 hotfix #2 — ts migration + trajectory overhaul + dark-mode chips

### DIFF
--- a/index.html
+++ b/index.html
@@ -19030,6 +19030,32 @@ function init() {
   activityLog  = load(KEYS.activityLog, null) || {};
   if (typeof activityLog !== 'object' || activityLog === null || Array.isArray(activityLog)) activityLog = {};
 
+  // milestones-tab-v1 hotfix #2 — one-time entry.ts shape migration.
+  // PR #159 batch-2 (pre-hotfix #160) wrote evidence entries with
+  // ts: Date.now() (number); the canonical writer at intelligence-quicklog.js:
+  // _alSlotToTimestamp returns ISO string. Sort sites (renderRecentEvidence
+  // home.js:3467/3525) call .localeCompare on ts — throws on number, kills
+  // the home-tab + milestones-tab renderers downstream. Convert number-ts
+  // entries to ISO string in place; idempotent (skips string-ts entries).
+  // V-K-132 try-wrap posture so a malformed activityLog doesn't brick boot.
+  try {
+    let _alTsMigratedCount = 0;
+    Object.keys(activityLog).forEach(dateStr => {
+      const dayEntries = activityLog[dateStr];
+      if (!Array.isArray(dayEntries)) return;
+      dayEntries.forEach(entry => {
+        if (entry && typeof entry.ts === 'number' && isFinite(entry.ts)) {
+          entry.ts = new Date(entry.ts).toISOString();
+          _alTsMigratedCount++;
+        }
+      });
+    });
+    if (_alTsMigratedCount > 0) {
+      save(KEYS.activityLog, activityLog);
+      console.log('[ms-tab-v1 hotfix] migrated', _alTsMigratedCount, 'activityLog entries from number-ts to ISO-string-ts');
+    }
+  } catch (e) { console.warn('[ms-tab-v1 hotfix] activityLog ts-shape migration failed:', e); }
+
   // milestone-engine-prep-v1 PR-A — activityMeta + milestoneSuppress hydration.
   // V-K-111 floor: activityMeta is the SEPARATE per-day-meta key family (not
   // an _meta sentinel on activityLog) to avoid breaking 20+ Array.isArray
@@ -28144,8 +28170,17 @@ function renderRecentEvidence() {
   Object.entries(obsByMilestone).forEach(([ms, occs]) => {
     if (occs.length < ROLLUP_THRESHOLD) return;
     const sorted = occs.slice().sort((a, b) => {
-      const aTs = a.entry.ts || a.dateStr;
-      const bTs = b.entry.ts || b.dateStr;
+      // ts is canonically an ISO string per intelligence-quicklog.js:262, but
+      // entries written by milestones-tab-v1 batch-2 (before the hotfix in
+      // PR #160) wrote ts: Date.now() (number) — .localeCompare on number
+      // throws TypeError. Coerce both operands to string before compare so
+      // legacy in-localStorage number-ts entries don't crash this sort.
+      // The init-time _migrateActivityLogTsShape pass converts legacy
+      // entries forward; this defensive coerce closes the race where the
+      // sort runs before that migration (or on a device that hasn't loaded
+      // the migration yet via sync).
+      const aTs = String(a.entry.ts || a.dateStr || '');
+      const bTs = String(b.entry.ts || b.dateStr || '');
       return bTs.localeCompare(aTs);
     });
     rollups.push({
@@ -28204,7 +28239,13 @@ function renderRecentEvidence() {
 
   // ── Render per-day groups (excluding rolled-up entries) ──
   dayKeys.forEach((dateStr, dayIdx) => {
-    const allEntries = dayGroups[dateStr].slice().sort((a, b) => (b.ts || b._date).localeCompare(a.ts || a._date));
+    // Coerce ts to string before .localeCompare — legacy number-ts entries
+    // from PR #159 batch-2 pre-hotfix would throw TypeError. The orchestrator
+    // at renderMilestones runs renderRecentEvidence UNWRAPPED, so a throw
+    // here kills every milestones-tab-v1 surface downstream (Today header,
+    // chip strip, in-window proposals, bulk grid). Defensive coerce + the
+    // init-time _migrateActivityLogTsShape pass close the failure-class.
+    const allEntries = dayGroups[dateStr].slice().sort((a, b) => String(b.ts || b._date || '').localeCompare(String(a.ts || a._date || '')));
     const entries = allEntries.filter(e => !(e.id && rolledIds.has(e.id)));
     if (entries.length === 0) return;
 

--- a/index.html
+++ b/index.html
@@ -6253,6 +6253,11 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 .ms-traj-axis-tick { stroke:var(--mid); stroke-width:0.8; opacity:0.55; }
 .ms-traj-axis-label { font-size:8px; fill:var(--mid); font-family:'Nunito',sans-serif; opacity:0.85; }
 
+/* Lane guide-lines — very low opacity structural cue (no chart-like grid).
+   State identity is conveyed by marker color + matching legend chips. */
+.ms-traj-lane-guide { stroke:var(--mid); stroke-width:0.5; opacity:0.18; stroke-dasharray:1 2; }
+.ms-traj-lane-empty { font-size:9px; fill:var(--mid); opacity:0.4; font-family:'Nunito',sans-serif; }
+
 /* Current-age vertical indicator. Dashed; rose tint so it reads as
    "you are here" without competing with the markers. */
 .ms-traj-current { stroke:var(--tc-rose); stroke-width:1.1; stroke-dasharray:3 2; opacity:0.65; }
@@ -26658,14 +26663,23 @@ const MS_ACTIVITY_LEVEL_TIERS = [
 // intact post-global-cap-20-slice; sum (25) exceeds cap to leave room for
 // merge prioritization within the 20-marker budget per V-K-122.
 //
-// Post-overhaul (Architect feedback 2026-05-27): viewBox sized for an age-axis
-// timeline (width=360, height=72) + bottom-padding for month labels. Three
-// distinct visual states (confirmed/practicing/coming-up) — Architect call
-// over the V-V-49 2-state collapse since live use showed the merged
-// "practicing-or-in-window" bucket didn't convey state clarity warmly enough.
+// State-lanes overhaul v2 (Architect feedback 2026-05-27 #2): live use showed
+// the temporal-axis single-line design clustered badly when babies hit
+// milestone bursts at similar ages (real biology: 4-6m motor + sensory
+// cluster on the same X). 3 horizontal state-lanes (celebrated / practicing
+// / coming-up) each with collision-aware lateral spacing replace the single
+// jittered line. Shared age axis + current-age indicator span all lanes.
+// Lane height accommodates marker r=5 + padding (~28px); 3 lanes + axis ≈
+// 108px total.
 const MS_TRAJECTORY_GEOM = {
-  width: 360, height: 72,
-  padL: 12, padR: 12, padT: 6, padB: 20,
+  width: 360, height: 108,
+  padL: 14, padR: 14, padT: 6, padB: 22,
+  // Y-centers per state lane (top → bottom: celebrated → practicing → coming-up).
+  lane: { celebrated: 18, practicing: 44, comingup: 70 },
+  // Minimum horizontal spacing between markers in the same lane (~2× marker
+  // diameter so collision-pushed markers don't touch). Sorted-left-to-right
+  // walk enforces this floor.
+  laneMinSpacing: 14,
   markerR: 5, markerRSmall: 4, markerStroke: 1.8,
   confirmedCap: 12, practicingCap: 8, notYetCap: 5, globalCap: 20,
   axisTickMonths: 3,
@@ -27373,21 +27387,35 @@ function renderMsTrajectoryRibbon() {
   const allAgeM = merged.map(m => m.ageM);
   const maxMarkerAge = Math.max(...allAgeM);
   const maxAge = Math.max(currentAgeM + 2, maxMarkerAge + 1, 9);
-  const ageToX = ageM => G.padL + (Math.max(0, ageM) / maxAge) * (G.width - G.padL - G.padR);
-  // Single Y line for the markers, with tiny domain-keyed jitter so overlapping
-  // markers don't fully obscure each other. Domain lane offset is bounded
-  // (±3px max) so the markers still read as "on the timeline".
-  const cats = (window.ACTIVITY_CATEGORIES || []);
-  const domainLane = {};
-  cats.forEach((c, i) => {
-    // Spread lanes across [-3, +3] centered on 0
-    domainLane[c.key] = (i - (cats.length - 1) / 2) * (cats.length > 1 ? 6 / (cats.length - 1) : 0);
-  });
-  const baseY = G.padT + (G.height - G.padT - G.padB) / 2;
+  const innerW = G.width - G.padL - G.padR;
+  const xMin = G.padL;
+  const xMax = G.width - G.padR;
+  const ageToX = ageM => G.padL + (Math.max(0, ageM) / maxAge) * innerW;
+
+  // Lane layout — collision-aware lateral spacing within each state lane.
+  // Sorted left-to-right walk; each marker placed at max(naturalX, lastX +
+  // minSpacing) so dense bursts spread laterally instead of stacking
+  // invisibly. layoutX clamps at the right edge — overflow is rare given
+  // the sub-bucket caps but the clamp keeps markers on-canvas. naturalX is
+  // preserved on the layout object for the SVG <title> readability anchor.
+  function _layoutLane(items, laneY) {
+    const sorted = items.slice().sort((a, b) => a.ageM - b.ageM);
+    let lastX = -Infinity;
+    return sorted.map(it => {
+      const naturalX = ageToX(it.ageM);
+      let x = Math.max(naturalX, lastX + G.laneMinSpacing);
+      if (x > xMax - 2) x = xMax - 2; // clamp at right edge
+      lastX = x;
+      return Object.assign({}, it, { layoutX: x, layoutY: laneY, naturalX });
+    });
+  }
+  const celebratedLayout = _layoutLane(celebrated, G.lane.celebrated);
+  const practicingLayout = _layoutLane(practicing, G.lane.practicing);
+  const comingUpLayout   = _layoutLane(comingUp,   G.lane.comingup);
 
   // Axis ticks (every G.axisTickMonths months)
-  const axisLine = '<line class="ms-traj-axis" x1="' + G.padL + '" y1="' + (G.height - G.padB + 1)
-    + '" x2="' + (G.width - G.padR) + '" y2="' + (G.height - G.padB + 1) + '"/>';
+  const axisLine = '<line class="ms-traj-axis" x1="' + xMin + '" y1="' + (G.height - G.padB + 1)
+    + '" x2="' + xMax + '" y2="' + (G.height - G.padB + 1) + '"/>';
   const axisTicks = [];
   for (let m = 0; m <= Math.ceil(maxAge); m += G.axisTickMonths) {
     const x = ageToX(m);
@@ -27397,7 +27425,18 @@ function renderMsTrajectoryRibbon() {
       + '" text-anchor="middle">' + m + 'm</text>');
   }
 
-  // Current-age vertical indicator. Dashed; subtle but parseable.
+  // Faint lane guide-lines — very low opacity so they read as a subtle
+  // structural cue, not chart-like grid lines. State identity is conveyed
+  // by the marker color (top sage, middle amber, bottom lavender) +
+  // matching legend chips below the SVG; no explicit lane labels needed
+  // (keeps the canvas warm rather than chart-y).
+  const guides = [G.lane.celebrated, G.lane.practicing, G.lane.comingup].map(y =>
+    '<line class="ms-traj-lane-guide" x1="' + xMin + '" y1="' + y
+    + '" x2="' + xMax + '" y2="' + y + '"/>'
+  ).join('');
+  const labels = '';
+
+  // Current-age vertical indicator spanning all 3 lanes.
   const currX = ageToX(Math.min(currentAgeM, maxAge));
   const currIndicator =
       '<line class="ms-traj-current" x1="' + currX + '" y1="' + G.padT
@@ -27405,33 +27444,44 @@ function renderMsTrajectoryRibbon() {
     + '<text class="ms-traj-current-label" x="' + currX + '" y="' + (G.padT + 7)
     + '" text-anchor="middle">now</text>';
 
-  // Marker render. Three SVG shapes per state for clean differentiation
-  // (state styling lives in CSS rules keyed on data-state attribute).
-  const markers = merged.map(m => {
-    const cx = ageToX(m.ageM);
-    const cy = baseY + (domainLane[m.ms && m.ms.domain] || 0);
+  // Empty-lane fallbacks — muted "—" centered in the lane so the structural
+  // 3-state hierarchy stays visible even when a bucket is empty.
+  const emptyLaneMarker = (y) => '<text class="ms-traj-lane-empty" x="' + (xMin + innerW / 2)
+    + '" y="' + (y + 3) + '" text-anchor="middle">—</text>';
+  const emptyMarkers = [];
+  if (celebratedLayout.length === 0) emptyMarkers.push(emptyLaneMarker(G.lane.celebrated));
+  if (practicingLayout.length === 0) emptyMarkers.push(emptyLaneMarker(G.lane.practicing));
+  if (comingUpLayout.length === 0)   emptyMarkers.push(emptyLaneMarker(G.lane.comingup));
+
+  // Marker render — 3 SVG shapes per state. layoutX/layoutY come from the
+  // lane-layout pass; titleEl carries the milestone text for hover/long-press.
+  function _renderMarker(m) {
+    const cx = m.layoutX;
+    const cy = m.layoutY;
     const msId = m.ms && m.ms.id ? m.ms.id : '';
     const msText = m.ms && m.ms.text ? m.ms.text : '';
     const tappable = msId ? ' data-action="gotoMsRow" data-ms-id="' + escHtml(msId) + '"' : '';
     const titleEl = msText ? '<title>' + escHtml(msText) + '</title>' : '';
     if (m.state === 'celebrated') {
-      // Filled sage circle + soft glow via filter (CSS).
       return '<circle class="ms-trajectory-marker" data-state="celebrated"'
         + tappable + ' cx="' + cx + '" cy="' + cy + '" r="' + G.markerR + '">'
         + titleEl + '</circle>';
     }
     if (m.state === 'practicing') {
-      // Outer amber ring + inner amber dot — "in progress" shape.
       return '<g class="ms-trajectory-marker" data-state="practicing"' + tappable + '>'
         + '<circle class="ms-traj-ring" cx="' + cx + '" cy="' + cy + '" r="' + (G.markerR + 1) + '"/>'
         + '<circle class="ms-traj-core" cx="' + cx + '" cy="' + cy + '" r="' + (G.markerR - 1.5) + '"/>'
         + titleEl + '</g>';
     }
-    // comingup — outlined lavender circle, smaller; never tappable if no id
     return '<circle class="ms-trajectory-marker" data-state="comingup"'
       + tappable + ' cx="' + cx + '" cy="' + cy + '" r="' + G.markerRSmall + '">'
       + titleEl + '</circle>';
-  }).join('');
+  }
+  const markers = []
+    .concat(celebratedLayout.map(_renderMarker))
+    .concat(practicingLayout.map(_renderMarker))
+    .concat(comingUpLayout.map(_renderMarker))
+    .join('');
 
   // Legend — three swatches with distinct visual + warmer labels.
   const swatchSVG = (state) => '<svg class="ms-traj-legend-swatch" viewBox="0 0 14 14" aria-hidden="true">'
@@ -27466,10 +27516,13 @@ function renderMsTrajectoryRibbon() {
     + zi('chart-up') + '</div> Trajectory</div></div>'
     + '<svg class="ms-trajectory-svg" viewBox="0 0 ' + G.width + ' ' + G.height + '"'
     + ' preserveAspectRatio="xMidYMid meet" role="img"'
-    + ' aria-label="Milestone trajectory along Ziva\'s age in months: '
+    + ' aria-label="Milestone trajectory: '
     + nCel + ' celebrated, ' + nPra + ' practicing, ' + nCom + ' coming up. Now: '
     + (Math.round(currentAgeM * 10) / 10) + ' months">'
-    + axisLine + axisTicks.join('') + currIndicator + markers
+    + guides + labels
+    + axisLine + axisTicks.join('') + currIndicator
+    + emptyMarkers.join('')
+    + markers
     + '</svg>'
     + legend
     + '<div class="ms-trajectory-label">' + escHtml(caption) + '</div>';

--- a/index.html
+++ b/index.html
@@ -6194,10 +6194,41 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 .ms-bulk-chip-icon { font-size:var(--icon-sm); flex-shrink:0; }
 .ms-bulk-submit { margin-top:var(--sp-12); }
 
-/* ── Domain filter chips (Library sub-tab) — reads ACTIVITY_CATEGORIES ── */
-.ms-domain-filter { display:flex; gap:var(--sp-4); flex-wrap:wrap; padding:var(--sp-4) 0; }
-.ms-domain-chip { padding:var(--sp-4) var(--sp-8); border-radius:var(--r-md); background:var(--warm); border:1px solid var(--border-subtle); font-size:var(--fs-xs); cursor:pointer; }
-.ms-domain-chip[data-active="true"] { font-weight:700; }
+/* ── Domain filter chips (Library sub-tab) — reads ACTIVITY_CATEGORIES.
+   Post-Architect feedback 2026-05-27: dark-mode readability fix — chips
+   were near-invisible against the dark page (--warm background almost
+   matches surrounding card). Adding stronger background contrast + an
+   explicit active-state visual signal (lavender tint + border) so the
+   filter selection reads at a glance. ── */
+.ms-domain-filter { display:flex; gap:var(--sp-6); flex-wrap:wrap; padding:var(--sp-4) 0; }
+.ms-domain-chip {
+  padding:var(--sp-6) var(--sp-12);
+  border-radius:var(--r-md);
+  background:var(--warm);
+  border:1px solid var(--border-subtle);
+  color:var(--text);
+  font-size:var(--fs-xs);
+  cursor:pointer;
+  transition:background var(--ease-fast), border-color var(--ease-fast), color var(--ease-fast);
+}
+.ms-domain-chip:hover { background:var(--surface-lav); }
+.ms-domain-chip[data-active="true"] {
+  font-weight:700;
+  background:var(--surface-lav);
+  border-color:var(--lavender);
+  color:var(--tc-lav);
+}
+[data-theme="dark"] .ms-domain-chip {
+  background:rgba(255,255,255,0.06);
+  border-color:rgba(255,255,255,0.14);
+  color:var(--text);
+}
+[data-theme="dark"] .ms-domain-chip:hover { background:rgba(201,184,232,0.16); }
+[data-theme="dark"] .ms-domain-chip[data-active="true"] {
+  background:rgba(201,184,232,0.22);
+  border-color:var(--lavender);
+  color:var(--tc-lav);
+}
 
 /* Domain filter visibility class — class-driven hide for milestoneList items
    per HR-2 (no inline style mutation). filterMsDomain toggles this class on
@@ -6209,17 +6240,48 @@ body.ql-locked .dark-toggle { pointer-events:none; }
    V-K-122: global cap 20 markers post-bucket-merge.
    V-V-66: ≥9px marker diameter + ≥1.8px stroke at 320px viewport.
    Lavender domain accent: --surface-lav background. */
+/* ── Trajectory ribbon — MAJOR OVERHAUL post-Architect feedback 2026-05-27.
+   3 visual states (celebrated/practicing/coming-up) + age-axis + current-age
+   indicator + warmer narrative caption. The V-V-49 2-state collapse is
+   rebated per Architect call: live use showed "practicing-or-in-window"
+   merged bucket didn't convey state clarity warmly enough. ── */
 .ms-trajectory-card { padding:var(--sp-12) var(--sp-16); background:var(--surface-lav); }
-.ms-trajectory-svg { width:100%; height:48px; display:block; }
-.ms-trajectory-marker { stroke-width:1.8; }
-.ms-trajectory-marker[data-state="confirmed"] { fill:currentColor; stroke:none; }
-.ms-trajectory-marker[data-state="hedged"] { fill:transparent; stroke:currentColor; }
+.ms-trajectory-svg { width:100%; height:auto; display:block; }
+
+/* Age axis (bottom). Subtle line with periodic ticks + month labels. */
+.ms-traj-axis { stroke:var(--mid); stroke-width:0.6; opacity:0.5; }
+.ms-traj-axis-tick { stroke:var(--mid); stroke-width:0.8; opacity:0.55; }
+.ms-traj-axis-label { font-size:8px; fill:var(--mid); font-family:'Nunito',sans-serif; opacity:0.85; }
+
+/* Current-age vertical indicator. Dashed; rose tint so it reads as
+   "you are here" without competing with the markers. */
+.ms-traj-current { stroke:var(--tc-rose); stroke-width:1.1; stroke-dasharray:3 2; opacity:0.65; }
+.ms-traj-current-label { font-size:8px; fill:var(--tc-rose); font-family:'Nunito',sans-serif; font-weight:700; }
+
+/* Markers — 3 distinct states. V-V-66 ≥9px-diameter / ≥1.8px-stroke pixel-
+   scale floor honored at default sizes (markerR:5 → 10px diameter;
+   markerRSmall:4 → 8px borderline, compensated by 1.8px stroke). */
+.ms-trajectory-marker { transition: filter var(--ease-fast); }
+.ms-trajectory-marker[data-state="celebrated"] { fill:var(--sage-deepest); stroke:none; filter:drop-shadow(0 0 1.5px rgba(95,140,120,0.45)); }
+.ms-trajectory-marker[data-state="practicing"] { /* group element — children carry the visual */ }
+.ms-trajectory-marker[data-state="practicing"] .ms-traj-ring { fill:transparent; stroke:var(--amber-deep); stroke-width:1.8; }
+.ms-trajectory-marker[data-state="practicing"] .ms-traj-core { fill:var(--amber-deep); stroke:none; }
+.ms-trajectory-marker[data-state="comingup"]  { fill:transparent; stroke:var(--lavender); stroke-width:1.8; stroke-dasharray:2 1.5; opacity:0.85; }
 .ms-trajectory-marker[data-action="gotoMsRow"] { cursor:pointer; }
-.ms-trajectory-marker[data-action="gotoMsRow"]:hover { stroke-width:2.4; }
-.ms-trajectory-legend { display:flex; gap:var(--sp-12); justify-content:center; padding:var(--sp-8) 0 var(--sp-4); font-size:var(--fs-2xs); color:var(--mid); }
+.ms-trajectory-marker[data-action="gotoMsRow"]:hover { filter:brightness(1.15) drop-shadow(0 0 2px rgba(95,140,120,0.55)); }
+
+/* Legend swatches use the SAME styling as the markers so the visual key
+   on the page matches the markers exactly. */
+.ms-trajectory-legend { display:flex; gap:var(--sp-12); justify-content:center; padding:var(--sp-8) 0 var(--sp-4); font-size:var(--fs-2xs); color:var(--mid); flex-wrap:wrap; }
 .ms-traj-legend-item { display:inline-flex; align-items:center; gap:var(--sp-4); }
-.ms-traj-legend-swatch { width:12px; height:12px; }
-.ms-trajectory-label { font-size:var(--fs-2xs); color:var(--light); margin-top:var(--sp-4); text-align:center; }
+.ms-traj-legend-item[data-state="celebrated"] { color:var(--tc-sage); font-weight:600; }
+.ms-traj-legend-item[data-state="practicing"] { color:var(--tc-amber); font-weight:600; }
+.ms-traj-legend-item[data-state="comingup"]   { color:var(--tc-lav); font-weight:600; }
+.ms-traj-legend-swatch { width:14px; height:14px; flex-shrink:0; }
+.ms-traj-legend-swatch circle[data-state="celebrated"] { fill:var(--sage-deepest); stroke:none; }
+.ms-traj-legend-swatch circle[data-state="comingup"]   { fill:transparent; stroke:var(--lavender); stroke-width:1.8; stroke-dasharray:2 1.5; }
+
+.ms-trajectory-label { font-size:var(--fs-xs); color:var(--mid); margin-top:var(--sp-6); text-align:center; line-height:1.4; padding:0 var(--sp-8); }
 
 /* Brief landing-confirmation highlight for milestone rows scrolled into view
    by trajectory ribbon tap. Fades over 1.8s; class is removed by JS. */
@@ -26595,9 +26657,18 @@ const MS_ACTIVITY_LEVEL_TIERS = [
 // confirmed=12 / practicing=8 / not-yet=5 keeps each bucket's priority signal
 // intact post-global-cap-20-slice; sum (25) exceeds cap to leave room for
 // merge prioritization within the 20-marker budget per V-K-122.
+//
+// Post-overhaul (Architect feedback 2026-05-27): viewBox sized for an age-axis
+// timeline (width=360, height=72) + bottom-padding for month labels. Three
+// distinct visual states (confirmed/practicing/coming-up) — Architect call
+// over the V-V-49 2-state collapse since live use showed the merged
+// "practicing-or-in-window" bucket didn't convey state clarity warmly enough.
 const MS_TRAJECTORY_GEOM = {
-  width: 320, height: 48, padding: 16, markerR: 4.5,
+  width: 360, height: 72,
+  padL: 12, padR: 12, padT: 6, padB: 20,
+  markerR: 5, markerRSmall: 4, markerStroke: 1.8,
   confirmedCap: 12, practicingCap: 8, notYetCap: 5, globalCap: 20,
+  axisTickMonths: 3,
 };
 
 // Regression-honesty floor threshold (V-M-104 + V-M-121) — Maren NOTE-1
@@ -27189,105 +27260,219 @@ function filterMsDomain(target) {
 // bucket-merge per V-K-122. ≥9px diameter + ≥1.8px stroke per V-V-66.
 // Color: domain-keyed (reads ACTIVITY_CATEGORIES[milestone.domain].accent).
 // Performance gate: renders within 200ms (cipher-3 budget).
+// Compute age in fractional months at a given ISO date (or today). Used by
+// the trajectory ribbon to position markers along an age X-axis. Returns
+// null when the date is unparseable so the caller can skip the marker
+// rather than coerce-to-zero (which would mis-place malformed dates at
+// birth-age in the visualization).
+function _msAgeMonthsAt(isoDate) {
+  if (!isoDate) return null;
+  const a = ageAt(isoDate);
+  if (!a || (a.months === 0 && a.days === 0 && isoDate)) {
+    // Verify by re-parsing — ageAt returns {0,0} both for DOB and for invalid input
+    const parsed = new Date(isoDate);
+    if (isNaN(parsed.getTime())) return null;
+  }
+  return (a.months || 0) + ((a.days || 0) / 30.44);
+}
+
+// Trajectory ribbon (Patterns sub-tab; return-visit surface 2). MAJOR
+// OVERHAUL post-Architect feedback 2026-05-27 (V-V-49 collapse rebated):
+// - Temporal X-axis (age in months) replaces evenly-spaced markers; markers
+//   land at the age they were celebrated/started/expected, conveying Ziva's
+//   journey along time rather than as a flat dot sequence.
+// - 3 distinct visual states (over V-V-49 2-state collapse): "celebrated"
+//   (sage filled) / "practicing" (amber filled + sage ring halo) / "coming
+//   up" (lavender outlined). Architect call: warmth + clarity > the V-V-49
+//   collapse, since live use showed the merged hedged-bucket didn't convey
+//   state cleanly. The labels also no longer share the "or" pattern that
+//   collapsed two distinct journey-states into one chip.
+// - Month-axis ticks every 3 months along the bottom with labels.
+// - Dashed vertical "now" indicator at Ziva's current age — gives the
+//   parent the answer to "where is Ziva today?" without reading prose.
+// - All markers tappable when they have a milestone id (V-V-48 contract).
+// - SVG <title> for native hover/long-press tooltip showing milestone text.
 function renderMsTrajectoryRibbon() {
   const el = document.getElementById('msTrajectoryRibbon');
   if (!el) return;
-  // Collect 3 buckets: confirmed + practicing + in-window not-yet
-  const cats = (window.ACTIVITY_CATEGORIES || []);
-  const accentByDomain = {};
-  cats.forEach(c => { accentByDomain[c.key] = c.accent; });
-  const ageDays = _zivaAgeInDays(today());
 
-  // Bucket 1: confirmed (top by recency; sub-bucket cap from MS_TRAJECTORY_GEOM).
-  // Skip rows whose stage timestamps are missing/invalid rather than coercing
-  // to epoch-0 (which would silently bucket malformed dates as "oldest" 1970).
-  const confirmedAll = (milestones || []).filter(m => m.status === 'consistent' || m.status === 'mastered')
+  const G = MS_TRAJECTORY_GEOM;
+  const ageDays = _zivaAgeInDays(today());
+  const currentAgeM = ageDays / 30.44;
+
+  // Bucket 1: celebrated (consistent + mastered)
+  const celebrated = (milestones || [])
+    .filter(m => m.status === 'consistent' || m.status === 'mastered')
     .map(m => {
-      const ts = new Date(m.consistentAt || m.masteredAt || 0).getTime();
-      return { ms: m, domain: m.domain || m.cat || 'motor', ts: isFinite(ts) ? ts : 0, state: 'confirmed', priority: 0 };
+      const dateStr = m.consistentAt || m.masteredAt;
+      const ageM = _msAgeMonthsAt(dateStr);
+      return ageM == null ? null : {
+        ms: m, ageM, state: 'celebrated',
+        ts: new Date(dateStr).getTime(),
+      };
     })
-    .filter(x => x.ts > 0)
-    .sort((a, b) => b.ts - a.ts);
-  // Bucket 2: practicing
-  const practicingAll = (milestones || []).filter(m => m.status === 'practicing' || m.status === 'emerging')
+    .filter(Boolean)
+    .sort((a, b) => b.ts - a.ts)
+    .slice(0, G.confirmedCap);
+
+  // Bucket 2: practicing (practicing + emerging)
+  const practicing = (milestones || [])
+    .filter(m => m.status === 'practicing' || m.status === 'emerging')
     .map(m => {
-      const ts = new Date(m.practicingAt || m.emergingAt || 0).getTime();
-      return { ms: m, domain: m.domain || m.cat || 'motor', ts: isFinite(ts) ? ts : 0, state: 'hedged', priority: 0.5 };
-    });
-  // Bucket 3: in-window not-yet (≤MS_TRAJECTORY_GEOM.notYetCap floor)
-  let inWindowNotYet = [];
+      const dateStr = m.practicingAt || m.emergingAt;
+      const ageM = _msAgeMonthsAt(dateStr);
+      return ageM == null ? null : {
+        ms: m, ageM, state: 'practicing',
+        ts: new Date(dateStr).getTime(),
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.ts - a.ts)
+    .slice(0, G.practicingCap);
+
+  // Bucket 3: in-window not-yet (anticipation)
+  let comingUp = [];
   try {
     if (typeof _getInWindowMilestones === 'function') {
-      inWindowNotYet = (_getInWindowMilestones(ageDays, Infinity, {}) || [])
+      comingUp = (_getInWindowMilestones(ageDays, Infinity, {}) || [])
         .filter(it => it.evidenceStatus === 'not-yet')
-        .map(it => ({
-          ms: { text: it.text, domain: it.domain },
-          domain: it.domain || 'motor',
-          ts: 0,
-          state: 'hedged',
-          priority: it.priority || 0,
-        }));
+        .map(it => {
+          // window.expectedStartMonths is the clinical-band start; position
+          // markers at the band-start for the "coming up" framing (rather
+          // than current age, which would cluster them at the 'now' line).
+          const win = it.window || {};
+          const startM = (typeof win.expectedStartMonths === 'number') ? win.expectedStartMonths
+            : (typeof win.expectedStart === 'number' ? win.expectedStart / 30.44 : currentAgeM);
+          return {
+            ms: { text: it.text, id: it.milestoneId, domain: it.domain },
+            ageM: startM,
+            state: 'comingup',
+            priority: it.priority || 0,
+          };
+        })
+        .sort((a, b) => (b.priority || 0) - (a.priority || 0))
+        .slice(0, G.notYetCap);
     }
-  } catch (e) { inWindowNotYet = []; }
-  inWindowNotYet = inWindowNotYet
-    .sort((a, b) => (b.priority || 0) - (a.priority || 0))
-    .slice(0, MS_TRAJECTORY_GEOM.notYetCap);
+  } catch (e) { comingUp = []; }
 
-  // Merge + global cap from MS_TRAJECTORY_GEOM (V-K-122). Sub-bucket caps
-  // are author choices documented at the geometry-const block above.
-  let merged = []
-    .concat(confirmedAll.slice(0, MS_TRAJECTORY_GEOM.confirmedCap))
-    .concat(practicingAll.slice(0, MS_TRAJECTORY_GEOM.practicingCap))
-    .concat(inWindowNotYet);
-  merged = merged.slice(0, MS_TRAJECTORY_GEOM.globalCap);
+  // Merged + global cap. Sub-bucket caps already applied above; the global
+  // cap (V-K-122) is the final safety floor.
+  const merged = [].concat(celebrated, practicing, comingUp).slice(0, G.globalCap);
+  const nCel = merged.filter(m => m.state === 'celebrated').length;
+  const nPra = merged.filter(m => m.state === 'practicing').length;
+  const nCom = merged.filter(m => m.state === 'comingup').length;
+
   if (merged.length === 0) {
-    el.innerHTML = '<div class="card-title"><div class="icon icon-lav">' + zi('chart-up') + '</div> Trajectory</div>'
-      + '<div class="t-sub-light text-center py-4">No milestone trajectory yet — early days.</div>';
+    el.innerHTML = '<div class="card-header"><div class="card-title"><div class="icon icon-lav">'
+      + zi('chart-up') + '</div> Trajectory</div></div>'
+      + '<div class="t-sub-light text-center py-4">Ziva\'s journey is just beginning — milestones will appear here as she grows.</div>';
     return;
   }
-  // Render SVG ribbon — markers spaced evenly across the viewBox width
-  const { width: w, height: h, padding, markerR } = MS_TRAJECTORY_GEOM;
-  const innerW = w - padding * 2;
-  const step = merged.length > 1 ? innerW / (merged.length - 1) : 0;
-  // Count by state for the legend below the SVG (warmth signal: tells the
-  // parent what they're looking at without needing to tap individual markers).
-  let nConfirmed = 0, nHedged = 0;
-  const markers = merged.map((m, i) => {
-    const cx = padding + step * i;
-    const cy = h / 2;
-    const accent = accentByDomain[m.domain] || 'lavender';
-    const color = 'var(--' + accent + ')';
-    const isConfirmed = m.state === 'confirmed';
-    if (isConfirmed) nConfirmed++; else nHedged++;
+
+  // X-axis range. min: 0m (birth). max: at least currentAge + 2, or maxMarker + 1.
+  const allAgeM = merged.map(m => m.ageM);
+  const maxMarkerAge = Math.max(...allAgeM);
+  const maxAge = Math.max(currentAgeM + 2, maxMarkerAge + 1, 9);
+  const ageToX = ageM => G.padL + (Math.max(0, ageM) / maxAge) * (G.width - G.padL - G.padR);
+  // Single Y line for the markers, with tiny domain-keyed jitter so overlapping
+  // markers don't fully obscure each other. Domain lane offset is bounded
+  // (±3px max) so the markers still read as "on the timeline".
+  const cats = (window.ACTIVITY_CATEGORIES || []);
+  const domainLane = {};
+  cats.forEach((c, i) => {
+    // Spread lanes across [-3, +3] centered on 0
+    domainLane[c.key] = (i - (cats.length - 1) / 2) * (cats.length > 1 ? 6 / (cats.length - 1) : 0);
+  });
+  const baseY = G.padT + (G.height - G.padT - G.padB) / 2;
+
+  // Axis ticks (every G.axisTickMonths months)
+  const axisLine = '<line class="ms-traj-axis" x1="' + G.padL + '" y1="' + (G.height - G.padB + 1)
+    + '" x2="' + (G.width - G.padR) + '" y2="' + (G.height - G.padB + 1) + '"/>';
+  const axisTicks = [];
+  for (let m = 0; m <= Math.ceil(maxAge); m += G.axisTickMonths) {
+    const x = ageToX(m);
+    axisTicks.push('<line class="ms-traj-axis-tick" x1="' + x + '" y1="' + (G.height - G.padB + 1)
+      + '" x2="' + x + '" y2="' + (G.height - G.padB + 4) + '"/>');
+    axisTicks.push('<text class="ms-traj-axis-label" x="' + x + '" y="' + (G.height - 3)
+      + '" text-anchor="middle">' + m + 'm</text>');
+  }
+
+  // Current-age vertical indicator. Dashed; subtle but parseable.
+  const currX = ageToX(Math.min(currentAgeM, maxAge));
+  const currIndicator =
+      '<line class="ms-traj-current" x1="' + currX + '" y1="' + G.padT
+    + '" x2="' + currX + '" y2="' + (G.height - G.padB + 1) + '"/>'
+    + '<text class="ms-traj-current-label" x="' + currX + '" y="' + (G.padT + 7)
+    + '" text-anchor="middle">now</text>';
+
+  // Marker render. Three SVG shapes per state for clean differentiation
+  // (state styling lives in CSS rules keyed on data-state attribute).
+  const markers = merged.map(m => {
+    const cx = ageToX(m.ageM);
+    const cy = baseY + (domainLane[m.ms && m.ms.domain] || 0);
     const msId = m.ms && m.ms.id ? m.ms.id : '';
     const msText = m.ms && m.ms.text ? m.ms.text : '';
-    // V-V-48 fold-close: markers are tappable; tap → gotoCard('track',
-    // 'milestoneRow_'+id) navigates to the row on the Library sub-tab.
-    // SVG <title> child provides the native hover/long-press tooltip.
-    // Confirmed markers have data-ms-id (id known); not-yet/practicing
-    // engine-derived items may lack id and render non-tappable (no
-    // data-action) so the parent isn't promised navigation that won't work.
-    // HR-2 carve-out (Maren NOTE-3 close): inline style passes a CSS token
-    // through `color` to power the `currentColor` reference in the marker's
-    // CSS rule. Registry → currentColor pass-through keeps ACTIVITY_CATEGORIES
-    // as the single source of truth for accent (5-rule alternative would
-    // duplicate the registry in CSS — the failure-mode the 9th gate prevents).
     const tappable = msId ? ' data-action="gotoMsRow" data-ms-id="' + escHtml(msId) + '"' : '';
     const titleEl = msText ? '<title>' + escHtml(msText) + '</title>' : '';
-    return '<circle class="ms-trajectory-marker" data-state="' + (isConfirmed ? 'confirmed' : 'hedged')
-      + '"' + tappable
-      + ' cx="' + cx + '" cy="' + cy + '" r="' + markerR + '" style="color:' + color + '">'
+    if (m.state === 'celebrated') {
+      // Filled sage circle + soft glow via filter (CSS).
+      return '<circle class="ms-trajectory-marker" data-state="celebrated"'
+        + tappable + ' cx="' + cx + '" cy="' + cy + '" r="' + G.markerR + '">'
+        + titleEl + '</circle>';
+    }
+    if (m.state === 'practicing') {
+      // Outer amber ring + inner amber dot — "in progress" shape.
+      return '<g class="ms-trajectory-marker" data-state="practicing"' + tappable + '>'
+        + '<circle class="ms-traj-ring" cx="' + cx + '" cy="' + cy + '" r="' + (G.markerR + 1) + '"/>'
+        + '<circle class="ms-traj-core" cx="' + cx + '" cy="' + cy + '" r="' + (G.markerR - 1.5) + '"/>'
+        + titleEl + '</g>';
+    }
+    // comingup — outlined lavender circle, smaller; never tappable if no id
+    return '<circle class="ms-trajectory-marker" data-state="comingup"'
+      + tappable + ' cx="' + cx + '" cy="' + cy + '" r="' + G.markerRSmall + '">'
       + titleEl + '</circle>';
   }).join('');
-  // Legend + caption — give the parent the visual key without a tap.
+
+  // Legend — three swatches with distinct visual + warmer labels.
+  const swatchSVG = (state) => '<svg class="ms-traj-legend-swatch" viewBox="0 0 14 14" aria-hidden="true">'
+    + (state === 'practicing'
+        ? '<circle class="ms-traj-ring" cx="7" cy="7" r="6"/><circle class="ms-traj-core" cx="7" cy="7" r="2.5"/>'
+        : '<circle data-state="' + state + '" cx="7" cy="7" r="' + (state === 'comingup' ? '5' : '6') + '"/>')
+    + '</svg>';
   const legend = '<div class="ms-trajectory-legend">'
-    + '<span class="ms-traj-legend-item"><svg class="ms-traj-legend-swatch" viewBox="0 0 12 12"><circle cx="6" cy="6" r="4.5" data-state="confirmed" style="color:var(--lavender)"/></svg> Confirmed (' + nConfirmed + ')</span>'
-    + '<span class="ms-traj-legend-item"><svg class="ms-traj-legend-swatch" viewBox="0 0 12 12"><circle cx="6" cy="6" r="4.5" data-state="hedged" style="color:var(--lavender)"/></svg> Practicing or in-window (' + nHedged + ')</span>'
+    + '<span class="ms-traj-legend-item" data-state="celebrated">' + swatchSVG('celebrated') + ' ' + nCel + ' celebrated</span>'
+    + '<span class="ms-traj-legend-item" data-state="practicing">' + swatchSVG('practicing') + ' ' + nPra + ' practicing</span>'
+    + '<span class="ms-traj-legend-item" data-state="comingup">' + swatchSVG('comingup') + ' ' + nCom + ' coming up</span>'
     + '</div>';
-  el.innerHTML = '<div class="card-header"><div class="card-title"><div class="icon icon-lav">' + zi('chart-up') + '</div> Trajectory</div></div>'
-    + '<svg class="ms-trajectory-svg" viewBox="0 0 ' + w + ' ' + h + '" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Milestone trajectory: ' + nConfirmed + ' confirmed, ' + nHedged + ' practicing or in-window">' + markers + '</svg>'
+
+  // Narrative caption — warmer than "X markers on Ziva's timeline".
+  // Phrases the picture as a journey, not as a count of dots. Half-awake-test
+  // anchor: a tired parent should grok the present-state from the caption
+  // alone, without parsing the markers.
+  let caption;
+  if (nCel > 0 && nCom > 0) {
+    caption = 'Ziva has celebrated ' + nCel + ', is working on ' + nPra
+      + (nPra === 1 ? '' : '')
+      + ', with ' + nCom + ' more on the horizon. Tap a marker for details.';
+  } else if (nCel > 0) {
+    caption = nCel + ' milestone' + (nCel === 1 ? '' : 's') + ' celebrated. Tap a marker for details.';
+  } else if (nPra > 0) {
+    caption = nPra + ' milestone' + (nPra === 1 ? '' : 's') + ' in progress. Tap a marker for details.';
+  } else {
+    caption = nCom + ' coming up — Ziva\'s journey is just starting.';
+  }
+
+  el.innerHTML = '<div class="card-header"><div class="card-title"><div class="icon icon-lav">'
+    + zi('chart-up') + '</div> Trajectory</div></div>'
+    + '<svg class="ms-trajectory-svg" viewBox="0 0 ' + G.width + ' ' + G.height + '"'
+    + ' preserveAspectRatio="xMidYMid meet" role="img"'
+    + ' aria-label="Milestone trajectory along Ziva\'s age in months: '
+    + nCel + ' celebrated, ' + nPra + ' practicing, ' + nCom + ' coming up. Now: '
+    + (Math.round(currentAgeM * 10) / 10) + ' months">'
+    + axisLine + axisTicks.join('') + currIndicator + markers
+    + '</svg>'
     + legend
-    + '<div class="ms-trajectory-label">' + escHtml(String(merged.length)) + ' milestones on Ziva\'s timeline. Tap a confirmed marker to jump to the milestone.</div>';
+    + '<div class="ms-trajectory-label">' + escHtml(caption) + '</div>';
 }
 
 // Trajectory marker tap → switch to Library sub-tab + scroll to the row.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.27-22",
+  "version": "2026.05.27-23",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.27-23",
+  "version": "2026.05.27-24",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.27-21",
+  "version": "2026.05.27-22",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -1136,6 +1136,32 @@ function init() {
   activityLog  = load(KEYS.activityLog, null) || {};
   if (typeof activityLog !== 'object' || activityLog === null || Array.isArray(activityLog)) activityLog = {};
 
+  // milestones-tab-v1 hotfix #2 — one-time entry.ts shape migration.
+  // PR #159 batch-2 (pre-hotfix #160) wrote evidence entries with
+  // ts: Date.now() (number); the canonical writer at intelligence-quicklog.js:
+  // _alSlotToTimestamp returns ISO string. Sort sites (renderRecentEvidence
+  // home.js:3467/3525) call .localeCompare on ts — throws on number, kills
+  // the home-tab + milestones-tab renderers downstream. Convert number-ts
+  // entries to ISO string in place; idempotent (skips string-ts entries).
+  // V-K-132 try-wrap posture so a malformed activityLog doesn't brick boot.
+  try {
+    let _alTsMigratedCount = 0;
+    Object.keys(activityLog).forEach(dateStr => {
+      const dayEntries = activityLog[dateStr];
+      if (!Array.isArray(dayEntries)) return;
+      dayEntries.forEach(entry => {
+        if (entry && typeof entry.ts === 'number' && isFinite(entry.ts)) {
+          entry.ts = new Date(entry.ts).toISOString();
+          _alTsMigratedCount++;
+        }
+      });
+    });
+    if (_alTsMigratedCount > 0) {
+      save(KEYS.activityLog, activityLog);
+      console.log('[ms-tab-v1 hotfix] migrated', _alTsMigratedCount, 'activityLog entries from number-ts to ISO-string-ts');
+    }
+  } catch (e) { console.warn('[ms-tab-v1 hotfix] activityLog ts-shape migration failed:', e); }
+
   // milestone-engine-prep-v1 PR-A — activityMeta + milestoneSuppress hydration.
   // V-K-111 floor: activityMeta is the SEPARATE per-day-meta key family (not
   // an _meta sentinel on activityLog) to avoid breaking 20+ Array.isArray

--- a/split/home.js
+++ b/split/home.js
@@ -1887,9 +1887,18 @@ const MS_ACTIVITY_LEVEL_TIERS = [
 // confirmed=12 / practicing=8 / not-yet=5 keeps each bucket's priority signal
 // intact post-global-cap-20-slice; sum (25) exceeds cap to leave room for
 // merge prioritization within the 20-marker budget per V-K-122.
+//
+// Post-overhaul (Architect feedback 2026-05-27): viewBox sized for an age-axis
+// timeline (width=360, height=72) + bottom-padding for month labels. Three
+// distinct visual states (confirmed/practicing/coming-up) — Architect call
+// over the V-V-49 2-state collapse since live use showed the merged
+// "practicing-or-in-window" bucket didn't convey state clarity warmly enough.
 const MS_TRAJECTORY_GEOM = {
-  width: 320, height: 48, padding: 16, markerR: 4.5,
+  width: 360, height: 72,
+  padL: 12, padR: 12, padT: 6, padB: 20,
+  markerR: 5, markerRSmall: 4, markerStroke: 1.8,
   confirmedCap: 12, practicingCap: 8, notYetCap: 5, globalCap: 20,
+  axisTickMonths: 3,
 };
 
 // Regression-honesty floor threshold (V-M-104 + V-M-121) — Maren NOTE-1
@@ -2481,105 +2490,219 @@ function filterMsDomain(target) {
 // bucket-merge per V-K-122. ≥9px diameter + ≥1.8px stroke per V-V-66.
 // Color: domain-keyed (reads ACTIVITY_CATEGORIES[milestone.domain].accent).
 // Performance gate: renders within 200ms (cipher-3 budget).
+// Compute age in fractional months at a given ISO date (or today). Used by
+// the trajectory ribbon to position markers along an age X-axis. Returns
+// null when the date is unparseable so the caller can skip the marker
+// rather than coerce-to-zero (which would mis-place malformed dates at
+// birth-age in the visualization).
+function _msAgeMonthsAt(isoDate) {
+  if (!isoDate) return null;
+  const a = ageAt(isoDate);
+  if (!a || (a.months === 0 && a.days === 0 && isoDate)) {
+    // Verify by re-parsing — ageAt returns {0,0} both for DOB and for invalid input
+    const parsed = new Date(isoDate);
+    if (isNaN(parsed.getTime())) return null;
+  }
+  return (a.months || 0) + ((a.days || 0) / 30.44);
+}
+
+// Trajectory ribbon (Patterns sub-tab; return-visit surface 2). MAJOR
+// OVERHAUL post-Architect feedback 2026-05-27 (V-V-49 collapse rebated):
+// - Temporal X-axis (age in months) replaces evenly-spaced markers; markers
+//   land at the age they were celebrated/started/expected, conveying Ziva's
+//   journey along time rather than as a flat dot sequence.
+// - 3 distinct visual states (over V-V-49 2-state collapse): "celebrated"
+//   (sage filled) / "practicing" (amber filled + sage ring halo) / "coming
+//   up" (lavender outlined). Architect call: warmth + clarity > the V-V-49
+//   collapse, since live use showed the merged hedged-bucket didn't convey
+//   state cleanly. The labels also no longer share the "or" pattern that
+//   collapsed two distinct journey-states into one chip.
+// - Month-axis ticks every 3 months along the bottom with labels.
+// - Dashed vertical "now" indicator at Ziva's current age — gives the
+//   parent the answer to "where is Ziva today?" without reading prose.
+// - All markers tappable when they have a milestone id (V-V-48 contract).
+// - SVG <title> for native hover/long-press tooltip showing milestone text.
 function renderMsTrajectoryRibbon() {
   const el = document.getElementById('msTrajectoryRibbon');
   if (!el) return;
-  // Collect 3 buckets: confirmed + practicing + in-window not-yet
-  const cats = (window.ACTIVITY_CATEGORIES || []);
-  const accentByDomain = {};
-  cats.forEach(c => { accentByDomain[c.key] = c.accent; });
-  const ageDays = _zivaAgeInDays(today());
 
-  // Bucket 1: confirmed (top by recency; sub-bucket cap from MS_TRAJECTORY_GEOM).
-  // Skip rows whose stage timestamps are missing/invalid rather than coercing
-  // to epoch-0 (which would silently bucket malformed dates as "oldest" 1970).
-  const confirmedAll = (milestones || []).filter(m => m.status === 'consistent' || m.status === 'mastered')
+  const G = MS_TRAJECTORY_GEOM;
+  const ageDays = _zivaAgeInDays(today());
+  const currentAgeM = ageDays / 30.44;
+
+  // Bucket 1: celebrated (consistent + mastered)
+  const celebrated = (milestones || [])
+    .filter(m => m.status === 'consistent' || m.status === 'mastered')
     .map(m => {
-      const ts = new Date(m.consistentAt || m.masteredAt || 0).getTime();
-      return { ms: m, domain: m.domain || m.cat || 'motor', ts: isFinite(ts) ? ts : 0, state: 'confirmed', priority: 0 };
+      const dateStr = m.consistentAt || m.masteredAt;
+      const ageM = _msAgeMonthsAt(dateStr);
+      return ageM == null ? null : {
+        ms: m, ageM, state: 'celebrated',
+        ts: new Date(dateStr).getTime(),
+      };
     })
-    .filter(x => x.ts > 0)
-    .sort((a, b) => b.ts - a.ts);
-  // Bucket 2: practicing
-  const practicingAll = (milestones || []).filter(m => m.status === 'practicing' || m.status === 'emerging')
+    .filter(Boolean)
+    .sort((a, b) => b.ts - a.ts)
+    .slice(0, G.confirmedCap);
+
+  // Bucket 2: practicing (practicing + emerging)
+  const practicing = (milestones || [])
+    .filter(m => m.status === 'practicing' || m.status === 'emerging')
     .map(m => {
-      const ts = new Date(m.practicingAt || m.emergingAt || 0).getTime();
-      return { ms: m, domain: m.domain || m.cat || 'motor', ts: isFinite(ts) ? ts : 0, state: 'hedged', priority: 0.5 };
-    });
-  // Bucket 3: in-window not-yet (≤MS_TRAJECTORY_GEOM.notYetCap floor)
-  let inWindowNotYet = [];
+      const dateStr = m.practicingAt || m.emergingAt;
+      const ageM = _msAgeMonthsAt(dateStr);
+      return ageM == null ? null : {
+        ms: m, ageM, state: 'practicing',
+        ts: new Date(dateStr).getTime(),
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.ts - a.ts)
+    .slice(0, G.practicingCap);
+
+  // Bucket 3: in-window not-yet (anticipation)
+  let comingUp = [];
   try {
     if (typeof _getInWindowMilestones === 'function') {
-      inWindowNotYet = (_getInWindowMilestones(ageDays, Infinity, {}) || [])
+      comingUp = (_getInWindowMilestones(ageDays, Infinity, {}) || [])
         .filter(it => it.evidenceStatus === 'not-yet')
-        .map(it => ({
-          ms: { text: it.text, domain: it.domain },
-          domain: it.domain || 'motor',
-          ts: 0,
-          state: 'hedged',
-          priority: it.priority || 0,
-        }));
+        .map(it => {
+          // window.expectedStartMonths is the clinical-band start; position
+          // markers at the band-start for the "coming up" framing (rather
+          // than current age, which would cluster them at the 'now' line).
+          const win = it.window || {};
+          const startM = (typeof win.expectedStartMonths === 'number') ? win.expectedStartMonths
+            : (typeof win.expectedStart === 'number' ? win.expectedStart / 30.44 : currentAgeM);
+          return {
+            ms: { text: it.text, id: it.milestoneId, domain: it.domain },
+            ageM: startM,
+            state: 'comingup',
+            priority: it.priority || 0,
+          };
+        })
+        .sort((a, b) => (b.priority || 0) - (a.priority || 0))
+        .slice(0, G.notYetCap);
     }
-  } catch (e) { inWindowNotYet = []; }
-  inWindowNotYet = inWindowNotYet
-    .sort((a, b) => (b.priority || 0) - (a.priority || 0))
-    .slice(0, MS_TRAJECTORY_GEOM.notYetCap);
+  } catch (e) { comingUp = []; }
 
-  // Merge + global cap from MS_TRAJECTORY_GEOM (V-K-122). Sub-bucket caps
-  // are author choices documented at the geometry-const block above.
-  let merged = []
-    .concat(confirmedAll.slice(0, MS_TRAJECTORY_GEOM.confirmedCap))
-    .concat(practicingAll.slice(0, MS_TRAJECTORY_GEOM.practicingCap))
-    .concat(inWindowNotYet);
-  merged = merged.slice(0, MS_TRAJECTORY_GEOM.globalCap);
+  // Merged + global cap. Sub-bucket caps already applied above; the global
+  // cap (V-K-122) is the final safety floor.
+  const merged = [].concat(celebrated, practicing, comingUp).slice(0, G.globalCap);
+  const nCel = merged.filter(m => m.state === 'celebrated').length;
+  const nPra = merged.filter(m => m.state === 'practicing').length;
+  const nCom = merged.filter(m => m.state === 'comingup').length;
+
   if (merged.length === 0) {
-    el.innerHTML = '<div class="card-title"><div class="icon icon-lav">' + zi('chart-up') + '</div> Trajectory</div>'
-      + '<div class="t-sub-light text-center py-4">No milestone trajectory yet — early days.</div>';
+    el.innerHTML = '<div class="card-header"><div class="card-title"><div class="icon icon-lav">'
+      + zi('chart-up') + '</div> Trajectory</div></div>'
+      + '<div class="t-sub-light text-center py-4">Ziva\'s journey is just beginning — milestones will appear here as she grows.</div>';
     return;
   }
-  // Render SVG ribbon — markers spaced evenly across the viewBox width
-  const { width: w, height: h, padding, markerR } = MS_TRAJECTORY_GEOM;
-  const innerW = w - padding * 2;
-  const step = merged.length > 1 ? innerW / (merged.length - 1) : 0;
-  // Count by state for the legend below the SVG (warmth signal: tells the
-  // parent what they're looking at without needing to tap individual markers).
-  let nConfirmed = 0, nHedged = 0;
-  const markers = merged.map((m, i) => {
-    const cx = padding + step * i;
-    const cy = h / 2;
-    const accent = accentByDomain[m.domain] || 'lavender';
-    const color = 'var(--' + accent + ')';
-    const isConfirmed = m.state === 'confirmed';
-    if (isConfirmed) nConfirmed++; else nHedged++;
+
+  // X-axis range. min: 0m (birth). max: at least currentAge + 2, or maxMarker + 1.
+  const allAgeM = merged.map(m => m.ageM);
+  const maxMarkerAge = Math.max(...allAgeM);
+  const maxAge = Math.max(currentAgeM + 2, maxMarkerAge + 1, 9);
+  const ageToX = ageM => G.padL + (Math.max(0, ageM) / maxAge) * (G.width - G.padL - G.padR);
+  // Single Y line for the markers, with tiny domain-keyed jitter so overlapping
+  // markers don't fully obscure each other. Domain lane offset is bounded
+  // (±3px max) so the markers still read as "on the timeline".
+  const cats = (window.ACTIVITY_CATEGORIES || []);
+  const domainLane = {};
+  cats.forEach((c, i) => {
+    // Spread lanes across [-3, +3] centered on 0
+    domainLane[c.key] = (i - (cats.length - 1) / 2) * (cats.length > 1 ? 6 / (cats.length - 1) : 0);
+  });
+  const baseY = G.padT + (G.height - G.padT - G.padB) / 2;
+
+  // Axis ticks (every G.axisTickMonths months)
+  const axisLine = '<line class="ms-traj-axis" x1="' + G.padL + '" y1="' + (G.height - G.padB + 1)
+    + '" x2="' + (G.width - G.padR) + '" y2="' + (G.height - G.padB + 1) + '"/>';
+  const axisTicks = [];
+  for (let m = 0; m <= Math.ceil(maxAge); m += G.axisTickMonths) {
+    const x = ageToX(m);
+    axisTicks.push('<line class="ms-traj-axis-tick" x1="' + x + '" y1="' + (G.height - G.padB + 1)
+      + '" x2="' + x + '" y2="' + (G.height - G.padB + 4) + '"/>');
+    axisTicks.push('<text class="ms-traj-axis-label" x="' + x + '" y="' + (G.height - 3)
+      + '" text-anchor="middle">' + m + 'm</text>');
+  }
+
+  // Current-age vertical indicator. Dashed; subtle but parseable.
+  const currX = ageToX(Math.min(currentAgeM, maxAge));
+  const currIndicator =
+      '<line class="ms-traj-current" x1="' + currX + '" y1="' + G.padT
+    + '" x2="' + currX + '" y2="' + (G.height - G.padB + 1) + '"/>'
+    + '<text class="ms-traj-current-label" x="' + currX + '" y="' + (G.padT + 7)
+    + '" text-anchor="middle">now</text>';
+
+  // Marker render. Three SVG shapes per state for clean differentiation
+  // (state styling lives in CSS rules keyed on data-state attribute).
+  const markers = merged.map(m => {
+    const cx = ageToX(m.ageM);
+    const cy = baseY + (domainLane[m.ms && m.ms.domain] || 0);
     const msId = m.ms && m.ms.id ? m.ms.id : '';
     const msText = m.ms && m.ms.text ? m.ms.text : '';
-    // V-V-48 fold-close: markers are tappable; tap → gotoCard('track',
-    // 'milestoneRow_'+id) navigates to the row on the Library sub-tab.
-    // SVG <title> child provides the native hover/long-press tooltip.
-    // Confirmed markers have data-ms-id (id known); not-yet/practicing
-    // engine-derived items may lack id and render non-tappable (no
-    // data-action) so the parent isn't promised navigation that won't work.
-    // HR-2 carve-out (Maren NOTE-3 close): inline style passes a CSS token
-    // through `color` to power the `currentColor` reference in the marker's
-    // CSS rule. Registry → currentColor pass-through keeps ACTIVITY_CATEGORIES
-    // as the single source of truth for accent (5-rule alternative would
-    // duplicate the registry in CSS — the failure-mode the 9th gate prevents).
     const tappable = msId ? ' data-action="gotoMsRow" data-ms-id="' + escHtml(msId) + '"' : '';
     const titleEl = msText ? '<title>' + escHtml(msText) + '</title>' : '';
-    return '<circle class="ms-trajectory-marker" data-state="' + (isConfirmed ? 'confirmed' : 'hedged')
-      + '"' + tappable
-      + ' cx="' + cx + '" cy="' + cy + '" r="' + markerR + '" style="color:' + color + '">'
+    if (m.state === 'celebrated') {
+      // Filled sage circle + soft glow via filter (CSS).
+      return '<circle class="ms-trajectory-marker" data-state="celebrated"'
+        + tappable + ' cx="' + cx + '" cy="' + cy + '" r="' + G.markerR + '">'
+        + titleEl + '</circle>';
+    }
+    if (m.state === 'practicing') {
+      // Outer amber ring + inner amber dot — "in progress" shape.
+      return '<g class="ms-trajectory-marker" data-state="practicing"' + tappable + '>'
+        + '<circle class="ms-traj-ring" cx="' + cx + '" cy="' + cy + '" r="' + (G.markerR + 1) + '"/>'
+        + '<circle class="ms-traj-core" cx="' + cx + '" cy="' + cy + '" r="' + (G.markerR - 1.5) + '"/>'
+        + titleEl + '</g>';
+    }
+    // comingup — outlined lavender circle, smaller; never tappable if no id
+    return '<circle class="ms-trajectory-marker" data-state="comingup"'
+      + tappable + ' cx="' + cx + '" cy="' + cy + '" r="' + G.markerRSmall + '">'
       + titleEl + '</circle>';
   }).join('');
-  // Legend + caption — give the parent the visual key without a tap.
+
+  // Legend — three swatches with distinct visual + warmer labels.
+  const swatchSVG = (state) => '<svg class="ms-traj-legend-swatch" viewBox="0 0 14 14" aria-hidden="true">'
+    + (state === 'practicing'
+        ? '<circle class="ms-traj-ring" cx="7" cy="7" r="6"/><circle class="ms-traj-core" cx="7" cy="7" r="2.5"/>'
+        : '<circle data-state="' + state + '" cx="7" cy="7" r="' + (state === 'comingup' ? '5' : '6') + '"/>')
+    + '</svg>';
   const legend = '<div class="ms-trajectory-legend">'
-    + '<span class="ms-traj-legend-item"><svg class="ms-traj-legend-swatch" viewBox="0 0 12 12"><circle cx="6" cy="6" r="4.5" data-state="confirmed" style="color:var(--lavender)"/></svg> Confirmed (' + nConfirmed + ')</span>'
-    + '<span class="ms-traj-legend-item"><svg class="ms-traj-legend-swatch" viewBox="0 0 12 12"><circle cx="6" cy="6" r="4.5" data-state="hedged" style="color:var(--lavender)"/></svg> Practicing or in-window (' + nHedged + ')</span>'
+    + '<span class="ms-traj-legend-item" data-state="celebrated">' + swatchSVG('celebrated') + ' ' + nCel + ' celebrated</span>'
+    + '<span class="ms-traj-legend-item" data-state="practicing">' + swatchSVG('practicing') + ' ' + nPra + ' practicing</span>'
+    + '<span class="ms-traj-legend-item" data-state="comingup">' + swatchSVG('comingup') + ' ' + nCom + ' coming up</span>'
     + '</div>';
-  el.innerHTML = '<div class="card-header"><div class="card-title"><div class="icon icon-lav">' + zi('chart-up') + '</div> Trajectory</div></div>'
-    + '<svg class="ms-trajectory-svg" viewBox="0 0 ' + w + ' ' + h + '" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Milestone trajectory: ' + nConfirmed + ' confirmed, ' + nHedged + ' practicing or in-window">' + markers + '</svg>'
+
+  // Narrative caption — warmer than "X markers on Ziva's timeline".
+  // Phrases the picture as a journey, not as a count of dots. Half-awake-test
+  // anchor: a tired parent should grok the present-state from the caption
+  // alone, without parsing the markers.
+  let caption;
+  if (nCel > 0 && nCom > 0) {
+    caption = 'Ziva has celebrated ' + nCel + ', is working on ' + nPra
+      + (nPra === 1 ? '' : '')
+      + ', with ' + nCom + ' more on the horizon. Tap a marker for details.';
+  } else if (nCel > 0) {
+    caption = nCel + ' milestone' + (nCel === 1 ? '' : 's') + ' celebrated. Tap a marker for details.';
+  } else if (nPra > 0) {
+    caption = nPra + ' milestone' + (nPra === 1 ? '' : 's') + ' in progress. Tap a marker for details.';
+  } else {
+    caption = nCom + ' coming up — Ziva\'s journey is just starting.';
+  }
+
+  el.innerHTML = '<div class="card-header"><div class="card-title"><div class="icon icon-lav">'
+    + zi('chart-up') + '</div> Trajectory</div></div>'
+    + '<svg class="ms-trajectory-svg" viewBox="0 0 ' + G.width + ' ' + G.height + '"'
+    + ' preserveAspectRatio="xMidYMid meet" role="img"'
+    + ' aria-label="Milestone trajectory along Ziva\'s age in months: '
+    + nCel + ' celebrated, ' + nPra + ' practicing, ' + nCom + ' coming up. Now: '
+    + (Math.round(currentAgeM * 10) / 10) + ' months">'
+    + axisLine + axisTicks.join('') + currIndicator + markers
+    + '</svg>'
     + legend
-    + '<div class="ms-trajectory-label">' + escHtml(String(merged.length)) + ' milestones on Ziva\'s timeline. Tap a confirmed marker to jump to the milestone.</div>';
+    + '<div class="ms-trajectory-label">' + escHtml(caption) + '</div>';
 }
 
 // Trajectory marker tap → switch to Library sub-tab + scroll to the row.

--- a/split/home.js
+++ b/split/home.js
@@ -1888,14 +1888,23 @@ const MS_ACTIVITY_LEVEL_TIERS = [
 // intact post-global-cap-20-slice; sum (25) exceeds cap to leave room for
 // merge prioritization within the 20-marker budget per V-K-122.
 //
-// Post-overhaul (Architect feedback 2026-05-27): viewBox sized for an age-axis
-// timeline (width=360, height=72) + bottom-padding for month labels. Three
-// distinct visual states (confirmed/practicing/coming-up) — Architect call
-// over the V-V-49 2-state collapse since live use showed the merged
-// "practicing-or-in-window" bucket didn't convey state clarity warmly enough.
+// State-lanes overhaul v2 (Architect feedback 2026-05-27 #2): live use showed
+// the temporal-axis single-line design clustered badly when babies hit
+// milestone bursts at similar ages (real biology: 4-6m motor + sensory
+// cluster on the same X). 3 horizontal state-lanes (celebrated / practicing
+// / coming-up) each with collision-aware lateral spacing replace the single
+// jittered line. Shared age axis + current-age indicator span all lanes.
+// Lane height accommodates marker r=5 + padding (~28px); 3 lanes + axis ≈
+// 108px total.
 const MS_TRAJECTORY_GEOM = {
-  width: 360, height: 72,
-  padL: 12, padR: 12, padT: 6, padB: 20,
+  width: 360, height: 108,
+  padL: 14, padR: 14, padT: 6, padB: 22,
+  // Y-centers per state lane (top → bottom: celebrated → practicing → coming-up).
+  lane: { celebrated: 18, practicing: 44, comingup: 70 },
+  // Minimum horizontal spacing between markers in the same lane (~2× marker
+  // diameter so collision-pushed markers don't touch). Sorted-left-to-right
+  // walk enforces this floor.
+  laneMinSpacing: 14,
   markerR: 5, markerRSmall: 4, markerStroke: 1.8,
   confirmedCap: 12, practicingCap: 8, notYetCap: 5, globalCap: 20,
   axisTickMonths: 3,
@@ -2603,21 +2612,35 @@ function renderMsTrajectoryRibbon() {
   const allAgeM = merged.map(m => m.ageM);
   const maxMarkerAge = Math.max(...allAgeM);
   const maxAge = Math.max(currentAgeM + 2, maxMarkerAge + 1, 9);
-  const ageToX = ageM => G.padL + (Math.max(0, ageM) / maxAge) * (G.width - G.padL - G.padR);
-  // Single Y line for the markers, with tiny domain-keyed jitter so overlapping
-  // markers don't fully obscure each other. Domain lane offset is bounded
-  // (±3px max) so the markers still read as "on the timeline".
-  const cats = (window.ACTIVITY_CATEGORIES || []);
-  const domainLane = {};
-  cats.forEach((c, i) => {
-    // Spread lanes across [-3, +3] centered on 0
-    domainLane[c.key] = (i - (cats.length - 1) / 2) * (cats.length > 1 ? 6 / (cats.length - 1) : 0);
-  });
-  const baseY = G.padT + (G.height - G.padT - G.padB) / 2;
+  const innerW = G.width - G.padL - G.padR;
+  const xMin = G.padL;
+  const xMax = G.width - G.padR;
+  const ageToX = ageM => G.padL + (Math.max(0, ageM) / maxAge) * innerW;
+
+  // Lane layout — collision-aware lateral spacing within each state lane.
+  // Sorted left-to-right walk; each marker placed at max(naturalX, lastX +
+  // minSpacing) so dense bursts spread laterally instead of stacking
+  // invisibly. layoutX clamps at the right edge — overflow is rare given
+  // the sub-bucket caps but the clamp keeps markers on-canvas. naturalX is
+  // preserved on the layout object for the SVG <title> readability anchor.
+  function _layoutLane(items, laneY) {
+    const sorted = items.slice().sort((a, b) => a.ageM - b.ageM);
+    let lastX = -Infinity;
+    return sorted.map(it => {
+      const naturalX = ageToX(it.ageM);
+      let x = Math.max(naturalX, lastX + G.laneMinSpacing);
+      if (x > xMax - 2) x = xMax - 2; // clamp at right edge
+      lastX = x;
+      return Object.assign({}, it, { layoutX: x, layoutY: laneY, naturalX });
+    });
+  }
+  const celebratedLayout = _layoutLane(celebrated, G.lane.celebrated);
+  const practicingLayout = _layoutLane(practicing, G.lane.practicing);
+  const comingUpLayout   = _layoutLane(comingUp,   G.lane.comingup);
 
   // Axis ticks (every G.axisTickMonths months)
-  const axisLine = '<line class="ms-traj-axis" x1="' + G.padL + '" y1="' + (G.height - G.padB + 1)
-    + '" x2="' + (G.width - G.padR) + '" y2="' + (G.height - G.padB + 1) + '"/>';
+  const axisLine = '<line class="ms-traj-axis" x1="' + xMin + '" y1="' + (G.height - G.padB + 1)
+    + '" x2="' + xMax + '" y2="' + (G.height - G.padB + 1) + '"/>';
   const axisTicks = [];
   for (let m = 0; m <= Math.ceil(maxAge); m += G.axisTickMonths) {
     const x = ageToX(m);
@@ -2627,7 +2650,18 @@ function renderMsTrajectoryRibbon() {
       + '" text-anchor="middle">' + m + 'm</text>');
   }
 
-  // Current-age vertical indicator. Dashed; subtle but parseable.
+  // Faint lane guide-lines — very low opacity so they read as a subtle
+  // structural cue, not chart-like grid lines. State identity is conveyed
+  // by the marker color (top sage, middle amber, bottom lavender) +
+  // matching legend chips below the SVG; no explicit lane labels needed
+  // (keeps the canvas warm rather than chart-y).
+  const guides = [G.lane.celebrated, G.lane.practicing, G.lane.comingup].map(y =>
+    '<line class="ms-traj-lane-guide" x1="' + xMin + '" y1="' + y
+    + '" x2="' + xMax + '" y2="' + y + '"/>'
+  ).join('');
+  const labels = '';
+
+  // Current-age vertical indicator spanning all 3 lanes.
   const currX = ageToX(Math.min(currentAgeM, maxAge));
   const currIndicator =
       '<line class="ms-traj-current" x1="' + currX + '" y1="' + G.padT
@@ -2635,33 +2669,44 @@ function renderMsTrajectoryRibbon() {
     + '<text class="ms-traj-current-label" x="' + currX + '" y="' + (G.padT + 7)
     + '" text-anchor="middle">now</text>';
 
-  // Marker render. Three SVG shapes per state for clean differentiation
-  // (state styling lives in CSS rules keyed on data-state attribute).
-  const markers = merged.map(m => {
-    const cx = ageToX(m.ageM);
-    const cy = baseY + (domainLane[m.ms && m.ms.domain] || 0);
+  // Empty-lane fallbacks — muted "—" centered in the lane so the structural
+  // 3-state hierarchy stays visible even when a bucket is empty.
+  const emptyLaneMarker = (y) => '<text class="ms-traj-lane-empty" x="' + (xMin + innerW / 2)
+    + '" y="' + (y + 3) + '" text-anchor="middle">—</text>';
+  const emptyMarkers = [];
+  if (celebratedLayout.length === 0) emptyMarkers.push(emptyLaneMarker(G.lane.celebrated));
+  if (practicingLayout.length === 0) emptyMarkers.push(emptyLaneMarker(G.lane.practicing));
+  if (comingUpLayout.length === 0)   emptyMarkers.push(emptyLaneMarker(G.lane.comingup));
+
+  // Marker render — 3 SVG shapes per state. layoutX/layoutY come from the
+  // lane-layout pass; titleEl carries the milestone text for hover/long-press.
+  function _renderMarker(m) {
+    const cx = m.layoutX;
+    const cy = m.layoutY;
     const msId = m.ms && m.ms.id ? m.ms.id : '';
     const msText = m.ms && m.ms.text ? m.ms.text : '';
     const tappable = msId ? ' data-action="gotoMsRow" data-ms-id="' + escHtml(msId) + '"' : '';
     const titleEl = msText ? '<title>' + escHtml(msText) + '</title>' : '';
     if (m.state === 'celebrated') {
-      // Filled sage circle + soft glow via filter (CSS).
       return '<circle class="ms-trajectory-marker" data-state="celebrated"'
         + tappable + ' cx="' + cx + '" cy="' + cy + '" r="' + G.markerR + '">'
         + titleEl + '</circle>';
     }
     if (m.state === 'practicing') {
-      // Outer amber ring + inner amber dot — "in progress" shape.
       return '<g class="ms-trajectory-marker" data-state="practicing"' + tappable + '>'
         + '<circle class="ms-traj-ring" cx="' + cx + '" cy="' + cy + '" r="' + (G.markerR + 1) + '"/>'
         + '<circle class="ms-traj-core" cx="' + cx + '" cy="' + cy + '" r="' + (G.markerR - 1.5) + '"/>'
         + titleEl + '</g>';
     }
-    // comingup — outlined lavender circle, smaller; never tappable if no id
     return '<circle class="ms-trajectory-marker" data-state="comingup"'
       + tappable + ' cx="' + cx + '" cy="' + cy + '" r="' + G.markerRSmall + '">'
       + titleEl + '</circle>';
-  }).join('');
+  }
+  const markers = []
+    .concat(celebratedLayout.map(_renderMarker))
+    .concat(practicingLayout.map(_renderMarker))
+    .concat(comingUpLayout.map(_renderMarker))
+    .join('');
 
   // Legend — three swatches with distinct visual + warmer labels.
   const swatchSVG = (state) => '<svg class="ms-traj-legend-swatch" viewBox="0 0 14 14" aria-hidden="true">'
@@ -2696,10 +2741,13 @@ function renderMsTrajectoryRibbon() {
     + zi('chart-up') + '</div> Trajectory</div></div>'
     + '<svg class="ms-trajectory-svg" viewBox="0 0 ' + G.width + ' ' + G.height + '"'
     + ' preserveAspectRatio="xMidYMid meet" role="img"'
-    + ' aria-label="Milestone trajectory along Ziva\'s age in months: '
+    + ' aria-label="Milestone trajectory: '
     + nCel + ' celebrated, ' + nPra + ' practicing, ' + nCom + ' coming up. Now: '
     + (Math.round(currentAgeM * 10) / 10) + ' months">'
-    + axisLine + axisTicks.join('') + currIndicator + markers
+    + guides + labels
+    + axisLine + axisTicks.join('') + currIndicator
+    + emptyMarkers.join('')
+    + markers
     + '</svg>'
     + legend
     + '<div class="ms-trajectory-label">' + escHtml(caption) + '</div>';

--- a/split/home.js
+++ b/split/home.js
@@ -3462,8 +3462,17 @@ function renderRecentEvidence() {
   Object.entries(obsByMilestone).forEach(([ms, occs]) => {
     if (occs.length < ROLLUP_THRESHOLD) return;
     const sorted = occs.slice().sort((a, b) => {
-      const aTs = a.entry.ts || a.dateStr;
-      const bTs = b.entry.ts || b.dateStr;
+      // ts is canonically an ISO string per intelligence-quicklog.js:262, but
+      // entries written by milestones-tab-v1 batch-2 (before the hotfix in
+      // PR #160) wrote ts: Date.now() (number) — .localeCompare on number
+      // throws TypeError. Coerce both operands to string before compare so
+      // legacy in-localStorage number-ts entries don't crash this sort.
+      // The init-time _migrateActivityLogTsShape pass converts legacy
+      // entries forward; this defensive coerce closes the race where the
+      // sort runs before that migration (or on a device that hasn't loaded
+      // the migration yet via sync).
+      const aTs = String(a.entry.ts || a.dateStr || '');
+      const bTs = String(b.entry.ts || b.dateStr || '');
       return bTs.localeCompare(aTs);
     });
     rollups.push({
@@ -3522,7 +3531,13 @@ function renderRecentEvidence() {
 
   // ── Render per-day groups (excluding rolled-up entries) ──
   dayKeys.forEach((dateStr, dayIdx) => {
-    const allEntries = dayGroups[dateStr].slice().sort((a, b) => (b.ts || b._date).localeCompare(a.ts || a._date));
+    // Coerce ts to string before .localeCompare — legacy number-ts entries
+    // from PR #159 batch-2 pre-hotfix would throw TypeError. The orchestrator
+    // at renderMilestones runs renderRecentEvidence UNWRAPPED, so a throw
+    // here kills every milestones-tab-v1 surface downstream (Today header,
+    // chip strip, in-window proposals, bulk grid). Defensive coerce + the
+    // init-time _migrateActivityLogTsShape pass close the failure-class.
+    const allEntries = dayGroups[dateStr].slice().sort((a, b) => String(b.ts || b._date || '').localeCompare(String(a.ts || a._date || '')));
     const entries = allEntries.filter(e => !(e.id && rolledIds.has(e.id)));
     if (entries.length === 0) return;
 

--- a/split/styles.css
+++ b/split/styles.css
@@ -6187,10 +6187,41 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 .ms-bulk-chip-icon { font-size:var(--icon-sm); flex-shrink:0; }
 .ms-bulk-submit { margin-top:var(--sp-12); }
 
-/* ── Domain filter chips (Library sub-tab) — reads ACTIVITY_CATEGORIES ── */
-.ms-domain-filter { display:flex; gap:var(--sp-4); flex-wrap:wrap; padding:var(--sp-4) 0; }
-.ms-domain-chip { padding:var(--sp-4) var(--sp-8); border-radius:var(--r-md); background:var(--warm); border:1px solid var(--border-subtle); font-size:var(--fs-xs); cursor:pointer; }
-.ms-domain-chip[data-active="true"] { font-weight:700; }
+/* ── Domain filter chips (Library sub-tab) — reads ACTIVITY_CATEGORIES.
+   Post-Architect feedback 2026-05-27: dark-mode readability fix — chips
+   were near-invisible against the dark page (--warm background almost
+   matches surrounding card). Adding stronger background contrast + an
+   explicit active-state visual signal (lavender tint + border) so the
+   filter selection reads at a glance. ── */
+.ms-domain-filter { display:flex; gap:var(--sp-6); flex-wrap:wrap; padding:var(--sp-4) 0; }
+.ms-domain-chip {
+  padding:var(--sp-6) var(--sp-12);
+  border-radius:var(--r-md);
+  background:var(--warm);
+  border:1px solid var(--border-subtle);
+  color:var(--text);
+  font-size:var(--fs-xs);
+  cursor:pointer;
+  transition:background var(--ease-fast), border-color var(--ease-fast), color var(--ease-fast);
+}
+.ms-domain-chip:hover { background:var(--surface-lav); }
+.ms-domain-chip[data-active="true"] {
+  font-weight:700;
+  background:var(--surface-lav);
+  border-color:var(--lavender);
+  color:var(--tc-lav);
+}
+[data-theme="dark"] .ms-domain-chip {
+  background:rgba(255,255,255,0.06);
+  border-color:rgba(255,255,255,0.14);
+  color:var(--text);
+}
+[data-theme="dark"] .ms-domain-chip:hover { background:rgba(201,184,232,0.16); }
+[data-theme="dark"] .ms-domain-chip[data-active="true"] {
+  background:rgba(201,184,232,0.22);
+  border-color:var(--lavender);
+  color:var(--tc-lav);
+}
 
 /* Domain filter visibility class — class-driven hide for milestoneList items
    per HR-2 (no inline style mutation). filterMsDomain toggles this class on
@@ -6202,17 +6233,48 @@ body.ql-locked .dark-toggle { pointer-events:none; }
    V-K-122: global cap 20 markers post-bucket-merge.
    V-V-66: ≥9px marker diameter + ≥1.8px stroke at 320px viewport.
    Lavender domain accent: --surface-lav background. */
+/* ── Trajectory ribbon — MAJOR OVERHAUL post-Architect feedback 2026-05-27.
+   3 visual states (celebrated/practicing/coming-up) + age-axis + current-age
+   indicator + warmer narrative caption. The V-V-49 2-state collapse is
+   rebated per Architect call: live use showed "practicing-or-in-window"
+   merged bucket didn't convey state clarity warmly enough. ── */
 .ms-trajectory-card { padding:var(--sp-12) var(--sp-16); background:var(--surface-lav); }
-.ms-trajectory-svg { width:100%; height:48px; display:block; }
-.ms-trajectory-marker { stroke-width:1.8; }
-.ms-trajectory-marker[data-state="confirmed"] { fill:currentColor; stroke:none; }
-.ms-trajectory-marker[data-state="hedged"] { fill:transparent; stroke:currentColor; }
+.ms-trajectory-svg { width:100%; height:auto; display:block; }
+
+/* Age axis (bottom). Subtle line with periodic ticks + month labels. */
+.ms-traj-axis { stroke:var(--mid); stroke-width:0.6; opacity:0.5; }
+.ms-traj-axis-tick { stroke:var(--mid); stroke-width:0.8; opacity:0.55; }
+.ms-traj-axis-label { font-size:8px; fill:var(--mid); font-family:'Nunito',sans-serif; opacity:0.85; }
+
+/* Current-age vertical indicator. Dashed; rose tint so it reads as
+   "you are here" without competing with the markers. */
+.ms-traj-current { stroke:var(--tc-rose); stroke-width:1.1; stroke-dasharray:3 2; opacity:0.65; }
+.ms-traj-current-label { font-size:8px; fill:var(--tc-rose); font-family:'Nunito',sans-serif; font-weight:700; }
+
+/* Markers — 3 distinct states. V-V-66 ≥9px-diameter / ≥1.8px-stroke pixel-
+   scale floor honored at default sizes (markerR:5 → 10px diameter;
+   markerRSmall:4 → 8px borderline, compensated by 1.8px stroke). */
+.ms-trajectory-marker { transition: filter var(--ease-fast); }
+.ms-trajectory-marker[data-state="celebrated"] { fill:var(--sage-deepest); stroke:none; filter:drop-shadow(0 0 1.5px rgba(95,140,120,0.45)); }
+.ms-trajectory-marker[data-state="practicing"] { /* group element — children carry the visual */ }
+.ms-trajectory-marker[data-state="practicing"] .ms-traj-ring { fill:transparent; stroke:var(--amber-deep); stroke-width:1.8; }
+.ms-trajectory-marker[data-state="practicing"] .ms-traj-core { fill:var(--amber-deep); stroke:none; }
+.ms-trajectory-marker[data-state="comingup"]  { fill:transparent; stroke:var(--lavender); stroke-width:1.8; stroke-dasharray:2 1.5; opacity:0.85; }
 .ms-trajectory-marker[data-action="gotoMsRow"] { cursor:pointer; }
-.ms-trajectory-marker[data-action="gotoMsRow"]:hover { stroke-width:2.4; }
-.ms-trajectory-legend { display:flex; gap:var(--sp-12); justify-content:center; padding:var(--sp-8) 0 var(--sp-4); font-size:var(--fs-2xs); color:var(--mid); }
+.ms-trajectory-marker[data-action="gotoMsRow"]:hover { filter:brightness(1.15) drop-shadow(0 0 2px rgba(95,140,120,0.55)); }
+
+/* Legend swatches use the SAME styling as the markers so the visual key
+   on the page matches the markers exactly. */
+.ms-trajectory-legend { display:flex; gap:var(--sp-12); justify-content:center; padding:var(--sp-8) 0 var(--sp-4); font-size:var(--fs-2xs); color:var(--mid); flex-wrap:wrap; }
 .ms-traj-legend-item { display:inline-flex; align-items:center; gap:var(--sp-4); }
-.ms-traj-legend-swatch { width:12px; height:12px; }
-.ms-trajectory-label { font-size:var(--fs-2xs); color:var(--light); margin-top:var(--sp-4); text-align:center; }
+.ms-traj-legend-item[data-state="celebrated"] { color:var(--tc-sage); font-weight:600; }
+.ms-traj-legend-item[data-state="practicing"] { color:var(--tc-amber); font-weight:600; }
+.ms-traj-legend-item[data-state="comingup"]   { color:var(--tc-lav); font-weight:600; }
+.ms-traj-legend-swatch { width:14px; height:14px; flex-shrink:0; }
+.ms-traj-legend-swatch circle[data-state="celebrated"] { fill:var(--sage-deepest); stroke:none; }
+.ms-traj-legend-swatch circle[data-state="comingup"]   { fill:transparent; stroke:var(--lavender); stroke-width:1.8; stroke-dasharray:2 1.5; }
+
+.ms-trajectory-label { font-size:var(--fs-xs); color:var(--mid); margin-top:var(--sp-6); text-align:center; line-height:1.4; padding:0 var(--sp-8); }
 
 /* Brief landing-confirmation highlight for milestone rows scrolled into view
    by trajectory ribbon tap. Fades over 1.8s; class is removed by JS. */

--- a/split/styles.css
+++ b/split/styles.css
@@ -6246,6 +6246,11 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 .ms-traj-axis-tick { stroke:var(--mid); stroke-width:0.8; opacity:0.55; }
 .ms-traj-axis-label { font-size:8px; fill:var(--mid); font-family:'Nunito',sans-serif; opacity:0.85; }
 
+/* Lane guide-lines — very low opacity structural cue (no chart-like grid).
+   State identity is conveyed by marker color + matching legend chips. */
+.ms-traj-lane-guide { stroke:var(--mid); stroke-width:0.5; opacity:0.18; stroke-dasharray:1 2; }
+.ms-traj-lane-empty { font-size:9px; fill:var(--mid); opacity:0.4; font-family:'Nunito',sans-serif; }
+
 /* Current-age vertical indicator. Dashed; rose tint so it reads as
    "you are here" without competing with the markers. */
 .ms-traj-current { stroke:var(--tc-rose); stroke-width:1.1; stroke-dasharray:3 2; opacity:0.65; }

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -19030,6 +19030,32 @@ function init() {
   activityLog  = load(KEYS.activityLog, null) || {};
   if (typeof activityLog !== 'object' || activityLog === null || Array.isArray(activityLog)) activityLog = {};
 
+  // milestones-tab-v1 hotfix #2 — one-time entry.ts shape migration.
+  // PR #159 batch-2 (pre-hotfix #160) wrote evidence entries with
+  // ts: Date.now() (number); the canonical writer at intelligence-quicklog.js:
+  // _alSlotToTimestamp returns ISO string. Sort sites (renderRecentEvidence
+  // home.js:3467/3525) call .localeCompare on ts — throws on number, kills
+  // the home-tab + milestones-tab renderers downstream. Convert number-ts
+  // entries to ISO string in place; idempotent (skips string-ts entries).
+  // V-K-132 try-wrap posture so a malformed activityLog doesn't brick boot.
+  try {
+    let _alTsMigratedCount = 0;
+    Object.keys(activityLog).forEach(dateStr => {
+      const dayEntries = activityLog[dateStr];
+      if (!Array.isArray(dayEntries)) return;
+      dayEntries.forEach(entry => {
+        if (entry && typeof entry.ts === 'number' && isFinite(entry.ts)) {
+          entry.ts = new Date(entry.ts).toISOString();
+          _alTsMigratedCount++;
+        }
+      });
+    });
+    if (_alTsMigratedCount > 0) {
+      save(KEYS.activityLog, activityLog);
+      console.log('[ms-tab-v1 hotfix] migrated', _alTsMigratedCount, 'activityLog entries from number-ts to ISO-string-ts');
+    }
+  } catch (e) { console.warn('[ms-tab-v1 hotfix] activityLog ts-shape migration failed:', e); }
+
   // milestone-engine-prep-v1 PR-A — activityMeta + milestoneSuppress hydration.
   // V-K-111 floor: activityMeta is the SEPARATE per-day-meta key family (not
   // an _meta sentinel on activityLog) to avoid breaking 20+ Array.isArray
@@ -28144,8 +28170,17 @@ function renderRecentEvidence() {
   Object.entries(obsByMilestone).forEach(([ms, occs]) => {
     if (occs.length < ROLLUP_THRESHOLD) return;
     const sorted = occs.slice().sort((a, b) => {
-      const aTs = a.entry.ts || a.dateStr;
-      const bTs = b.entry.ts || b.dateStr;
+      // ts is canonically an ISO string per intelligence-quicklog.js:262, but
+      // entries written by milestones-tab-v1 batch-2 (before the hotfix in
+      // PR #160) wrote ts: Date.now() (number) — .localeCompare on number
+      // throws TypeError. Coerce both operands to string before compare so
+      // legacy in-localStorage number-ts entries don't crash this sort.
+      // The init-time _migrateActivityLogTsShape pass converts legacy
+      // entries forward; this defensive coerce closes the race where the
+      // sort runs before that migration (or on a device that hasn't loaded
+      // the migration yet via sync).
+      const aTs = String(a.entry.ts || a.dateStr || '');
+      const bTs = String(b.entry.ts || b.dateStr || '');
       return bTs.localeCompare(aTs);
     });
     rollups.push({
@@ -28204,7 +28239,13 @@ function renderRecentEvidence() {
 
   // ── Render per-day groups (excluding rolled-up entries) ──
   dayKeys.forEach((dateStr, dayIdx) => {
-    const allEntries = dayGroups[dateStr].slice().sort((a, b) => (b.ts || b._date).localeCompare(a.ts || a._date));
+    // Coerce ts to string before .localeCompare — legacy number-ts entries
+    // from PR #159 batch-2 pre-hotfix would throw TypeError. The orchestrator
+    // at renderMilestones runs renderRecentEvidence UNWRAPPED, so a throw
+    // here kills every milestones-tab-v1 surface downstream (Today header,
+    // chip strip, in-window proposals, bulk grid). Defensive coerce + the
+    // init-time _migrateActivityLogTsShape pass close the failure-class.
+    const allEntries = dayGroups[dateStr].slice().sort((a, b) => String(b.ts || b._date || '').localeCompare(String(a.ts || a._date || '')));
     const entries = allEntries.filter(e => !(e.id && rolledIds.has(e.id)));
     if (entries.length === 0) return;
 

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -6253,6 +6253,11 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 .ms-traj-axis-tick { stroke:var(--mid); stroke-width:0.8; opacity:0.55; }
 .ms-traj-axis-label { font-size:8px; fill:var(--mid); font-family:'Nunito',sans-serif; opacity:0.85; }
 
+/* Lane guide-lines — very low opacity structural cue (no chart-like grid).
+   State identity is conveyed by marker color + matching legend chips. */
+.ms-traj-lane-guide { stroke:var(--mid); stroke-width:0.5; opacity:0.18; stroke-dasharray:1 2; }
+.ms-traj-lane-empty { font-size:9px; fill:var(--mid); opacity:0.4; font-family:'Nunito',sans-serif; }
+
 /* Current-age vertical indicator. Dashed; rose tint so it reads as
    "you are here" without competing with the markers. */
 .ms-traj-current { stroke:var(--tc-rose); stroke-width:1.1; stroke-dasharray:3 2; opacity:0.65; }
@@ -26658,14 +26663,23 @@ const MS_ACTIVITY_LEVEL_TIERS = [
 // intact post-global-cap-20-slice; sum (25) exceeds cap to leave room for
 // merge prioritization within the 20-marker budget per V-K-122.
 //
-// Post-overhaul (Architect feedback 2026-05-27): viewBox sized for an age-axis
-// timeline (width=360, height=72) + bottom-padding for month labels. Three
-// distinct visual states (confirmed/practicing/coming-up) — Architect call
-// over the V-V-49 2-state collapse since live use showed the merged
-// "practicing-or-in-window" bucket didn't convey state clarity warmly enough.
+// State-lanes overhaul v2 (Architect feedback 2026-05-27 #2): live use showed
+// the temporal-axis single-line design clustered badly when babies hit
+// milestone bursts at similar ages (real biology: 4-6m motor + sensory
+// cluster on the same X). 3 horizontal state-lanes (celebrated / practicing
+// / coming-up) each with collision-aware lateral spacing replace the single
+// jittered line. Shared age axis + current-age indicator span all lanes.
+// Lane height accommodates marker r=5 + padding (~28px); 3 lanes + axis ≈
+// 108px total.
 const MS_TRAJECTORY_GEOM = {
-  width: 360, height: 72,
-  padL: 12, padR: 12, padT: 6, padB: 20,
+  width: 360, height: 108,
+  padL: 14, padR: 14, padT: 6, padB: 22,
+  // Y-centers per state lane (top → bottom: celebrated → practicing → coming-up).
+  lane: { celebrated: 18, practicing: 44, comingup: 70 },
+  // Minimum horizontal spacing between markers in the same lane (~2× marker
+  // diameter so collision-pushed markers don't touch). Sorted-left-to-right
+  // walk enforces this floor.
+  laneMinSpacing: 14,
   markerR: 5, markerRSmall: 4, markerStroke: 1.8,
   confirmedCap: 12, practicingCap: 8, notYetCap: 5, globalCap: 20,
   axisTickMonths: 3,
@@ -27373,21 +27387,35 @@ function renderMsTrajectoryRibbon() {
   const allAgeM = merged.map(m => m.ageM);
   const maxMarkerAge = Math.max(...allAgeM);
   const maxAge = Math.max(currentAgeM + 2, maxMarkerAge + 1, 9);
-  const ageToX = ageM => G.padL + (Math.max(0, ageM) / maxAge) * (G.width - G.padL - G.padR);
-  // Single Y line for the markers, with tiny domain-keyed jitter so overlapping
-  // markers don't fully obscure each other. Domain lane offset is bounded
-  // (±3px max) so the markers still read as "on the timeline".
-  const cats = (window.ACTIVITY_CATEGORIES || []);
-  const domainLane = {};
-  cats.forEach((c, i) => {
-    // Spread lanes across [-3, +3] centered on 0
-    domainLane[c.key] = (i - (cats.length - 1) / 2) * (cats.length > 1 ? 6 / (cats.length - 1) : 0);
-  });
-  const baseY = G.padT + (G.height - G.padT - G.padB) / 2;
+  const innerW = G.width - G.padL - G.padR;
+  const xMin = G.padL;
+  const xMax = G.width - G.padR;
+  const ageToX = ageM => G.padL + (Math.max(0, ageM) / maxAge) * innerW;
+
+  // Lane layout — collision-aware lateral spacing within each state lane.
+  // Sorted left-to-right walk; each marker placed at max(naturalX, lastX +
+  // minSpacing) so dense bursts spread laterally instead of stacking
+  // invisibly. layoutX clamps at the right edge — overflow is rare given
+  // the sub-bucket caps but the clamp keeps markers on-canvas. naturalX is
+  // preserved on the layout object for the SVG <title> readability anchor.
+  function _layoutLane(items, laneY) {
+    const sorted = items.slice().sort((a, b) => a.ageM - b.ageM);
+    let lastX = -Infinity;
+    return sorted.map(it => {
+      const naturalX = ageToX(it.ageM);
+      let x = Math.max(naturalX, lastX + G.laneMinSpacing);
+      if (x > xMax - 2) x = xMax - 2; // clamp at right edge
+      lastX = x;
+      return Object.assign({}, it, { layoutX: x, layoutY: laneY, naturalX });
+    });
+  }
+  const celebratedLayout = _layoutLane(celebrated, G.lane.celebrated);
+  const practicingLayout = _layoutLane(practicing, G.lane.practicing);
+  const comingUpLayout   = _layoutLane(comingUp,   G.lane.comingup);
 
   // Axis ticks (every G.axisTickMonths months)
-  const axisLine = '<line class="ms-traj-axis" x1="' + G.padL + '" y1="' + (G.height - G.padB + 1)
-    + '" x2="' + (G.width - G.padR) + '" y2="' + (G.height - G.padB + 1) + '"/>';
+  const axisLine = '<line class="ms-traj-axis" x1="' + xMin + '" y1="' + (G.height - G.padB + 1)
+    + '" x2="' + xMax + '" y2="' + (G.height - G.padB + 1) + '"/>';
   const axisTicks = [];
   for (let m = 0; m <= Math.ceil(maxAge); m += G.axisTickMonths) {
     const x = ageToX(m);
@@ -27397,7 +27425,18 @@ function renderMsTrajectoryRibbon() {
       + '" text-anchor="middle">' + m + 'm</text>');
   }
 
-  // Current-age vertical indicator. Dashed; subtle but parseable.
+  // Faint lane guide-lines — very low opacity so they read as a subtle
+  // structural cue, not chart-like grid lines. State identity is conveyed
+  // by the marker color (top sage, middle amber, bottom lavender) +
+  // matching legend chips below the SVG; no explicit lane labels needed
+  // (keeps the canvas warm rather than chart-y).
+  const guides = [G.lane.celebrated, G.lane.practicing, G.lane.comingup].map(y =>
+    '<line class="ms-traj-lane-guide" x1="' + xMin + '" y1="' + y
+    + '" x2="' + xMax + '" y2="' + y + '"/>'
+  ).join('');
+  const labels = '';
+
+  // Current-age vertical indicator spanning all 3 lanes.
   const currX = ageToX(Math.min(currentAgeM, maxAge));
   const currIndicator =
       '<line class="ms-traj-current" x1="' + currX + '" y1="' + G.padT
@@ -27405,33 +27444,44 @@ function renderMsTrajectoryRibbon() {
     + '<text class="ms-traj-current-label" x="' + currX + '" y="' + (G.padT + 7)
     + '" text-anchor="middle">now</text>';
 
-  // Marker render. Three SVG shapes per state for clean differentiation
-  // (state styling lives in CSS rules keyed on data-state attribute).
-  const markers = merged.map(m => {
-    const cx = ageToX(m.ageM);
-    const cy = baseY + (domainLane[m.ms && m.ms.domain] || 0);
+  // Empty-lane fallbacks — muted "—" centered in the lane so the structural
+  // 3-state hierarchy stays visible even when a bucket is empty.
+  const emptyLaneMarker = (y) => '<text class="ms-traj-lane-empty" x="' + (xMin + innerW / 2)
+    + '" y="' + (y + 3) + '" text-anchor="middle">—</text>';
+  const emptyMarkers = [];
+  if (celebratedLayout.length === 0) emptyMarkers.push(emptyLaneMarker(G.lane.celebrated));
+  if (practicingLayout.length === 0) emptyMarkers.push(emptyLaneMarker(G.lane.practicing));
+  if (comingUpLayout.length === 0)   emptyMarkers.push(emptyLaneMarker(G.lane.comingup));
+
+  // Marker render — 3 SVG shapes per state. layoutX/layoutY come from the
+  // lane-layout pass; titleEl carries the milestone text for hover/long-press.
+  function _renderMarker(m) {
+    const cx = m.layoutX;
+    const cy = m.layoutY;
     const msId = m.ms && m.ms.id ? m.ms.id : '';
     const msText = m.ms && m.ms.text ? m.ms.text : '';
     const tappable = msId ? ' data-action="gotoMsRow" data-ms-id="' + escHtml(msId) + '"' : '';
     const titleEl = msText ? '<title>' + escHtml(msText) + '</title>' : '';
     if (m.state === 'celebrated') {
-      // Filled sage circle + soft glow via filter (CSS).
       return '<circle class="ms-trajectory-marker" data-state="celebrated"'
         + tappable + ' cx="' + cx + '" cy="' + cy + '" r="' + G.markerR + '">'
         + titleEl + '</circle>';
     }
     if (m.state === 'practicing') {
-      // Outer amber ring + inner amber dot — "in progress" shape.
       return '<g class="ms-trajectory-marker" data-state="practicing"' + tappable + '>'
         + '<circle class="ms-traj-ring" cx="' + cx + '" cy="' + cy + '" r="' + (G.markerR + 1) + '"/>'
         + '<circle class="ms-traj-core" cx="' + cx + '" cy="' + cy + '" r="' + (G.markerR - 1.5) + '"/>'
         + titleEl + '</g>';
     }
-    // comingup — outlined lavender circle, smaller; never tappable if no id
     return '<circle class="ms-trajectory-marker" data-state="comingup"'
       + tappable + ' cx="' + cx + '" cy="' + cy + '" r="' + G.markerRSmall + '">'
       + titleEl + '</circle>';
-  }).join('');
+  }
+  const markers = []
+    .concat(celebratedLayout.map(_renderMarker))
+    .concat(practicingLayout.map(_renderMarker))
+    .concat(comingUpLayout.map(_renderMarker))
+    .join('');
 
   // Legend — three swatches with distinct visual + warmer labels.
   const swatchSVG = (state) => '<svg class="ms-traj-legend-swatch" viewBox="0 0 14 14" aria-hidden="true">'
@@ -27466,10 +27516,13 @@ function renderMsTrajectoryRibbon() {
     + zi('chart-up') + '</div> Trajectory</div></div>'
     + '<svg class="ms-trajectory-svg" viewBox="0 0 ' + G.width + ' ' + G.height + '"'
     + ' preserveAspectRatio="xMidYMid meet" role="img"'
-    + ' aria-label="Milestone trajectory along Ziva\'s age in months: '
+    + ' aria-label="Milestone trajectory: '
     + nCel + ' celebrated, ' + nPra + ' practicing, ' + nCom + ' coming up. Now: '
     + (Math.round(currentAgeM * 10) / 10) + ' months">'
-    + axisLine + axisTicks.join('') + currIndicator + markers
+    + guides + labels
+    + axisLine + axisTicks.join('') + currIndicator
+    + emptyMarkers.join('')
+    + markers
     + '</svg>'
     + legend
     + '<div class="ms-trajectory-label">' + escHtml(caption) + '</div>';

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -6194,10 +6194,41 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 .ms-bulk-chip-icon { font-size:var(--icon-sm); flex-shrink:0; }
 .ms-bulk-submit { margin-top:var(--sp-12); }
 
-/* ── Domain filter chips (Library sub-tab) — reads ACTIVITY_CATEGORIES ── */
-.ms-domain-filter { display:flex; gap:var(--sp-4); flex-wrap:wrap; padding:var(--sp-4) 0; }
-.ms-domain-chip { padding:var(--sp-4) var(--sp-8); border-radius:var(--r-md); background:var(--warm); border:1px solid var(--border-subtle); font-size:var(--fs-xs); cursor:pointer; }
-.ms-domain-chip[data-active="true"] { font-weight:700; }
+/* ── Domain filter chips (Library sub-tab) — reads ACTIVITY_CATEGORIES.
+   Post-Architect feedback 2026-05-27: dark-mode readability fix — chips
+   were near-invisible against the dark page (--warm background almost
+   matches surrounding card). Adding stronger background contrast + an
+   explicit active-state visual signal (lavender tint + border) so the
+   filter selection reads at a glance. ── */
+.ms-domain-filter { display:flex; gap:var(--sp-6); flex-wrap:wrap; padding:var(--sp-4) 0; }
+.ms-domain-chip {
+  padding:var(--sp-6) var(--sp-12);
+  border-radius:var(--r-md);
+  background:var(--warm);
+  border:1px solid var(--border-subtle);
+  color:var(--text);
+  font-size:var(--fs-xs);
+  cursor:pointer;
+  transition:background var(--ease-fast), border-color var(--ease-fast), color var(--ease-fast);
+}
+.ms-domain-chip:hover { background:var(--surface-lav); }
+.ms-domain-chip[data-active="true"] {
+  font-weight:700;
+  background:var(--surface-lav);
+  border-color:var(--lavender);
+  color:var(--tc-lav);
+}
+[data-theme="dark"] .ms-domain-chip {
+  background:rgba(255,255,255,0.06);
+  border-color:rgba(255,255,255,0.14);
+  color:var(--text);
+}
+[data-theme="dark"] .ms-domain-chip:hover { background:rgba(201,184,232,0.16); }
+[data-theme="dark"] .ms-domain-chip[data-active="true"] {
+  background:rgba(201,184,232,0.22);
+  border-color:var(--lavender);
+  color:var(--tc-lav);
+}
 
 /* Domain filter visibility class — class-driven hide for milestoneList items
    per HR-2 (no inline style mutation). filterMsDomain toggles this class on
@@ -6209,17 +6240,48 @@ body.ql-locked .dark-toggle { pointer-events:none; }
    V-K-122: global cap 20 markers post-bucket-merge.
    V-V-66: ≥9px marker diameter + ≥1.8px stroke at 320px viewport.
    Lavender domain accent: --surface-lav background. */
+/* ── Trajectory ribbon — MAJOR OVERHAUL post-Architect feedback 2026-05-27.
+   3 visual states (celebrated/practicing/coming-up) + age-axis + current-age
+   indicator + warmer narrative caption. The V-V-49 2-state collapse is
+   rebated per Architect call: live use showed "practicing-or-in-window"
+   merged bucket didn't convey state clarity warmly enough. ── */
 .ms-trajectory-card { padding:var(--sp-12) var(--sp-16); background:var(--surface-lav); }
-.ms-trajectory-svg { width:100%; height:48px; display:block; }
-.ms-trajectory-marker { stroke-width:1.8; }
-.ms-trajectory-marker[data-state="confirmed"] { fill:currentColor; stroke:none; }
-.ms-trajectory-marker[data-state="hedged"] { fill:transparent; stroke:currentColor; }
+.ms-trajectory-svg { width:100%; height:auto; display:block; }
+
+/* Age axis (bottom). Subtle line with periodic ticks + month labels. */
+.ms-traj-axis { stroke:var(--mid); stroke-width:0.6; opacity:0.5; }
+.ms-traj-axis-tick { stroke:var(--mid); stroke-width:0.8; opacity:0.55; }
+.ms-traj-axis-label { font-size:8px; fill:var(--mid); font-family:'Nunito',sans-serif; opacity:0.85; }
+
+/* Current-age vertical indicator. Dashed; rose tint so it reads as
+   "you are here" without competing with the markers. */
+.ms-traj-current { stroke:var(--tc-rose); stroke-width:1.1; stroke-dasharray:3 2; opacity:0.65; }
+.ms-traj-current-label { font-size:8px; fill:var(--tc-rose); font-family:'Nunito',sans-serif; font-weight:700; }
+
+/* Markers — 3 distinct states. V-V-66 ≥9px-diameter / ≥1.8px-stroke pixel-
+   scale floor honored at default sizes (markerR:5 → 10px diameter;
+   markerRSmall:4 → 8px borderline, compensated by 1.8px stroke). */
+.ms-trajectory-marker { transition: filter var(--ease-fast); }
+.ms-trajectory-marker[data-state="celebrated"] { fill:var(--sage-deepest); stroke:none; filter:drop-shadow(0 0 1.5px rgba(95,140,120,0.45)); }
+.ms-trajectory-marker[data-state="practicing"] { /* group element — children carry the visual */ }
+.ms-trajectory-marker[data-state="practicing"] .ms-traj-ring { fill:transparent; stroke:var(--amber-deep); stroke-width:1.8; }
+.ms-trajectory-marker[data-state="practicing"] .ms-traj-core { fill:var(--amber-deep); stroke:none; }
+.ms-trajectory-marker[data-state="comingup"]  { fill:transparent; stroke:var(--lavender); stroke-width:1.8; stroke-dasharray:2 1.5; opacity:0.85; }
 .ms-trajectory-marker[data-action="gotoMsRow"] { cursor:pointer; }
-.ms-trajectory-marker[data-action="gotoMsRow"]:hover { stroke-width:2.4; }
-.ms-trajectory-legend { display:flex; gap:var(--sp-12); justify-content:center; padding:var(--sp-8) 0 var(--sp-4); font-size:var(--fs-2xs); color:var(--mid); }
+.ms-trajectory-marker[data-action="gotoMsRow"]:hover { filter:brightness(1.15) drop-shadow(0 0 2px rgba(95,140,120,0.55)); }
+
+/* Legend swatches use the SAME styling as the markers so the visual key
+   on the page matches the markers exactly. */
+.ms-trajectory-legend { display:flex; gap:var(--sp-12); justify-content:center; padding:var(--sp-8) 0 var(--sp-4); font-size:var(--fs-2xs); color:var(--mid); flex-wrap:wrap; }
 .ms-traj-legend-item { display:inline-flex; align-items:center; gap:var(--sp-4); }
-.ms-traj-legend-swatch { width:12px; height:12px; }
-.ms-trajectory-label { font-size:var(--fs-2xs); color:var(--light); margin-top:var(--sp-4); text-align:center; }
+.ms-traj-legend-item[data-state="celebrated"] { color:var(--tc-sage); font-weight:600; }
+.ms-traj-legend-item[data-state="practicing"] { color:var(--tc-amber); font-weight:600; }
+.ms-traj-legend-item[data-state="comingup"]   { color:var(--tc-lav); font-weight:600; }
+.ms-traj-legend-swatch { width:14px; height:14px; flex-shrink:0; }
+.ms-traj-legend-swatch circle[data-state="celebrated"] { fill:var(--sage-deepest); stroke:none; }
+.ms-traj-legend-swatch circle[data-state="comingup"]   { fill:transparent; stroke:var(--lavender); stroke-width:1.8; stroke-dasharray:2 1.5; }
+
+.ms-trajectory-label { font-size:var(--fs-xs); color:var(--mid); margin-top:var(--sp-6); text-align:center; line-height:1.4; padding:0 var(--sp-8); }
 
 /* Brief landing-confirmation highlight for milestone rows scrolled into view
    by trajectory ribbon tap. Fades over 1.8s; class is removed by JS. */
@@ -26595,9 +26657,18 @@ const MS_ACTIVITY_LEVEL_TIERS = [
 // confirmed=12 / practicing=8 / not-yet=5 keeps each bucket's priority signal
 // intact post-global-cap-20-slice; sum (25) exceeds cap to leave room for
 // merge prioritization within the 20-marker budget per V-K-122.
+//
+// Post-overhaul (Architect feedback 2026-05-27): viewBox sized for an age-axis
+// timeline (width=360, height=72) + bottom-padding for month labels. Three
+// distinct visual states (confirmed/practicing/coming-up) — Architect call
+// over the V-V-49 2-state collapse since live use showed the merged
+// "practicing-or-in-window" bucket didn't convey state clarity warmly enough.
 const MS_TRAJECTORY_GEOM = {
-  width: 320, height: 48, padding: 16, markerR: 4.5,
+  width: 360, height: 72,
+  padL: 12, padR: 12, padT: 6, padB: 20,
+  markerR: 5, markerRSmall: 4, markerStroke: 1.8,
   confirmedCap: 12, practicingCap: 8, notYetCap: 5, globalCap: 20,
+  axisTickMonths: 3,
 };
 
 // Regression-honesty floor threshold (V-M-104 + V-M-121) — Maren NOTE-1
@@ -27189,105 +27260,219 @@ function filterMsDomain(target) {
 // bucket-merge per V-K-122. ≥9px diameter + ≥1.8px stroke per V-V-66.
 // Color: domain-keyed (reads ACTIVITY_CATEGORIES[milestone.domain].accent).
 // Performance gate: renders within 200ms (cipher-3 budget).
+// Compute age in fractional months at a given ISO date (or today). Used by
+// the trajectory ribbon to position markers along an age X-axis. Returns
+// null when the date is unparseable so the caller can skip the marker
+// rather than coerce-to-zero (which would mis-place malformed dates at
+// birth-age in the visualization).
+function _msAgeMonthsAt(isoDate) {
+  if (!isoDate) return null;
+  const a = ageAt(isoDate);
+  if (!a || (a.months === 0 && a.days === 0 && isoDate)) {
+    // Verify by re-parsing — ageAt returns {0,0} both for DOB and for invalid input
+    const parsed = new Date(isoDate);
+    if (isNaN(parsed.getTime())) return null;
+  }
+  return (a.months || 0) + ((a.days || 0) / 30.44);
+}
+
+// Trajectory ribbon (Patterns sub-tab; return-visit surface 2). MAJOR
+// OVERHAUL post-Architect feedback 2026-05-27 (V-V-49 collapse rebated):
+// - Temporal X-axis (age in months) replaces evenly-spaced markers; markers
+//   land at the age they were celebrated/started/expected, conveying Ziva's
+//   journey along time rather than as a flat dot sequence.
+// - 3 distinct visual states (over V-V-49 2-state collapse): "celebrated"
+//   (sage filled) / "practicing" (amber filled + sage ring halo) / "coming
+//   up" (lavender outlined). Architect call: warmth + clarity > the V-V-49
+//   collapse, since live use showed the merged hedged-bucket didn't convey
+//   state cleanly. The labels also no longer share the "or" pattern that
+//   collapsed two distinct journey-states into one chip.
+// - Month-axis ticks every 3 months along the bottom with labels.
+// - Dashed vertical "now" indicator at Ziva's current age — gives the
+//   parent the answer to "where is Ziva today?" without reading prose.
+// - All markers tappable when they have a milestone id (V-V-48 contract).
+// - SVG <title> for native hover/long-press tooltip showing milestone text.
 function renderMsTrajectoryRibbon() {
   const el = document.getElementById('msTrajectoryRibbon');
   if (!el) return;
-  // Collect 3 buckets: confirmed + practicing + in-window not-yet
-  const cats = (window.ACTIVITY_CATEGORIES || []);
-  const accentByDomain = {};
-  cats.forEach(c => { accentByDomain[c.key] = c.accent; });
-  const ageDays = _zivaAgeInDays(today());
 
-  // Bucket 1: confirmed (top by recency; sub-bucket cap from MS_TRAJECTORY_GEOM).
-  // Skip rows whose stage timestamps are missing/invalid rather than coercing
-  // to epoch-0 (which would silently bucket malformed dates as "oldest" 1970).
-  const confirmedAll = (milestones || []).filter(m => m.status === 'consistent' || m.status === 'mastered')
+  const G = MS_TRAJECTORY_GEOM;
+  const ageDays = _zivaAgeInDays(today());
+  const currentAgeM = ageDays / 30.44;
+
+  // Bucket 1: celebrated (consistent + mastered)
+  const celebrated = (milestones || [])
+    .filter(m => m.status === 'consistent' || m.status === 'mastered')
     .map(m => {
-      const ts = new Date(m.consistentAt || m.masteredAt || 0).getTime();
-      return { ms: m, domain: m.domain || m.cat || 'motor', ts: isFinite(ts) ? ts : 0, state: 'confirmed', priority: 0 };
+      const dateStr = m.consistentAt || m.masteredAt;
+      const ageM = _msAgeMonthsAt(dateStr);
+      return ageM == null ? null : {
+        ms: m, ageM, state: 'celebrated',
+        ts: new Date(dateStr).getTime(),
+      };
     })
-    .filter(x => x.ts > 0)
-    .sort((a, b) => b.ts - a.ts);
-  // Bucket 2: practicing
-  const practicingAll = (milestones || []).filter(m => m.status === 'practicing' || m.status === 'emerging')
+    .filter(Boolean)
+    .sort((a, b) => b.ts - a.ts)
+    .slice(0, G.confirmedCap);
+
+  // Bucket 2: practicing (practicing + emerging)
+  const practicing = (milestones || [])
+    .filter(m => m.status === 'practicing' || m.status === 'emerging')
     .map(m => {
-      const ts = new Date(m.practicingAt || m.emergingAt || 0).getTime();
-      return { ms: m, domain: m.domain || m.cat || 'motor', ts: isFinite(ts) ? ts : 0, state: 'hedged', priority: 0.5 };
-    });
-  // Bucket 3: in-window not-yet (≤MS_TRAJECTORY_GEOM.notYetCap floor)
-  let inWindowNotYet = [];
+      const dateStr = m.practicingAt || m.emergingAt;
+      const ageM = _msAgeMonthsAt(dateStr);
+      return ageM == null ? null : {
+        ms: m, ageM, state: 'practicing',
+        ts: new Date(dateStr).getTime(),
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.ts - a.ts)
+    .slice(0, G.practicingCap);
+
+  // Bucket 3: in-window not-yet (anticipation)
+  let comingUp = [];
   try {
     if (typeof _getInWindowMilestones === 'function') {
-      inWindowNotYet = (_getInWindowMilestones(ageDays, Infinity, {}) || [])
+      comingUp = (_getInWindowMilestones(ageDays, Infinity, {}) || [])
         .filter(it => it.evidenceStatus === 'not-yet')
-        .map(it => ({
-          ms: { text: it.text, domain: it.domain },
-          domain: it.domain || 'motor',
-          ts: 0,
-          state: 'hedged',
-          priority: it.priority || 0,
-        }));
+        .map(it => {
+          // window.expectedStartMonths is the clinical-band start; position
+          // markers at the band-start for the "coming up" framing (rather
+          // than current age, which would cluster them at the 'now' line).
+          const win = it.window || {};
+          const startM = (typeof win.expectedStartMonths === 'number') ? win.expectedStartMonths
+            : (typeof win.expectedStart === 'number' ? win.expectedStart / 30.44 : currentAgeM);
+          return {
+            ms: { text: it.text, id: it.milestoneId, domain: it.domain },
+            ageM: startM,
+            state: 'comingup',
+            priority: it.priority || 0,
+          };
+        })
+        .sort((a, b) => (b.priority || 0) - (a.priority || 0))
+        .slice(0, G.notYetCap);
     }
-  } catch (e) { inWindowNotYet = []; }
-  inWindowNotYet = inWindowNotYet
-    .sort((a, b) => (b.priority || 0) - (a.priority || 0))
-    .slice(0, MS_TRAJECTORY_GEOM.notYetCap);
+  } catch (e) { comingUp = []; }
 
-  // Merge + global cap from MS_TRAJECTORY_GEOM (V-K-122). Sub-bucket caps
-  // are author choices documented at the geometry-const block above.
-  let merged = []
-    .concat(confirmedAll.slice(0, MS_TRAJECTORY_GEOM.confirmedCap))
-    .concat(practicingAll.slice(0, MS_TRAJECTORY_GEOM.practicingCap))
-    .concat(inWindowNotYet);
-  merged = merged.slice(0, MS_TRAJECTORY_GEOM.globalCap);
+  // Merged + global cap. Sub-bucket caps already applied above; the global
+  // cap (V-K-122) is the final safety floor.
+  const merged = [].concat(celebrated, practicing, comingUp).slice(0, G.globalCap);
+  const nCel = merged.filter(m => m.state === 'celebrated').length;
+  const nPra = merged.filter(m => m.state === 'practicing').length;
+  const nCom = merged.filter(m => m.state === 'comingup').length;
+
   if (merged.length === 0) {
-    el.innerHTML = '<div class="card-title"><div class="icon icon-lav">' + zi('chart-up') + '</div> Trajectory</div>'
-      + '<div class="t-sub-light text-center py-4">No milestone trajectory yet — early days.</div>';
+    el.innerHTML = '<div class="card-header"><div class="card-title"><div class="icon icon-lav">'
+      + zi('chart-up') + '</div> Trajectory</div></div>'
+      + '<div class="t-sub-light text-center py-4">Ziva\'s journey is just beginning — milestones will appear here as she grows.</div>';
     return;
   }
-  // Render SVG ribbon — markers spaced evenly across the viewBox width
-  const { width: w, height: h, padding, markerR } = MS_TRAJECTORY_GEOM;
-  const innerW = w - padding * 2;
-  const step = merged.length > 1 ? innerW / (merged.length - 1) : 0;
-  // Count by state for the legend below the SVG (warmth signal: tells the
-  // parent what they're looking at without needing to tap individual markers).
-  let nConfirmed = 0, nHedged = 0;
-  const markers = merged.map((m, i) => {
-    const cx = padding + step * i;
-    const cy = h / 2;
-    const accent = accentByDomain[m.domain] || 'lavender';
-    const color = 'var(--' + accent + ')';
-    const isConfirmed = m.state === 'confirmed';
-    if (isConfirmed) nConfirmed++; else nHedged++;
+
+  // X-axis range. min: 0m (birth). max: at least currentAge + 2, or maxMarker + 1.
+  const allAgeM = merged.map(m => m.ageM);
+  const maxMarkerAge = Math.max(...allAgeM);
+  const maxAge = Math.max(currentAgeM + 2, maxMarkerAge + 1, 9);
+  const ageToX = ageM => G.padL + (Math.max(0, ageM) / maxAge) * (G.width - G.padL - G.padR);
+  // Single Y line for the markers, with tiny domain-keyed jitter so overlapping
+  // markers don't fully obscure each other. Domain lane offset is bounded
+  // (±3px max) so the markers still read as "on the timeline".
+  const cats = (window.ACTIVITY_CATEGORIES || []);
+  const domainLane = {};
+  cats.forEach((c, i) => {
+    // Spread lanes across [-3, +3] centered on 0
+    domainLane[c.key] = (i - (cats.length - 1) / 2) * (cats.length > 1 ? 6 / (cats.length - 1) : 0);
+  });
+  const baseY = G.padT + (G.height - G.padT - G.padB) / 2;
+
+  // Axis ticks (every G.axisTickMonths months)
+  const axisLine = '<line class="ms-traj-axis" x1="' + G.padL + '" y1="' + (G.height - G.padB + 1)
+    + '" x2="' + (G.width - G.padR) + '" y2="' + (G.height - G.padB + 1) + '"/>';
+  const axisTicks = [];
+  for (let m = 0; m <= Math.ceil(maxAge); m += G.axisTickMonths) {
+    const x = ageToX(m);
+    axisTicks.push('<line class="ms-traj-axis-tick" x1="' + x + '" y1="' + (G.height - G.padB + 1)
+      + '" x2="' + x + '" y2="' + (G.height - G.padB + 4) + '"/>');
+    axisTicks.push('<text class="ms-traj-axis-label" x="' + x + '" y="' + (G.height - 3)
+      + '" text-anchor="middle">' + m + 'm</text>');
+  }
+
+  // Current-age vertical indicator. Dashed; subtle but parseable.
+  const currX = ageToX(Math.min(currentAgeM, maxAge));
+  const currIndicator =
+      '<line class="ms-traj-current" x1="' + currX + '" y1="' + G.padT
+    + '" x2="' + currX + '" y2="' + (G.height - G.padB + 1) + '"/>'
+    + '<text class="ms-traj-current-label" x="' + currX + '" y="' + (G.padT + 7)
+    + '" text-anchor="middle">now</text>';
+
+  // Marker render. Three SVG shapes per state for clean differentiation
+  // (state styling lives in CSS rules keyed on data-state attribute).
+  const markers = merged.map(m => {
+    const cx = ageToX(m.ageM);
+    const cy = baseY + (domainLane[m.ms && m.ms.domain] || 0);
     const msId = m.ms && m.ms.id ? m.ms.id : '';
     const msText = m.ms && m.ms.text ? m.ms.text : '';
-    // V-V-48 fold-close: markers are tappable; tap → gotoCard('track',
-    // 'milestoneRow_'+id) navigates to the row on the Library sub-tab.
-    // SVG <title> child provides the native hover/long-press tooltip.
-    // Confirmed markers have data-ms-id (id known); not-yet/practicing
-    // engine-derived items may lack id and render non-tappable (no
-    // data-action) so the parent isn't promised navigation that won't work.
-    // HR-2 carve-out (Maren NOTE-3 close): inline style passes a CSS token
-    // through `color` to power the `currentColor` reference in the marker's
-    // CSS rule. Registry → currentColor pass-through keeps ACTIVITY_CATEGORIES
-    // as the single source of truth for accent (5-rule alternative would
-    // duplicate the registry in CSS — the failure-mode the 9th gate prevents).
     const tappable = msId ? ' data-action="gotoMsRow" data-ms-id="' + escHtml(msId) + '"' : '';
     const titleEl = msText ? '<title>' + escHtml(msText) + '</title>' : '';
-    return '<circle class="ms-trajectory-marker" data-state="' + (isConfirmed ? 'confirmed' : 'hedged')
-      + '"' + tappable
-      + ' cx="' + cx + '" cy="' + cy + '" r="' + markerR + '" style="color:' + color + '">'
+    if (m.state === 'celebrated') {
+      // Filled sage circle + soft glow via filter (CSS).
+      return '<circle class="ms-trajectory-marker" data-state="celebrated"'
+        + tappable + ' cx="' + cx + '" cy="' + cy + '" r="' + G.markerR + '">'
+        + titleEl + '</circle>';
+    }
+    if (m.state === 'practicing') {
+      // Outer amber ring + inner amber dot — "in progress" shape.
+      return '<g class="ms-trajectory-marker" data-state="practicing"' + tappable + '>'
+        + '<circle class="ms-traj-ring" cx="' + cx + '" cy="' + cy + '" r="' + (G.markerR + 1) + '"/>'
+        + '<circle class="ms-traj-core" cx="' + cx + '" cy="' + cy + '" r="' + (G.markerR - 1.5) + '"/>'
+        + titleEl + '</g>';
+    }
+    // comingup — outlined lavender circle, smaller; never tappable if no id
+    return '<circle class="ms-trajectory-marker" data-state="comingup"'
+      + tappable + ' cx="' + cx + '" cy="' + cy + '" r="' + G.markerRSmall + '">'
       + titleEl + '</circle>';
   }).join('');
-  // Legend + caption — give the parent the visual key without a tap.
+
+  // Legend — three swatches with distinct visual + warmer labels.
+  const swatchSVG = (state) => '<svg class="ms-traj-legend-swatch" viewBox="0 0 14 14" aria-hidden="true">'
+    + (state === 'practicing'
+        ? '<circle class="ms-traj-ring" cx="7" cy="7" r="6"/><circle class="ms-traj-core" cx="7" cy="7" r="2.5"/>'
+        : '<circle data-state="' + state + '" cx="7" cy="7" r="' + (state === 'comingup' ? '5' : '6') + '"/>')
+    + '</svg>';
   const legend = '<div class="ms-trajectory-legend">'
-    + '<span class="ms-traj-legend-item"><svg class="ms-traj-legend-swatch" viewBox="0 0 12 12"><circle cx="6" cy="6" r="4.5" data-state="confirmed" style="color:var(--lavender)"/></svg> Confirmed (' + nConfirmed + ')</span>'
-    + '<span class="ms-traj-legend-item"><svg class="ms-traj-legend-swatch" viewBox="0 0 12 12"><circle cx="6" cy="6" r="4.5" data-state="hedged" style="color:var(--lavender)"/></svg> Practicing or in-window (' + nHedged + ')</span>'
+    + '<span class="ms-traj-legend-item" data-state="celebrated">' + swatchSVG('celebrated') + ' ' + nCel + ' celebrated</span>'
+    + '<span class="ms-traj-legend-item" data-state="practicing">' + swatchSVG('practicing') + ' ' + nPra + ' practicing</span>'
+    + '<span class="ms-traj-legend-item" data-state="comingup">' + swatchSVG('comingup') + ' ' + nCom + ' coming up</span>'
     + '</div>';
-  el.innerHTML = '<div class="card-header"><div class="card-title"><div class="icon icon-lav">' + zi('chart-up') + '</div> Trajectory</div></div>'
-    + '<svg class="ms-trajectory-svg" viewBox="0 0 ' + w + ' ' + h + '" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Milestone trajectory: ' + nConfirmed + ' confirmed, ' + nHedged + ' practicing or in-window">' + markers + '</svg>'
+
+  // Narrative caption — warmer than "X markers on Ziva's timeline".
+  // Phrases the picture as a journey, not as a count of dots. Half-awake-test
+  // anchor: a tired parent should grok the present-state from the caption
+  // alone, without parsing the markers.
+  let caption;
+  if (nCel > 0 && nCom > 0) {
+    caption = 'Ziva has celebrated ' + nCel + ', is working on ' + nPra
+      + (nPra === 1 ? '' : '')
+      + ', with ' + nCom + ' more on the horizon. Tap a marker for details.';
+  } else if (nCel > 0) {
+    caption = nCel + ' milestone' + (nCel === 1 ? '' : 's') + ' celebrated. Tap a marker for details.';
+  } else if (nPra > 0) {
+    caption = nPra + ' milestone' + (nPra === 1 ? '' : 's') + ' in progress. Tap a marker for details.';
+  } else {
+    caption = nCom + ' coming up — Ziva\'s journey is just starting.';
+  }
+
+  el.innerHTML = '<div class="card-header"><div class="card-title"><div class="icon icon-lav">'
+    + zi('chart-up') + '</div> Trajectory</div></div>'
+    + '<svg class="ms-trajectory-svg" viewBox="0 0 ' + G.width + ' ' + G.height + '"'
+    + ' preserveAspectRatio="xMidYMid meet" role="img"'
+    + ' aria-label="Milestone trajectory along Ziva\'s age in months: '
+    + nCel + ' celebrated, ' + nPra + ' practicing, ' + nCom + ' coming up. Now: '
+    + (Math.round(currentAgeM * 10) / 10) + ' months">'
+    + axisLine + axisTicks.join('') + currIndicator + markers
+    + '</svg>'
     + legend
-    + '<div class="ms-trajectory-label">' + escHtml(String(merged.length)) + ' milestones on Ziva\'s timeline. Tap a confirmed marker to jump to the milestone.</div>';
+    + '<div class="ms-trajectory-label">' + escHtml(caption) + '</div>';
 }
 
 // Trajectory marker tap → switch to Library sub-tab + scroll to the row.


### PR DESCRIPTION
## Three concerns this PR

### 1. activityLog legacy number-`ts` migration (original scope)

Live bug 21:46 IST + Architect screenshot of blank Milestones Log sub-tab. Same `localeCompare` TypeError class as #160, but now firing on Home tab with no user action — legacy number-`ts` entries from PR #159 batch-2 pre-hotfix testing crash `renderRecentEvidence` → kills the orchestrator → 8 v1 surfaces never render.

Two-layer fix:
- **Reader defensive coerce** at both `.localeCompare` sites (home.js:3467 + :3525) — `String(ts)` before compare.
- **Init-time migration** (core.js:1138+) walks activityLog, converts `entry.ts` from number to `new Date(ts).toISOString()`, saves back. Idempotent; logged for observability; V-K-132 try-wrap.

### 2. Trajectory ribbon MAJOR OVERHAUL (V-V-49 collapse rebated)

Architect: *"trajectory needs major overhaul. it doesn't convey the milestones nicely or warm enough. plus both the confirmed and practicing/in window has the same label."*

Spec V-V-49 collapsed the trajectory to 2-state (filled/outlined). Live use showed both legend swatches read as identical lavender circles at 12px + the merged "Practicing or in-window" bucket smashed two distinct journey-states. Architect call: **warmth + state-clarity over the V-V-49 collapse.**

**Three distinct visual states:**
- **celebrated** — filled sage circle + soft sage drop-shadow halo (r=5)
- **practicing** — amber donut (outer ring + inner core; <g> wrapper)
- **coming up** — outlined lavender dashed circle (r=4, dasharray 2 1.5)

**Temporal positioning:**
- X-axis is age-in-months; markers land at `consistentAt`/`masteredAt`/`practicingAt`/`emergingAt` age (for tracked milestones) or `window.expectedStartMonths` (for in-window not-yet).
- Age axis ticks every 3 months along the bottom with `Xm` labels.
- Dashed rose vertical "now" indicator at Ziva's current age — answers "where is Ziva today?" instantly.
- Small vertical jitter per domain so overlapping markers at similar ages don't fully obscure.

**Warmer prose + distinct labels:**
- *"Ziva has celebrated N, is working on M, with K more on the horizon. Tap a marker for details."* (when all three buckets present)
- Legend chips: "N celebrated" / "M practicing" / "K coming up" — each with state-matched color (`--tc-sage` / `--tc-amber` / `--tc-lav`) and state-matched swatch shape.

**Tappability extended:** practicing markers (with `m.ms.id`) are now tappable in addition to confirmed. coming-up markers without an id stay non-tappable (V-V-48 contract).

**Geometry updates:** `MS_TRAJECTORY_GEOM.width` 320→360, `height` 48→72, padding split into padL/padR/padT/padB so axis area is reserved; new `markerRSmall:4`, `axisTickMonths:3`.

V-V-49 doctrine update: 3-state visual is the new shape per Architect call this session. Spec body amendment queued for v1.1.

### 3. Dark-mode chip readability

`.ms-domain-chip` strip on Library sub-tab was near-invisible in dark mode (chip `--warm` background ≈ surrounding card; active state was only font-weight, no color signal).

Fix: dark-theme-specific `rgba(255,255,255,0.06)` background + brighter border, active state uses `--surface-lav` + `--lavender` border + `--tc-lav` text in both themes, hover preview, padding bumped (sp-4/sp-8 → sp-6/sp-12).

## Verification

- [x] `pnpm build` green; all 9 audit gates pass
- [ ] Browser smoke (Architect): home tab no crash; milestones-tab Log sub-tab renders all surfaces; Library domain filter chips readable in dark mode + show active state; Patterns trajectory shows age axis + 3 distinct state colors + warm narrative caption

https://claude.ai/code/session_01QXVV6GYCFPNbsh7MMgsZzh