### PR TITLE
Motion One — fix 404 CDN URL + fallback CSS instant-collapse bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -6247,28 +6247,28 @@ body.ql-locked .dark-toggle { pointer-events:none; }
   background:var(--surface);
   border-left:var(--accent-w) solid var(--al-border, var(--lavender));
   box-shadow:0 1px 4px rgba(0,0,0,0.04);
-  /* Tap-out + push-down animation support — closes Architect feedback
-     2026-05-27 #7. Confirm/Practicing slide the card left out of the
-     stack ("make way for other options"); Not-yet slides the card down
-     to be reordered to the bottom on the next render. transform-origin
-     left to keep the slide feel anchored. */
+  /* Tap-out + push-down animation support (Architect 2026-05-27 #7+#10).
+     Motion One drives the primary animation when window.Motion is available;
+     these CSS rules are the FALLBACK path (offline parent, blocked CDN,
+     cached pre-Motion HTML). Transitions only animate transform + opacity —
+     padding/margin/max-height collapse was removed because non-animatable
+     auto→0 transitions caused an instant height-jump that read as
+     "disappearing" rather than "swiping out" (Architect bug-report fix
+     2026-05-27 #11). The card retains its slot during the slide; the
+     subsequent renderMilestones() removes it from the DOM cleanly. */
   transform-origin:left center;
-  transition:transform var(--ease-med), opacity var(--ease-med), max-height var(--ease-med), margin var(--ease-med);
-  overflow:hidden;
+  transition:transform var(--ease-med), opacity var(--ease-med);
 }
 .ms-inwindow-card[data-safety-tier="true"] { border:3px solid var(--rose-deep); }
 .ms-inwindow-card.is-sliding-out {
   transform:translateX(-110%);
   opacity:0;
-  max-height:0;
-  margin-top:0;
-  margin-bottom:0;
-  padding-top:0;
-  padding-bottom:0;
+  pointer-events:none;
 }
 .ms-inwindow-card.is-sliding-down {
   transform:translateY(40px) scale(0.96);
   opacity:0.35;
+  pointer-events:none;
 }
 /* Deprioritized cards (pushed to bottom via Not-yet tap) — visually muted
    so they read as "answered but kept around". Still tappable; the parent
@@ -10391,7 +10391,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
      checks `window.Motion` and falls back to CSS-class transitions if it
      hasn't loaded (offline parent on a flight, blocked CDN, etc.). Loaded
      after Chart.js so chart rendering takes priority on cold-start. -->
-<script src="https://cdn.jsdelivr.net/npm/motion@10.18.0/dist/motion.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/motion@10.18.0/dist/motion.min.js" defer></script>
 </head>
 <body>
 <!-- ═══ Ziva Sketch Icon Set ═══ -->

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.27-29",
+  "version": "2026.05.27-30",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/build.sh
+++ b/split/build.sh
@@ -133,7 +133,7 @@ cat <<'MID'
      checks `window.Motion` and falls back to CSS-class transitions if it
      hasn't loaded (offline parent on a flight, blocked CDN, etc.). Loaded
      after Chart.js so chart rendering takes priority on cold-start. -->
-<script src="https://cdn.jsdelivr.net/npm/motion@10.18.0/dist/motion.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/motion@10.18.0/dist/motion.min.js" defer></script>
 </head>
 <body>
 MID

--- a/split/styles.css
+++ b/split/styles.css
@@ -6240,28 +6240,28 @@ body.ql-locked .dark-toggle { pointer-events:none; }
   background:var(--surface);
   border-left:var(--accent-w) solid var(--al-border, var(--lavender));
   box-shadow:0 1px 4px rgba(0,0,0,0.04);
-  /* Tap-out + push-down animation support — closes Architect feedback
-     2026-05-27 #7. Confirm/Practicing slide the card left out of the
-     stack ("make way for other options"); Not-yet slides the card down
-     to be reordered to the bottom on the next render. transform-origin
-     left to keep the slide feel anchored. */
+  /* Tap-out + push-down animation support (Architect 2026-05-27 #7+#10).
+     Motion One drives the primary animation when window.Motion is available;
+     these CSS rules are the FALLBACK path (offline parent, blocked CDN,
+     cached pre-Motion HTML). Transitions only animate transform + opacity —
+     padding/margin/max-height collapse was removed because non-animatable
+     auto→0 transitions caused an instant height-jump that read as
+     "disappearing" rather than "swiping out" (Architect bug-report fix
+     2026-05-27 #11). The card retains its slot during the slide; the
+     subsequent renderMilestones() removes it from the DOM cleanly. */
   transform-origin:left center;
-  transition:transform var(--ease-med), opacity var(--ease-med), max-height var(--ease-med), margin var(--ease-med);
-  overflow:hidden;
+  transition:transform var(--ease-med), opacity var(--ease-med);
 }
 .ms-inwindow-card[data-safety-tier="true"] { border:3px solid var(--rose-deep); }
 .ms-inwindow-card.is-sliding-out {
   transform:translateX(-110%);
   opacity:0;
-  max-height:0;
-  margin-top:0;
-  margin-bottom:0;
-  padding-top:0;
-  padding-bottom:0;
+  pointer-events:none;
 }
 .ms-inwindow-card.is-sliding-down {
   transform:translateY(40px) scale(0.96);
   opacity:0.35;
+  pointer-events:none;
 }
 /* Deprioritized cards (pushed to bottom via Not-yet tap) — visually muted
    so they read as "answered but kept around". Still tappable; the parent

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -6247,28 +6247,28 @@ body.ql-locked .dark-toggle { pointer-events:none; }
   background:var(--surface);
   border-left:var(--accent-w) solid var(--al-border, var(--lavender));
   box-shadow:0 1px 4px rgba(0,0,0,0.04);
-  /* Tap-out + push-down animation support — closes Architect feedback
-     2026-05-27 #7. Confirm/Practicing slide the card left out of the
-     stack ("make way for other options"); Not-yet slides the card down
-     to be reordered to the bottom on the next render. transform-origin
-     left to keep the slide feel anchored. */
+  /* Tap-out + push-down animation support (Architect 2026-05-27 #7+#10).
+     Motion One drives the primary animation when window.Motion is available;
+     these CSS rules are the FALLBACK path (offline parent, blocked CDN,
+     cached pre-Motion HTML). Transitions only animate transform + opacity —
+     padding/margin/max-height collapse was removed because non-animatable
+     auto→0 transitions caused an instant height-jump that read as
+     "disappearing" rather than "swiping out" (Architect bug-report fix
+     2026-05-27 #11). The card retains its slot during the slide; the
+     subsequent renderMilestones() removes it from the DOM cleanly. */
   transform-origin:left center;
-  transition:transform var(--ease-med), opacity var(--ease-med), max-height var(--ease-med), margin var(--ease-med);
-  overflow:hidden;
+  transition:transform var(--ease-med), opacity var(--ease-med);
 }
 .ms-inwindow-card[data-safety-tier="true"] { border:3px solid var(--rose-deep); }
 .ms-inwindow-card.is-sliding-out {
   transform:translateX(-110%);
   opacity:0;
-  max-height:0;
-  margin-top:0;
-  margin-bottom:0;
-  padding-top:0;
-  padding-bottom:0;
+  pointer-events:none;
 }
 .ms-inwindow-card.is-sliding-down {
   transform:translateY(40px) scale(0.96);
   opacity:0.35;
+  pointer-events:none;
 }
 /* Deprioritized cards (pushed to bottom via Not-yet tap) — visually muted
    so they read as "answered but kept around". Still tappable; the parent
@@ -10391,7 +10391,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
      checks `window.Motion` and falls back to CSS-class transitions if it
      hasn't loaded (offline parent on a flight, blocked CDN, etc.). Loaded
      after Chart.js so chart rendering takes priority on cold-start. -->
-<script src="https://cdn.jsdelivr.net/npm/motion@10.18.0/dist/motion.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/motion@10.18.0/dist/motion.min.js" defer></script>
 </head>
 <body>
 <!-- ═══ Ziva Sketch Icon Set ═══ -->


### PR DESCRIPTION
## Motion One never loaded — wrong CDN path + fallback CSS bug

Architect: *"I don't think Motion One is working, it doesn't look buttery, cards are just disappearing instead of swiping out."*

### Root cause #1 — `dist/motion.js` is 404

PR #162's `build.sh` pointed at `https://cdn.jsdelivr.net/npm/motion@10.18.0/dist/motion.js` — that file **doesn't exist** in the motion package. The correct UMD distribution is `dist/motion.min.js` (24KB minified, IIFE exposing `window.Motion`).

Verified:
```
curl -sI cdn.jsdelivr.net/npm/motion@10.18.0/dist/motion.js     → 404
curl -sI cdn.jsdelivr.net/npm/motion@10.18.0/dist/motion.min.js → 200 (immutable cache)
```

Cross-checked via the jsDelivr package listing — only `motion.min.js` exists under `dist/`. Net effect: `window.Motion` was never defined → every opt-in check fell through to the CSS-class fallback → production-quality multi-keyframe + spring physics never ran.

### Root cause #2 — Fallback CSS had an instant-collapse jump

The `.is-sliding-out` fallback class also set `max-height: 0`, `padding-top/bottom: 0`, `margin-top/bottom: 0`. CSS can't transition `auto → 0` for max-height, and padding wasn't even in the transition list. Result:

- `transform` / `opacity` tweened over 220ms ✓
- `padding` / `margin` / `max-height` jumped to 0 instantly ✗
- Card collapsed vertically in one frame, then the transform slide ran on a flat zero-height element

Read as "card disappears" not "card slides out."

## Fix

**build.sh** — point at `dist/motion.min.js`.

**styles.css** — simplified fallback classes to `transform` + `opacity` only. Card keeps its slot during the slide; `renderMilestones()` removes it from the DOM cleanly when the animation completes. Added `pointer-events: none` so a sliding card can't catch a stray tap.

## Note on PWA caching

The PWA service worker may cache the old broken-URL HTML. To pick up the new build after merge:
- Hard refresh (Ctrl+Shift+R) on the live URL, OR
- DevTools → Application → Service Workers → Update on Reload

Vercel preview + GitHub Pages re-deploy automatically on merge to main.

## Verification

- [x] `pnpm build` green; all 9 audit gates pass
- [x] Motion CDN URL verified 200 + immutable
- [ ] Browser smoke (Architect): tap Confirm/Practicing → Tinder-swipe with rotation; tap Not yet → spring-physics drop + settle

https://claude.ai/code/session_01QXVV6GYCFPNbsh7MMgsZzh

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXVV6GYCFPNbsh7MMgsZzh)_