### PR TITLE
food-sub-tab-v1 F-2 — Log entry form (structured item builder)

### DIFF
--- a/docs/DESIGN_PRINCIPLES.md
+++ b/docs/DESIGN_PRINCIPLES.md
@@ -424,7 +424,7 @@ See ARCHITECTURE_PATTERNS.md §13 for the Read/Act/Flow framework.
 
 > **Sync note:** This checklist should stay in sync with QA_PROCESS.md §4.
 
-### Build-time audit gates (9 live as of 2026-05-28 PM)
+### Build-time audit gates (10 live as of 2026-05-29)
 
 Every `pnpm build` runs these gates sequentially in `split/build.sh`; any failure aborts the build:
 
@@ -439,6 +439,7 @@ Every `pnpm build` runs these gates sequentially in `split/build.sh`; any failur
 | 7 | `audit-card-priority-v3-6.sh` | v3-6 — bans ad-hoc `card-{urgent\|notable\|ambient}` classes + verifies `renderInfo*` producer-coverage. | v3-6 IMPL |
 | 8 | `audit-no-personalised-prediction-v1.sh` | milestone-engine-prep-v1 — Scope A bans hardcoded source attribution + `(unverified)` parenthetical; Scope B bans personalised-prediction prose. Python regex + 5 adversarial self-tests. | PR #153 |
 | 9 | `audit-activity-categories-v1.sh` | milestones-tab-v1 — bans 3+-of-5 category-key array permutations + `\bcatOrder\s*=` idiom + 4+-of-5 obj-literal forks (with multi-line brace-tracking). Opt-in marker `// activity-categories-ok: <rationale>`. | PR #159 |
+| 10 | `audit-feed-sheet-wiring-v1.sh` | food-sub-tab-v1 F-2 — required-presence gate. Asserts the 4 FOB Feed sheet wrap IDs (`qlFeedRepeat/Combos/Items/Next/Wrap`), the `_fdWriteStructuredMeal` writer call in `saveQLFeed`, 7 F-2 handlers, 7 core.js dispatcher routes, ≥30 `NUTRITION_QTY_DEFAULTS` entries, ≥10 `CURATED_COMBOS` with all 4 slots covered. Enforces ratification #5's hard tap-budget (3/4/6) by guarding the wiring that enables those budgets. | PR #168 |
 
 ### Hard Rule Checks
 - [ ] HR-1: Zero emojis in new code

--- a/docs/SHARED_API.md
+++ b/docs/SHARED_API.md
@@ -283,7 +283,6 @@ This is the critical section. Each entry documents a function that is **defined*
 | `generateTomorrowPrep()` | — | prep plan object |
 | `checkFoodCombo()` | — | void (renders combo result) |
 | `renderTips()` | — | void (DOM render) |
-| `renderQLFreqPills()` | — | void (DOM render) |
 | `updateQLFeedDropdown()` | — | void (DOM render) |
 | `resetQLSheet()` | — | void (reset QL state) |
 | `getMdiColor(score)` | number | CSS color string |

--- a/docs/specs/food-sub-tab-v1-f2-mockup.html
+++ b/docs/specs/food-sub-tab-v1-f2-mockup.html
@@ -1,0 +1,995 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Food Sub-Tab v1 F-2 — UX policy mockup (three options)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:wght@600;700&family=Nunito:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+:root {
+  --cream: #fffaf7;
+  --white: #ffffff;
+  --warm: #fef6f0;
+  --text: #2a1f1c;
+  --mid: #6b5d57;
+  --light: #9a8b85;
+  --sage: #b5d5c5;
+  --sage-light: #e8f5ef;
+  --tc-sage: #3a7060;
+  --rose: #f2a8b8;
+  --rose-light: #fde8ed;
+  --tc-rose: #9e3e52;
+  --amber: #e8b86d;
+  --amber-light: #fef6e8;
+  --tc-amber: #8a6520;
+  --lavender: #c9b8e8;
+  --lav-light: #f0ebfb;
+  --tc-lav: #6e5e9a;
+  --sky-light: #e8f4fa;
+  --peach: #fad4b4;
+  --peach-light: #fef3ea;
+  --surface-warn: #fffdf5;
+  --tc-warn: #856404;
+  --border-warn: #ffc107;
+  --sp-2: 2px;  --sp-4: 4px;  --sp-6: 6px;  --sp-8: 8px;
+  --sp-10: 10px; --sp-12: 12px; --sp-16: 16px;
+  --sp-20: 20px; --sp-24: 24px; --sp-32: 32px;
+  --fs-2xs: 0.56rem; --fs-xs: 0.65rem; --fs-sm: 0.75rem;
+  --fs-base: 0.85rem; --fs-md: 0.95rem; --fs-lg: 1.1rem;
+  --fs-xl: 1.35rem; --fs-2xl: 1.6rem;
+  --r-sm: 4px; --r-md: 8px; --r-lg: 12px;
+  --r-xl: 14px; --r-2xl: 20px; --r-full: 9999px;
+  --ls-wide: 0.08em;
+  --shadow-sm: 0 1px 3px rgba(60, 40, 40, 0.08);
+  --shadow-md: 0 2px 8px rgba(60, 40, 40, 0.1);
+  --shadow-card: 0 4px 16px rgba(60, 40, 40, 0.08);
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: 'Nunito', sans-serif;
+  background: var(--cream);
+  color: var(--text);
+  font-size: var(--fs-base);
+  line-height: 1.5;
+  padding: 0;
+}
+.page {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: var(--sp-24) var(--sp-16);
+}
+header.intro {
+  background: linear-gradient(180deg, var(--peach-light) 0%, var(--cream) 100%);
+  border-radius: var(--r-2xl);
+  padding: var(--sp-24) var(--sp-20);
+  margin-bottom: var(--sp-32);
+  box-shadow: var(--shadow-sm);
+}
+header.intro h1 {
+  font-family: 'Fraunces', serif;
+  font-weight: 700;
+  font-size: var(--fs-2xl);
+  margin: 0 0 var(--sp-8) 0;
+  line-height: 1.2;
+  color: var(--text);
+}
+header.intro .sub {
+  color: var(--mid);
+  font-size: var(--fs-md);
+  margin: 0 0 var(--sp-16) 0;
+}
+header.intro .meta {
+  display: flex; flex-wrap: wrap; gap: var(--sp-8);
+  font-size: var(--fs-xs);
+  color: var(--light);
+  text-transform: uppercase;
+  letter-spacing: var(--ls-wide);
+}
+header.intro .meta span {
+  background: var(--white);
+  padding: var(--sp-4) var(--sp-10);
+  border-radius: var(--r-full);
+  border: 1px solid #ece4dd;
+}
+.option-block {
+  margin-bottom: var(--sp-32);
+  padding-top: var(--sp-16);
+  border-top: 2px dashed #e6dad2;
+}
+.option-block:first-of-type { border-top: none; padding-top: 0; }
+.option-head {
+  display: flex; align-items: baseline; gap: var(--sp-12);
+  margin-bottom: var(--sp-8);
+  flex-wrap: wrap;
+}
+.option-pill {
+  display: inline-flex; align-items: center;
+  background: var(--lavender);
+  color: var(--text);
+  padding: var(--sp-4) var(--sp-12);
+  border-radius: var(--r-full);
+  font-weight: 700;
+  font-size: var(--fs-sm);
+  letter-spacing: var(--ls-wide);
+  text-transform: uppercase;
+}
+.option-head h2 {
+  font-family: 'Fraunces', serif;
+  font-weight: 700;
+  font-size: var(--fs-xl);
+  margin: 0;
+  line-height: 1.3;
+}
+.option-tag { font-size: var(--fs-xs); color: var(--mid); }
+.option-desc {
+  color: var(--mid);
+  font-size: var(--fs-base);
+  margin: 0 0 var(--sp-16) 0;
+  max-width: 720px;
+}
+.scope-strip {
+  display: flex; gap: var(--sp-8); flex-wrap: wrap;
+  margin-bottom: var(--sp-16);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--ls-wide);
+  color: var(--tc-sage);
+}
+.scope-strip .sw {
+  background: var(--sage-light);
+  padding: var(--sp-4) var(--sp-10);
+  border-radius: var(--r-full);
+  border: 1px solid var(--sage);
+}
+.scope-strip .sw.warn { background: var(--surface-warn); color: var(--tc-warn); border-color: var(--border-warn); }
+.scope-strip .sw.neutral { background: var(--warm); color: var(--mid); border-color: #ece4dd; }
+
+/* phone-frame surface mock */
+.phone-row {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--sp-20);
+}
+@media (min-width: 760px) {
+  .phone-row {
+    grid-template-columns: 1fr 1fr;
+    align-items: start;
+  }
+}
+.phone {
+  background: var(--cream);
+  border: 1px solid #e6dad2;
+  border-radius: var(--r-2xl);
+  padding: var(--sp-12);
+  box-shadow: var(--shadow-card);
+  max-width: 420px;
+  margin: 0 auto;
+  width: 100%;
+}
+.phone-label {
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--ls-wide);
+  color: var(--light);
+  text-align: center;
+  margin-bottom: var(--sp-8);
+}
+
+/* Inner surfaces — mirror styles.css */
+.tab-bar {
+  display: flex; gap: var(--sp-4); margin-bottom: var(--sp-12);
+  background: var(--warm);
+  padding: var(--sp-4);
+  border-radius: var(--r-full);
+}
+.tab-btn {
+  flex: 1;
+  text-align: center;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  padding: var(--sp-8) var(--sp-12);
+  border-radius: var(--r-full);
+  color: var(--mid);
+  cursor: default;
+  background: transparent;
+  border: none;
+}
+.tab-btn.active { background: var(--rose); color: var(--text); }
+
+.sub-tab-bar {
+  display: flex; gap: var(--sp-4); margin-bottom: var(--sp-12);
+  border-bottom: 1px solid #ece4dd;
+  padding-bottom: var(--sp-8);
+}
+.sub-tab-btn {
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  padding: var(--sp-6) var(--sp-12);
+  border-radius: var(--r-full);
+  color: var(--mid);
+  background: transparent;
+  border: none;
+}
+.sub-tab-btn.active { background: var(--rose); color: var(--text); }
+
+/* Section label */
+.section-label {
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: var(--ls-wide);
+  color: var(--mid);
+  margin: var(--sp-16) 0 var(--sp-8) 0;
+}
+
+/* Meal card — STRUCTURED (F-2 new) */
+.meal-card-structured {
+  background: var(--white);
+  border-radius: var(--r-xl);
+  padding: var(--sp-12) var(--sp-12);
+  margin-bottom: var(--sp-12);
+  box-shadow: var(--shadow-sm);
+  border-left: 3px solid var(--sage);
+}
+.meal-head {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: var(--sp-8);
+}
+.meal-title {
+  font-family: 'Fraunces', serif;
+  font-weight: 600;
+  font-size: var(--fs-md);
+  color: var(--text);
+}
+.meal-time-pill {
+  font-size: var(--fs-xs);
+  color: var(--tc-sage);
+  background: var(--sage-light);
+  padding: var(--sp-2) var(--sp-8);
+  border-radius: var(--r-full);
+  font-weight: 600;
+}
+.item-row {
+  display: flex; align-items: center; gap: var(--sp-8);
+  padding: var(--sp-6) 0;
+  border-bottom: 1px dashed #ece4dd;
+}
+.item-row:last-of-type { border-bottom: none; }
+.item-name {
+  flex: 1;
+  font-size: var(--fs-base);
+  color: var(--text);
+  font-weight: 500;
+}
+.item-qty {
+  font-size: var(--fs-sm);
+  color: var(--mid);
+  background: var(--warm);
+  padding: var(--sp-2) var(--sp-8);
+  border-radius: var(--r-md);
+  min-width: 56px; text-align: center;
+}
+.item-x {
+  width: 28px; height: 28px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: var(--r-full);
+  background: var(--rose-light); color: var(--tc-rose);
+  font-weight: 700;
+  font-size: var(--fs-base);
+}
+.item-row .nutri-tag {
+  font-size: var(--fs-2xs);
+  text-transform: uppercase;
+  letter-spacing: var(--ls-wide);
+  color: var(--tc-amber);
+  background: var(--amber-light);
+  padding: var(--sp-2) var(--sp-6);
+  border-radius: var(--r-sm);
+  font-weight: 700;
+}
+
+.add-item-bar {
+  display: flex; gap: var(--sp-6);
+  margin-top: var(--sp-10);
+  align-items: center;
+}
+.add-item-input {
+  flex: 1;
+  padding: var(--sp-8) var(--sp-10);
+  border: 1px solid #d8ccc4;
+  border-radius: var(--r-md);
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-base);
+  background: var(--cream);
+  color: var(--text);
+}
+.add-item-input::placeholder { color: var(--light); }
+.add-item-btn {
+  background: var(--sage); color: var(--text);
+  font-weight: 700;
+  font-size: var(--fs-base);
+  padding: var(--sp-8) var(--sp-16);
+  border-radius: var(--r-full);
+  border: none;
+  font-family: 'Nunito', sans-serif;
+}
+
+.quick-chip-rail {
+  margin-top: var(--sp-10);
+  display: flex; flex-wrap: wrap; gap: var(--sp-6);
+}
+.quick-chip {
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  padding: var(--sp-6) var(--sp-12);
+  border-radius: var(--r-full);
+  background: var(--sage-light);
+  color: var(--tc-sage);
+  border: 1px solid var(--sage);
+}
+.quick-chip-label {
+  font-size: var(--fs-2xs);
+  text-transform: uppercase;
+  letter-spacing: var(--ls-wide);
+  color: var(--light);
+  width: 100%;
+  margin-bottom: var(--sp-4);
+}
+
+/* LEGACY free-text card */
+.meal-card-legacy {
+  background: var(--white);
+  border-radius: var(--r-xl);
+  padding: var(--sp-12);
+  margin-bottom: var(--sp-12);
+  box-shadow: var(--shadow-sm);
+  border-left: 3px solid var(--peach);
+}
+.legacy-text-input {
+  width: 100%;
+  margin-top: var(--sp-8);
+  padding: var(--sp-10);
+  border: 1px solid #d8ccc4;
+  border-radius: var(--r-md);
+  background: var(--cream);
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-base);
+  color: var(--text);
+}
+.legacy-text-input.has-content { color: var(--text); }
+.legacy-dropdown-hint {
+  font-size: var(--fs-xs);
+  color: var(--light);
+  margin-top: var(--sp-4);
+  text-align: right;
+  font-style: italic;
+}
+
+/* Toggle (Option C) */
+.mode-toggle {
+  display: flex; align-items: center; gap: var(--sp-8);
+  background: var(--lav-light);
+  border-radius: var(--r-full);
+  padding: var(--sp-4);
+  margin-bottom: var(--sp-12);
+}
+.mode-toggle-btn {
+  flex: 1;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  padding: var(--sp-6) var(--sp-10);
+  border-radius: var(--r-full);
+  text-align: center;
+  color: var(--tc-lav);
+  background: transparent;
+  border: none;
+  font-family: 'Nunito', sans-serif;
+}
+.mode-toggle-btn.active { background: var(--lavender); color: var(--text); }
+.mode-toggle-info {
+  font-size: var(--fs-2xs);
+  text-transform: uppercase;
+  letter-spacing: var(--ls-wide);
+  color: var(--tc-lav);
+  margin-bottom: var(--sp-12);
+  text-align: center;
+}
+
+/* Cross-out for retired surface (Option A) */
+.retired-surface {
+  position: relative;
+  background: var(--warm);
+  border: 2px dashed var(--rose);
+  border-radius: var(--r-xl);
+  padding: var(--sp-16);
+  text-align: center;
+  color: var(--tc-rose);
+  font-style: italic;
+  font-size: var(--fs-sm);
+}
+.retired-surface::before {
+  content: 'RETIRED IN F-2';
+  display: block;
+  font-style: normal;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: var(--ls-wide);
+  font-size: var(--fs-xs);
+  color: var(--tc-rose);
+  margin-bottom: var(--sp-6);
+}
+
+.preserved-surface {
+  position: relative;
+  background: var(--sage-light);
+  border: 2px solid var(--sage);
+  border-radius: var(--r-xl);
+  padding: var(--sp-12);
+}
+.preserved-surface::before {
+  content: 'PRESERVED — unchanged by F-2';
+  display: block;
+  font-style: normal;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: var(--ls-wide);
+  font-size: var(--fs-2xs);
+  color: var(--tc-sage);
+  margin-bottom: var(--sp-8);
+}
+
+.note-box {
+  background: var(--lav-light);
+  border-left: 3px solid var(--lavender);
+  padding: var(--sp-12);
+  border-radius: var(--r-md);
+  margin-top: var(--sp-16);
+  font-size: var(--fs-sm);
+  color: var(--tc-lav);
+  line-height: 1.5;
+}
+.note-box strong { color: var(--text); }
+
+/* Trade-off table */
+.tradeoffs {
+  background: var(--white);
+  border-radius: var(--r-2xl);
+  padding: var(--sp-20);
+  box-shadow: var(--shadow-card);
+  margin-top: var(--sp-32);
+}
+.tradeoffs h2 {
+  font-family: 'Fraunces', serif;
+  font-weight: 700;
+  font-size: var(--fs-xl);
+  margin: 0 0 var(--sp-16) 0;
+}
+.tradeoffs table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--fs-sm);
+}
+.tradeoffs th, .tradeoffs td {
+  text-align: left;
+  padding: var(--sp-10) var(--sp-8);
+  border-bottom: 1px solid #ece4dd;
+  vertical-align: top;
+}
+.tradeoffs th {
+  font-weight: 700;
+  background: var(--warm);
+  color: var(--text);
+  text-transform: uppercase;
+  font-size: var(--fs-xs);
+  letter-spacing: var(--ls-wide);
+}
+.tradeoffs th:first-child { width: 28%; }
+.tradeoffs td.v-a { background: rgba(181, 213, 197, 0.18); }
+.tradeoffs td.v-b { background: rgba(232, 184, 109, 0.10); }
+.tradeoffs td.v-c { background: rgba(201, 184, 232, 0.12); }
+.tradeoffs tr:hover td { background: var(--warm); }
+
+.tradeoffs td .verdict {
+  font-weight: 700;
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--ls-wide);
+  display: inline-block;
+  padding: var(--sp-2) var(--sp-6);
+  border-radius: var(--r-sm);
+  margin-right: var(--sp-4);
+}
+.verdict.good { background: var(--sage-light); color: var(--tc-sage); }
+.verdict.watch { background: var(--amber-light); color: var(--tc-amber); }
+.verdict.cost { background: var(--rose-light); color: var(--tc-rose); }
+.verdict.neutral { background: var(--lav-light); color: var(--tc-lav); }
+
+.recommendation {
+  margin-top: var(--sp-24);
+  background: var(--sage-light);
+  border-radius: var(--r-2xl);
+  padding: var(--sp-20);
+  border-left: 4px solid var(--sage);
+}
+.recommendation h3 {
+  font-family: 'Fraunces', serif;
+  font-weight: 700;
+  font-size: var(--fs-lg);
+  margin: 0 0 var(--sp-8) 0;
+  color: var(--tc-sage);
+}
+.recommendation p { margin: 0 0 var(--sp-8) 0; color: var(--text); }
+.recommendation .signature {
+  font-size: var(--fs-xs);
+  color: var(--mid);
+  font-style: italic;
+  margin-top: var(--sp-16);
+}
+
+footer {
+  margin-top: var(--sp-32);
+  padding-top: var(--sp-16);
+  border-top: 1px solid #ece4dd;
+  font-size: var(--fs-xs);
+  color: var(--light);
+  text-align: center;
+}
+footer a { color: var(--tc-lav); }
+</style>
+</head>
+<body>
+<div class="page">
+
+<header class="intro">
+  <h1>Food Sub-Tab v1 — F-2 entry-form policy</h1>
+  <p class="sub">Three implementation options for the structured meal-entry surface. Same item-builder pattern (typeahead + quick-add chips + qty/unit pickers); they differ on what happens to the legacy free-text meal-input on the home tab.</p>
+  <div class="meta">
+    <span>spec: docs/specs/food-sub-tab-v1.md</span>
+    <span>F-1 shipped: PR #165</span>
+    <span>F-5 normalizer: lands AFTER F-2</span>
+    <span>Architect decision needed</span>
+  </div>
+</header>
+
+<!-- ───────────────────────────── OPTION A ───────────────────────────── -->
+<section class="option-block">
+  <div class="option-head">
+    <span class="option-pill">Option A</span>
+    <h2>Full replace — structured-only on diet Log; legacy text-input retired</h2>
+  </div>
+  <p class="option-desc">The diet Log sub-tab becomes the single canonical meal-entry surface. The home-tab <code>.meal-input-wrap</code> per-meal text cards are retired this PR; the home tab keeps Today So Far / Diet Quick Picker / Intel banner unchanged, but loses the inline meal-input cards. Spec §4 alignment: "Save → emits structured shape; legacy <code>text</code> compat field generated for downstream readers." One canonical surface; F-5 normalizer reads two shapes (legacy stored records + new structured).</p>
+  <div class="scope-strip">
+    <span class="sw">1 entry surface</span>
+    <span class="sw">2 stored shapes (legacy + structured)</span>
+    <span class="sw warn">retires home meal-input</span>
+    <span class="sw">cleanest UX</span>
+  </div>
+  <div class="phone-row">
+
+    <div class="phone">
+      <div class="phone-label">Diet tab → Log sub-tab</div>
+      <div class="tab-bar">
+        <button class="tab-btn">Home</button>
+        <button class="tab-btn active">Track</button>
+        <button class="tab-btn">Care</button>
+      </div>
+      <div class="sub-tab-bar">
+        <button class="sub-tab-btn active">Log</button>
+        <button class="sub-tab-btn">Library</button>
+        <button class="sub-tab-btn">Patterns</button>
+      </div>
+
+      <div class="section-label">Today · Wed, May 27</div>
+
+      <div class="meal-card-structured">
+        <div class="meal-head">
+          <span class="meal-title">Breakfast</span>
+          <span class="meal-time-pill">8:30 am</span>
+        </div>
+        <div class="item-row">
+          <span class="item-name">Paratha</span>
+          <span class="nutri-tag">gluten</span>
+          <span class="item-qty">1 pc</span>
+          <span class="item-x">×</span>
+        </div>
+        <div class="item-row">
+          <span class="item-name">Ghee</span>
+          <span class="nutri-tag">dairy</span>
+          <span class="item-qty">1 tsp</span>
+          <span class="item-x">×</span>
+        </div>
+        <div class="item-row">
+          <span class="item-name">Banana</span>
+          <span class="item-qty">½ pc</span>
+          <span class="item-x">×</span>
+        </div>
+        <div class="quick-chip-rail">
+          <span class="quick-chip-label">Quick-add (last 7d most recent)</span>
+          <span class="quick-chip">+ Idli</span>
+          <span class="quick-chip">+ Dosa</span>
+          <span class="quick-chip">+ Porridge</span>
+          <span class="quick-chip">+ Curd</span>
+        </div>
+        <div class="add-item-bar">
+          <input class="add-item-input" placeholder="Add item — try 'dal'…">
+          <button class="add-item-btn">Add</button>
+        </div>
+      </div>
+
+      <div class="meal-card-structured" style="border-left-color: var(--amber);">
+        <div class="meal-head">
+          <span class="meal-title">Lunch</span>
+          <span class="meal-time-pill" style="background: var(--amber-light); color: var(--tc-amber);">empty</span>
+        </div>
+        <div class="add-item-bar">
+          <input class="add-item-input" placeholder="What did Ziva have at lunch?">
+          <button class="add-item-btn">Add</button>
+        </div>
+        <div class="quick-chip-rail">
+          <span class="quick-chip-label">Quick-add (last 30d most frequent at lunch)</span>
+          <span class="quick-chip">+ Dal khichdi</span>
+          <span class="quick-chip">+ Curd rice</span>
+          <span class="quick-chip">+ Ragi porridge</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="phone">
+      <div class="phone-label">Home tab — meal-input cards retired</div>
+      <div class="tab-bar">
+        <button class="tab-btn active">Home</button>
+        <button class="tab-btn">Track</button>
+        <button class="tab-btn">Care</button>
+      </div>
+      <div class="section-label">Today So Far</div>
+      <div class="meal-card-legacy" style="border-left-color: var(--sky-light);">
+        <span class="meal-title">Day at a glance</span>
+        <div style="margin-top: 6px; font-size: var(--fs-sm); color: var(--mid);">Breakfast logged · 3 items · 1 hr ago</div>
+      </div>
+
+      <div class="section-label">Meal-input cards</div>
+      <div class="retired-surface">
+        <code>.meal-input-wrap</code> per-meal text cards removed.<br>
+        Tap "Add to log" → opens diet Log sub-tab.
+      </div>
+
+      <div class="section-label">Diet Quick Picker</div>
+      <div class="preserved-surface">
+        <div style="display: flex; gap: 6px; flex-wrap: wrap;">
+          <span class="quick-chip" style="background: var(--peach-light); border-color: var(--peach); color: var(--tc-amber);">Iron foods</span>
+          <span class="quick-chip" style="background: var(--peach-light); border-color: var(--peach); color: var(--tc-amber);">Brain fats</span>
+          <span class="quick-chip" style="background: var(--peach-light); border-color: var(--peach); color: var(--tc-amber);">Probiotics</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="note-box">
+    <strong>Trade-off in one line:</strong> simplest mental model + cleanest F-5 normalizer test surface, but burns the parent's existing home-tab meal-input muscle memory. Risk: a parent typing at the home tab will hit dead space until they relearn the Log sub-tab. Mitigation: home-tab "Day at a glance" card includes a "+ Add to log" CTA that opens the diet Log sub-tab.
+  </div>
+</section>
+
+<!-- ───────────────────────────── OPTION B ───────────────────────────── -->
+<section class="option-block">
+  <div class="option-head">
+    <span class="option-pill" style="background: var(--amber);">Option B</span>
+    <h2>Coexist — structured on diet Log; home-tab legacy preserved</h2>
+  </div>
+  <p class="option-desc">The diet Log sub-tab ships the new structured item builder. The home-tab <code>.meal-input-wrap</code> per-meal text cards are preserved unchanged — parents who use the home-tab quick-input keep the muscle memory they have. F-3 (Library consolidation) or a later PR can unify the surfaces; F-5 normalizer reads three shapes (legacy stored + free-text-now + structured). Lowest risk; preserves existing parent flow.</p>
+  <div class="scope-strip">
+    <span class="sw">2 entry surfaces</span>
+    <span class="sw">3 stored shapes (legacy + free-text + structured)</span>
+    <span class="sw neutral">home meal-input unchanged</span>
+    <span class="sw">muscle memory preserved</span>
+  </div>
+  <div class="phone-row">
+
+    <div class="phone">
+      <div class="phone-label">Diet tab → Log sub-tab</div>
+      <div class="tab-bar">
+        <button class="tab-btn">Home</button>
+        <button class="tab-btn active">Track</button>
+        <button class="tab-btn">Care</button>
+      </div>
+      <div class="sub-tab-bar">
+        <button class="sub-tab-btn active">Log</button>
+        <button class="sub-tab-btn">Library</button>
+        <button class="sub-tab-btn">Patterns</button>
+      </div>
+
+      <div class="section-label">Today · Wed, May 27</div>
+
+      <div class="meal-card-structured">
+        <div class="meal-head">
+          <span class="meal-title">Breakfast</span>
+          <span class="meal-time-pill">8:30 am</span>
+        </div>
+        <div class="item-row">
+          <span class="item-name">Paratha</span>
+          <span class="nutri-tag">gluten</span>
+          <span class="item-qty">1 pc</span>
+          <span class="item-x">×</span>
+        </div>
+        <div class="item-row">
+          <span class="item-name">Ghee</span>
+          <span class="nutri-tag">dairy</span>
+          <span class="item-qty">1 tsp</span>
+          <span class="item-x">×</span>
+        </div>
+        <div class="item-row">
+          <span class="item-name">Banana</span>
+          <span class="item-qty">½ pc</span>
+          <span class="item-x">×</span>
+        </div>
+        <div class="quick-chip-rail">
+          <span class="quick-chip-label">Quick-add</span>
+          <span class="quick-chip">+ Idli</span>
+          <span class="quick-chip">+ Dosa</span>
+          <span class="quick-chip">+ Curd</span>
+        </div>
+        <div class="add-item-bar">
+          <input class="add-item-input" placeholder="Add item — try 'dal'…">
+          <button class="add-item-btn">Add</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="phone">
+      <div class="phone-label">Home tab — legacy meal-input preserved</div>
+      <div class="tab-bar">
+        <button class="tab-btn active">Home</button>
+        <button class="tab-btn">Track</button>
+        <button class="tab-btn">Care</button>
+      </div>
+      <div class="section-label">Today So Far</div>
+      <div class="meal-card-legacy" style="border-left-color: var(--sky-light);">
+        <span class="meal-title">Day at a glance</span>
+        <div style="margin-top: 6px; font-size: var(--fs-sm); color: var(--mid);">Breakfast logged · 3 items · 1 hr ago</div>
+      </div>
+
+      <div class="section-label">Meal-input cards (legacy free-text)</div>
+      <div class="preserved-surface">
+        <div class="meal-card-legacy" style="margin: 0 0 8px 0; box-shadow: none; background: var(--white);">
+          <div class="meal-head">
+            <span class="meal-title">Breakfast</span>
+            <span class="meal-time-pill">8:30 am</span>
+          </div>
+          <input class="legacy-text-input has-content" value="paratha with ghee, banana">
+          <div class="legacy-dropdown-hint">tap any food in the type-ahead</div>
+        </div>
+        <div class="meal-card-legacy" style="margin: 0; box-shadow: none; background: var(--white); border-left-color: var(--amber);">
+          <div class="meal-head">
+            <span class="meal-title">Lunch</span>
+            <span class="meal-time-pill" style="background: var(--amber-light); color: var(--tc-amber);">empty</span>
+          </div>
+          <input class="legacy-text-input" placeholder="What did Ziva have at lunch?">
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="note-box">
+    <strong>Trade-off in one line:</strong> safest path for parent flow + zero muscle-memory cost, but the app has two entry surfaces emitting different shapes — F-5 normalizer must read three shapes (legacy stored + free-text-now + structured). Two surfaces also means a parent who logs structured on diet Log but glances at the home meal-input may not see the latest entries reflected without a cross-surface render. F-3 (or a follow-up PR) unifies later.
+  </div>
+</section>
+
+<!-- ───────────────────────────── OPTION C ───────────────────────────── -->
+<section class="option-block">
+  <div class="option-head">
+    <span class="option-pill" style="background: var(--lavender);">Option C</span>
+    <h2>Toggle — structured by default; "Simple mode" opt-in fallback</h2>
+  </div>
+  <p class="option-desc">The diet Log sub-tab shows the structured item builder by default. A persistent toggle pill at the top lets parents switch the sub-tab into "Simple mode" — free-text per-meal cards inside the same Log sub-tab. Mode preference saves to localStorage. Home-tab meal-input cards retired (same as Option A). Highest UX safety net; doubles the form surface area inside the Log sub-tab; F-5 normalizer reads three shapes.</p>
+  <div class="scope-strip">
+    <span class="sw">1 entry surface, 2 modes</span>
+    <span class="sw">3 stored shapes</span>
+    <span class="sw warn">retires home meal-input</span>
+    <span class="sw warn">2× UX code surface</span>
+  </div>
+  <div class="phone-row">
+
+    <div class="phone">
+      <div class="phone-label">Diet Log — Structured mode (default)</div>
+      <div class="tab-bar">
+        <button class="tab-btn">Home</button>
+        <button class="tab-btn active">Track</button>
+        <button class="tab-btn">Care</button>
+      </div>
+      <div class="sub-tab-bar">
+        <button class="sub-tab-btn active">Log</button>
+        <button class="sub-tab-btn">Library</button>
+        <button class="sub-tab-btn">Patterns</button>
+      </div>
+
+      <div class="mode-toggle">
+        <button class="mode-toggle-btn active">Structured</button>
+        <button class="mode-toggle-btn">Simple</button>
+      </div>
+      <div class="mode-toggle-info">your choice — saved across sessions</div>
+
+      <div class="meal-card-structured">
+        <div class="meal-head">
+          <span class="meal-title">Breakfast</span>
+          <span class="meal-time-pill">8:30 am</span>
+        </div>
+        <div class="item-row">
+          <span class="item-name">Paratha</span>
+          <span class="nutri-tag">gluten</span>
+          <span class="item-qty">1 pc</span>
+          <span class="item-x">×</span>
+        </div>
+        <div class="item-row">
+          <span class="item-name">Ghee</span>
+          <span class="nutri-tag">dairy</span>
+          <span class="item-qty">1 tsp</span>
+          <span class="item-x">×</span>
+        </div>
+        <div class="quick-chip-rail">
+          <span class="quick-chip">+ Idli</span>
+          <span class="quick-chip">+ Banana</span>
+          <span class="quick-chip">+ Curd</span>
+        </div>
+        <div class="add-item-bar">
+          <input class="add-item-input" placeholder="Add item…">
+          <button class="add-item-btn">Add</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="phone">
+      <div class="phone-label">Diet Log — Simple mode (toggled)</div>
+      <div class="tab-bar">
+        <button class="tab-btn">Home</button>
+        <button class="tab-btn active">Track</button>
+        <button class="tab-btn">Care</button>
+      </div>
+      <div class="sub-tab-bar">
+        <button class="sub-tab-btn active">Log</button>
+        <button class="sub-tab-btn">Library</button>
+        <button class="sub-tab-btn">Patterns</button>
+      </div>
+
+      <div class="mode-toggle">
+        <button class="mode-toggle-btn">Structured</button>
+        <button class="mode-toggle-btn active">Simple</button>
+      </div>
+      <div class="mode-toggle-info">your choice — saved across sessions</div>
+
+      <div class="meal-card-legacy">
+        <div class="meal-head">
+          <span class="meal-title">Breakfast</span>
+          <span class="meal-time-pill">8:30 am</span>
+        </div>
+        <input class="legacy-text-input has-content" value="paratha with ghee, banana">
+        <div class="legacy-dropdown-hint">type-ahead picks single food</div>
+      </div>
+      <div class="meal-card-legacy" style="border-left-color: var(--amber);">
+        <div class="meal-head">
+          <span class="meal-title">Lunch</span>
+          <span class="meal-time-pill" style="background: var(--amber-light); color: var(--tc-amber);">empty</span>
+        </div>
+        <input class="legacy-text-input" placeholder="What did Ziva have at lunch?">
+      </div>
+      <div class="meal-card-legacy" style="border-left-color: var(--lavender);">
+        <div class="meal-head">
+          <span class="meal-title">Dinner</span>
+          <span class="meal-time-pill" style="background: var(--lav-light); color: var(--tc-lav);">empty</span>
+        </div>
+        <input class="legacy-text-input" placeholder="What did Ziva have at dinner?">
+      </div>
+    </div>
+  </div>
+
+  <div class="note-box">
+    <strong>Trade-off in one line:</strong> highest safety net + lets parents choose, but doubles the code surface inside the Log sub-tab (every render path branches on mode); F-5 normalizer must read three shapes; the toggle itself becomes a UX surface to design + test (where does it sit, does it persist across days, does it animate). Likely overbuilt for Ziva-first; could become useful when the app eventually supports multiple babies / multiple caretakers with different preferences.
+  </div>
+</section>
+
+<!-- ───────────────────────────── TRADE-OFF MATRIX ───────────────────────────── -->
+<div class="tradeoffs">
+  <h2>Trade-off matrix</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Axis</th>
+        <th>A — Full replace</th>
+        <th>B — Coexist</th>
+        <th>C — Toggle</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Entry surfaces</strong></td>
+        <td class="v-a"><span class="verdict good">1</span> diet Log only</td>
+        <td class="v-b"><span class="verdict watch">2</span> diet Log + home meal-input</td>
+        <td class="v-c"><span class="verdict watch">1 + mode</span> diet Log w/ toggle</td>
+      </tr>
+      <tr>
+        <td><strong>Stored shapes (F-5 reads)</strong></td>
+        <td class="v-a"><span class="verdict good">2</span> legacy + structured</td>
+        <td class="v-b"><span class="verdict watch">3</span> legacy + free-text + structured</td>
+        <td class="v-c"><span class="verdict watch">3</span> legacy + simple-mode-text + structured</td>
+      </tr>
+      <tr>
+        <td><strong>Code surface (lines added)</strong></td>
+        <td class="v-a"><span class="verdict good">smallest</span> ~750 LOC est.</td>
+        <td class="v-b"><span class="verdict neutral">medium</span> ~900 LOC est. (preserves home path)</td>
+        <td class="v-c"><span class="verdict cost">largest</span> ~1,150 LOC est. (both modes live)</td>
+      </tr>
+      <tr>
+        <td><strong>Parent muscle-memory</strong></td>
+        <td class="v-a"><span class="verdict cost">burned</span> home meal-input gone</td>
+        <td class="v-b"><span class="verdict good">preserved</span> home unchanged</td>
+        <td class="v-c"><span class="verdict good">preserved via toggle</span> opt-in</td>
+      </tr>
+      <tr>
+        <td><strong>F-5 normalizer test surface</strong></td>
+        <td class="v-a"><span class="verdict good">simplest</span> 2 shapes</td>
+        <td class="v-b"><span class="verdict watch">harder</span> 3 shapes, cross-surface drift</td>
+        <td class="v-c"><span class="verdict watch">harder</span> 3 shapes</td>
+      </tr>
+      <tr>
+        <td><strong>"Single source of truth" arc</strong></td>
+        <td class="v-a"><span class="verdict good">direct</span> diet Log canonical</td>
+        <td class="v-b"><span class="verdict watch">requires F-3 unification</span></td>
+        <td class="v-c"><span class="verdict cost">requires future deprecation arc</span></td>
+      </tr>
+      <tr>
+        <td><strong>Mobile 1-handed tap budget</strong></td>
+        <td class="v-a"><span class="verdict good">best</span> one place</td>
+        <td class="v-b"><span class="verdict watch">worst</span> may flip-flop</td>
+        <td class="v-c"><span class="verdict neutral">medium</span> one extra tap to choose mode</td>
+      </tr>
+      <tr>
+        <td><strong>Spec §4 alignment</strong></td>
+        <td class="v-a"><span class="verdict good">direct</span> "Save → emits structured"</td>
+        <td class="v-b"><span class="verdict watch">partial</span> home tab still free-text</td>
+        <td class="v-c"><span class="verdict watch">mixed</span> structured default + free-text mode</td>
+      </tr>
+      <tr>
+        <td><strong>Risk of regression</strong></td>
+        <td class="v-a"><span class="verdict watch">moderate</span> replaces home muscle memory</td>
+        <td class="v-b"><span class="verdict good">lowest</span> home unchanged</td>
+        <td class="v-c"><span class="verdict watch">moderate</span> toggle state across sessions</td>
+      </tr>
+      <tr>
+        <td><strong>Honesty axis (CV3-006)</strong></td>
+        <td class="v-a"><span class="verdict good">PASS</span> one entry; clear source</td>
+        <td class="v-b"><span class="verdict watch">PASS-with-note</span> dual sources to track</td>
+        <td class="v-c"><span class="verdict good">PASS</span> per-mode source clear</td>
+      </tr>
+      <tr>
+        <td><strong>Warmth axis (CV3-006)</strong></td>
+        <td class="v-a"><span class="verdict watch">mixed</span> new pattern to learn</td>
+        <td class="v-b"><span class="verdict good">PASS</span> familiar home unchanged</td>
+        <td class="v-c"><span class="verdict good">PASS</span> parent choice respected</td>
+      </tr>
+      <tr>
+        <td><strong>Extensibility (CV3-006)</strong></td>
+        <td class="v-a"><span class="verdict good">PASS</span> single surface to extend</td>
+        <td class="v-b"><span class="verdict watch">PASS</span> two surfaces to extend in lockstep</td>
+        <td class="v-c"><span class="verdict cost">cost</span> every new feature × 2 modes</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="recommendation">
+  <h3>Lyra's read</h3>
+  <p>I lean <strong>Option A — Full replace</strong> for this session. The food-sub-tab F-1 scaffold (PR #165) already moved the meal-card surface conceptually into the diet Log sub-tab — the home-tab <code>.meal-input-wrap</code> is the legacy holdover; F-2's job is to make the diet Log the canonical entry. F-5 normalizer test surface stays at 2 shapes (legacy stored + structured), the cleanest path for the v3-8 normalizer arc.</p>
+  <p>That said: if the muscle-memory risk feels load-bearing — parents type at the home tab today, and a sudden retirement could read as "the app took away the place I log breakfast" — <strong>Option B</strong> is the safer compromise. The cost is F-3 (or a later PR) needs to unify, and F-5 reads three shapes. That cost is real but bounded.</p>
+  <p><strong>Option C</strong> reads to me as a v2-or-later feature, not a v1 one. The toggle adds UX complexity for a Ziva-first app where there's one parent + one caretaker; if SproutLab ever generalises (multi-baby, multi-caretaker with divergent preferences), C becomes the obvious move. For now: the doubled code surface + the toggle-state UX design is overbuilt.</p>
+  <p>Whatever you pick, F-2 will ship typeahead + quick-add chips + qty/unit pickers as the structured surface — those are core to the spec. The variable is what happens to home-tab <code>.meal-input-wrap</code>.</p>
+  <div class="signature">— Lyra, F-2 scoping. Mockup served for Architect decision. After ratification, I'll fold the chosen option into the F-2 IMPL PR + run <code>/code-review xhigh</code> before the canon-cc-008 chain (AGENTS.md Rule 13).</div>
+</div>
+
+<footer>
+  food-sub-tab-v1 F-2 mockup · spec: <code>docs/specs/food-sub-tab-v1.md</code> · F-1: PR #165 · F-2 branch: <code>claude/food-sub-tab-v1-impl-GXBKC</code>
+</footer>
+
+</div>
+</body>
+</html>

--- a/docs/specs/food-sub-tab-v1-f2-mockup.html
+++ b/docs/specs/food-sub-tab-v1-f2-mockup.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-<title>Food Sub-Tab v1 F-2 — UX policy mockup (three options)</title>
+<title>Food Sub-Tab v1 F-2 — FOB Feed sheet redesign (revised mockup)</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:wght@600;700&family=Nunito:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -17,6 +17,7 @@
   --light: #9a8b85;
   --sage: #b5d5c5;
   --sage-light: #e8f5ef;
+  --sage-deep: #3d7a60;
   --tc-sage: #3a7060;
   --rose: #f2a8b8;
   --rose-light: #fde8ed;
@@ -33,7 +34,7 @@
   --surface-warn: #fffdf5;
   --tc-warn: #856404;
   --border-warn: #ffc107;
-  --sp-2: 2px;  --sp-4: 4px;  --sp-6: 6px;  --sp-8: 8px;
+  --sp-2: 2px; --sp-4: 4px; --sp-6: 6px; --sp-8: 8px;
   --sp-10: 10px; --sp-12: 12px; --sp-16: 16px;
   --sp-20: 20px; --sp-24: 24px; --sp-32: 32px;
   --fs-2xs: 0.56rem; --fs-xs: 0.65rem; --fs-sm: 0.75rem;
@@ -45,6 +46,7 @@
   --shadow-sm: 0 1px 3px rgba(60, 40, 40, 0.08);
   --shadow-md: 0 2px 8px rgba(60, 40, 40, 0.1);
   --shadow-card: 0 4px 16px rgba(60, 40, 40, 0.08);
+  --shadow-sheet: 0 -4px 24px rgba(60, 40, 40, 0.15);
 }
 * { box-sizing: border-box; }
 body {
@@ -54,13 +56,9 @@ body {
   color: var(--text);
   font-size: var(--fs-base);
   line-height: 1.5;
-  padding: 0;
 }
-.page {
-  max-width: 980px;
-  margin: 0 auto;
-  padding: var(--sp-24) var(--sp-16);
-}
+.page { max-width: 1100px; margin: 0 auto; padding: var(--sp-24) var(--sp-16); }
+
 header.intro {
   background: linear-gradient(180deg, var(--peach-light) 0%, var(--cream) 100%);
   border-radius: var(--r-2xl);
@@ -70,104 +68,113 @@ header.intro {
 }
 header.intro h1 {
   font-family: 'Fraunces', serif;
-  font-weight: 700;
-  font-size: var(--fs-2xl);
-  margin: 0 0 var(--sp-8) 0;
-  line-height: 1.2;
-  color: var(--text);
+  font-weight: 700; font-size: var(--fs-2xl);
+  margin: 0 0 var(--sp-8) 0; line-height: 1.2;
 }
-header.intro .sub {
-  color: var(--mid);
-  font-size: var(--fs-md);
-  margin: 0 0 var(--sp-16) 0;
-}
+header.intro .sub { color: var(--mid); font-size: var(--fs-md); margin: 0 0 var(--sp-16) 0; }
 header.intro .meta {
   display: flex; flex-wrap: wrap; gap: var(--sp-8);
-  font-size: var(--fs-xs);
-  color: var(--light);
-  text-transform: uppercase;
-  letter-spacing: var(--ls-wide);
+  font-size: var(--fs-xs); color: var(--light);
+  text-transform: uppercase; letter-spacing: var(--ls-wide);
 }
 header.intro .meta span {
+  background: var(--white); padding: var(--sp-4) var(--sp-10);
+  border-radius: var(--r-full); border: 1px solid #ece4dd;
+}
+
+.ratifications {
   background: var(--white);
-  padding: var(--sp-4) var(--sp-10);
+  border-radius: var(--r-2xl);
+  padding: var(--sp-16);
+  margin-bottom: var(--sp-32);
+  border-left: 4px solid var(--sage);
+}
+.ratifications h2 {
+  font-family: 'Fraunces', serif;
+  font-size: var(--fs-md); margin: 0 0 var(--sp-8) 0;
+  color: var(--tc-sage);
+}
+.ratifications ul { margin: 0; padding-left: var(--sp-20); font-size: var(--fs-sm); }
+.ratifications li { margin-bottom: var(--sp-4); color: var(--text); }
+
+/* ── Flow diagram ── */
+.flow-diagram {
+  display: flex; align-items: center; gap: var(--sp-8);
+  margin: var(--sp-16) 0 var(--sp-24) 0;
+  padding: var(--sp-12);
+  background: var(--warm);
+  border-radius: var(--r-xl);
+  flex-wrap: wrap; justify-content: center;
+}
+.flow-step {
+  display: inline-flex; align-items: center; gap: var(--sp-6);
+  background: var(--white);
+  padding: var(--sp-8) var(--sp-12);
   border-radius: var(--r-full);
+  font-size: var(--fs-sm); font-weight: 600;
   border: 1px solid #ece4dd;
 }
-.option-block {
+.flow-step .num {
+  width: 22px; height: 22px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: var(--r-full);
+  background: var(--sage); color: var(--text);
+  font-weight: 700; font-size: var(--fs-xs);
+}
+.flow-arr { color: var(--light); font-weight: 700; }
+
+/* ── Scenario blocks ── */
+.scenario {
   margin-bottom: var(--sp-32);
   padding-top: var(--sp-16);
   border-top: 2px dashed #e6dad2;
 }
-.option-block:first-of-type { border-top: none; padding-top: 0; }
-.option-head {
-  display: flex; align-items: baseline; gap: var(--sp-12);
-  margin-bottom: var(--sp-8);
-  flex-wrap: wrap;
+.scenario:first-of-type { border-top: none; padding-top: 0; }
+.scenario-head {
+  display: flex; align-items: center; gap: var(--sp-12);
+  margin-bottom: var(--sp-8); flex-wrap: wrap;
 }
-.option-pill {
-  display: inline-flex; align-items: center;
-  background: var(--lavender);
+.tap-badge {
+  display: inline-flex; align-items: center; gap: var(--sp-4);
+  background: var(--sage);
   color: var(--text);
   padding: var(--sp-4) var(--sp-12);
   border-radius: var(--r-full);
-  font-weight: 700;
-  font-size: var(--fs-sm);
+  font-weight: 700; font-size: var(--fs-sm);
   letter-spacing: var(--ls-wide);
   text-transform: uppercase;
 }
-.option-head h2 {
+.tap-badge.medium { background: var(--amber); }
+.tap-badge.long { background: var(--lavender); }
+.tap-badge.detail { background: var(--peach); }
+.scenario-head h2 {
   font-family: 'Fraunces', serif;
-  font-weight: 700;
-  font-size: var(--fs-xl);
-  margin: 0;
-  line-height: 1.3;
+  font-weight: 700; font-size: var(--fs-lg);
+  margin: 0; line-height: 1.3;
 }
-.option-tag { font-size: var(--fs-xs); color: var(--mid); }
-.option-desc {
-  color: var(--mid);
-  font-size: var(--fs-base);
-  margin: 0 0 var(--sp-16) 0;
-  max-width: 720px;
+.scenario-desc {
+  color: var(--mid); font-size: var(--fs-base);
+  margin: 0 0 var(--sp-16) 0; max-width: 720px;
 }
-.scope-strip {
-  display: flex; gap: var(--sp-8); flex-wrap: wrap;
-  margin-bottom: var(--sp-16);
-  font-size: var(--fs-xs);
-  text-transform: uppercase;
-  letter-spacing: var(--ls-wide);
-  color: var(--tc-sage);
-}
-.scope-strip .sw {
-  background: var(--sage-light);
-  padding: var(--sp-4) var(--sp-10);
-  border-radius: var(--r-full);
-  border: 1px solid var(--sage);
-}
-.scope-strip .sw.warn { background: var(--surface-warn); color: var(--tc-warn); border-color: var(--border-warn); }
-.scope-strip .sw.neutral { background: var(--warm); color: var(--mid); border-color: #ece4dd; }
 
-/* phone-frame surface mock */
+/* ── Phone frame mock ── */
 .phone-row {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: var(--sp-20);
+  display: grid; grid-template-columns: 1fr; gap: var(--sp-20);
 }
 @media (min-width: 760px) {
-  .phone-row {
-    grid-template-columns: 1fr 1fr;
-    align-items: start;
-  }
+  .phone-row.two { grid-template-columns: 1fr 1fr; align-items: start; }
+  .phone-row.three { grid-template-columns: 1fr 1fr 1fr; align-items: start; }
 }
 .phone {
   background: var(--cream);
   border: 1px solid #e6dad2;
   border-radius: var(--r-2xl);
-  padding: var(--sp-12);
+  padding: var(--sp-10);
   box-shadow: var(--shadow-card);
-  max-width: 420px;
+  max-width: 400px;
   margin: 0 auto;
   width: 100%;
+  position: relative;
 }
 .phone-label {
   font-size: var(--fs-xs);
@@ -178,269 +185,355 @@ header.intro .meta span {
   margin-bottom: var(--sp-8);
 }
 
-/* Inner surfaces — mirror styles.css */
-.tab-bar {
-  display: flex; gap: var(--sp-4); margin-bottom: var(--sp-12);
-  background: var(--warm);
-  padding: var(--sp-4);
-  border-radius: var(--r-full);
-}
-.tab-btn {
-  flex: 1;
-  text-align: center;
-  font-size: var(--fs-sm);
-  font-weight: 600;
-  padding: var(--sp-8) var(--sp-12);
-  border-radius: var(--r-full);
-  color: var(--mid);
-  cursor: default;
-  background: transparent;
-  border: none;
-}
-.tab-btn.active { background: var(--rose); color: var(--text); }
-
-.sub-tab-bar {
-  display: flex; gap: var(--sp-4); margin-bottom: var(--sp-12);
-  border-bottom: 1px solid #ece4dd;
-  padding-bottom: var(--sp-8);
-}
-.sub-tab-btn {
-  font-size: var(--fs-sm);
-  font-weight: 600;
-  padding: var(--sp-6) var(--sp-12);
-  border-radius: var(--r-full);
-  color: var(--mid);
-  background: transparent;
-  border: none;
-}
-.sub-tab-btn.active { background: var(--rose); color: var(--text); }
-
-/* Section label */
-.section-label {
-  font-size: var(--fs-sm);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: var(--ls-wide);
-  color: var(--mid);
-  margin: var(--sp-16) 0 var(--sp-8) 0;
-}
-
-/* Meal card — STRUCTURED (F-2 new) */
-.meal-card-structured {
+/* Tab strip (background context) */
+.bg-context {
   background: var(--white);
   border-radius: var(--r-xl);
-  padding: var(--sp-12) var(--sp-12);
-  margin-bottom: var(--sp-12);
-  box-shadow: var(--shadow-sm);
-  border-left: 3px solid var(--sage);
+  padding: var(--sp-10);
+  margin-bottom: var(--sp-4);
+  opacity: 0.55;
+  filter: blur(0.4px);
+  pointer-events: none;
 }
-.meal-head {
-  display: flex; align-items: center; justify-content: space-between;
-  margin-bottom: var(--sp-8);
+.bg-context .bc-line {
+  height: 10px; background: var(--warm);
+  border-radius: var(--r-sm); margin-bottom: var(--sp-6);
 }
-.meal-title {
-  font-family: 'Fraunces', serif;
-  font-weight: 600;
-  font-size: var(--fs-md);
-  color: var(--text);
+.bg-context .bc-line.short { width: 40%; }
+.bg-context .bc-line.med { width: 70%; }
+
+/* ── Bottom sheet (Log Feed) ── */
+.bottom-sheet {
+  background: var(--white);
+  border-radius: var(--r-2xl) var(--r-2xl) var(--sp-8) var(--sp-8);
+  padding: var(--sp-12);
+  box-shadow: var(--shadow-sheet);
+  position: relative;
 }
-.meal-time-pill {
-  font-size: var(--fs-xs);
-  color: var(--tc-sage);
-  background: var(--sage-light);
-  padding: var(--sp-2) var(--sp-8);
+.sheet-grip {
+  width: 36px; height: 4px;
+  background: #d8ccc4;
   border-radius: var(--r-full);
-  font-weight: 600;
+  margin: 0 auto var(--sp-12);
+}
+.sheet-title {
+  font-family: 'Fraunces', serif;
+  font-weight: 700; font-size: var(--fs-lg);
+  text-align: center;
+  margin: 0 0 var(--sp-12) 0;
+}
+.sheet-close {
+  position: absolute; right: var(--sp-12); top: var(--sp-12);
+  width: 28px; height: 28px;
+  border-radius: var(--r-full);
+  background: var(--warm); color: var(--mid);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-weight: 700;
+}
+
+/* Section label (small caps) */
+.sec-lbl {
+  font-size: var(--fs-2xs);
+  text-transform: uppercase;
+  letter-spacing: var(--ls-wide);
+  color: var(--mid); font-weight: 700;
+  margin: var(--sp-12) 0 var(--sp-6) 0;
+}
+
+/* Meal slot strip (B/L/D/S) */
+.meal-slot-strip {
+  display: flex; gap: var(--sp-6); margin-bottom: var(--sp-8);
+}
+.meal-slot {
+  flex: 1; min-height: 40px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: var(--r-lg);
+  background: var(--warm);
+  font-weight: 700; font-size: var(--fs-sm);
+  color: var(--mid);
+  border: 1.5px solid transparent;
+}
+.meal-slot.active.b { background: var(--amber-light); color: var(--tc-amber); border-color: var(--amber); }
+.meal-slot.active.l { background: var(--sage-light); color: var(--tc-sage); border-color: var(--sage); }
+.meal-slot.active.d { background: var(--lav-light); color: var(--tc-lav); border-color: var(--lavender); }
+.meal-slot.active.s { background: var(--peach-light); color: var(--tc-amber); border-color: var(--peach); }
+.meal-slot .slot-time { font-size: var(--fs-2xs); font-weight: 600; margin-top: 2px; }
+.meal-slot { flex-direction: column; }
+.meal-slot.inferred::after {
+  content: 'inferred';
+  font-size: 8px; text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--tc-sage); margin-top: 1px;
+}
+
+/* L1 — Same as / Repeat chips */
+.repeat-rail {
+  display: flex; flex-direction: column; gap: var(--sp-6);
+}
+.repeat-chip {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: var(--sp-10) var(--sp-12);
+  background: var(--white);
+  border: 1.5px solid var(--sage);
+  border-radius: var(--r-xl);
+  font-size: var(--fs-sm);
+  box-shadow: var(--shadow-sm);
+}
+.repeat-chip.primary {
+  background: var(--sage-light);
+  border-width: 2px;
+}
+.repeat-chip .rc-head {
+  display: flex; align-items: center; gap: var(--sp-6);
+  font-weight: 700; color: var(--tc-sage);
+}
+.repeat-chip .rc-body {
+  font-size: var(--fs-xs);
+  color: var(--mid);
+  margin-top: 2px;
+  font-weight: 500;
+}
+.repeat-chip .rc-icon {
+  width: 28px; height: 28px;
+  background: var(--sage); color: var(--text);
+  border-radius: var(--r-full);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-weight: 700; font-size: var(--fs-base);
+}
+.repeat-chip .rc-tap {
+  font-size: var(--fs-2xs); color: var(--tc-sage);
+  text-transform: uppercase; letter-spacing: var(--ls-wide); font-weight: 700;
+}
+
+/* L2 — Combo template chip */
+.combo-chip {
+  display: block;
+  padding: var(--sp-10) var(--sp-12);
+  background: var(--lav-light);
+  border: 1.5px solid var(--lavender);
+  border-radius: var(--r-xl);
+  margin-bottom: var(--sp-6);
+}
+.combo-chip-title {
+  display: flex; align-items: center; gap: var(--sp-6);
+  font-weight: 700; color: var(--tc-lav);
+  font-size: var(--fs-sm);
+}
+.combo-chip-title .conf {
+  margin-left: auto;
+  font-size: var(--fs-2xs);
+  background: var(--lavender); color: var(--text);
+  padding: var(--sp-2) var(--sp-6);
+  border-radius: var(--r-full);
+  font-weight: 700;
+}
+.combo-chip-foods {
+  font-size: var(--fs-xs); color: var(--mid);
+  margin-top: var(--sp-4);
+}
+
+/* ── Item rows (added) ── */
+.items-list {
+  background: var(--white);
+  border: 1px solid #ece4dd;
+  border-radius: var(--r-xl);
+  margin-bottom: var(--sp-10);
+  overflow: hidden;
+}
+.items-list .empty {
+  text-align: center; color: var(--light); padding: var(--sp-16); font-style: italic; font-size: var(--fs-sm);
 }
 .item-row {
   display: flex; align-items: center; gap: var(--sp-8);
-  padding: var(--sp-6) 0;
-  border-bottom: 1px dashed #ece4dd;
+  padding: var(--sp-8) var(--sp-10);
+  border-bottom: 1px solid #f4ece6;
 }
 .item-row:last-of-type { border-bottom: none; }
-.item-name {
-  flex: 1;
-  font-size: var(--fs-base);
-  color: var(--text);
-  font-weight: 500;
+.item-icon {
+  width: 24px; height: 24px;
+  background: var(--sage-light); color: var(--tc-sage);
+  border-radius: var(--r-full);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: var(--fs-sm); font-weight: 700; flex-shrink: 0;
+}
+.item-name { flex: 1; font-weight: 600; font-size: var(--fs-base); }
+.item-name .meta {
+  font-size: var(--fs-2xs); color: var(--light);
+  text-transform: uppercase; letter-spacing: var(--ls-wide);
+  display: block; margin-top: 1px; font-weight: 500;
 }
 .item-qty {
-  font-size: var(--fs-sm);
-  color: var(--mid);
+  display: inline-flex; align-items: center;
   background: var(--warm);
-  padding: var(--sp-2) var(--sp-8);
-  border-radius: var(--r-md);
-  min-width: 56px; text-align: center;
+  border-radius: var(--r-full);
+  padding: 2px;
+  font-size: var(--fs-sm);
 }
-.item-x {
+.qty-step {
   width: 28px; height: 28px;
   display: inline-flex; align-items: center; justify-content: center;
   border-radius: var(--r-full);
-  background: var(--rose-light); color: var(--tc-rose);
+  background: var(--white); color: var(--tc-sage);
+  font-weight: 700; font-size: var(--fs-base);
+  border: 1px solid #ece4dd;
+}
+.qty-val {
+  padding: 0 var(--sp-8);
   font-weight: 700;
-  font-size: var(--fs-base);
-}
-.item-row .nutri-tag {
-  font-size: var(--fs-2xs);
-  text-transform: uppercase;
-  letter-spacing: var(--ls-wide);
-  color: var(--tc-amber);
-  background: var(--amber-light);
-  padding: var(--sp-2) var(--sp-6);
-  border-radius: var(--r-sm);
-  font-weight: 700;
-}
-
-.add-item-bar {
-  display: flex; gap: var(--sp-6);
-  margin-top: var(--sp-10);
-  align-items: center;
-}
-.add-item-input {
-  flex: 1;
-  padding: var(--sp-8) var(--sp-10);
-  border: 1px solid #d8ccc4;
-  border-radius: var(--r-md);
-  font-family: 'Nunito', sans-serif;
-  font-size: var(--fs-base);
-  background: var(--cream);
+  min-width: 48px; text-align: center;
+  font-size: var(--fs-sm);
   color: var(--text);
 }
-.add-item-input::placeholder { color: var(--light); }
-.add-item-btn {
-  background: var(--sage); color: var(--text);
-  font-weight: 700;
-  font-size: var(--fs-base);
-  padding: var(--sp-8) var(--sp-16);
+.qty-val .qty-unit {
+  font-size: var(--fs-2xs); color: var(--mid);
+  text-transform: lowercase; letter-spacing: 0; font-weight: 500;
+}
+.item-x {
+  width: 24px; height: 24px;
+  display: inline-flex; align-items: center; justify-content: center;
   border-radius: var(--r-full);
-  border: none;
-  font-family: 'Nunito', sans-serif;
+  background: var(--rose-light); color: var(--tc-rose);
+  font-weight: 700; font-size: var(--fs-sm);
+  margin-left: var(--sp-4);
+  flex-shrink: 0;
 }
 
-.quick-chip-rail {
-  margin-top: var(--sp-10);
-  display: flex; flex-wrap: wrap; gap: var(--sp-6);
+/* Predicted next-item ribbon (L3) */
+.next-ribbon {
+  display: flex; gap: var(--sp-6);
+  overflow-x: auto;
+  padding: var(--sp-6) 0;
 }
-.quick-chip {
-  font-size: var(--fs-sm);
-  font-weight: 600;
+.next-chip {
+  display: inline-flex; align-items: center; gap: var(--sp-4);
+  background: var(--sage-light);
+  color: var(--tc-sage);
+  font-weight: 700; font-size: var(--fs-sm);
   padding: var(--sp-6) var(--sp-12);
   border-radius: var(--r-full);
-  background: var(--sage-light);
-  color: var(--tc-sage);
   border: 1px solid var(--sage);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
-.quick-chip-label {
-  font-size: var(--fs-2xs);
-  text-transform: uppercase;
-  letter-spacing: var(--ls-wide);
-  color: var(--light);
-  width: 100%;
-  margin-bottom: var(--sp-4);
+.next-chip .conf {
+  font-size: 9px;
+  background: var(--white); color: var(--tc-sage);
+  border-radius: var(--r-full);
+  padding: 1px 5px;
+  margin-left: 3px;
+  font-weight: 700;
 }
 
-/* LEGACY free-text card */
-.meal-card-legacy {
-  background: var(--white);
-  border-radius: var(--r-xl);
-  padding: var(--sp-12);
-  margin-bottom: var(--sp-12);
-  box-shadow: var(--shadow-sm);
-  border-left: 3px solid var(--peach);
-}
-.legacy-text-input {
-  width: 100%;
+/* Add row (typeahead) */
+.add-row {
+  display: flex; gap: var(--sp-6);
   margin-top: var(--sp-8);
-  padding: var(--sp-10);
-  border: 1px solid #d8ccc4;
+}
+.add-input {
+  flex: 1;
+  padding: var(--sp-8) var(--sp-10);
+  border: 1.5px solid var(--sage);
   border-radius: var(--r-md);
-  background: var(--cream);
   font-family: 'Nunito', sans-serif;
   font-size: var(--fs-base);
+  background: var(--white);
   color: var(--text);
 }
-.legacy-text-input.has-content { color: var(--text); }
-.legacy-dropdown-hint {
-  font-size: var(--fs-xs);
-  color: var(--light);
+.add-input::placeholder { color: var(--light); }
+.add-input.typed { color: var(--text); font-weight: 600; }
+
+/* Typeahead popover */
+.typeahead {
   margin-top: var(--sp-4);
-  text-align: right;
-  font-style: italic;
+  background: var(--white);
+  border: 1px solid #ece4dd;
+  border-radius: var(--r-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
 }
+.ta-row {
+  display: flex; align-items: center; gap: var(--sp-6);
+  padding: var(--sp-8) var(--sp-10);
+  border-bottom: 1px solid #f4ece6;
+}
+.ta-row:last-of-type { border-bottom: none; }
+.ta-row.match { background: var(--sage-light); }
+.ta-row .ta-name { flex: 1; font-weight: 600; font-size: var(--fs-base); }
+.ta-row .ta-name .hi { color: var(--tc-sage); text-decoration: underline; }
+.ta-row .ta-meta { font-size: var(--fs-2xs); color: var(--mid); text-transform: uppercase; letter-spacing: var(--ls-wide); }
 
-/* Toggle (Option C) */
-.mode-toggle {
-  display: flex; align-items: center; gap: var(--sp-8);
-  background: var(--lav-light);
-  border-radius: var(--r-full);
-  padding: var(--sp-4);
-  margin-bottom: var(--sp-12);
+/* Overall intake + Time row */
+.foot-row {
+  display: flex; gap: var(--sp-6);
+  margin-top: var(--sp-10);
+  align-items: stretch;
 }
-.mode-toggle-btn {
+.foot-field {
   flex: 1;
-  font-size: var(--fs-sm);
-  font-weight: 600;
-  padding: var(--sp-6) var(--sp-10);
-  border-radius: var(--r-full);
-  text-align: center;
-  color: var(--tc-lav);
-  background: transparent;
-  border: none;
-  font-family: 'Nunito', sans-serif;
+  background: var(--white);
+  border: 1px solid #ece4dd;
+  border-radius: var(--r-md);
+  padding: var(--sp-6) var(--sp-8);
 }
-.mode-toggle-btn.active { background: var(--lavender); color: var(--text); }
-.mode-toggle-info {
-  font-size: var(--fs-2xs);
-  text-transform: uppercase;
-  letter-spacing: var(--ls-wide);
-  color: var(--tc-lav);
-  margin-bottom: var(--sp-12);
-  text-align: center;
+.foot-field .ff-lbl {
+  font-size: 9px;
+  text-transform: uppercase; letter-spacing: var(--ls-wide);
+  color: var(--light); font-weight: 700;
+  margin-bottom: 2px;
 }
-
-/* Cross-out for retired surface (Option A) */
-.retired-surface {
-  position: relative;
-  background: var(--warm);
-  border: 2px dashed var(--rose);
-  border-radius: var(--r-xl);
-  padding: var(--sp-16);
+.foot-field .ff-val { font-size: var(--fs-sm); font-weight: 600; }
+.intake-strip { display: flex; gap: 2px; margin-top: 2px; }
+.intake-pill {
+  flex: 1;
+  font-size: 9px;
   text-align: center;
-  color: var(--tc-rose);
-  font-style: italic;
-  font-size: var(--fs-sm);
-}
-.retired-surface::before {
-  content: 'RETIRED IN F-2';
-  display: block;
-  font-style: normal;
+  padding: 4px 2px;
+  border-radius: var(--r-sm);
+  background: var(--warm); color: var(--mid);
   font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: var(--ls-wide);
-  font-size: var(--fs-xs);
-  color: var(--tc-rose);
-  margin-bottom: var(--sp-6);
 }
+.intake-pill.active { background: var(--sage); color: var(--text); }
 
-.preserved-surface {
-  position: relative;
-  background: var(--sage-light);
-  border: 2px solid var(--sage);
-  border-radius: var(--r-xl);
+/* Save button */
+.save-btn {
+  display: block; width: 100%;
+  background: var(--sage-deep);
+  color: var(--white);
+  font-weight: 700; font-size: var(--fs-md);
   padding: var(--sp-12);
-}
-.preserved-surface::before {
-  content: 'PRESERVED — unchanged by F-2';
-  display: block;
-  font-style: normal;
-  font-weight: 700;
-  text-transform: uppercase;
+  border-radius: var(--r-full);
+  margin-top: var(--sp-12);
+  border: none; font-family: 'Nunito', sans-serif;
+  text-align: center;
   letter-spacing: var(--ls-wide);
-  font-size: var(--fs-2xs);
-  color: var(--tc-sage);
-  margin-bottom: var(--sp-8);
+  text-transform: uppercase;
+}
+.save-btn.auto::after {
+  content: ' · auto in 2s';
+  font-size: var(--fs-xs);
+  font-weight: 500;
+  text-transform: none;
+  opacity: 0.8;
 }
 
+/* Highlight rings on key element for tap-path */
+.tap-target {
+  position: relative;
+}
+.tap-target::after {
+  content: '';
+  position: absolute;
+  inset: -4px;
+  border-radius: var(--r-2xl);
+  border: 2px dashed var(--tc-rose);
+  pointer-events: none;
+  animation: pulse 1.8s ease-in-out infinite;
+}
+@keyframes pulse {
+  0%, 100% { opacity: 0.6; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.02); }
+}
+
+/* Note + caption */
 .note-box {
   background: var(--lav-light);
   border-left: 3px solid var(--lavender);
@@ -452,82 +545,93 @@ header.intro .meta span {
   line-height: 1.5;
 }
 .note-box strong { color: var(--text); }
+.note-box code {
+  background: var(--white);
+  padding: 1px 6px; border-radius: var(--r-sm);
+  font-size: var(--fs-xs);
+}
 
-/* Trade-off table */
-.tradeoffs {
+.callout {
+  background: var(--sage-light);
+  border-left: 3px solid var(--sage);
+  padding: var(--sp-12);
+  border-radius: var(--r-md);
+  margin-top: var(--sp-12);
+  font-size: var(--fs-sm);
+  color: var(--text);
+}
+.callout strong { color: var(--tc-sage); }
+
+/* Data shape block */
+.data-shape {
+  background: #1c1719;
+  color: #e4d7cd;
+  border-radius: var(--r-xl);
+  padding: var(--sp-16);
+  margin-top: var(--sp-16);
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-size: var(--fs-xs);
+  overflow-x: auto;
+  line-height: 1.6;
+}
+.data-shape .k { color: #c9b8e8; }
+.data-shape .s { color: #b5d5c5; }
+.data-shape .n { color: #fad4b4; }
+.data-shape .c { color: #6b5d57; font-style: italic; }
+
+/* Intelligence layer block */
+.intel-layers {
   background: var(--white);
   border-radius: var(--r-2xl);
   padding: var(--sp-20);
   box-shadow: var(--shadow-card);
   margin-top: var(--sp-32);
 }
-.tradeoffs h2 {
+.intel-layers h2 {
   font-family: 'Fraunces', serif;
-  font-weight: 700;
-  font-size: var(--fs-xl);
+  font-weight: 700; font-size: var(--fs-xl);
   margin: 0 0 var(--sp-16) 0;
 }
-.tradeoffs table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: var(--fs-sm);
-}
-.tradeoffs th, .tradeoffs td {
-  text-align: left;
-  padding: var(--sp-10) var(--sp-8);
+.layer {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: var(--sp-12);
+  padding: var(--sp-12) 0;
   border-bottom: 1px solid #ece4dd;
-  vertical-align: top;
 }
-.tradeoffs th {
-  font-weight: 700;
-  background: var(--warm);
-  color: var(--text);
-  text-transform: uppercase;
-  font-size: var(--fs-xs);
+.layer:last-of-type { border-bottom: none; }
+.layer .lname {
+  background: var(--lav-light);
+  color: var(--tc-lav);
+  font-weight: 700; font-size: var(--fs-sm);
+  text-align: center;
+  padding: var(--sp-8) var(--sp-6);
+  border-radius: var(--r-md);
   letter-spacing: var(--ls-wide);
-}
-.tradeoffs th:first-child { width: 28%; }
-.tradeoffs td.v-a { background: rgba(181, 213, 197, 0.18); }
-.tradeoffs td.v-b { background: rgba(232, 184, 109, 0.10); }
-.tradeoffs td.v-c { background: rgba(201, 184, 232, 0.12); }
-.tradeoffs tr:hover td { background: var(--warm); }
-
-.tradeoffs td .verdict {
-  font-weight: 700;
-  font-size: var(--fs-xs);
   text-transform: uppercase;
-  letter-spacing: var(--ls-wide);
-  display: inline-block;
-  padding: var(--sp-2) var(--sp-6);
-  border-radius: var(--r-sm);
-  margin-right: var(--sp-4);
+  align-self: start;
 }
-.verdict.good { background: var(--sage-light); color: var(--tc-sage); }
-.verdict.watch { background: var(--amber-light); color: var(--tc-amber); }
-.verdict.cost { background: var(--rose-light); color: var(--tc-rose); }
-.verdict.neutral { background: var(--lav-light); color: var(--tc-lav); }
+.layer .ldesc { font-size: var(--fs-sm); color: var(--text); }
+.layer .ldesc strong { color: var(--text); }
+.layer .ldesc .src { font-size: var(--fs-xs); color: var(--mid); margin-top: var(--sp-4); display: block; }
 
-.recommendation {
-  margin-top: var(--sp-24);
-  background: var(--sage-light);
+/* Open issues block */
+.open-issues {
+  background: var(--surface-warn);
   border-radius: var(--r-2xl);
   padding: var(--sp-20);
-  border-left: 4px solid var(--sage);
+  border-left: 4px solid var(--border-warn);
+  margin-top: var(--sp-32);
 }
-.recommendation h3 {
+.open-issues h2 {
   font-family: 'Fraunces', serif;
-  font-weight: 700;
-  font-size: var(--fs-lg);
-  margin: 0 0 var(--sp-8) 0;
-  color: var(--tc-sage);
+  font-weight: 700; font-size: var(--fs-lg);
+  margin: 0 0 var(--sp-12) 0;
+  color: var(--tc-warn);
 }
-.recommendation p { margin: 0 0 var(--sp-8) 0; color: var(--text); }
-.recommendation .signature {
-  font-size: var(--fs-xs);
-  color: var(--mid);
-  font-style: italic;
-  margin-top: var(--sp-16);
-}
+.open-issues ol { padding-left: var(--sp-20); margin: 0; }
+.open-issues li { margin-bottom: var(--sp-10); font-size: var(--fs-sm); }
+.open-issues li strong { color: var(--text); }
 
 footer {
   margin-top: var(--sp-32);
@@ -537,457 +641,571 @@ footer {
   color: var(--light);
   text-align: center;
 }
-footer a { color: var(--tc-lav); }
 </style>
 </head>
 <body>
 <div class="page">
 
 <header class="intro">
-  <h1>Food Sub-Tab v1 — F-2 entry-form policy</h1>
-  <p class="sub">Three implementation options for the structured meal-entry surface. Same item-builder pattern (typeahead + quick-add chips + qty/unit pickers); they differ on what happens to the legacy free-text meal-input on the home tab.</p>
+  <h1>F-2 — FOB Feed sheet redesign (revised)</h1>
+  <p class="sub">Mockup v2 — after Architect ratification of six scoping questions. Target surface: <strong>FOB → FEED Log Feed sheet</strong> (the canonical meal-entry surface today). The diet Log sub-tab scaffold from PR #165 stays as-is; F-3 fills it as the richer review surface. Four scenarios: 3-tap repeat · 4-tap combo template · 6-tap novel · per-food quantity stepper.</p>
   <div class="meta">
     <span>spec: docs/specs/food-sub-tab-v1.md</span>
-    <span>F-1 shipped: PR #165</span>
-    <span>F-5 normalizer: lands AFTER F-2</span>
-    <span>Architect decision needed</span>
+    <span>data: 79 days of ziva_feeding analyzed</span>
+    <span>tap budget: 3 (repeat) / 6 (novel) — HARD</span>
+    <span>F-1: PR #165</span>
+    <span>F-5 normalizer: after F-2</span>
   </div>
 </header>
 
-<!-- ───────────────────────────── OPTION A ───────────────────────────── -->
-<section class="option-block">
-  <div class="option-head">
-    <span class="option-pill">Option A</span>
-    <h2>Full replace — structured-only on diet Log; legacy text-input retired</h2>
-  </div>
-  <p class="option-desc">The diet Log sub-tab becomes the single canonical meal-entry surface. The home-tab <code>.meal-input-wrap</code> per-meal text cards are retired this PR; the home tab keeps Today So Far / Diet Quick Picker / Intel banner unchanged, but loses the inline meal-input cards. Spec §4 alignment: "Save → emits structured shape; legacy <code>text</code> compat field generated for downstream readers." One canonical surface; F-5 normalizer reads two shapes (legacy stored records + new structured).</p>
-  <div class="scope-strip">
-    <span class="sw">1 entry surface</span>
-    <span class="sw">2 stored shapes (legacy + structured)</span>
-    <span class="sw warn">retires home meal-input</span>
-    <span class="sw">cleanest UX</span>
-  </div>
-  <div class="phone-row">
-
-    <div class="phone">
-      <div class="phone-label">Diet tab → Log sub-tab</div>
-      <div class="tab-bar">
-        <button class="tab-btn">Home</button>
-        <button class="tab-btn active">Track</button>
-        <button class="tab-btn">Care</button>
-      </div>
-      <div class="sub-tab-bar">
-        <button class="sub-tab-btn active">Log</button>
-        <button class="sub-tab-btn">Library</button>
-        <button class="sub-tab-btn">Patterns</button>
-      </div>
-
-      <div class="section-label">Today · Wed, May 27</div>
-
-      <div class="meal-card-structured">
-        <div class="meal-head">
-          <span class="meal-title">Breakfast</span>
-          <span class="meal-time-pill">8:30 am</span>
-        </div>
-        <div class="item-row">
-          <span class="item-name">Paratha</span>
-          <span class="nutri-tag">gluten</span>
-          <span class="item-qty">1 pc</span>
-          <span class="item-x">×</span>
-        </div>
-        <div class="item-row">
-          <span class="item-name">Ghee</span>
-          <span class="nutri-tag">dairy</span>
-          <span class="item-qty">1 tsp</span>
-          <span class="item-x">×</span>
-        </div>
-        <div class="item-row">
-          <span class="item-name">Banana</span>
-          <span class="item-qty">½ pc</span>
-          <span class="item-x">×</span>
-        </div>
-        <div class="quick-chip-rail">
-          <span class="quick-chip-label">Quick-add (last 7d most recent)</span>
-          <span class="quick-chip">+ Idli</span>
-          <span class="quick-chip">+ Dosa</span>
-          <span class="quick-chip">+ Porridge</span>
-          <span class="quick-chip">+ Curd</span>
-        </div>
-        <div class="add-item-bar">
-          <input class="add-item-input" placeholder="Add item — try 'dal'…">
-          <button class="add-item-btn">Add</button>
-        </div>
-      </div>
-
-      <div class="meal-card-structured" style="border-left-color: var(--amber);">
-        <div class="meal-head">
-          <span class="meal-title">Lunch</span>
-          <span class="meal-time-pill" style="background: var(--amber-light); color: var(--tc-amber);">empty</span>
-        </div>
-        <div class="add-item-bar">
-          <input class="add-item-input" placeholder="What did Ziva have at lunch?">
-          <button class="add-item-btn">Add</button>
-        </div>
-        <div class="quick-chip-rail">
-          <span class="quick-chip-label">Quick-add (last 30d most frequent at lunch)</span>
-          <span class="quick-chip">+ Dal khichdi</span>
-          <span class="quick-chip">+ Curd rice</span>
-          <span class="quick-chip">+ Ragi porridge</span>
-        </div>
-      </div>
-    </div>
-
-    <div class="phone">
-      <div class="phone-label">Home tab — meal-input cards retired</div>
-      <div class="tab-bar">
-        <button class="tab-btn active">Home</button>
-        <button class="tab-btn">Track</button>
-        <button class="tab-btn">Care</button>
-      </div>
-      <div class="section-label">Today So Far</div>
-      <div class="meal-card-legacy" style="border-left-color: var(--sky-light);">
-        <span class="meal-title">Day at a glance</span>
-        <div style="margin-top: 6px; font-size: var(--fs-sm); color: var(--mid);">Breakfast logged · 3 items · 1 hr ago</div>
-      </div>
-
-      <div class="section-label">Meal-input cards</div>
-      <div class="retired-surface">
-        <code>.meal-input-wrap</code> per-meal text cards removed.<br>
-        Tap "Add to log" → opens diet Log sub-tab.
-      </div>
-
-      <div class="section-label">Diet Quick Picker</div>
-      <div class="preserved-surface">
-        <div style="display: flex; gap: 6px; flex-wrap: wrap;">
-          <span class="quick-chip" style="background: var(--peach-light); border-color: var(--peach); color: var(--tc-amber);">Iron foods</span>
-          <span class="quick-chip" style="background: var(--peach-light); border-color: var(--peach); color: var(--tc-amber);">Brain fats</span>
-          <span class="quick-chip" style="background: var(--peach-light); border-color: var(--peach); color: var(--tc-amber);">Probiotics</span>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="note-box">
-    <strong>Trade-off in one line:</strong> simplest mental model + cleanest F-5 normalizer test surface, but burns the parent's existing home-tab meal-input muscle memory. Risk: a parent typing at the home tab will hit dead space until they relearn the Log sub-tab. Mitigation: home-tab "Day at a glance" card includes a "+ Add to log" CTA that opens the diet Log sub-tab.
-  </div>
-</section>
-
-<!-- ───────────────────────────── OPTION B ───────────────────────────── -->
-<section class="option-block">
-  <div class="option-head">
-    <span class="option-pill" style="background: var(--amber);">Option B</span>
-    <h2>Coexist — structured on diet Log; home-tab legacy preserved</h2>
-  </div>
-  <p class="option-desc">The diet Log sub-tab ships the new structured item builder. The home-tab <code>.meal-input-wrap</code> per-meal text cards are preserved unchanged — parents who use the home-tab quick-input keep the muscle memory they have. F-3 (Library consolidation) or a later PR can unify the surfaces; F-5 normalizer reads three shapes (legacy stored + free-text-now + structured). Lowest risk; preserves existing parent flow.</p>
-  <div class="scope-strip">
-    <span class="sw">2 entry surfaces</span>
-    <span class="sw">3 stored shapes (legacy + free-text + structured)</span>
-    <span class="sw neutral">home meal-input unchanged</span>
-    <span class="sw">muscle memory preserved</span>
-  </div>
-  <div class="phone-row">
-
-    <div class="phone">
-      <div class="phone-label">Diet tab → Log sub-tab</div>
-      <div class="tab-bar">
-        <button class="tab-btn">Home</button>
-        <button class="tab-btn active">Track</button>
-        <button class="tab-btn">Care</button>
-      </div>
-      <div class="sub-tab-bar">
-        <button class="sub-tab-btn active">Log</button>
-        <button class="sub-tab-btn">Library</button>
-        <button class="sub-tab-btn">Patterns</button>
-      </div>
-
-      <div class="section-label">Today · Wed, May 27</div>
-
-      <div class="meal-card-structured">
-        <div class="meal-head">
-          <span class="meal-title">Breakfast</span>
-          <span class="meal-time-pill">8:30 am</span>
-        </div>
-        <div class="item-row">
-          <span class="item-name">Paratha</span>
-          <span class="nutri-tag">gluten</span>
-          <span class="item-qty">1 pc</span>
-          <span class="item-x">×</span>
-        </div>
-        <div class="item-row">
-          <span class="item-name">Ghee</span>
-          <span class="nutri-tag">dairy</span>
-          <span class="item-qty">1 tsp</span>
-          <span class="item-x">×</span>
-        </div>
-        <div class="item-row">
-          <span class="item-name">Banana</span>
-          <span class="item-qty">½ pc</span>
-          <span class="item-x">×</span>
-        </div>
-        <div class="quick-chip-rail">
-          <span class="quick-chip-label">Quick-add</span>
-          <span class="quick-chip">+ Idli</span>
-          <span class="quick-chip">+ Dosa</span>
-          <span class="quick-chip">+ Curd</span>
-        </div>
-        <div class="add-item-bar">
-          <input class="add-item-input" placeholder="Add item — try 'dal'…">
-          <button class="add-item-btn">Add</button>
-        </div>
-      </div>
-    </div>
-
-    <div class="phone">
-      <div class="phone-label">Home tab — legacy meal-input preserved</div>
-      <div class="tab-bar">
-        <button class="tab-btn active">Home</button>
-        <button class="tab-btn">Track</button>
-        <button class="tab-btn">Care</button>
-      </div>
-      <div class="section-label">Today So Far</div>
-      <div class="meal-card-legacy" style="border-left-color: var(--sky-light);">
-        <span class="meal-title">Day at a glance</span>
-        <div style="margin-top: 6px; font-size: var(--fs-sm); color: var(--mid);">Breakfast logged · 3 items · 1 hr ago</div>
-      </div>
-
-      <div class="section-label">Meal-input cards (legacy free-text)</div>
-      <div class="preserved-surface">
-        <div class="meal-card-legacy" style="margin: 0 0 8px 0; box-shadow: none; background: var(--white);">
-          <div class="meal-head">
-            <span class="meal-title">Breakfast</span>
-            <span class="meal-time-pill">8:30 am</span>
-          </div>
-          <input class="legacy-text-input has-content" value="paratha with ghee, banana">
-          <div class="legacy-dropdown-hint">tap any food in the type-ahead</div>
-        </div>
-        <div class="meal-card-legacy" style="margin: 0; box-shadow: none; background: var(--white); border-left-color: var(--amber);">
-          <div class="meal-head">
-            <span class="meal-title">Lunch</span>
-            <span class="meal-time-pill" style="background: var(--amber-light); color: var(--tc-amber);">empty</span>
-          </div>
-          <input class="legacy-text-input" placeholder="What did Ziva have at lunch?">
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="note-box">
-    <strong>Trade-off in one line:</strong> safest path for parent flow + zero muscle-memory cost, but the app has two entry surfaces emitting different shapes — F-5 normalizer must read three shapes (legacy stored + free-text-now + structured). Two surfaces also means a parent who logs structured on diet Log but glances at the home meal-input may not see the latest entries reflected without a cross-surface render. F-3 (or a follow-up PR) unifies later.
-  </div>
-</section>
-
-<!-- ───────────────────────────── OPTION C ───────────────────────────── -->
-<section class="option-block">
-  <div class="option-head">
-    <span class="option-pill" style="background: var(--lavender);">Option C</span>
-    <h2>Toggle — structured by default; "Simple mode" opt-in fallback</h2>
-  </div>
-  <p class="option-desc">The diet Log sub-tab shows the structured item builder by default. A persistent toggle pill at the top lets parents switch the sub-tab into "Simple mode" — free-text per-meal cards inside the same Log sub-tab. Mode preference saves to localStorage. Home-tab meal-input cards retired (same as Option A). Highest UX safety net; doubles the form surface area inside the Log sub-tab; F-5 normalizer reads three shapes.</p>
-  <div class="scope-strip">
-    <span class="sw">1 entry surface, 2 modes</span>
-    <span class="sw">3 stored shapes</span>
-    <span class="sw warn">retires home meal-input</span>
-    <span class="sw warn">2× UX code surface</span>
-  </div>
-  <div class="phone-row">
-
-    <div class="phone">
-      <div class="phone-label">Diet Log — Structured mode (default)</div>
-      <div class="tab-bar">
-        <button class="tab-btn">Home</button>
-        <button class="tab-btn active">Track</button>
-        <button class="tab-btn">Care</button>
-      </div>
-      <div class="sub-tab-bar">
-        <button class="sub-tab-btn active">Log</button>
-        <button class="sub-tab-btn">Library</button>
-        <button class="sub-tab-btn">Patterns</button>
-      </div>
-
-      <div class="mode-toggle">
-        <button class="mode-toggle-btn active">Structured</button>
-        <button class="mode-toggle-btn">Simple</button>
-      </div>
-      <div class="mode-toggle-info">your choice — saved across sessions</div>
-
-      <div class="meal-card-structured">
-        <div class="meal-head">
-          <span class="meal-title">Breakfast</span>
-          <span class="meal-time-pill">8:30 am</span>
-        </div>
-        <div class="item-row">
-          <span class="item-name">Paratha</span>
-          <span class="nutri-tag">gluten</span>
-          <span class="item-qty">1 pc</span>
-          <span class="item-x">×</span>
-        </div>
-        <div class="item-row">
-          <span class="item-name">Ghee</span>
-          <span class="nutri-tag">dairy</span>
-          <span class="item-qty">1 tsp</span>
-          <span class="item-x">×</span>
-        </div>
-        <div class="quick-chip-rail">
-          <span class="quick-chip">+ Idli</span>
-          <span class="quick-chip">+ Banana</span>
-          <span class="quick-chip">+ Curd</span>
-        </div>
-        <div class="add-item-bar">
-          <input class="add-item-input" placeholder="Add item…">
-          <button class="add-item-btn">Add</button>
-        </div>
-      </div>
-    </div>
-
-    <div class="phone">
-      <div class="phone-label">Diet Log — Simple mode (toggled)</div>
-      <div class="tab-bar">
-        <button class="tab-btn">Home</button>
-        <button class="tab-btn active">Track</button>
-        <button class="tab-btn">Care</button>
-      </div>
-      <div class="sub-tab-bar">
-        <button class="sub-tab-btn active">Log</button>
-        <button class="sub-tab-btn">Library</button>
-        <button class="sub-tab-btn">Patterns</button>
-      </div>
-
-      <div class="mode-toggle">
-        <button class="mode-toggle-btn">Structured</button>
-        <button class="mode-toggle-btn active">Simple</button>
-      </div>
-      <div class="mode-toggle-info">your choice — saved across sessions</div>
-
-      <div class="meal-card-legacy">
-        <div class="meal-head">
-          <span class="meal-title">Breakfast</span>
-          <span class="meal-time-pill">8:30 am</span>
-        </div>
-        <input class="legacy-text-input has-content" value="paratha with ghee, banana">
-        <div class="legacy-dropdown-hint">type-ahead picks single food</div>
-      </div>
-      <div class="meal-card-legacy" style="border-left-color: var(--amber);">
-        <div class="meal-head">
-          <span class="meal-title">Lunch</span>
-          <span class="meal-time-pill" style="background: var(--amber-light); color: var(--tc-amber);">empty</span>
-        </div>
-        <input class="legacy-text-input" placeholder="What did Ziva have at lunch?">
-      </div>
-      <div class="meal-card-legacy" style="border-left-color: var(--lavender);">
-        <div class="meal-head">
-          <span class="meal-title">Dinner</span>
-          <span class="meal-time-pill" style="background: var(--lav-light); color: var(--tc-lav);">empty</span>
-        </div>
-        <input class="legacy-text-input" placeholder="What did Ziva have at dinner?">
-      </div>
-    </div>
-  </div>
-
-  <div class="note-box">
-    <strong>Trade-off in one line:</strong> highest safety net + lets parents choose, but doubles the code surface inside the Log sub-tab (every render path branches on mode); F-5 normalizer must read three shapes; the toggle itself becomes a UX surface to design + test (where does it sit, does it persist across days, does it animate). Likely overbuilt for Ziva-first; could become useful when the app eventually supports multiple babies / multiple caretakers with different preferences.
-  </div>
-</section>
-
-<!-- ───────────────────────────── TRADE-OFF MATRIX ───────────────────────────── -->
-<div class="tradeoffs">
-  <h2>Trade-off matrix</h2>
-  <table>
-    <thead>
-      <tr>
-        <th>Axis</th>
-        <th>A — Full replace</th>
-        <th>B — Coexist</th>
-        <th>C — Toggle</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><strong>Entry surfaces</strong></td>
-        <td class="v-a"><span class="verdict good">1</span> diet Log only</td>
-        <td class="v-b"><span class="verdict watch">2</span> diet Log + home meal-input</td>
-        <td class="v-c"><span class="verdict watch">1 + mode</span> diet Log w/ toggle</td>
-      </tr>
-      <tr>
-        <td><strong>Stored shapes (F-5 reads)</strong></td>
-        <td class="v-a"><span class="verdict good">2</span> legacy + structured</td>
-        <td class="v-b"><span class="verdict watch">3</span> legacy + free-text + structured</td>
-        <td class="v-c"><span class="verdict watch">3</span> legacy + simple-mode-text + structured</td>
-      </tr>
-      <tr>
-        <td><strong>Code surface (lines added)</strong></td>
-        <td class="v-a"><span class="verdict good">smallest</span> ~750 LOC est.</td>
-        <td class="v-b"><span class="verdict neutral">medium</span> ~900 LOC est. (preserves home path)</td>
-        <td class="v-c"><span class="verdict cost">largest</span> ~1,150 LOC est. (both modes live)</td>
-      </tr>
-      <tr>
-        <td><strong>Parent muscle-memory</strong></td>
-        <td class="v-a"><span class="verdict cost">burned</span> home meal-input gone</td>
-        <td class="v-b"><span class="verdict good">preserved</span> home unchanged</td>
-        <td class="v-c"><span class="verdict good">preserved via toggle</span> opt-in</td>
-      </tr>
-      <tr>
-        <td><strong>F-5 normalizer test surface</strong></td>
-        <td class="v-a"><span class="verdict good">simplest</span> 2 shapes</td>
-        <td class="v-b"><span class="verdict watch">harder</span> 3 shapes, cross-surface drift</td>
-        <td class="v-c"><span class="verdict watch">harder</span> 3 shapes</td>
-      </tr>
-      <tr>
-        <td><strong>"Single source of truth" arc</strong></td>
-        <td class="v-a"><span class="verdict good">direct</span> diet Log canonical</td>
-        <td class="v-b"><span class="verdict watch">requires F-3 unification</span></td>
-        <td class="v-c"><span class="verdict cost">requires future deprecation arc</span></td>
-      </tr>
-      <tr>
-        <td><strong>Mobile 1-handed tap budget</strong></td>
-        <td class="v-a"><span class="verdict good">best</span> one place</td>
-        <td class="v-b"><span class="verdict watch">worst</span> may flip-flop</td>
-        <td class="v-c"><span class="verdict neutral">medium</span> one extra tap to choose mode</td>
-      </tr>
-      <tr>
-        <td><strong>Spec §4 alignment</strong></td>
-        <td class="v-a"><span class="verdict good">direct</span> "Save → emits structured"</td>
-        <td class="v-b"><span class="verdict watch">partial</span> home tab still free-text</td>
-        <td class="v-c"><span class="verdict watch">mixed</span> structured default + free-text mode</td>
-      </tr>
-      <tr>
-        <td><strong>Risk of regression</strong></td>
-        <td class="v-a"><span class="verdict watch">moderate</span> replaces home muscle memory</td>
-        <td class="v-b"><span class="verdict good">lowest</span> home unchanged</td>
-        <td class="v-c"><span class="verdict watch">moderate</span> toggle state across sessions</td>
-      </tr>
-      <tr>
-        <td><strong>Honesty axis (CV3-006)</strong></td>
-        <td class="v-a"><span class="verdict good">PASS</span> one entry; clear source</td>
-        <td class="v-b"><span class="verdict watch">PASS-with-note</span> dual sources to track</td>
-        <td class="v-c"><span class="verdict good">PASS</span> per-mode source clear</td>
-      </tr>
-      <tr>
-        <td><strong>Warmth axis (CV3-006)</strong></td>
-        <td class="v-a"><span class="verdict watch">mixed</span> new pattern to learn</td>
-        <td class="v-b"><span class="verdict good">PASS</span> familiar home unchanged</td>
-        <td class="v-c"><span class="verdict good">PASS</span> parent choice respected</td>
-      </tr>
-      <tr>
-        <td><strong>Extensibility (CV3-006)</strong></td>
-        <td class="v-a"><span class="verdict good">PASS</span> single surface to extend</td>
-        <td class="v-b"><span class="verdict watch">PASS</span> two surfaces to extend in lockstep</td>
-        <td class="v-c"><span class="verdict cost">cost</span> every new feature × 2 modes</td>
-      </tr>
-    </tbody>
-  </table>
+<div class="ratifications">
+  <h2>Six ratifications carried into this revision</h2>
+  <ul>
+    <li><strong>1. Alternative path</strong> — F-2 = FOB Log Feed sheet only. Diet Log sub-tab scaffold (PR #165) untouched; F-3 fills it as the richer review surface.</li>
+    <li><strong>2. Dynamic combos</strong> — rolling 14d top-N per meal-slot. Intelligence layer reserves a slot for curated combo fallback (covers cold-start).</li>
+    <li><strong>3. Per-meal intake kept</strong> — Few bites / Half / Most / All as secondary field; <strong>defaults to "Most" (0.75)</strong>. Honest baseline: parents tap UP to "All" when Ziva finishes everything, or DOWN to Half/Few when she doesn't. "All" as default would bias the data upward (busy parents won't step-down on a normal day).</li>
+    <li><strong>4. Quantity defaults in NUTRITION</strong> — extend rows with <code>defaultQty + defaultUnit</code> (data.js, Kael's region; single source of truth; audit-gate-friendly).</li>
+    <li><strong>5. Hard tap-budget limits</strong> — 3-tap repeat / 6-tap novel enforced as build-time regression guards. Tighten/loosen after live use.</li>
+    <li><strong>6. "Same as lunch (today)" for dinner</strong> — green light. Data shows 46% of days have identical lunch + dinner — biggest single-tap win available.</li>
+  </ul>
 </div>
 
-<div class="recommendation">
-  <h3>Lyra's read</h3>
-  <p>I lean <strong>Option A — Full replace</strong> for this session. The food-sub-tab F-1 scaffold (PR #165) already moved the meal-card surface conceptually into the diet Log sub-tab — the home-tab <code>.meal-input-wrap</code> is the legacy holdover; F-2's job is to make the diet Log the canonical entry. F-5 normalizer test surface stays at 2 shapes (legacy stored + structured), the cleanest path for the v3-8 normalizer arc.</p>
-  <p>That said: if the muscle-memory risk feels load-bearing — parents type at the home tab today, and a sudden retirement could read as "the app took away the place I log breakfast" — <strong>Option B</strong> is the safer compromise. The cost is F-3 (or a later PR) needs to unify, and F-5 reads three shapes. That cost is real but bounded.</p>
-  <p><strong>Option C</strong> reads to me as a v2-or-later feature, not a v1 one. The toggle adds UX complexity for a Ziva-first app where there's one parent + one caretaker; if SproutLab ever generalises (multi-baby, multi-caretaker with divergent preferences), C becomes the obvious move. For now: the doubled code surface + the toggle-state UX design is overbuilt.</p>
-  <p>Whatever you pick, F-2 will ship typeahead + quick-add chips + qty/unit pickers as the structured surface — those are core to the spec. The variable is what happens to home-tab <code>.meal-input-wrap</code>.</p>
-  <div class="signature">— Lyra, F-2 scoping. Mockup served for Architect decision. After ratification, I'll fold the chosen option into the F-2 IMPL PR + run <code>/code-review xhigh</code> before the canon-cc-008 chain (AGENTS.md Rule 13).</div>
+<div class="flow-diagram">
+  <span class="flow-step"><span class="num">1</span> FOB tap</span>
+  <span class="flow-arr">→</span>
+  <span class="flow-step"><span class="num">2</span> FEED tap</span>
+  <span class="flow-arr">→</span>
+  <span class="flow-step"><span class="num">3+</span> Log Feed sheet</span>
+</div>
+
+<!-- ─────────────────────── SCENARIO 1 — 3-TAP REPEAT ─────────────────────── -->
+<section class="scenario">
+  <div class="scenario-head">
+    <span class="tap-badge">3 taps</span>
+    <h2>Repeat scenario — "Same as yesterday's breakfast"</h2>
+  </div>
+  <p class="scenario-desc">Parent opens FOB during breakfast time. Sheet auto-infers meal slot from time-of-day (morning → B). At the top sits the most-likely repeat: yesterday's same-slot meal as a single primary chip. <strong>Tap 3 fills the meal AND auto-saves after a 2-second confirmation window</strong> (visible countdown; tap anywhere to cancel + edit). 70% of meals follow this path in the data.</p>
+
+  <div class="phone-row">
+    <div class="phone">
+      <div class="phone-label">Tap 3 — inside Log Feed sheet</div>
+
+      <div class="bg-context">
+        <div class="bc-line med"></div>
+        <div class="bc-line short"></div>
+        <div class="bc-line"></div>
+      </div>
+
+      <div class="bottom-sheet">
+        <div class="sheet-grip"></div>
+        <button class="sheet-close">×</button>
+        <h3 class="sheet-title">Log Feed</h3>
+
+        <div class="sec-lbl">MEAL · inferred from time of day</div>
+        <div class="meal-slot-strip">
+          <div class="meal-slot active b inferred">B<span class="slot-time">8a</span></div>
+          <div class="meal-slot">L<span class="slot-time">1p</span></div>
+          <div class="meal-slot">D<span class="slot-time">8p</span></div>
+          <div class="meal-slot">S<span class="slot-time">any</span></div>
+        </div>
+
+        <div class="sec-lbl">YOUR USUAL · tap to log + save</div>
+        <div class="repeat-rail">
+          <div class="repeat-chip primary tap-target">
+            <div>
+              <div class="rc-head"><span class="rc-icon">↻</span> Yesterday's breakfast</div>
+              <div class="rc-body">Avocado mash · Blueberry · Mango puree</div>
+            </div>
+            <span class="rc-tap">tap → save</span>
+          </div>
+          <div class="repeat-chip">
+            <div>
+              <div class="rc-head">3 days ago</div>
+              <div class="rc-body">Avocado mash · Banana mash · Blueberry</div>
+            </div>
+            <span class="rc-tap">tap to use</span>
+          </div>
+        </div>
+
+        <div class="sec-lbl">OR BUILD FROM SCRATCH</div>
+        <div class="add-row">
+          <input class="add-input" placeholder="Type to add… (e.g. 'av' for Avocado mash)">
+        </div>
+
+        <button class="save-btn auto">Save Feed</button>
+      </div>
+    </div>
+
+    <div class="phone">
+      <div class="phone-label">Result — auto-saved · meal pre-filled</div>
+
+      <div class="bg-context">
+        <div class="bc-line med"></div>
+        <div class="bc-line"></div>
+        <div class="bc-line short"></div>
+      </div>
+
+      <div class="bottom-sheet">
+        <div class="sheet-grip"></div>
+        <h3 class="sheet-title">Logged · Breakfast 8:30 am</h3>
+
+        <div class="items-list">
+          <div class="item-row">
+            <span class="item-icon">A</span>
+            <div class="item-name">Avocado mash<span class="meta">library · 1 pc</span></div>
+            <span class="item-qty"><span class="qty-step">−</span><span class="qty-val">½ <span class="qty-unit">pc</span></span><span class="qty-step">+</span></span>
+          </div>
+          <div class="item-row">
+            <span class="item-icon">B</span>
+            <div class="item-name">Blueberry<span class="meta">library · 5 pc</span></div>
+            <span class="item-qty"><span class="qty-step">−</span><span class="qty-val">5 <span class="qty-unit">pc</span></span><span class="qty-step">+</span></span>
+          </div>
+          <div class="item-row">
+            <span class="item-icon">M</span>
+            <div class="item-name">Mango puree<span class="meta">library · ¼ pc</span></div>
+            <span class="item-qty"><span class="qty-step">−</span><span class="qty-val">¼ <span class="qty-unit">pc</span></span><span class="qty-step">+</span></span>
+          </div>
+        </div>
+
+        <div class="foot-row">
+          <div class="foot-field">
+            <div class="ff-lbl">Time</div>
+            <div class="ff-val">8:30 am</div>
+          </div>
+          <div class="foot-field">
+            <div class="ff-lbl">Overall intake · default</div>
+            <div class="intake-strip">
+              <div class="intake-pill">Few</div>
+              <div class="intake-pill">Half</div>
+              <div class="intake-pill active">Most</div>
+              <div class="intake-pill">All</div>
+            </div>
+          </div>
+        </div>
+
+        <button class="save-btn" style="background: var(--sage);">✓ Logged · tap to edit</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="note-box">
+    <strong>Tap count breakdown:</strong> Tap 1 = FOB · Tap 2 = FEED · Tap 3 = "Yesterday's breakfast" chip → sheet enters 2s auto-save window. Total = <strong>3 taps</strong>. Parent can tap anywhere to cancel auto-save + edit (e.g., bump Avocado mash from ½ → 1 pc, drop Mango, change intake). If parent taps cancel + edit, total path becomes Scenario 4 (qty stepper). The auto-save is forgiving: it surfaces a banner "Logged · undo" for 8 seconds post-save.
+  </div>
+</section>
+
+<!-- ─────────────────────── SCENARIO 2 — 4-TAP COMBO TEMPLATE ─────────────────────── -->
+<section class="scenario">
+  <div class="scenario-head">
+    <span class="tap-badge medium">4 taps</span>
+    <h2>Combo template — "Your usual breakfast" (no exact yesterday match)</h2>
+  </div>
+  <p class="scenario-desc">Scenario where yesterday's breakfast doesn't quite fit (e.g., parent fed something different yesterday + wants the "standard" usual). System surfaces the rolling 14d top-N combo as a chip. From the data: Avocado + Blueberry + Banana mash AND Avocado + Blueberry + Mango both hit 7× in the dataset → two competing top combos shown. Parent taps the right one, system fills, auto-saves.</p>
+
+  <div class="phone-row">
+    <div class="phone">
+      <div class="phone-label">Combo chips · "Your usual" patterns</div>
+
+      <div class="bottom-sheet">
+        <div class="sheet-grip"></div>
+        <h3 class="sheet-title">Log Feed</h3>
+
+        <div class="sec-lbl">MEAL</div>
+        <div class="meal-slot-strip">
+          <div class="meal-slot active b">B<span class="slot-time">8a</span></div>
+          <div class="meal-slot">L<span class="slot-time">1p</span></div>
+          <div class="meal-slot">D<span class="slot-time">8p</span></div>
+          <div class="meal-slot">S<span class="slot-time">any</span></div>
+        </div>
+
+        <div class="sec-lbl">YOUR USUAL BREAKFAST · last 14 days</div>
+        <div class="combo-chip tap-target">
+          <div class="combo-chip-title">
+            ⌬ Avocado mash + Blueberry + Mango
+            <span class="conf">7×</span>
+          </div>
+          <div class="combo-chip-foods">your usual breakfast · ½ pc + 5 pc + ¼ pc</div>
+        </div>
+        <div class="combo-chip">
+          <div class="combo-chip-title">
+            ⌬ Avocado mash + Banana mash + Blueberry
+            <span class="conf">7×</span>
+          </div>
+          <div class="combo-chip-foods">your other usual · ½ pc + ½ pc + 5 pc</div>
+        </div>
+
+        <div class="sec-lbl">RECENT · last 7 days</div>
+        <div class="repeat-rail">
+          <div class="repeat-chip">
+            <div>
+              <div class="rc-head">Yesterday</div>
+              <div class="rc-body">Apple puree · Almonds · Walnut</div>
+            </div>
+            <span class="rc-tap">tap to use</span>
+          </div>
+        </div>
+
+        <button class="save-btn auto">Save Feed</button>
+      </div>
+    </div>
+
+    <div class="phone">
+      <div class="phone-label">After combo tap — pre-filled with per-food qty</div>
+
+      <div class="bottom-sheet">
+        <div class="sheet-grip"></div>
+        <h3 class="sheet-title">Log Feed · Breakfast</h3>
+
+        <div class="items-list">
+          <div class="item-row">
+            <span class="item-icon">A</span>
+            <div class="item-name">Avocado mash<span class="meta">from combo · default ½ pc</span></div>
+            <span class="item-qty"><span class="qty-step">−</span><span class="qty-val">½ <span class="qty-unit">pc</span></span><span class="qty-step">+</span></span>
+          </div>
+          <div class="item-row">
+            <span class="item-icon">B</span>
+            <div class="item-name">Blueberry<span class="meta">from combo · default 5 pc</span></div>
+            <span class="item-qty"><span class="qty-step">−</span><span class="qty-val">5 <span class="qty-unit">pc</span></span><span class="qty-step">+</span></span>
+          </div>
+          <div class="item-row">
+            <span class="item-icon">M</span>
+            <div class="item-name">Mango<span class="meta">from combo · default ¼ pc</span></div>
+            <span class="item-qty"><span class="qty-step">−</span><span class="qty-val">¼ <span class="qty-unit">pc</span></span><span class="qty-step">+</span></span>
+          </div>
+        </div>
+
+        <div class="next-ribbon">
+          <span class="next-chip">+ Banana mash<span class="conf">43%</span></span>
+          <span class="next-chip">+ Apple puree<span class="conf">28%</span></span>
+          <span class="next-chip">+ Ghee<span class="conf">19%</span></span>
+        </div>
+
+        <div class="foot-row">
+          <div class="foot-field">
+            <div class="ff-lbl">Time</div>
+            <div class="ff-val">8:30 am</div>
+          </div>
+          <div class="foot-field">
+            <div class="ff-lbl">Intake · default Most</div>
+            <div class="intake-strip">
+              <div class="intake-pill">Few</div>
+              <div class="intake-pill">Half</div>
+              <div class="intake-pill active">Most</div>
+              <div class="intake-pill">All</div>
+            </div>
+          </div>
+        </div>
+
+        <button class="save-btn">Save Feed</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="note-box">
+    <strong>Tap count:</strong> FOB · FEED · "Avocado + Blueberry + Mango" combo chip · Save = <strong>4 taps</strong>. The next-item ribbon stays available — parent can still add Banana mash in tap 5 if Ziva had it today. Combo chips are dynamic from a rolling 14d window (per ratification #2) — if Ziva's diet shifts, the surfaced combos shift with it. Cold-start (first 14 days of use) falls back to the curated combo registry slot in the intelligence layer.
+  </div>
+</section>
+
+<!-- ─────────────────────── SCENARIO 3 — 6-TAP NOVEL ─────────────────────── -->
+<section class="scenario">
+  <div class="scenario-head">
+    <span class="tap-badge long">6 taps</span>
+    <h2>Novel meal — typeahead + next-item prediction ribbon</h2>
+  </div>
+  <p class="scenario-desc">Parent introduces a new combination Ziva hasn't had before. Type "av" → typeahead matches Avocado mash on first character pair (no need to type the full name). Tap to accept. System surfaces predicted next-item chips by co-occurrence (Blueberry @94% based on 33 of 35 prior Avocado-mash meals). Parent taps next chip; system surfaces the next ribbon. Loop until done. <strong>Per-food quantity defaults from NUTRITION</strong>.</p>
+
+  <div class="phone-row">
+    <div class="phone">
+      <div class="phone-label">Tap 3 — type "av" → typeahead</div>
+      <div class="bottom-sheet">
+        <div class="sheet-grip"></div>
+        <h3 class="sheet-title">Log Feed</h3>
+
+        <div class="meal-slot-strip">
+          <div class="meal-slot active b">B<span class="slot-time">8a</span></div>
+          <div class="meal-slot">L<span class="slot-time">1p</span></div>
+          <div class="meal-slot">D<span class="slot-time">8p</span></div>
+          <div class="meal-slot">S<span class="slot-time">any</span></div>
+        </div>
+
+        <div class="sec-lbl">ITEMS</div>
+        <div class="items-list">
+          <div class="empty">Type to start adding</div>
+        </div>
+
+        <div class="add-row">
+          <input class="add-input typed tap-target" value="av">
+        </div>
+        <div class="typeahead">
+          <div class="ta-row match">
+            <span class="item-icon">A</span>
+            <div class="ta-name"><span class="hi">Av</span>ocado mash</div>
+            <span class="ta-meta">library · ½ pc default</span>
+          </div>
+          <div class="ta-row">
+            <span class="item-icon">A</span>
+            <div class="ta-name"><span class="hi">Av</span>ocado (whole)</div>
+            <span class="ta-meta">library · 1 pc default</span>
+          </div>
+        </div>
+
+        <button class="save-btn" style="background: #d8ccc4; color: var(--mid);">Save Feed (empty)</button>
+      </div>
+    </div>
+
+    <div class="phone">
+      <div class="phone-label">Tap 4 — first item added · next-item ribbon</div>
+      <div class="bottom-sheet">
+        <div class="sheet-grip"></div>
+        <h3 class="sheet-title">Log Feed · Breakfast</h3>
+
+        <div class="items-list">
+          <div class="item-row">
+            <span class="item-icon">A</span>
+            <div class="item-name">Avocado mash<span class="meta">typeahead · default ½ pc</span></div>
+            <span class="item-qty"><span class="qty-step">−</span><span class="qty-val">½ <span class="qty-unit">pc</span></span><span class="qty-step">+</span></span>
+            <span class="item-x">×</span>
+          </div>
+        </div>
+
+        <div class="sec-lbl">YOU USUALLY ADD · tap to add</div>
+        <div class="next-ribbon">
+          <span class="next-chip tap-target">+ Blueberry<span class="conf">94%</span></span>
+          <span class="next-chip">+ Banana mash<span class="conf">43%</span></span>
+          <span class="next-chip">+ Mango puree<span class="conf">40%</span></span>
+          <span class="next-chip">+ Mango<span class="conf">29%</span></span>
+        </div>
+
+        <div class="add-row">
+          <input class="add-input" placeholder="…or type another item">
+        </div>
+
+        <button class="save-btn">Save Feed</button>
+      </div>
+    </div>
+
+    <div class="phone">
+      <div class="phone-label">Tap 5 — Blueberry added · next ribbon refreshes</div>
+      <div class="bottom-sheet">
+        <div class="sheet-grip"></div>
+        <h3 class="sheet-title">Log Feed · Breakfast</h3>
+
+        <div class="items-list">
+          <div class="item-row">
+            <span class="item-icon">A</span>
+            <div class="item-name">Avocado mash<span class="meta">½ pc</span></div>
+            <span class="item-qty"><span class="qty-step">−</span><span class="qty-val">½ <span class="qty-unit">pc</span></span><span class="qty-step">+</span></span>
+          </div>
+          <div class="item-row">
+            <span class="item-icon">B</span>
+            <div class="item-name">Blueberry<span class="meta">next-pick · 5 pc</span></div>
+            <span class="item-qty"><span class="qty-step">−</span><span class="qty-val">5 <span class="qty-unit">pc</span></span><span class="qty-step">+</span></span>
+          </div>
+        </div>
+
+        <div class="sec-lbl">USUALLY WITH AVOCADO + BLUEBERRY</div>
+        <div class="next-ribbon">
+          <span class="next-chip">+ Mango<span class="conf">42%</span></span>
+          <span class="next-chip">+ Banana mash<span class="conf">38%</span></span>
+          <span class="next-chip">+ Prune puree<span class="conf">10%</span></span>
+        </div>
+
+        <button class="save-btn tap-target">Save Feed</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="note-box">
+    <strong>Tap count:</strong> FOB · FEED · type "av" + tap Avocado mash (counts as 1 tap — typing is gestural; tap accepts) · tap "+ Blueberry" · (optionally tap "+ Mango") · Save = <strong>5-6 taps</strong>. The next-item ribbon recomputes after each add — it reads the rolling 14d pair-count map. <strong>Confidence % is shown so the parent sees why</strong> the suggestion is there (Honesty axis — CV3-006). Tap-budget guard: instrument the render to count taps from sheet-open to Save; regression test asserts ≤6 for a novel-meal fixture.
+  </div>
+</section>
+
+<!-- ─────────────────────── SCENARIO 4 — QTY STEPPER ─────────────────────── -->
+<section class="scenario">
+  <div class="scenario-head">
+    <span class="tap-badge detail">DETAIL</span>
+    <h2>Per-food quantity stepper · NUTRITION defaults</h2>
+  </div>
+  <p class="scenario-desc">Each item row carries <code>[− qty unit +]</code> inline. Defaults come from the food's NUTRITION row (<code>defaultQty</code> + <code>defaultUnit</code> per ratification #4). Single tap steps ± by the food's natural increment (Ghee = ±½ tsp; Walnut = ±1 pc; Avocado = ±¼ pc). Long-press the qty value opens a numeric keypad for exact entry. Adjusting qty <strong>does not count toward the tap budget</strong> — it's editing, not entry. The default values mean the common case requires zero qty taps.</p>
+
+  <div class="phone-row two">
+    <div class="phone">
+      <div class="phone-label">Stepper at rest · all defaults applied</div>
+      <div class="bottom-sheet" style="box-shadow: var(--shadow-card);">
+        <h3 class="sheet-title" style="margin-bottom: var(--sp-8);">Quantity stepper · examples</h3>
+
+        <div class="items-list">
+          <div class="item-row">
+            <span class="item-icon">G</span>
+            <div class="item-name">Ghee (cow)<span class="meta">step ±½ tsp</span></div>
+            <span class="item-qty"><span class="qty-step">−</span><span class="qty-val">1 <span class="qty-unit">tsp</span></span><span class="qty-step">+</span></span>
+          </div>
+          <div class="item-row">
+            <span class="item-icon">A</span>
+            <div class="item-name">Apple<span class="meta">step ±¼ pc</span></div>
+            <span class="item-qty"><span class="qty-step">−</span><span class="qty-val">½ <span class="qty-unit">pc</span></span><span class="qty-step">+</span></span>
+          </div>
+          <div class="item-row">
+            <span class="item-icon">W</span>
+            <div class="item-name">Walnut<span class="meta">step ±1 pc</span></div>
+            <span class="item-qty"><span class="qty-step">−</span><span class="qty-val">1 <span class="qty-unit">pc</span></span><span class="qty-step">+</span></span>
+          </div>
+          <div class="item-row">
+            <span class="item-icon">K</span>
+            <div class="item-name">Khichdi (masoor dal)<span class="meta">step ±¼ bowl</span></div>
+            <span class="item-qty"><span class="qty-step">−</span><span class="qty-val">1 <span class="qty-unit">bowl</span></span><span class="qty-step">+</span></span>
+          </div>
+          <div class="item-row">
+            <span class="item-icon">B</span>
+            <div class="item-name">Blueberry<span class="meta">step ±2 pc</span></div>
+            <span class="item-qty"><span class="qty-step">−</span><span class="qty-val">5 <span class="qty-unit">pc</span></span><span class="qty-step">+</span></span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="phone">
+      <div class="phone-label">After stepping — qty adjusted on 2 items</div>
+      <div class="bottom-sheet" style="box-shadow: var(--shadow-card);">
+        <h3 class="sheet-title" style="margin-bottom: var(--sp-8);">Lunch · Khichdi template</h3>
+
+        <div class="items-list">
+          <div class="item-row">
+            <span class="item-icon">K</span>
+            <div class="item-name">Khichdi (masoor dal)<span class="meta">tapped + once</span></div>
+            <span class="item-qty"><span class="qty-step">−</span><span class="qty-val" style="color: var(--tc-sage);">1¼ <span class="qty-unit">bowl</span></span><span class="qty-step">+</span></span>
+          </div>
+          <div class="item-row">
+            <span class="item-icon">G</span>
+            <div class="item-name">Ghee (cow)<span class="meta">default</span></div>
+            <span class="item-qty"><span class="qty-step">−</span><span class="qty-val">1 <span class="qty-unit">tsp</span></span><span class="qty-step">+</span></span>
+          </div>
+          <div class="item-row">
+            <span class="item-icon">W</span>
+            <div class="item-name">Walnut<span class="meta">tapped + twice</span></div>
+            <span class="item-qty"><span class="qty-step">−</span><span class="qty-val" style="color: var(--tc-sage);">3 <span class="qty-unit">pc</span></span><span class="qty-step">+</span></span>
+          </div>
+          <div class="item-row">
+            <span class="item-icon">A</span>
+            <div class="item-name">Almonds<span class="meta">default</span></div>
+            <span class="item-qty"><span class="qty-step">−</span><span class="qty-val">2 <span class="qty-unit">pc</span></span><span class="qty-step">+</span></span>
+          </div>
+          <div class="item-row">
+            <span class="item-icon">C</span>
+            <div class="item-name">Carrot<span class="meta">default</span></div>
+            <span class="item-qty"><span class="qty-step">−</span><span class="qty-val">¼ <span class="qty-unit">cup</span></span><span class="qty-step">+</span></span>
+          </div>
+        </div>
+
+        <div class="foot-row">
+          <div class="foot-field">
+            <div class="ff-lbl">Time</div>
+            <div class="ff-val">1:15 pm</div>
+          </div>
+          <div class="foot-field">
+            <div class="ff-lbl">Intake</div>
+            <div class="intake-strip">
+              <div class="intake-pill">Few</div>
+              <div class="intake-pill">Half</div>
+              <div class="intake-pill active">Most</div>
+              <div class="intake-pill">All</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="callout">
+    <strong>Why per-food + per-meal both kept:</strong> per-food <code>qty</code> answers "how much of each thing"; per-meal <code>overallIntake</code> answers "did Ziva finish what was offered". The second covers "had 2 bites and pushed away" (intake = Few bites) even when all items are listed — a distinct semantic. <strong>Default = "Most" (0.75)</strong> for honest baseline: parents tap UP to "All" when Ziva finishes everything, or DOWN to Half / Few on harder days. "All" as a default would silently bias the data upward — busy parents wouldn't step-down on a normal day. "Most" reflects the realistic typical meal where Ziva eats most-but-not-all.
+  </div>
+</section>
+
+<!-- ─────────────────────── DATA SHAPE ─────────────────────── -->
+<section class="scenario">
+  <div class="scenario-head">
+    <h2 style="font-family: 'Fraunces', serif;">What gets written to disk</h2>
+  </div>
+  <p class="scenario-desc">F-2 emits the structured shape declared in PR #165 (data.js — <code>_FEEDING_V1_SCHEMA_VERSION = 1</code>). Per-food <code>qty</code> + <code>unit</code> live on each item; per-meal <code>overallIntake</code> sits alongside. Legacy <code>text</code> + <code>{meal}_intake</code> + <code>{meal}_time</code> compat fields generated so existing readers (home tab "Today's Meals" summary, diet stats, combo intelligence) keep working until F-5 normalizes everything.</p>
+  <div class="data-shape">
+<pre style="margin: 0;"><span class="c">// What F-2 writes after Scenario 1 (3-tap repeat) on 2026-05-28</span>
+feedingData[<span class="s">'2026-05-28'</span>] = {
+  breakfast: {
+    items: [
+      { name: <span class="s">'Avocado mash'</span>, qty: <span class="n">0.5</span>, unit: <span class="s">'pc'</span>, nutritionRef: <span class="s">'avocado mash'</span>, source: <span class="s">'repeat'</span> },
+      { name: <span class="s">'Blueberry'</span>,    qty: <span class="n">5</span>,   unit: <span class="s">'pc'</span>, nutritionRef: <span class="s">'blueberry'</span>,    source: <span class="s">'repeat'</span> },
+      { name: <span class="s">'Mango puree'</span>,  qty: <span class="n">0.25</span>,unit: <span class="s">'pc'</span>, nutritionRef: <span class="s">'mango'</span>,        source: <span class="s">'repeat'</span> },
+    ],
+    time: <span class="s">'08:30'</span>,
+    overallIntake: <span class="n">0.75</span>,                           <span class="c">// 0.25/0.5/0.75/1 — DEFAULTS to 0.75 (Most) for honest baseline</span>
+    derivedAllergens: [],                       <span class="c">// computed at write per ratified scope-Q3</span>
+    derivedFatBearing: <span class="n">false</span>,
+    sourceFlow: <span class="s">'fob-repeat'</span>,                   <span class="c">// fob-repeat | fob-combo | fob-novel | diet-tab</span>
+
+    <span class="c">// LEGACY COMPAT (auto-generated; readers untouched until F-5)</span>
+    text: <span class="s">'Avocado mash, Blueberry, Mango puree'</span>,
+  },
+  breakfast_time: <span class="s">'08:30'</span>,                       <span class="c">// legacy field name preserved</span>
+  breakfast_intake: <span class="n">0.75</span>,                         <span class="c">// legacy field name preserved (Most)</span>
+}</pre>
+  </div>
+  <div class="note-box">
+    <strong>Migration policy unchanged from spec §3:</strong> lazy. No rewrite of existing 79 days of legacy string records. New writes emit structured; old reads come through <code>parseFeeding</code> (F-5) which tolerates both shapes. <code>sourceFlow</code> field new in v2 mockup — lets us measure which entry path parents actually use (telemetry for "is the 3-tap path actually getting used 70% of the time, like the data suggests it could?").
+  </div>
+</section>
+
+<!-- ─────────────────────── INTELLIGENCE LAYERS ─────────────────────── -->
+<div class="intel-layers">
+  <h2>Autofill intelligence — four layers</h2>
+  <div class="layer">
+    <span class="lname">L1</span>
+    <div class="ldesc">
+      <strong>Repeat — "Same as yesterday's B" / "Same as lunch (today)"</strong>
+      One-tap full-meal apply. Surfaces the most recent same-slot meal (or, for dinner, today's lunch — per ratification #6, the 46% match rate makes this the single biggest UX win).
+      <span class="src">Source: ziva_feeding · last 1-7 days · per meal slot</span>
+    </div>
+  </div>
+  <div class="layer">
+    <span class="lname">L2</span>
+    <div class="ldesc">
+      <strong>Combo template — "Your usual breakfast"</strong>
+      Rolling 14d top-N combos per meal slot. Currently the data has two co-tied top combos (7×) for breakfast — both surfaced. Confidence % shown.
+      <span class="src">Source: dynamic 14d rolling window · cold-start fallback to <code>CURATED_COMBOS</code> intelligence-layer registry (covers first 14 days of use; ratification #2 reserves this slot)</span>
+    </div>
+  </div>
+  <div class="layer">
+    <span class="lname">L3</span>
+    <div class="ldesc">
+      <strong>Next-item prediction ribbon</strong>
+      After each item added, ranked "+ X" chips by co-occurrence with current item set. Refreshes on each add (e.g., Avocado→Blueberry@94%; Avocado+Blueberry→Mango@42%). Confidence % shown — Honesty axis honored.
+      <span class="src">Source: dynamic 14d pair-count map · keyed on items already in current meal</span>
+    </div>
+  </div>
+  <div class="layer">
+    <span class="lname">L4</span>
+    <div class="ldesc">
+      <strong>Typeahead</strong>
+      As-you-type match against NUTRITION + parent's introduced foods (ziva_foods list). Existing typeahead pattern extended to surface the food's default qty inline in the dropdown row.
+      <span class="src">Source: NUTRITION (live) · ziva_foods (47 introduced foods)</span>
+    </div>
+  </div>
+</div>
+
+<!-- ─────────────────────── OPEN ISSUES ─────────────────────── -->
+<div class="open-issues">
+  <h2>Open issues — confirm before I open IMPL commits</h2>
+  <ol>
+    <li><strong>Meal-slot inference</strong> — Scenario 1 assumes "morning → B, midday → L, evening → D". Need bands. Proposed: 5-11a → B, 11a-3p → L, 5-9p → D, anywhere else → S (default selected). Parent can override with 1 tap. Confirm bands?</li>
+    <li><strong>2-second auto-save window</strong> — Scenario 1's "tap chip → 2s countdown → save" is novel. Alternative: explicit Save button always required (=4 taps for repeat path, but no surprise saves). I lean auto-save because the "Logged · undo" banner gives 8s safety net. Confirm?</li>
+    <li><strong>Quantity step semantics</strong> — fractional steps for things like Avocado (¼ pc step) require a UI for ¼ / ½ / ¾ display. Proposed: store as floats; render as unicode vulgar fractions (¼ ½ ¾) or "0.25" if outside the common set. Long-press qty value opens numeric keypad for exact entry. OK?</li>
+    <li><strong>Curated combo registry shape</strong> — for L2 cold-start fallback (ratification #2). Proposed shape: <code>{ slot: 'breakfast', items: ['Ragi porridge', 'Ghee', 'Banana mash'], rationale: 'pediatrician-suggested', minAgeMonths: 6 }</code> in data.js. Could seed with 4-6 entries (breakfast/lunch/dinner/snack standards) until rolling-14d has signal. Confirm rough shape?</li>
+    <li><strong>Diet Log sub-tab — F-3 surface</strong> — by ratification #1, F-2 only touches FOB. The F-1 scaffold's diet Log sub-tab stays as a placeholder with "Tap to open FOB Log Feed" CTA? Or empty? Or shows today's logged meals as read-only review? I lean read-only review (zero new IMPL surface, but the sub-tab earns its existence).</li>
+    <li><strong>What does the "Skip remaining" link do</strong> in the home tab Today's Meals card (screenshot 2)? If a parent taps "skip remaining" — does it mark lunch + dinner as intentionally-skipped vs missing-data? F-2 might want to write <code>{ skipped: true }</code> on those slots for honesty in nutrition snapshot computation.</li>
+    <li><strong>Tap-budget regression-test fixture</strong> — to make ratification #5 enforceable. Proposed: <code>tests/e2e/food-fob-tap-budget.spec.ts</code> with two fixtures: (a) yesterday's-breakfast-present → 3 taps from FOB to Logged; (b) novel "av-bl-ma" meal → 6 taps from FOB to Logged. Fails the build if either exceeds. Acceptable as a guard?</li>
+  </ol>
 </div>
 
 <footer>
-  food-sub-tab-v1 F-2 mockup · spec: <code>docs/specs/food-sub-tab-v1.md</code> · F-1: PR #165 · F-2 branch: <code>claude/food-sub-tab-v1-impl-GXBKC</code>
+  Revised mockup v2 · F-2 redesigned around FOB Log Feed sheet · spec: <code>docs/specs/food-sub-tab-v1.md</code> · F-1: PR #165 · F-2 PR: #168 (draft, awaiting design ratification) · branch: <code>claude/food-sub-tab-v1-impl-GXBKC</code>
 </footer>
 
 </div>

--- a/docs/specs/food-sub-tab-v1.md
+++ b/docs/specs/food-sub-tab-v1.md
@@ -6,7 +6,28 @@
 **Author:** Lyra (main-session — Mode-1 spec authoring)
 **Status:** v1 RATIFIED — all 10 v0 scope-questions answered with Lyra's proposed defaults. F-1 implementation arc can open against this spec.
 
-> **F-1 IMPL ratified 2026-05-28 PM** (PR #165, sha `daa9756`). Sub-tab navigation scaffold (Log / Library / Patterns; mirrors milestones-tab-v1 doctrine — V-V-46 chrome inherited from `.track-sub-btn.active`; `.diet-sub-bar` + `.diet-sub-btn` + `.diet-sub-panel` classes mirror `.ms-sub-bar`/`.ms-sub-btn`/`.ms-sub-panel`) + swipe parity (3rd-nesting-level swipe extension for Track→Diet inner sub-tabs) + structured shape schema declared (`window._FEEDING_V1_SCHEMA_VERSION = 1` + `parseFeedingV1Stub` + `isStructuredFeedingV1` helpers in data.js; full shape contract in 60-line inline doc block; F-5 will implement the real `parseFeeding` normalizer). Bonus closure: long-standing meal-dropdown keyboard-dismiss + caret-position friction folded into PR #165 via `pointerdown` delegation + `setSelectionRange(len, len)` — multi-food entry now flows without breaks on mobile. F-2..F-5 queued for the next session.
+> **F-1 IMPL ratified 2026-05-28 PM** (PR #165, sha `daa9756`). Sub-tab navigation scaffold (Log / Library / Patterns; mirrors milestones-tab-v1 doctrine — V-V-46 chrome inherited from `.track-sub-btn.active`; `.diet-sub-bar` + `.diet-sub-btn` + `.diet-sub-panel` classes mirror `.ms-sub-bar`/`.ms-sub-btn`/`.ms-sub-panel`) + swipe parity (3rd-nesting-level swipe extension for Track→Diet inner sub-tabs) + structured shape schema declared (`window._FEEDING_V1_SCHEMA_VERSION = 1` + `parseFeedingV1Stub` + `isStructuredFeedingV1` helpers in data.js; full shape contract in 60-line inline doc block; F-5 will implement the real `parseFeeding` normalizer). Bonus closure: long-standing meal-dropdown keyboard-dismiss + caret-position friction folded into PR #165 via `pointerdown` delegation + `setSelectionRange(len, len)` — multi-food entry now flows without breaks on mobile.
+
+> **F-2 IMPL ratified 2026-05-29** (PR #168, stages 1-4). **Scope reframed mid-discussion** — the canonical meal-entry surface today is the **FOB → FEED Log Feed sheet**, NOT a home meal-input card (the original v1 spec section "UX surfaces · Log sub-tab" mis-located the entry surface; corrected here). F-2 redesigns the FOB Feed sheet as the speed path; the diet Log sub-tab scaffold from PR #165 stays as-is and becomes the **richer review surface in F-3**.
+>
+> Seven Architect ratifications drive the redesign:
+> 1. **F-2 = FOB sheet only.** Diet Log sub-tab untouched until F-3.
+> 2. **Dynamic 14d-rolling combos + curated cold-start fallback.** `CURATED_COMBOS` registry seeds 12 entries (4 breakfast / 5 lunch+dinner / 3 snack) age-gated for 6-9m; rolling combos take over once ≥7 days of signal exist in the slot.
+> 3. **Per-meal overall intake defaults to "Most" (0.75), not "All" (1).** Honest baseline; "All" as default would bias data upward (busy parents won't step down on a normal day). Parents tap UP to "All" when Ziva finishes everything.
+> 4. **Per-food qty defaults extend NUTRITION** via the `NUTRITION_QTY_DEFAULTS` sidecar registry in data.js (Kael's region). 30+ explicit per-food entries cover the top-used foods; `_fdResolveQtyDefaults(foodName)` falls through to a 13-category resolver for the rest.
+> 5. **Hard tap-budget limits** as build-time guards. 3-tap repeat / 6-tap novel — enforced by `audit-feed-sheet-wiring-v1.sh` (10th audit gate; required-presence assertions on the 4 template wraps + writer call + 7 handlers + 7 dispatcher routes + qty/combo registry floors).
+> 6. **"Same as today's lunch"** dinner chip — leads the L1 Repeat rail when today's lunch is logged (46% lunch==dinner match rate in the 79-day feeding-data sample makes this the biggest one-tap UX win).
+> 7. **Skipped meals write the canonical `SKIPPED_MEAL` sentinel** (`'—skipped—'` per `core.js:3119`) so existing readers (home Today's Meals, diet stats, ISL day-summary, medical fat-context detector) render correctly without modification.
+>
+> **Four autofill intelligence layers wired:**
+> - **L1 Repeat** — `_fdGetRepeatCandidates(meal, n)`. Same-as-yesterday + same-as-today-lunch (dinner).
+> - **L2 Combo template** — `_fdGetCombosForMeal(meal)`. Rolling 14d top-N (`freq >= 2`) with curated fallback when `daysWithSignal < 7`.
+> - **L3 Next-item prediction** — `_fdGetNextItemPredictions(currentItems, meal, n)`. Co-occurrence-ranked with honest confidence % surfaced per chip (CV3-006 Honesty axis — parents see WHY a chip is there). Floor 20% filters noisy 1-of-14 hits.
+> - **L4 Typeahead** — `_fdSearchNutrition(query)`. Three sources: NUTRITION canonical names + ziva_foods introduced + recent items from feedingData last-14d.
+>
+> **Structured shape (sidecar architecture):** writes land at `feedingData[date][meal + '_v1']` (canonical structured shape `{items[], time, overallIntake, sourceFlow, schemaVersion, writtenAt}`) AND `feedingData[date][meal]` (legacy comma-joined string for downstream readers). Read-side canonical reader `_fdReadDayMeal(dayObj, mealKey)` returns the F-2 view regardless of which shape sits on disk. `_fdWriteStructuredMeal(dateKey, meal, payload)` is the canonical writer. Legacy `[meal]_time` + `[meal]_intake` day-level fields preserved.
+>
+> **Telemetry** — `sourceFlow` field on the structured payload measures which entry path parents actually use: `fob-repeat` | `fob-combo` | `fob-novel` | `fob-feed` (Save without repeat/combo) | `diet-tab` (reserved for F-3 review surface).
 **Promoted from:**
 - Chronicle §4.2 v3-8 row — names Food Sub-Tab as pre-required (parseFeeding normalizer must know the food-sub-tab incoming shape at v1 design time)
 - Architect direction this session: sequencing — "we'll implement this sleep upgrade after food sub-tab arc is completed. keeps the features and upgrades sequential and easy to track."

--- a/index.html
+++ b/index.html
@@ -16949,11 +16949,17 @@ window.parseFeedingV1Stub = window.parseFeedingV1;
 // muted "Skipped" pills and are excluded from nutrition-snapshot diversity
 // penalties. Reversible — writing a real entry overwrites the skip.
 // ═══════════════════════════════════════════════════════════════════════
+// Writes the canonical SKIPPED_MEAL sentinel at the legacy [meal] field
+// (matches existing app-wide pattern at core.js:3119; consumers in
+// home.js Today's Meals + diet.js stats + intelligence-cards.js + isl
+// all key off this sentinel — there's no reason to invent a new one).
+// Also clears any v1 sidecar from prior structured writes.
 window._fdMarkMealSkipped = function(dateKey, meal) {
   if (!dateKey || !meal) return false;
   var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
   if (!fd[dateKey]) fd[dateKey] = { breakfast: '', lunch: '', dinner: '', snack: '' };
-  fd[dateKey][meal] = { skipped: true, skippedAt: Date.now(), items: [] };
+  fd[dateKey][meal] = (typeof SKIPPED_MEAL !== 'undefined') ? SKIPPED_MEAL : '—skipped—';
+  delete fd[dateKey][meal + '_v1'];
   if (typeof save === 'function' && typeof KEYS !== 'undefined' && KEYS.feeding) {
     save(KEYS.feeding, fd);
   }
@@ -16968,26 +16974,35 @@ window._fdIsMealSkipped = function(dateKey, meal) {
   var day = fd[dateKey];
   if (!day) return false;
   var mv = day[meal];
-  return !!(mv && typeof mv === 'object' && mv.skipped === true);
+  var sentinel = (typeof SKIPPED_MEAL !== 'undefined') ? SKIPPED_MEAL : '—skipped—';
+  if (mv === sentinel) return true;
+  if (mv && typeof mv === 'object' && mv.skipped === true) return true;  // legacy F-2-prerelease shape
+  return false;
 };
 
 // ═══════════════════════════════════════════════════════════════════════
 // _fdWriteStructuredMeal — canonical writer for the F-2 FOB Feed sheet.
-// Writes the structured shape under feedingData[dateKey][meal] AND
-// auto-generates legacy compat fields (text, {meal}_time, {meal}_intake)
-// so existing readers (home.js Today's Meals summary, diet stats, combo
-// intelligence, parseMealNutrition) continue working unchanged until
-// F-5 lands the read-side normalizer.
+//
+// Backward-compat doctrine (load-bearing): existing readers across
+// home.js Today's Meals, diet.js stats + combos, intelligence-cards.js,
+// intelligence-isl.js, medical.js all assume `feedingData[date][meal]`
+// is a STRING. Writing an object there breaks every legacy reader.
+//
+// So this writer keeps the legacy string at [meal] (comma-joined item
+// names) AND tucks the rich structured shape into a [meal + '_v1']
+// SIDECAR field. F-2 readers (L1-L4 helpers, saveQLFeed, diet Log
+// sub-tab review) reach for the sidecar via _fdReadDayMeal; legacy
+// readers continue reading the comma-string at [meal] unchanged.
+// F-5's parseFeeding normalizer will eventually unify the reads.
 //
 // payload: { items: [{name, qty, unit, nutritionRef}], time, overallIntake, note, sourceFlow }
-// Returns the structured shape that was written.
+// Returns the structured shape that was written to the sidecar.
 // ═══════════════════════════════════════════════════════════════════════
 window._fdWriteStructuredMeal = function(dateKey, meal, payload) {
   if (!dateKey || !meal || !payload) return null;
   payload = payload || {};
   var items = Array.isArray(payload.items) ? payload.items.slice() : [];
-  // Legacy compat: comma-joined text for downstream readers (Today's Meals
-  // summary, diet combos, parseMealNutrition). Trailing comma kept off.
+  // Legacy comma-joined text — what existing readers expect at [meal].
   var textCompat = items.map(function(it) { return it.name; }).join(', ');
 
   var structured = {
@@ -16995,15 +17010,19 @@ window._fdWriteStructuredMeal = function(dateKey, meal, payload) {
     time: payload.time || null,
     overallIntake: (typeof payload.overallIntake === 'number') ? payload.overallIntake : 0.75,  // ratified DEFAULT "Most"
     note: payload.note || '',
-    sourceFlow: payload.sourceFlow || 'fob-feed',  // telemetry: fob-repeat | fob-combo | fob-novel | fob-feed | diet-tab
+    sourceFlow: payload.sourceFlow || 'fob-feed',
     schemaVersion: window._FEEDING_V1_SCHEMA_VERSION,
-    text: textCompat,
+    writtenAt: Date.now(),
   };
 
   var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
   if (!fd[dateKey]) fd[dateKey] = { breakfast: '', lunch: '', dinner: '', snack: '' };
-  fd[dateKey][meal] = structured;
-  // Legacy compat fields at the day level (existing readers reach for these)
+  // Legacy string at the canonical slot (load-bearing for existing readers).
+  fd[dateKey][meal] = textCompat;
+  // Structured shape in sidecar — F-2 readers (L1-L4 helpers + diet Log
+  // review surface) reach here for qty + sourceFlow + overallIntake.
+  fd[dateKey][meal + '_v1'] = structured;
+  // Legacy time + intake at the day level (existing readers reach for these).
   if (structured.time) fd[dateKey][meal + '_time'] = structured.time;
   fd[dateKey][meal + '_intake'] = structured.overallIntake;
 
@@ -17012,6 +17031,57 @@ window._fdWriteStructuredMeal = function(dateKey, meal, payload) {
   }
   if (typeof feedingData !== 'undefined') feedingData = fd;
   return structured;
+};
+
+// _fdReadDayMeal — canonical reader. Returns the F-2 view of a meal slot
+// regardless of which shape sits on disk. Reads the [meal + '_v1']
+// sidecar first; falls back to parsing the legacy string at [meal].
+// Returns: { items[], time, overallIntake, skipped, sourceFlow, legacyText }
+window._fdReadDayMeal = function(dayObj, mealKey) {
+  if (!dayObj || !mealKey) return { items: [], skipped: false };
+  var sentinel = (typeof SKIPPED_MEAL !== 'undefined') ? SKIPPED_MEAL : '—skipped—';
+  var legacy = dayObj[mealKey];
+  // Skip sentinel — both forms
+  if (legacy === sentinel) {
+    return { items: [], skipped: true, legacyText: sentinel };
+  }
+  // Sidecar present — return the structured shape
+  var sidecar = dayObj[mealKey + '_v1'];
+  if (sidecar && Array.isArray(sidecar.items)) {
+    return {
+      items: sidecar.items,
+      time: sidecar.time || dayObj[mealKey + '_time'] || null,
+      overallIntake: typeof sidecar.overallIntake === 'number' ? sidecar.overallIntake : (dayObj[mealKey + '_intake'] || 0.75),
+      sourceFlow: sidecar.sourceFlow || 'fob-feed',
+      skipped: false,
+      legacyText: typeof legacy === 'string' ? legacy : (sidecar.items.map(function(it){return it.name;}).join(', ')),
+    };
+  }
+  // Legacy F-2-prerelease structured-at-[meal] shape (early-development
+  // fixtures may carry this; treat as canonical and migrate-on-read).
+  if (legacy && typeof legacy === 'object' && Array.isArray(legacy.items)) {
+    return {
+      items: legacy.items,
+      time: legacy.time || dayObj[mealKey + '_time'] || null,
+      overallIntake: typeof legacy.overallIntake === 'number' ? legacy.overallIntake : 0.75,
+      sourceFlow: legacy.sourceFlow || 'fob-feed',
+      skipped: legacy.skipped === true,
+      legacyText: legacy.items.map(function(it){return it.name;}).join(', '),
+    };
+  }
+  // Pure legacy string — parse via comma-split + qty resolver
+  if (typeof legacy === 'string' && legacy.trim()) {
+    var parsed = window.parseFeedingV1(legacy);
+    return {
+      items: parsed.items || [],
+      time: dayObj[mealKey + '_time'] || null,
+      overallIntake: dayObj[mealKey + '_intake'] || 0.75,
+      sourceFlow: 'legacy-string',
+      skipped: false,
+      legacyText: legacy,
+    };
+  }
+  return { items: [], skipped: false, legacyText: '' };
 };
 
 // @@DATA_BLOCK_20_START@@ MILESTONE_STANDARDS
@@ -63479,22 +63549,21 @@ window._fdGetRepeatCandidates = function(meal, n) {
     return 'Last week';
   }
 
-  function structuredItemsFromMeal(mealVal) {
-    var parsed = window.parseFeedingV1(mealVal);
-    if (!parsed || !parsed.items || parsed.items.length === 0) return null;
-    if (parsed.skipped) return null;
-    // Hydrate any items missing qty/unit via the defaults resolver
-    var items = parsed.items.map(function(it) {
+  function itemsFromDay(day, mealKey) {
+    if (!day) return null;
+    var rec = window._fdReadDayMeal(day, mealKey);
+    if (!rec || rec.skipped || !rec.items || rec.items.length === 0) return null;
+    // Hydrate any items missing qty/unit (legacy-string-parsed records lack them).
+    return rec.items.map(function(it) {
       if (it.qty !== undefined && it.unit) return it;
-      var d = window._fdResolveQtyDefaults(it.name);
-      return Object.assign({}, it, { qty: d.qty, unit: d.unit });
+      var defaults = window._fdResolveQtyDefaults(it.name);
+      return Object.assign({}, it, { qty: defaults.qty, unit: defaults.unit });
     });
-    return items;
   }
 
   // Ratification #6 — for dinner, surface today's lunch FIRST if logged.
-  if (meal === 'dinner' && fd[todayStr] && fd[todayStr].lunch) {
-    var lunchItems = structuredItemsFromMeal(fd[todayStr].lunch);
+  if (meal === 'dinner' && fd[todayStr]) {
+    var lunchItems = itemsFromDay(fd[todayStr], 'lunch');
     if (lunchItems && lunchItems.length) {
       out.push({
         id: 'today-lunch',
@@ -63512,9 +63581,7 @@ window._fdGetRepeatCandidates = function(meal, n) {
   for (var d = 1; d <= 14 && out.length < n; d++) {
     var dd = new Date(); dd.setDate(dd.getDate() - d);
     var ds = toDateStr(dd);
-    var day = fd[ds];
-    if (!day) continue;
-    var items = structuredItemsFromMeal(day[meal]);
+    var items = itemsFromDay(fd[ds], meal);
     if (!items) continue;
     out.push({
       id: 'repeat-' + ds,
@@ -63555,18 +63622,18 @@ window._fdGetCombosForMeal = function(meal, opts) {
     if (ds < cutoffStr || ds > todayStr) return;
     var day = fd[ds];
     if (!day) return;
-    var parsed = window.parseFeedingV1(day[meal]);
-    if (!parsed || !parsed.items || parsed.items.length === 0 || parsed.skipped) return;
+    var rec = window._fdReadDayMeal(day, meal);
+    if (!rec || rec.skipped || !rec.items || rec.items.length === 0) return;
     daysWithSignal++;
-    var names = parsed.items.map(function(it){ return String(it.name || '').toLowerCase().trim(); })
-                            .filter(function(n){ return n.length > 1; });
+    var names = rec.items.map(function(it){ return String(it.name || '').toLowerCase().trim(); })
+                         .filter(function(n){ return n.length > 1; });
     if (names.length < 2) return;
     var sig = names.slice().sort().join('|');
-    if (!comboMap[sig]) comboMap[sig] = { items: parsed.items, freq: 0, lastDate: ds, names: names };
+    if (!comboMap[sig]) comboMap[sig] = { items: rec.items, freq: 0, lastDate: ds, names: names };
     comboMap[sig].freq++;
     if (ds > comboMap[sig].lastDate) {
       comboMap[sig].lastDate = ds;
-      comboMap[sig].items = parsed.items;  // refresh with most-recent qty/unit
+      comboMap[sig].items = rec.items;  // refresh with most-recent qty/unit
     }
   });
 
@@ -63671,9 +63738,9 @@ window._fdGetNextItemPredictions = function(currentItems, meal, n) {
     if (ds < cutoffStr || ds > todayStr) return;
     var day = fd[ds];
     if (!day) return;
-    var parsed = window.parseFeedingV1(day[meal]);
-    if (!parsed || !parsed.items || parsed.items.length === 0 || parsed.skipped) return;
-    var names = parsed.items.map(function(it){ return String(it.name || '').toLowerCase().trim(); });
+    var rec = window._fdReadDayMeal(day, meal);
+    if (!rec || rec.skipped || !rec.items || rec.items.length === 0) return;
+    var names = rec.items.map(function(it){ return String(it.name || '').toLowerCase().trim(); });
     // Does this day contain any anchor item?
     var hasAnchor = anchorNames.some(function(a) { return names.indexOf(a) >= 0; });
     if (!hasAnchor) return;
@@ -63681,7 +63748,7 @@ window._fdGetNextItemPredictions = function(currentItems, meal, n) {
     // Count every non-anchor item that appears
     names.forEach(function(n) {
       if (currentSet[n]) return;  // skip items already in current meal
-      if (!coCount[n]) coCount[n] = { name: parsed.items.find(function(it) { return String(it.name).toLowerCase().trim() === n; }).name, freq: 0 };
+      if (!coCount[n]) coCount[n] = { name: rec.items.find(function(it) { return String(it.name).toLowerCase().trim() === n; }).name, freq: 0 };
       coCount[n].freq++;
     });
   });
@@ -63770,9 +63837,9 @@ window._fdSearchNutrition = function(query, opts) {
       if (ds < cutoffStr) return;
       ['breakfast','lunch','dinner','snack'].forEach(function(m) {
         if (matches.length >= max * 2) return;
-        var parsed = window.parseFeedingV1(fd[ds][m]);
-        if (!parsed || !parsed.items) return;
-        parsed.items.forEach(function(it) {
+        var rec = window._fdReadDayMeal(fd[ds], m);
+        if (!rec || rec.skipped || !rec.items) return;
+        rec.items.forEach(function(it) {
           if (matches.length >= max * 2) return;
           var nm = it.name || '';
           if (nm.toLowerCase().indexOf(q) >= 0) pushMatch(nm, 'recent');
@@ -64459,11 +64526,18 @@ function saveQLFeed() {
   // Accuracy tracking
   _qlLogAction('feed:' + _qlMeal, _qlSuggestUsed);
 
-  // Build undo function
+  // Build undo function — restore prev legacy value AND clear the v1 sidecar
+  // (otherwise stale structured data lingers after undo).
   const undoDateStr = dateStr;
   const undoFn = () => {
     const f = load(KEYS.feeding, {}) || {};
-    if (f[undoDateStr]) { f[undoDateStr][undoMealKey] = prevMealValue; save(KEYS.feeding, f); feedingData = f; _islMarkDirty('diet'); }
+    if (f[undoDateStr]) {
+      f[undoDateStr][undoMealKey] = prevMealValue;
+      delete f[undoDateStr][undoMealKey + '_v1'];
+      save(KEYS.feeding, f);
+      feedingData = f;
+      _islMarkDirty('diet');
+    }
   };
 
   closeQuickLogAll();

--- a/index.html
+++ b/index.html
@@ -16836,13 +16836,13 @@ window._fdResolveQtyDefaults = function(foodName) {
   if (n && n.tags) {
     if (n.tags.indexOf('healthy-fats') >= 0 && /oil|ghee|butter/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['fat-cooking'];
     if (n.tags.indexOf('iron-rich') >= 0 && n.tags.indexOf('protein-rich') >= 0) return _FOOD_QTY_CATEGORY_DEFAULTS['dal-legume'];
-    if (n.tags.indexOf('energy') >= 0 && !n.tags.indexOf('digestive') >= 0) return _FOOD_QTY_CATEGORY_DEFAULTS['grain-staple'];
+    if (n.tags.indexOf('energy') >= 0 && n.tags.indexOf('digestive') < 0) return _FOOD_QTY_CATEGORY_DEFAULTS['grain-staple'];
   }
   // 4. Heuristic by nutrient profile
   if (n && n.nutrients) {
     if (n.nutrients.indexOf('water') >= 0) return _FOOD_QTY_CATEGORY_DEFAULTS['liquid-drink'];
   }
-  return _FOOD_QTY_CATEGORY_DEFAULTS['veg-piece'];
+  return _FOOD_QTY_CATEGORY_DEFAULTS['fallback'];
 };
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -16953,13 +16953,17 @@ window.parseFeedingV1Stub = window.parseFeedingV1;
 // (matches existing app-wide pattern at core.js:3119; consumers in
 // home.js Today's Meals + diet.js stats + intelligence-cards.js + isl
 // all key off this sentinel — there's no reason to invent a new one).
-// Also clears any v1 sidecar from prior structured writes.
+// Clears the v1 sidecar AND the legacy [meal+'_time']/[meal+'_intake']
+// fields so a skip is atomic — Today So Far + diet stats don't render
+// stale time/intake for what the parent just marked as skipped.
 window._fdMarkMealSkipped = function(dateKey, meal) {
   if (!dateKey || !meal) return false;
   var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
   if (!fd[dateKey]) fd[dateKey] = { breakfast: '', lunch: '', dinner: '', snack: '' };
   fd[dateKey][meal] = (typeof SKIPPED_MEAL !== 'undefined') ? SKIPPED_MEAL : '—skipped—';
   delete fd[dateKey][meal + '_v1'];
+  delete fd[dateKey][meal + '_time'];
+  delete fd[dateKey][meal + '_intake'];
   if (typeof save === 'function' && typeof KEYS !== 'undefined' && KEYS.feeding) {
     save(KEYS.feeding, fd);
   }
@@ -17022,9 +17026,23 @@ window._fdWriteStructuredMeal = function(dateKey, meal, payload) {
   // Structured shape in sidecar — F-2 readers (L1-L4 helpers + diet Log
   // review surface) reach here for qty + sourceFlow + overallIntake.
   fd[dateKey][meal + '_v1'] = structured;
-  // Legacy time + intake at the day level (existing readers reach for these).
+  // Legacy time at the day level (existing readers reach for this).
+  // Unconditionally write — if structured.time is null, clear the legacy
+  // field so undo/re-save flows don't leave a phantom time from a prior
+  // write attached to a different food.
   if (structured.time) fd[dateKey][meal + '_time'] = structured.time;
-  fd[dateKey][meal + '_intake'] = structured.overallIntake;
+  else delete fd[dateKey][meal + '_time'];
+  // Legacy intake at the day level — only for B/L/D. Snack has the
+  // chip in the F-2 UI but the legacy invariant (pre-F-2 saveQLFeed
+  // guard `_qlMeal !== 'snack'`) was that snack carries no intake at
+  // the day level. Existing readers (intelligence-cards.js, isl, diet
+  // stats) assume snack_intake is undefined for snacks; preserve that.
+  // F-2 readers reach structured.overallIntake via _fdReadDayMeal.
+  if (meal !== 'snack') {
+    fd[dateKey][meal + '_intake'] = structured.overallIntake;
+  } else {
+    delete fd[dateKey][meal + '_intake'];
+  }
 
   if (typeof save === 'function' && typeof KEYS !== 'undefined' && KEYS.feeding) {
     save(KEYS.feeding, fd);
@@ -19777,7 +19795,7 @@ function init() {
     else if (action === 'navFeedDay') { document.getElementById('feedingDate').value = arg; loadFeedingDay(); switchTab('diet'); }
     else if (action === 'navTabSub') { switchTab(arg); setTimeout(() => switchTrackSub(arg2), 100); }
     else if (action === 'closeScoreAndNav') { closeScorePopup(); setTimeout(() => switchTab(arg), 350); }
-    else if (action === 'qlMealAndOpen') { _qlMeal = arg; openQuickModal(arg2); }
+    else if (action === 'qlMealAndOpen') { _qlMeal = arg; _qlMealExplicit = true; openQuickModal(arg2); }
     else if (action === 'showHeatmapDetail') showHeatmapDetail(arg, parseInt(arg2), arg3);
     else if (action === 'openDoctorModal') { const a = arg; if (a) openDoctorModal(parseInt(a)); else openDoctorModal(); }
     else if (action === 'openFoodCatModal') openFoodCatModal(arg);
@@ -19948,7 +19966,7 @@ function init() {
     else if (action === 'deleteFoodAndRender') { deleteFood(arg); renderFoodCatSubContent(arg2); }
     else if (action === 'navTabSub') { switchTab(arg); setTimeout(() => switchTrackSub(arg2), 100); }
     else if (action === 'closeScoreAndNav') { closeScorePopup(); setTimeout(() => switchTab(arg), 350); }
-    else if (action === 'qlMealAndOpen') { _qlMeal = arg; openQuickModal(arg2); }
+    else if (action === 'qlMealAndOpen') { _qlMeal = arg; _qlMealExplicit = true; openQuickModal(arg2); }
     else if (action === 'closeAndPromptFever') { closeHomeSymptomChecker(); promptFeverTrack(); }
     else if (action === 'closeAndPromptDiarrhoea') { closeHomeSymptomChecker(); promptDiarrhoeaTrack(); }
     else if (action === 'closeAndPromptVomiting') { closeHomeSymptomChecker(); promptVomitingTrack(); }
@@ -20030,8 +20048,9 @@ function init() {
       } else if (arg === 'afternoon-poop') {
         openQuickModal('poop');
       } else if (arg2) {
-        // Feed nudge — pre-select meal type
+        // Feed nudge — pre-select meal type (F-2 fix C1: set explicit flag)
         _qlMeal = arg2;
+        _qlMealExplicit = true;
         openQuickModal('feed');
         setTimeout(function() {
           document.querySelectorAll('.ql-meal-pill').forEach(function(p) { p.classList.toggle('active', p.dataset.meal === arg2); });
@@ -35209,7 +35228,7 @@ function computeAlerts() {
           title: loggedMeals.length === 0 ? 'No meals logged today' : missingLabels + ' not logged today',
           body: bodyMsg,
           tip: 'Logging every meal — even "skipped" or "just breastmilk" — helps build an accurate picture of intake patterns.',
-          action: { label: 'Log ' + firstMissing.charAt(0).toUpperCase() + firstMissing.slice(1), fn: '_qlMeal="' + firstMissing + '";openQuickModal("feed")' },
+          action: { label: 'Log ' + firstMissing.charAt(0).toUpperCase() + firstMissing.slice(1), fn: '_qlMeal="' + firstMissing + '";_qlMealExplicit=true;openQuickModal("feed")' },
           tab: 'diet'        });
       }
     }
@@ -35930,7 +35949,7 @@ function renderTodayPlan() {
     time: '8–9', icon: zi('sun'), title: 'Breakfast',
     detail: bfDone ? iconText('check', todayEntry.breakfast) : bfSuggestion,
     tag: 'food', done: bfDone, htmlDetail: bfDone,
-    action: bfDone ? null : '_qlMeal="breakfast";openQuickModal("feed")'
+    action: bfDone ? null : '_qlMeal="breakfast";_qlMealExplicit=true;openQuickModal("feed")'
   });
 
   // Morning nap
@@ -36000,7 +36019,7 @@ function renderTodayPlan() {
     time: '12–1', icon: zi('sun'), title: 'Lunch',
     detail: lnDone ? iconText('check', todayEntry.lunch) : lnSuggestion,
     tag: 'food', done: lnDone, htmlDetail: lnDone,
-    action: lnDone ? null : '_qlMeal="lunch";openQuickModal("feed")'
+    action: lnDone ? null : '_qlMeal="lunch";_qlMealExplicit=true;openQuickModal("feed")'
   });
 
   // Afternoon nap
@@ -36074,7 +36093,7 @@ function renderTodayPlan() {
     time: '6–7', icon: zi('moon'), title: 'Dinner',
     detail: dnDone ? iconText('check', todayEntry.dinner) : dnSuggestion,
     tag: 'food', done: dnDone, htmlDetail: dnDone,
-    action: dnDone ? null : '_qlMeal="dinner";openQuickModal("feed")'
+    action: dnDone ? null : '_qlMeal="dinner";_qlMealExplicit=true;openQuickModal("feed")'
   });
 
   // Snack
@@ -36083,7 +36102,7 @@ function renderTodayPlan() {
     time: '10–4', icon: zi('spoon'), title: 'Snack',
     detail: skDone ? iconText('check', todayEntry.snack) : 'A quick bite between meals — fruit mash, ragi biscuit, or curd',
     tag: 'food', done: skDone, htmlDetail: skDone,
-    action: skDone ? null : '_qlMeal="snack";openQuickModal("feed")'
+    action: skDone ? null : '_qlMeal="snack";_qlMealExplicit=true;openQuickModal("feed")'
   });
 
   // Bedtime routine
@@ -39966,6 +39985,15 @@ function _miGetIntake(dateStr, meal) {
 function _miSetIntake(dateStr, meal, value) {
   if (!feedingData[dateStr]) return;
   feedingData[dateStr][meal + '_intake'] = value;
+  // F-2 fix (E_b): sync the structured sidecar's overallIntake too.
+  // Otherwise _fdReadDayMeal returns the stale sidecar value while
+  // legacy _miGetIntake returns the updated value — two surfaces
+  // disagree about the same meal's intake (FOB Feed L1 repeat shows
+  // old; home Today's Meals + diet stats show new).
+  var sidecar = feedingData[dateStr][meal + '_v1'];
+  if (sidecar && typeof sidecar === 'object') {
+    sidecar.overallIntake = value;
+  }
   save(KEYS.feeding, feedingData);
   _islMarkDirty('diet');
   // V-M-70: intake adjustment alone doesn't change meal content (so withFat won't flip),
@@ -59154,21 +59182,23 @@ function sgTapChip(food) {
     showQLToast('All meals are filled for today');
     return;
   }
+  // F-2 fix (C1): set _qlMeal + explicit flag BEFORE openQuickModal so
+  // the modal preserves intent (was: openQuickModal clobbered _qlMeal
+  // to detectMealType() then a setTimeout re-set it AFTER the rails had
+  // already rendered for the wrong slot).
+  _qlMeal = nextMeal;
+  _qlMealExplicit = true;
   openQuickLog();
   openQuickModal('feed');
-  // Set meal + prefill after modal opens (openQuickModal resets _qlMeal via detectMealType)
+  // F-2 fix (B2/C4): push the suggested food directly into _qlFeedItems
+  // via the canonical handler so it appears in the Items list (not just
+  // the typeahead input). Old code used updateQLFeedDropdown +
+  // pickQLFood which write to input only — bypassing the structured
+  // shape and leaving the Items list misleadingly empty.
   setTimeout(function() {
-    _qlMeal = nextMeal;
-    const inp = document.getElementById('qlFeedInput');
-    if (inp) {
-      inp.value = food;
-      inp.focus();
-      updateQLFeedDropdown();
+    if (typeof qlFeedAddItem === 'function' && food) {
+      qlFeedAddItem(food, 'typeahead');
     }
-    // Select correct meal pill
-    document.querySelectorAll('.ql-meal-pill').forEach(p => {
-      p.classList.toggle('active', p.dataset.meal === nextMeal);
-    });
   }, 50);
 }
 
@@ -61548,7 +61578,7 @@ function saveFeedingDay() {
     dinner:    document.getElementById('meal-dinner').disabled ? (existing.dinner || '') : document.getElementById('meal-dinner').value,
     snack:     document.getElementById('meal-snack').disabled ? (existing.snack || '') : document.getElementById('meal-snack').value,
   };
-  // Save optional meal times
+  // Save optional meal times + preserve F-2 sidecar when text unchanged
   ['breakfast','lunch','dinner','snack'].forEach(m => {
     const timeVal = document.getElementById('mealtime-' + m)?.value || '';
     if (timeVal) {
@@ -61560,6 +61590,18 @@ function saveFeedingDay() {
     if (existing[m + '_intake'] !== undefined) {
       feedingData[d][m + '_intake'] = existing[m + '_intake'];
     }
+    // F-2 fix (E_a): preserve the [meal + '_v1'] structured sidecar when
+    // the meal text didn't change. Without this, every Diet tab editor
+    // save silently drops the rich shape (items[], qty/unit, sourceFlow,
+    // overallIntake) that the FOB Feed sheet had written — Today So Far
+    // + L1-L4 helpers + future F-3 review surface all degrade to legacy
+    // comma-split with synthesized default qty.
+    if (existing[m + '_v1'] && feedingData[d][m] === (existing[m] || '')) {
+      feedingData[d][m + '_v1'] = existing[m + '_v1'];
+    }
+    // If text changed, the sidecar is intentionally dropped — the legacy
+    // string is now the source of truth post-edit (matches the pre-F-2
+    // behavior that this writer used to maintain implicitly).
   });
   save(KEYS.feeding, feedingData);
   _tsfMarkDirty();
@@ -61854,6 +61896,13 @@ function changeDate(dir) {
 // ─────────────────────────────────────────
 let _qlOpen = false;
 let _qlMeal = 'breakfast';
+// F-2 fix (C1): explicit-meal flag. Callers that pre-set _qlMeal before
+// openQuickModal('feed') set this to true so openQuickModal preserves
+// their intent instead of clobbering with detectMealType(). One-shot —
+// consumed (reset to false) inside openQuickModal. Without this guard,
+// every "Log Breakfast" home alert at 8 PM would silently re-route to
+// the dinner slot (detected by time-of-day) and load wrong-slot rails.
+let _qlMealExplicit = false;
 let _qlWake = 0;
 let _qlColor = 'yellow';
 let _qlCon = 'normal';
@@ -61913,7 +61962,14 @@ function openQuickModal(type) {
 
   // Pre-fill defaults
   if (type === 'feed') {
-    _qlMeal = detectMealType();
+    // F-2 fix (C1): preserve _qlMeal when a caller explicitly set it
+    // (via the _qlMealExplicit flag). Without this guard, callers like
+    // home-tab "Log Breakfast" alerts at 8 PM would have their intent
+    // clobbered to detectMealType()='dinner' and load wrong-slot rails.
+    if (!_qlMealExplicit) {
+      _qlMeal = detectMealType();
+    }
+    _qlMealExplicit = false;  // one-shot — consume the flag
     if (!_qlBackfillDate) _qlBackfillDate = null; // ensure reset for non-backfill
     document.querySelectorAll('.ql-meal-pill').forEach(p => {
       p.classList.toggle('active', p.dataset.meal === _qlMeal);
@@ -63536,10 +63592,16 @@ window._fdGetMealSlotByTime = function() {
 // sub    — items preview (truncated, comma-separated)
 // items  — array of {name, qty, unit, nutritionRef} ready to apply
 // source — 'today-lunch' | 'yesterday' | 'recent' (telemetry)
-window._fdGetRepeatCandidates = function(meal, n) {
+window._fdGetRepeatCandidates = function(meal, n, opts) {
   n = n || 3;
+  opts = opts || {};
   var out = [];
-  var todayStr = today();
+  // F-2 fix (A2): use opts.fromDate (caller's active date — typically
+  // _qlBackfillDate || today()) so backfill flows walk back from the
+  // RIGHT date. Without this, backfilling dinner for 2026-05-15
+  // surfaces today's lunch as "Same as today's lunch" + applying the
+  // chip writes today's items to the May 15 slot.
+  var todayStr = opts.fromDate || today();
   var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
 
   function dayLabel(daysAgo) {
@@ -63577,9 +63639,13 @@ window._fdGetRepeatCandidates = function(meal, n) {
     }
   }
 
-  // Walk back up to 14 days; collect candidates for the same slot.
+  // Walk back up to 14 days FROM the active date (todayStr; may be
+  // _qlBackfillDate). HR-12-safe: parse with explicit y/m/d construction.
+  var anchorParts = todayStr.split('-');
+  var anchorDate = new Date(parseInt(anchorParts[0]), parseInt(anchorParts[1]) - 1, parseInt(anchorParts[2]));  // HR-12-safe
   for (var d = 1; d <= 14 && out.length < n; d++) {
-    var dd = new Date(); dd.setDate(dd.getDate() - d);
+    var dd = new Date(anchorDate.getTime());
+    dd.setDate(dd.getDate() - d);
     var ds = toDateStr(dd);
     var items = itemsFromDay(fd[ds], meal);
     if (!items) continue;
@@ -63918,13 +63984,21 @@ function _qlConfirmSuggest() {
   _qlSuggestUsed = true;
   var pred = _qlActivePredictions.find(function(p) { return p.type === 'feed'; });
   if (!pred) return;
+  // F-2 fix (C1): mark meal explicit so openQuickModal preserves intent
   _qlMeal = pred.meal;
+  _qlMealExplicit = true;
   openQuickModal('feed');
+  // F-2 fix (C2): push predicted foods directly into _qlFeedItems so the
+  // Items list reflects what will be saved, not just the typeahead input
+  // (which would leave the Items list misleadingly empty until typed-text
+  // fold-in at Save time — and the items would route via 'fob-typed'
+  // bypassing the structured-shape clean-data gate).
   setTimeout(function() {
-    document.querySelectorAll('.ql-meal-pill').forEach(function(p) { p.classList.toggle('active', p.dataset.meal === pred.meal); });
-    if (pred.foods) {
-      var inp = document.getElementById('qlFeedInput');
-      if (inp) inp.value = pred.foods;
+    if (pred.foods && typeof qlFeedAddItem === 'function') {
+      String(pred.foods).split(/\s*\+\s*|,\s*/).forEach(function(name) {
+        var trimmed = name.trim();
+        if (trimmed) qlFeedAddItem(trimmed, 'typeahead');
+      });
     }
   }, 50);
 }
@@ -63933,18 +64007,17 @@ function _qlEditSuggest() {
   _qlSuggestUsed = true;
   var pred = _qlActivePredictions.find(function(p) { return p.type === 'feed'; });
   var meal = pred ? pred.meal : detectMealType();
+  // F-2 fix (C1): mark meal explicit so openQuickModal preserves intent
   _qlMeal = meal;
+  _qlMealExplicit = true;
   openQuickModal('feed');
-  setTimeout(function() {
-    document.querySelectorAll('.ql-meal-pill').forEach(function(p) { p.classList.toggle('active', p.dataset.meal === meal); });
-  }, 50);
 }
 
 // ═══════════════════════════════════════════════════════════════
 // SMART QUICK LOG — Post-Save Micro-Insights
 // ═══════════════════════════════════════════════════════════════
 
-function _qlFeedInsight() {
+function _qlFeedInsight(foodArg) {
   try {
     var todayStr = today();
     var day = feedingData[todayStr];
@@ -63952,7 +64025,11 @@ function _qlFeedInsight() {
     var mealCount = ['breakfast', 'lunch', 'dinner'].filter(function(m) { return day[m] && day[m].trim(); }).length;
     if (mealCount >= 3) return '3rd meal today \u2014 great variety!';
 
-    var food = document.getElementById('qlFeedInput')?.value?.trim() || '';
+    // F-2 fix (C3/E_e): saveQLFeed now clears qlFeedInput AFTER folding
+    // typed text into _qlFeedItems but BEFORE calling _qlFeedInsight.
+    // The legacy input-read path returns '' and the 'New food!' branch
+    // dies silently. Prefer the food arg (built from items by caller).
+    var food = (typeof foodArg === 'string' && foodArg) ? foodArg : (document.getElementById('qlFeedInput')?.value?.trim() || '');
     if (food) {
       var base = _baseFoodName(food);
       var isNew = !foods.some(function(f) { return _baseFoodName(f.name) === base; });
@@ -64100,9 +64177,13 @@ function qaAnswerFavoriteFoods() {
 }
 
 function setQLMeal(meal) {
+  // F-2 fix (C1): user-driven meal pill tap is explicit by intent
   _qlMeal = meal;
+  _qlMealExplicit = true;
   document.querySelectorAll('.ql-meal-pill').forEach(p => p.classList.toggle('active', p.dataset.meal === meal));
-  // F-2: refresh autofill regions on meal change — repeats + combos differ per slot.
+  // F-2: re-hydrate items from the new meal slot (preserves multi-save flow
+  // when parent switches B→L→D) + refresh autofill regions.
+  if (typeof _qlFeedReset === 'function') _qlFeedReset();
   if (typeof _qlRenderFeedSheet === 'function') _qlRenderFeedSheet();
 }
 
@@ -64170,6 +64251,28 @@ function _qlFeedReset() {
   if (inp) inp.value = '';
   var dd = document.getElementById('qlFeedDropdown');
   if (dd) { dd.innerHTML = ''; dd.classList.remove('open'); }
+  // F-2 fix (B1): if the slot is already logged for the active date,
+  // hydrate _qlFeedItems from the existing meal so re-opening the FOB
+  // Feed sheet on an already-logged meal preserves prior items. Without
+  // this, the historical "log a few items, come back, add more" flow
+  // silently destroys the prior save (REPLACE semantic + empty Items
+  // list on reopen). Skipped meals don't hydrate — parent re-opening
+  // a skipped slot is intentionally starting fresh.
+  var dateStr = _qlBackfillDate || today();
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+  if (fd[dateStr] && _qlMeal && typeof window._fdReadDayMeal === 'function') {
+    var rec = window._fdReadDayMeal(fd[dateStr], _qlMeal);
+    if (rec && !rec.skipped && rec.items && rec.items.length > 0) {
+      _qlFeedItems = rec.items.map(function(it) {
+        if (it.qty !== undefined && it.unit) return Object.assign({}, it);
+        var defaults = window._fdResolveQtyDefaults(it.name);
+        return Object.assign({}, it, { qty: defaults.qty, unit: defaults.unit });
+      });
+      // Preserve the original sourceFlow so re-save doesn't downgrade
+      // a 'fob-combo' meal to 'fob-feed' on an unchanged re-save.
+      _qlFeedSourceFlow = rec.sourceFlow || 'fob-feed';
+    }
+  }
 }
 
 // Render all dynamic regions of the FOB Feed sheet. Called on open + after
@@ -64183,11 +64286,19 @@ function _qlRenderFeedSheet() {
 
 // L1 — Repeat rail. Surfaces yesterday's/recent matching-slot meals as
 // one-tap apply chips. For dinner, "Same as today's lunch" leads if logged.
+// F-2 fix (A6): hidden once items are present (mirror the combos-rail
+// behavior). Otherwise an accidental tap on a still-visible repeat chip
+// silently wipes the parent's in-progress items with no undo affordance.
 function _qlRenderRepeatRail() {
   var wrap = document.getElementById('qlFeedRepeatWrap');
   var rail = document.getElementById('qlFeedRepeatRail');
   if (!wrap || !rail) return;
-  var candidates = window._fdGetRepeatCandidates(_qlMeal, 3);
+  if (_qlFeedItems.length > 0) {
+    wrap.style.display = 'none';
+    rail.innerHTML = '';
+    return;
+  }
+  var candidates = window._fdGetRepeatCandidates(_qlMeal, 3, { fromDate: _qlBackfillDate || today() });
   if (!candidates || candidates.length === 0) {
     wrap.style.display = 'none';
     rail.innerHTML = '';
@@ -64323,7 +64434,7 @@ function _qlRenderNextItemRibbon() {
 // ── F-2 handlers ──
 
 function qlFeedApplyRepeat(id) {
-  var cands = window._fdGetRepeatCandidates(_qlMeal, 6);
+  var cands = window._fdGetRepeatCandidates(_qlMeal, 6, { fromDate: _qlBackfillDate || today() });
   var found = cands.find(function(c) { return c.id === id; });
   if (!found) return;
   _qlFeedItems = found.items.slice().map(function(it) { return Object.assign({}, it); });
@@ -64342,22 +64453,36 @@ function qlFeedApplyCombo(id) {
 
 function qlFeedAddItem(name, source) {
   if (!name) return;
+  // F-2 fix (B4): dedup by base name. Same food added via L3 next-item +
+  // L4 typeahead would otherwise produce duplicate rows in _qlFeedItems,
+  // each with its own qty stepper, and double-count in the post-save
+  // nutrient flash + autoIntroduceFoodsFromDay. For F-2 a meal entry
+  // carries one item per food; quantity adjustments use the stepper.
+  var normalized = String(name).toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim();
+  var alreadyPresent = _qlFeedItems.some(function(it) {
+    var n = String(it.name).toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim();
+    return n === normalized;
+  });
+  // Clear typeahead input + dropdown regardless (parent's input was consumed)
+  var inp = document.getElementById('qlFeedInput');
+  if (inp) inp.value = '';
+  var dd = document.getElementById('qlFeedDropdown');
+  if (dd) { dd.innerHTML = ''; dd.classList.remove('open'); }
+  if (alreadyPresent) {
+    if (typeof showQLToast === 'function') showQLToast(name + ' already added — adjust qty with +/-', 2000);
+    return;
+  }
   var defaults = window._fdResolveQtyDefaults(name);
   _qlFeedItems.push({
     name: name,
     qty: defaults.qty,
     unit: defaults.unit,
-    nutritionRef: String(name).toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim(),
+    nutritionRef: normalized,
     source: source || 'manual',
   });
   if (source === 'next' || source === 'typeahead') {
     if (_qlFeedSourceFlow === 'fob-feed') _qlFeedSourceFlow = 'fob-novel';
   }
-  // Clear typeahead input + dropdown
-  var inp = document.getElementById('qlFeedInput');
-  if (inp) inp.value = '';
-  var dd = document.getElementById('qlFeedDropdown');
-  if (dd) { dd.innerHTML = ''; dd.classList.remove('open'); }
   _qlRenderFeedSheet();
 }
 
@@ -64413,21 +64538,42 @@ function qlFeedTypeaheadInput() {
 function qlFeedSkipMeal() {
   var dateStr = _qlBackfillDate || today();
   if (!_qlMeal) return;
-  // Capture prev value for undo
+  // F-2 fix (A3 + B3): capture FULL prev state for atomic undo —
+  // legacy [meal] string + [meal+'_v1'] sidecar + [meal+'_time'] +
+  // [meal+'_intake']. Otherwise undo restores only the legacy string
+  // and leaves a phantom time/intake or loses the structured shape.
   var fd = load(KEYS.feeding, {}) || {};
-  var prevVal = fd[dateStr] ? fd[dateStr][_qlMeal] : '';
+  var prevDay = fd[dateStr] || {};
+  var prevVal = prevDay[_qlMeal];
+  var prevSidecar = prevDay[_qlMeal + '_v1'];
+  var prevTime = prevDay[_qlMeal + '_time'];
+  var prevIntake = prevDay[_qlMeal + '_intake'];
   window._fdMarkMealSkipped(dateStr, _qlMeal);
   var meal = _qlMeal;
   var undoFn = function() {
     var f = load(KEYS.feeding, {}) || {};
-    if (f[dateStr]) { f[dateStr][meal] = prevVal || ''; save(KEYS.feeding, f); feedingData = f; }
+    if (!f[dateStr]) f[dateStr] = { breakfast: '', lunch: '', dinner: '', snack: '' };
+    if (prevVal !== undefined) f[dateStr][meal] = prevVal; else f[dateStr][meal] = '';
+    if (prevSidecar !== undefined) f[dateStr][meal + '_v1'] = prevSidecar; else delete f[dateStr][meal + '_v1'];
+    if (prevTime !== undefined) f[dateStr][meal + '_time'] = prevTime; else delete f[dateStr][meal + '_time'];
+    if (prevIntake !== undefined) f[dateStr][meal + '_intake'] = prevIntake; else delete f[dateStr][meal + '_intake'];
+    save(KEYS.feeding, f);
+    feedingData = f;
     if (typeof _islMarkDirty === 'function') _islMarkDirty('diet');
+    if (typeof updateMealSkipButtons === 'function') updateMealSkipButtons();
     var curTab2 = TAB_ORDER.find(function(t) { return document.getElementById('tab-' + t) && document.getElementById('tab-' + t).classList.contains('active'); });
     if (curTab2 === 'diet') { if (typeof initFeeding === 'function') initFeeding(); if (typeof renderDietStats === 'function') renderDietStats(); }
     if (curTab2 === 'home') renderHome();
   };
+  // F-2 fix (A4): reset _qlBackfillDate so subsequent QL opens (sleep/nap/poop/etc.)
+  // don't inherit stale backfill state across modal types.
+  _qlBackfillDate = null;
   closeQuickLogAll();
   showQLToast(capitalize(meal) + ' marked as skipped', 4000, undoFn);
+  // F-2 fix (R1): updateMealSkipButtons refreshes the Diet tab's per-meal
+  // Skip toggles so a subsequent tap on the now-stale legacy Skip button
+  // doesn't silently UNSKIP the meal we just skipped via FOB.
+  if (typeof updateMealSkipButtons === 'function') updateMealSkipButtons();
   var curTab = TAB_ORDER.find(function(t) { return document.getElementById('tab-' + t) && document.getElementById('tab-' + t).classList.contains('active'); });
   if (curTab === 'diet') { if (typeof initFeeding === 'function') initFeeding(); if (typeof renderDietStats === 'function') renderDietStats(); }
   if (curTab === 'home') renderHome();
@@ -64463,10 +64609,18 @@ function saveQLFeed() {
     return;
   }
 
-  // Capture prev value for undo BEFORE mutation
-  const feedingPrev = load(KEYS.feeding, {}) || {};
+  // Capture FULL prev state for atomic undo BEFORE mutation —
+  // legacy [meal] string + [meal+'_v1'] sidecar + [meal+'_time'] +
+  // [meal+'_intake']. Otherwise undo would restore only the legacy
+  // string and leave phantom time/intake from this save attached to
+  // the now-restored prior meal name (F-2 fix B3/D4/E_c/C5).
+  // In-memory read instead of disk reload (efficiency E6).
   const undoMealKey = _qlMeal;
-  const prevMealValue = (feedingPrev[dateStr] && feedingPrev[dateStr][undoMealKey]) || '';
+  const prevDay = (typeof feedingData !== 'undefined' && feedingData && feedingData[dateStr]) || {};
+  const prevMealValue = prevDay[undoMealKey] || '';
+  const prevSidecar = prevDay[undoMealKey + '_v1'];
+  const prevTime = prevDay[undoMealKey + '_time'];
+  const prevIntake = prevDay[undoMealKey + '_intake'];
 
   // Build the structured payload + write via the canonical F-2 writer.
   const qlTime = (document.getElementById('qlFeedTime')?.value) || null;
@@ -64521,23 +64675,32 @@ function saveQLFeed() {
 
   _qlBackfillDate = null; // reset backfill
 
-  // Smart QL: compute insight BEFORE closing modal
-  var qlInsight = _qlFeedInsight();
+  // Smart QL: compute insight BEFORE closing modal. Pass food string built
+  // from _qlFeedItems above (F-2 fix C3/E_e — the input was cleared after
+  // typed-text fold-in, so reading qlFeedInput.value would return '').
+  var qlInsight = _qlFeedInsight(food);
   // Accuracy tracking
   _qlLogAction('feed:' + _qlMeal, _qlSuggestUsed);
 
-  // Build undo function — restore prev legacy value AND clear the v1 sidecar
-  // (otherwise stale structured data lingers after undo).
+  // Build undo function — restore the FULL prev state atomically
+  // (legacy [meal] + [meal+'_v1'] sidecar + [meal+'_time'] +
+  // [meal+'_intake']). Each field uses prev-was-undefined →
+  // delete-the-key semantic so undo doesn't silently re-introduce
+  // a default 0.75 intake on a meal that had no intake set.
   const undoDateStr = dateStr;
   const undoFn = () => {
     const f = load(KEYS.feeding, {}) || {};
-    if (f[undoDateStr]) {
-      f[undoDateStr][undoMealKey] = prevMealValue;
-      delete f[undoDateStr][undoMealKey + '_v1'];
-      save(KEYS.feeding, f);
-      feedingData = f;
-      _islMarkDirty('diet');
-    }
+    if (!f[undoDateStr]) f[undoDateStr] = { breakfast: '', lunch: '', dinner: '', snack: '' };
+    f[undoDateStr][undoMealKey] = prevMealValue;
+    if (prevSidecar !== undefined) f[undoDateStr][undoMealKey + '_v1'] = prevSidecar;
+    else delete f[undoDateStr][undoMealKey + '_v1'];
+    if (prevTime !== undefined) f[undoDateStr][undoMealKey + '_time'] = prevTime;
+    else delete f[undoDateStr][undoMealKey + '_time'];
+    if (prevIntake !== undefined) f[undoDateStr][undoMealKey + '_intake'] = prevIntake;
+    else delete f[undoDateStr][undoMealKey + '_intake'];
+    save(KEYS.feeding, f);
+    feedingData = f;
+    _islMarkDirty('diet');
   };
 
   closeQuickLogAll();
@@ -65732,7 +65895,7 @@ function renderHomeMealProgress() {
         <div class="mi-prog-row">${_miRenderBar(_miVal)} <span class="mi-prog-label">${escHtml(_miLv.label)}</span></div>
       </div>`;
     } else {
-      html += `<div class="meal-prog-slot mps-empty" onclick="_qlMeal='${m.full}';openQuickModal('feed')">
+      html += `<div class="meal-prog-slot mps-empty" onclick="_qlMeal='${m.full}';_qlMealExplicit=true;openQuickModal('feed')">
         <div class="meal-prog-icon">${zi('target')}</div>
         <div class="meal-prog-label">${m.label}</div>
         <div class="meal-prog-food t-light" >tap to log</div>
@@ -66096,7 +66259,16 @@ function skipMeals(mealKeys) {
   const dateStr = today();
   if (!feedingData[dateStr]) feedingData[dateStr] = { breakfast:'', lunch:'', dinner:'', snack:'' };
   mealKeys.forEach(m => {
-    if (!feedingData[dateStr][m]) feedingData[dateStr][m] = '—skipped—';
+    if (!feedingData[dateStr][m]) {
+      feedingData[dateStr][m] = '—skipped—';
+      // F-2 fix (Alt1): clear the structured sidecar + legacy _time/_intake
+      // so a skip is atomic. Without this, a meal previously logged via
+      // FOB (sidecar present) then skipped via this home-tab "Skip
+      // remaining" path leaves the stale sidecar alongside the sentinel.
+      delete feedingData[dateStr][m + '_v1'];
+      delete feedingData[dateStr][m + '_time'];
+      delete feedingData[dateStr][m + '_intake'];
+    }
   });
   save(KEYS.feeding, feedingData);
   // V-M-70: complete the _refreshTodayMedWithFat contract on every feedingData mutation.
@@ -66118,6 +66290,11 @@ function skipSingleMeal(mealKey) {
 
   if (feedingData[dateStr][mealKey] && feedingData[dateStr][mealKey] !== '—skipped—') return; // already has food
   feedingData[dateStr][mealKey] = '—skipped—';
+  // F-2 fix (Alt1): clear the structured sidecar + legacy _time/_intake
+  // so a skip is atomic. Matches _fdMarkMealSkipped contract.
+  delete feedingData[dateStr][mealKey + '_v1'];
+  delete feedingData[dateStr][mealKey + '_time'];
+  delete feedingData[dateStr][mealKey + '_intake'];
   save(KEYS.feeding, feedingData);
   // V-M-70: complete the _refreshTodayMedWithFat contract.
   if (dateStr === today() && typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();

--- a/index.html
+++ b/index.html
@@ -6650,16 +6650,6 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 .ql-modal-close:hover { background:var(--rose-light); color:var(--tc-rose); }
 
 .ql-form { display:flex; flex-direction:column; gap:var(--sp-12); }
-/* Frequent meals pills */
-.ql-freq-row { display:flex; flex-wrap:wrap; gap:var(--sp-4); }
-.ql-freq-pill {
-  font-size:var(--fs-xs); padding:var(--sp-4) var(--sp-10); border-radius:var(--r-full);
-  background:var(--sage-light); border:1px solid rgba(181,213,197,0.4);
-  color:var(--tc-sage); cursor:pointer; white-space:nowrap;
-  max-width:140px;
-  transition:transform var(--ease-fast), background var(--ease-fast);
-}
-.ql-freq-pill:active { transform:scale(0.95); background:var(--accent-sage-deep); color:white; }
 /* Backfill date pills */
 .ql-bf-row { display:flex; gap:var(--sp-4); flex-wrap:wrap; }
 .ql-bf-pill {
@@ -6932,7 +6922,7 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 }
 .ql-feed-next-chip:active { transform:scale(0.94); }
 .ql-feed-next-conf {
-  font-size:9px;
+  font-size:var(--fs-2xs);
   background:var(--white); color:var(--tc-sage);
   border-radius:var(--r-full);
   padding:1px var(--sp-6);
@@ -6986,7 +6976,10 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 [data-theme="dark"] .ql-feed-repeat-head { color:#7ac0a0; }
 [data-theme="dark"] .ql-feed-combo-chip { background:#2a2240; border-color:var(--tc-lav); }
 [data-theme="dark"] .ql-feed-combo-head { color:#b8a8e0; }
-[data-theme="dark"] .ql-feed-combo-conf { background:var(--lavender); color:var(--text); }
+/* Deep-lavender badge with light text so the combo frequency/confidence
+   number stays legible in dark mode — the prior var(--text) flipped light
+   over the unchanged light-lavender fill (~1.42:1). (V-M-210 / V-V-210) */
+[data-theme="dark"] .ql-feed-combo-conf { background:#3a2f55; color:#e6dcf5; }
 [data-theme="dark"] .ql-feed-items-list { background:var(--surface); border-color:#3a2e3e; }
 [data-theme="dark"] .ql-feed-item-row { border-bottom-color:#3a2e3e; }
 [data-theme="dark"] .ql-feed-qty-stepper { background:#221c28; }
@@ -7395,8 +7388,6 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 @media (prefers-reduced-motion: reduce) {
   .sc-disclosure-toggle { transition:none; }
 }
-[data-theme="dark"] .ql-freq-pill { background:rgba(58,112,96,0.12); border-color:rgba(181,213,197,0.15); color:var(--tc-sage); }
-[data-theme="dark"] .ql-freq-pill:active { background:var(--accent-sage-deep); color:var(--body-bg); }
 [data-theme="dark"] .ql-bf-pill { background:rgba(201,184,232,0.1); border-color:rgba(201,184,232,0.15); }
 [data-theme="dark"] .ql-bf-pill.active { background:rgba(184,168,224,0.2); color:var(--tc-lav); border-color:rgba(184,168,224,0.35); }
 [data-theme="dark"] .meal-prog-slot { background:var(--card-bg); border-color:var(--card-border); }
@@ -16805,12 +16796,40 @@ window._FOOD_QTY_CATEGORY_DEFAULTS = {
   'veg-mashed':     { qty: 0.25, unit: 'cup',     step: 0.25 },
   'fruit-piece':    { qty: 0.5,  unit: 'pc',      step: 0.25 },
   'fruit-berry':    { qty: 5,    unit: 'pc',      step: 2    },
-  'fruit-mash':     { qty: 0.5,  unit: 'pc',      step: 0.25 },
+  'fruit-mash':     { qty: 2,    unit: 'tbsp',    step: 1    },
   'nut-piece':      { qty: 1,    unit: 'pc',      step: 1    },
   'fat-cooking':    { qty: 1,    unit: 'tsp',     step: 0.5  },
   'spice':          { qty: 0.25, unit: 'tsp',     step: 0.25 },
   'liquid-drink':   { qty: 0.5,  unit: 'cup',     step: 0.25 },
   'fallback':       { qty: 1,    unit: 'serving', step: 1    },
+};
+
+// Strip a prep-form word ("ragi porridge"→"ragi", "banana mash"→"banana",
+// "bajra roti"→"bajra") so a curated explicit override / NUTRITION row can
+// be matched before the broad category fallthrough. Returns '' when
+// stripping would empty the string (the food name IS the prep word, e.g.
+// "porridge", "roti") so callers fall back to the original base. (V-K-201)
+window._fdStripPrepSuffix = function(base) {
+  if (!base) return '';
+  return String(base)
+    .replace(/\b(porridge|mash|puree|pure|sauce|roti|chapati|paratha)\b/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
+// Resolve a food name to its best NUTRITION key for the nutrient join:
+// paren-strip, and if that isn't a NUTRITION row, try the prep-suffix-
+// stripped stem ("ragi porridge"→"ragi"). Falls back to the paren-stripped
+// base when neither matches, preserving legacy behavior. (V-K-200)
+window._fdNutritionRef = function(name) {
+  if (!name) return '';
+  var base = String(name).toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim();
+  if (typeof NUTRITION !== 'undefined' && NUTRITION) {
+    if (NUTRITION[base]) return base;
+    var stem = window._fdStripPrepSuffix(base);
+    if (stem && stem !== base && NUTRITION[stem]) return stem;
+  }
+  return base;
 };
 
 // Resolver — explicit override wins; category fallback otherwise.
@@ -16823,6 +16842,12 @@ window._fdResolveQtyDefaults = function(foodName) {
   // 1. Explicit per-food override
   if (NUTRITION_QTY_DEFAULTS[base]) return NUTRITION_QTY_DEFAULTS[base];
   if (NUTRITION_QTY_DEFAULTS[key])  return NUTRITION_QTY_DEFAULTS[key];
+  // 1b. Prep-suffix-stripped stem ("banana mash"→"banana") so a curated
+  //     explicit qty wins over the broad category catch below. Category
+  //     heuristics still run on the un-stripped base, so unnamed mashes
+  //     ("papaya puree") keep their fruit-mash default. (V-K-201)
+  var stem = window._fdStripPrepSuffix(base);
+  if (stem && stem !== base && NUTRITION_QTY_DEFAULTS[stem]) return NUTRITION_QTY_DEFAULTS[stem];
   // 2. Category resolver — name heuristics first
   if (/porridge|upma|halwa/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['porridge'];
   if (/\b(roti|chapati|paratha|naan|puri)\b/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['roti-flatbread'];
@@ -16923,6 +16948,11 @@ window.parseFeedingV1 = function(mealVal) {
   if (typeof mealVal === 'string') {
     var raw = mealVal.trim();
     if (!raw) return { items: [] };
+    // Skip sentinel reaching the normalizer directly (the live read path
+    // guards this in _fdReadDayMeal, but F-5 callers may invoke parseFeedingV1
+    // on the raw string) — must not emit a phantom "—skipped—" food. (V-K-202)
+    var sentinel = (typeof SKIPPED_MEAL !== 'undefined') ? SKIPPED_MEAL : '—skipped—';
+    if (raw === sentinel) return { items: [], skipped: true };
     var items = raw.split(',').map(function(s) {
       var name = s.trim().replace(/,+$/, '');
       if (!name) return null;
@@ -16932,7 +16962,7 @@ window.parseFeedingV1 = function(mealVal) {
         qty: defaults.qty,
         unit: defaults.unit,
         source: 'legacy-parse',
-        nutritionRef: name.toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim()
+        nutritionRef: window._fdNutritionRef(name)
       };
     }).filter(function(x) { return x; });
     return { items: items, _parsedFrom: 'legacy-string' };
@@ -41577,20 +41607,6 @@ function getTopMeals(n) {
     .map(m => ({ name: m.display.charAt(0).toUpperCase() + m.display.slice(1), count: m.count }));
 }
 
-function renderQLFreqPills() {
-  const wrap = document.getElementById('qlFreqWrap');
-  const el = document.getElementById('qlFreqPills');
-  if (!wrap || !el) return;
-
-  const top = getTopMeals(5);
-  if (top.length === 0) { wrap.style.display = 'none'; return; }
-
-  wrap.style.display = '';
-  el.innerHTML = top.map(m =>
-    `<div class="ql-freq-pill" onclick="document.getElementById('qlFeedInput').value='${escHtml(m.name).replace(/'/g, "\\'")}';document.getElementById('qlFeedInput').focus();" title="${m.count}× logged">${escHtml(m.name)}</div>`
-  ).join('');
-}
-
 // ── Meal progress on Home ──
 
 // ── MEAL DIVERSITY INDEX ──
@@ -63710,7 +63726,7 @@ window._fdGetCombosForMeal = function(meal, opts) {
     return curated.slice(0, maxResults).map(function(c, i) {
       var items = c.items.map(function(name) {
         var d = window._fdResolveQtyDefaults(name);
-        return { name: name, qty: d.qty, unit: d.unit, nutritionRef: name.toLowerCase().replace(/\s*\([^)]*\)\s*/g,'').trim(), source: 'curated' };
+        return { name: name, qty: d.qty, unit: d.unit, nutritionRef: window._fdNutritionRef(name), source: 'curated' };
       });
       return {
         id: 'curated-' + meal + '-' + i,
@@ -63737,7 +63753,7 @@ window._fdGetCombosForMeal = function(meal, opts) {
     return curated2.slice(0, maxResults).map(function(c, i) {
       var items = c.items.map(function(name) {
         var d = window._fdResolveQtyDefaults(name);
-        return { name: name, qty: d.qty, unit: d.unit, nutritionRef: name.toLowerCase().replace(/\s*\([^)]*\)\s*/g,'').trim(), source: 'curated' };
+        return { name: name, qty: d.qty, unit: d.unit, nutritionRef: window._fdNutritionRef(name), source: 'curated' };
       });
       return {
         id: 'curated-fallback-' + meal + '-' + i,
@@ -64289,7 +64305,22 @@ function _qlRenderFeedSheet() {
 // F-2 fix (A6): hidden once items are present (mirror the combos-rail
 // behavior). Otherwise an accidental tap on a still-visible repeat chip
 // silently wipes the parent's in-progress items with no undo affordance.
+// L1↔L2 dedup: the repeat rail (your actual history) and the combo rail
+// (templates / curated cold-start) can surface the identical food-set as two
+// differently-coloured chips. The repeat rail stashes its signatures here so
+// the combo rail can drop the duplicate and keep the more-authoritative
+// history chip. Reset at the top of every repeat-rail render. (V-V-204)
+var _qlRepeatSigs = [];
+function _qlFeedRailSig(itemsText) {
+  return String(itemsText || '').toLowerCase().split(',')
+    .map(function(s) { return s.trim(); })
+    .filter(function(s) { return s; })
+    .sort()
+    .join('|');
+}
+
 function _qlRenderRepeatRail() {
+  _qlRepeatSigs = [];
   var wrap = document.getElementById('qlFeedRepeatWrap');
   var rail = document.getElementById('qlFeedRepeatRail');
   if (!wrap || !rail) return;
@@ -64304,6 +64335,7 @@ function _qlRenderRepeatRail() {
     rail.innerHTML = '';
     return;
   }
+  _qlRepeatSigs = candidates.map(function(c) { return _qlFeedRailSig(c.itemsText); });
   wrap.style.display = '';
   rail.innerHTML = candidates.map(function(c, i) {
     return '<div class="ql-feed-repeat-chip' + (i === 0 ? ' primary' : '') + '"' +
@@ -64330,6 +64362,13 @@ function _qlRenderCombosRail() {
     return;
   }
   var combos = window._fdGetCombosForMeal(_qlMeal, { maxResults: 3 });
+  // Drop any combo whose food-set duplicates a repeat-rail chip already shown
+  // above (the history chip is more authoritative). (V-V-204)
+  if (combos && combos.length && _qlRepeatSigs.length) {
+    combos = combos.filter(function(c) {
+      return _qlRepeatSigs.indexOf(_qlFeedRailSig(c.itemsText)) === -1;
+    });
+  }
   if (!combos || combos.length === 0) {
     wrap.style.display = 'none';
     rail.innerHTML = '';
@@ -64360,14 +64399,19 @@ function _qlRenderItemsList() {
     list.innerHTML = '<div class="ql-feed-items-empty">Tap a combo above, or type an item below</div>';
     return;
   }
+  // Stable alphabetical order so the list has a fixed scan position across
+  // the four entry rails (combo-replace, repeat-replace, next/typeahead push)
+  // — sorting the array in place keeps the data-arg idx consistent with the
+  // qty-stepper / remove handlers. (V-V-202)
+  _qlFeedItems.sort(function(a, b) {
+    return String(a.name || '').toLowerCase().localeCompare(String(b.name || '').toLowerCase());
+  });
   list.innerHTML = _qlFeedItems.map(function(item, idx) {
     var initial = (item.name || '?').charAt(0).toUpperCase();
     var qtyDisplay = _qlFormatQty(item.qty);
     return '<div class="ql-feed-item-row">' +
            '<span class="ql-feed-item-icon">' + escHtml(initial) + '</span>' +
-           '<div class="ql-feed-item-name">' + escHtml(item.name) +
-             '<span class="ql-feed-item-meta">' + escHtml(item.source || 'manual') + '</span>' +
-           '</div>' +
+           '<div class="ql-feed-item-name">' + escHtml(item.name) + '</div>' +
            '<div class="ql-feed-qty-stepper">' +
              '<button class="ql-feed-qty-step" data-action="qlFeedAdjustQty" data-arg="' + idx + '" data-arg2="dec" type="button" aria-label="Decrease quantity">−</button>' +
              '<span class="ql-feed-qty-val">' + qtyDisplay +
@@ -64477,7 +64521,7 @@ function qlFeedAddItem(name, source) {
     name: name,
     qty: defaults.qty,
     unit: defaults.unit,
-    nutritionRef: normalized,
+    nutritionRef: window._fdNutritionRef(name),
     source: source || 'manual',
   });
   if (source === 'next' || source === 'typeahead') {
@@ -66350,43 +66394,6 @@ function updateMealSkipButtons() {
       if (input) { input.disabled = false; input.placeholder = 'Type to search foods...'; }
     }
   });
-}
-
-// ── Expanded same-as pills (yesterday's all meals) ──
-function renderQLSameAsPills() {
-  const wrap = document.getElementById('qlSameAsWrap');
-  const pills = document.getElementById('qlSameAsPills');
-  if (!wrap || !pills) return;
-
-  const todayEntry = feedingData[today()] || {};
-  const meals = [];
-  const seen = new Set();
-  function add(label, value) {
-    if (value && !seen.has(value)) { meals.push({ label, value }); seen.add(value); }
-  }
-
-  // Today's meals
-  add(zi('sun')+' Today B', todayEntry.breakfast);
-  add(zi('sun')+' Today L', todayEntry.lunch);
-  add(zi('moon')+' Today D', todayEntry.dinner);
-  add(zi('spoon')+' Today S', todayEntry.snack);
-
-  // Yesterday's meals (all three)
-  const yd = new Date(); yd.setDate(yd.getDate() - 1);
-  const ydEntry = feedingData[toDateStr(yd)] || {};
-  add(zi('clock')+' Yd B', ydEntry.breakfast);
-  add(zi('clock')+' Yd L', ydEntry.lunch);
-  add(zi('clock')+' Yd D', ydEntry.dinner);
-
-  if (meals.length === 0) {
-    wrap.style.display = 'none';
-    return;
-  }
-
-  wrap.style.display = '';
-  pills.innerHTML = meals.map(m =>
-    `<button class="btn-ghost" style="font-size:var(--fs-xs);padding:5px 10px;border-radius:var(--r-2xl);" onclick="document.getElementById('qlFeedInput').value='${escHtml(m.value).replace(/'/g, "\\'")}';this.closest('#qlSameAsWrap').style.display='none';">${m.label}</button>`
-  ).join('');
 }
 
 // Close QL dropdown on blur

--- a/index.html
+++ b/index.html
@@ -16452,6 +16452,301 @@ window.isStructuredFeedingV1 = function(mealVal) {
   return mealVal && typeof mealVal === 'object' && Array.isArray(mealVal.items);
 };
 
+// ═══════════════════════════════════════════════════════════════════════
+// F-2 — per-food quantity defaults, CURATED_COMBOS, skip state, write helper
+// Spec: docs/specs/food-sub-tab-v1.md §F-2; ratifications #2 + #4 + #6.
+// Sidecar registry `NUTRITION_QTY_DEFAULTS` carries explicit qty/unit/step
+// for the top-used foods (the ones the 79-day feeding-data sample shows
+// parents actually log). Foods without an explicit override fall through
+// `_fdResolveQtyDefaults` to a category-based default. Kept as a sidecar
+// (not inline NUTRITION fields) so the qty data is discoverable in one
+// block — same intent as ratification #4 ("extend NUTRITION rows") with
+// edit-locality + maintainability preserved.
+// ═══════════════════════════════════════════════════════════════════════
+
+// Per-food explicit qty defaults. Keys MUST exist in NUTRITION (the
+// audit gate verifies). qty is a number (fractional allowed); unit is a
+// short display string ('pc' / 'tsp' / 'bowl' / 'cup' / 'piece'); step
+// is the +/- increment a single qty-stepper tap applies.
+window.NUTRITION_QTY_DEFAULTS = {
+  // ── GRAINS & STAPLES ──
+  'khichdi':        { qty: 1,    unit: 'bowl', step: 0.25 },
+  'ragi':           { qty: 1,    unit: 'cup',  step: 0.25 },   // porridge form
+  'rice':           { qty: 0.5,  unit: 'bowl', step: 0.25 },
+  'suji':           { qty: 1,    unit: 'cup',  step: 0.25 },
+  'oats':           { qty: 1,    unit: 'cup',  step: 0.25 },
+  'bajra':          { qty: 1,    unit: 'pc',   step: 0.5 },    // roti form
+  'jowar':          { qty: 1,    unit: 'pc',   step: 0.5 },
+  'idli':           { qty: 1,    unit: 'pc',   step: 1 },
+  'dosa':           { qty: 1,    unit: 'pc',   step: 0.5 },
+  'roti':           { qty: 1,    unit: 'pc',   step: 0.5 },
+  'paratha':        { qty: 1,    unit: 'pc',   step: 0.5 },
+  'poha':           { qty: 0.5,  unit: 'bowl', step: 0.25 },
+  // ── LENTILS ──
+  'moong dal':      { qty: 0.5,  unit: 'bowl', step: 0.25 },
+  'masoor dal':     { qty: 0.5,  unit: 'bowl', step: 0.25 },
+  'toor dal':       { qty: 0.5,  unit: 'bowl', step: 0.25 },
+  // ── VEGETABLES ──
+  'carrot':         { qty: 0.25, unit: 'cup',  step: 0.25 },   // mashed/puree form
+  'beetroot':       { qty: 0.25, unit: 'cup',  step: 0.25 },
+  'bottle gourd':   { qty: 0.25, unit: 'cup',  step: 0.25 },
+  'spinach':        { qty: 0.25, unit: 'cup',  step: 0.25 },
+  'tomato':         { qty: 0.5,  unit: 'pc',   step: 0.5 },
+  'cucumber':       { qty: 0.5,  unit: 'pc',   step: 0.25 },
+  'beans':          { qty: 0.25, unit: 'cup',  step: 0.25 },
+  // ── FRUITS ──
+  'apple':          { qty: 0.5,  unit: 'pc',   step: 0.25 },
+  'banana':         { qty: 0.5,  unit: 'pc',   step: 0.25 },
+  'mango':          { qty: 0.25, unit: 'pc',   step: 0.25 },   // small pieces typical
+  'avocado':        { qty: 0.5,  unit: 'pc',   step: 0.25 },
+  'blueberry':      { qty: 5,    unit: 'pc',   step: 2 },
+  'pear':           { qty: 0.5,  unit: 'pc',   step: 0.25 },
+  'papaya':         { qty: 0.25, unit: 'pc',   step: 0.25 },
+  'watermelon':     { qty: 1,    unit: 'cup',  step: 0.5 },    // cubed
+  'pomegranate':    { qty: 0.25, unit: 'cup',  step: 0.25 },   // seeds
+  'date':           { qty: 1,    unit: 'pc',   step: 1 },
+  'chiku':          { qty: 0.5,  unit: 'pc',   step: 0.25 },
+  // ── DAIRY & FATS ──
+  'ghee':           { qty: 1,    unit: 'tsp',  step: 0.5 },
+  'curd':           { qty: 0.25, unit: 'cup',  step: 0.25 },
+  'paneer':         { qty: 1,    unit: 'tbsp', step: 0.5 },    // crumbled
+  // ── NUTS & SEEDS (powdered/soaked) ──
+  'almonds':        { qty: 2,    unit: 'pc',   step: 1 },
+  'walnut':         { qty: 1,    unit: 'pc',   step: 1 },
+  'cashew':         { qty: 2,    unit: 'pc',   step: 1 },
+  'flaxseed':       { qty: 0.5,  unit: 'tsp',  step: 0.5 },
+  'chia seeds':     { qty: 0.5,  unit: 'tsp',  step: 0.5 },
+  // ── SPICES (trace amounts for babies) ──
+  'jeera':          { qty: 0.25, unit: 'tsp',  step: 0.25 },
+  'cumin':          { qty: 0.25, unit: 'tsp',  step: 0.25 },
+  'turmeric':       { qty: 0.25, unit: 'tsp',  step: 0.25 },
+  // ── LIQUIDS ──
+  'coconut water':  { qty: 0.5,  unit: 'cup',  step: 0.25 },
+  'lemon':          { qty: 1,    unit: 'tsp',  step: 0.5 },    // juice
+};
+
+// Category-based fallback for any NUTRITION row without an explicit qty
+// override. `_fdResolveQtyDefaults` walks the food name + NUTRITION tags
+// to pick the best-fitting category. Foods that mismatch all heuristics
+// fall through to the 'fallback' bucket.
+window._FOOD_QTY_CATEGORY_DEFAULTS = {
+  'porridge':       { qty: 1,    unit: 'cup',     step: 0.25 },
+  'roti-flatbread': { qty: 1,    unit: 'pc',      step: 0.5  },
+  'grain-staple':   { qty: 0.5,  unit: 'bowl',    step: 0.25 },
+  'dal-legume':     { qty: 0.5,  unit: 'bowl',    step: 0.25 },
+  'veg-piece':      { qty: 0.5,  unit: 'pc',      step: 0.25 },
+  'veg-mashed':     { qty: 0.25, unit: 'cup',     step: 0.25 },
+  'fruit-piece':    { qty: 0.5,  unit: 'pc',      step: 0.25 },
+  'fruit-berry':    { qty: 5,    unit: 'pc',      step: 2    },
+  'fruit-mash':     { qty: 0.5,  unit: 'pc',      step: 0.25 },
+  'nut-piece':      { qty: 1,    unit: 'pc',      step: 1    },
+  'fat-cooking':    { qty: 1,    unit: 'tsp',     step: 0.5  },
+  'spice':          { qty: 0.25, unit: 'tsp',     step: 0.25 },
+  'liquid-drink':   { qty: 0.5,  unit: 'cup',     step: 0.25 },
+  'fallback':       { qty: 1,    unit: 'serving', step: 1    },
+};
+
+// Resolver — explicit override wins; category fallback otherwise.
+// Returns { qty, unit, step }; never null.
+window._fdResolveQtyDefaults = function(foodName) {
+  if (!foodName) return _FOOD_QTY_CATEGORY_DEFAULTS.fallback;
+  var key = String(foodName).toLowerCase().trim();
+  // Strip parenthetical variants ("ghee (cow)" → "ghee"; "khichdi (masoor dal)" → "khichdi")
+  var base = key.replace(/\s*\([^)]*\)\s*/g, '').trim();
+  // 1. Explicit per-food override
+  if (NUTRITION_QTY_DEFAULTS[base]) return NUTRITION_QTY_DEFAULTS[base];
+  if (NUTRITION_QTY_DEFAULTS[key])  return NUTRITION_QTY_DEFAULTS[key];
+  // 2. Category resolver — name heuristics first
+  if (/porridge|upma|halwa/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['porridge'];
+  if (/\b(roti|chapati|paratha|naan|puri)\b/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['roti-flatbread'];
+  if (/\bdal\b|chickpeas|rajma|chole|peas/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['dal-legume'];
+  if (/\b(berry|cherry|grape|raisin)\b/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['fruit-berry'];
+  if (/mash|puree|sauce/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['fruit-mash'];
+  if (/(juice|water|coconut water|milk)/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['liquid-drink'];
+  if (/(seed|sesame|flax|chia)/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['spice'];
+  // 3. Tag-based fallback from NUTRITION
+  var n = (typeof NUTRITION !== 'undefined' && NUTRITION[base]) || (typeof NUTRITION !== 'undefined' && NUTRITION[key]);
+  if (n && n.tags) {
+    if (n.tags.indexOf('healthy-fats') >= 0 && /oil|ghee|butter/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['fat-cooking'];
+    if (n.tags.indexOf('iron-rich') >= 0 && n.tags.indexOf('protein-rich') >= 0) return _FOOD_QTY_CATEGORY_DEFAULTS['dal-legume'];
+    if (n.tags.indexOf('energy') >= 0 && !n.tags.indexOf('digestive') >= 0) return _FOOD_QTY_CATEGORY_DEFAULTS['grain-staple'];
+  }
+  // 4. Heuristic by nutrient profile
+  if (n && n.nutrients) {
+    if (n.nutrients.indexOf('water') >= 0) return _FOOD_QTY_CATEGORY_DEFAULTS['liquid-drink'];
+  }
+  return _FOOD_QTY_CATEGORY_DEFAULTS['veg-piece'];
+};
+
+// ═══════════════════════════════════════════════════════════════════════
+// CURATED_COMBOS — L2 autofill cold-start fallback (ratification #2 + #4)
+// 12 seed entries: 4 breakfast / 5 lunch+dinner / 3 snack. Age-gated via
+// minAgeMonths; surfaced when rolling-14d window has <7 days of signal.
+// Future curation arc (deferred) can expand from pediatrician guidelines.
+// ═══════════════════════════════════════════════════════════════════════
+window.CURATED_COMBOS = [
+  // ── BREAKFAST (4) ──
+  { slot: 'breakfast', items: ['Ragi porridge', 'Ghee (cow)', 'Banana mash'],
+    rationale: 'iron-base breakfast — ragi for iron, ghee for calorie density, banana for sweetness',
+    minAgeMonths: 6 },
+  { slot: 'breakfast', items: ['Avocado mash', 'Blueberry', 'Mango puree'],
+    rationale: 'good-fat + vitamin-C breakfast',
+    minAgeMonths: 6 },
+  { slot: 'breakfast', items: ['Suji', 'Ghee (cow)', 'Apple puree'],
+    rationale: 'soft-grain breakfast — gentle on stomach + cooked fruit pairing',
+    minAgeMonths: 6 },
+  { slot: 'breakfast', items: ['Oats porridge', 'Ghee (cow)', 'Banana mash'],
+    rationale: 'cereal-fruit breakfast — fibre + slow carbs',
+    minAgeMonths: 7 },
+  // ── LUNCH / DINNER (5) ──
+  { slot: 'lunch', items: ['Khichdi (masoor dal)', 'Ghee (cow)', 'Carrot', 'Bottle gourd'],
+    rationale: 'staple khichdi — protein + ghee + 2 veggies',
+    minAgeMonths: 6 },
+  { slot: 'lunch', items: ['Bajra roti', 'Masoor dal', 'Ghee (cow)', 'Spinach'],
+    rationale: 'millet-roti lunch — bajra for variety + iron-rich spinach',
+    minAgeMonths: 8 },
+  { slot: 'dinner', items: ['Khichdi (moong dal)', 'Ghee (cow)', 'Beetroot', 'Carrot'],
+    rationale: 'lighter moong dal dinner — easier overnight digestion',
+    minAgeMonths: 6 },
+  { slot: 'dinner', items: ['Rice', 'Masoor dal', 'Ghee (cow)'],
+    rationale: 'simple rice + dal dinner — fall-back when kitchen is light',
+    minAgeMonths: 6 },
+  { slot: 'lunch', items: ['Idli', 'Ghee (cow)', 'Tomato'],
+    rationale: 'south-Indian lunch — fermented + gut-friendly',
+    minAgeMonths: 7 },
+  // ── SNACK (3) ──
+  { slot: 'snack', items: ['Cucumber', 'Mango'],
+    rationale: 'hydration + sweet snack',
+    minAgeMonths: 7 },
+  { slot: 'snack', items: ['Coconut water', 'Cucumber'],
+    rationale: 'hot-day hydration — electrolytes + cooling',
+    minAgeMonths: 7 },
+  { slot: 'snack', items: ['Banana', 'Almonds'],
+    rationale: 'calorie-dense snack — fruit + nut for sustained energy',
+    minAgeMonths: 8 },
+];
+
+// Curated combo lookup — returns entries matching slot + Ziva's current age.
+window._fdGetCuratedCombosForMeal = function(meal, ageMonths) {
+  if (!meal || !Array.isArray(CURATED_COMBOS)) return [];
+  return CURATED_COMBOS.filter(function(c) {
+    if (c.slot !== meal) return false;
+    if (typeof ageMonths === 'number' && c.minAgeMonths > ageMonths) return false;
+    return true;
+  });
+};
+
+// ═══════════════════════════════════════════════════════════════════════
+// parseFeedingV1 — read-side normalizer (F-2 ships partial; F-5 ships
+// the full v3-8 parseFeeding tolerating ALL three shapes).
+// Returns: { items: [{name, qty, unit, ...}], time, overallIntake, ... }
+// regardless of input shape. Legacy strings parse via comma-split + qty
+// resolver. Skipped slots return { skipped: true, items: [] }.
+// ═══════════════════════════════════════════════════════════════════════
+window.parseFeedingV1 = function(mealVal) {
+  // Skipped state
+  if (mealVal && typeof mealVal === 'object' && mealVal.skipped === true) {
+    return { items: [], skipped: true, skippedAt: mealVal.skippedAt || null };
+  }
+  // Structured shape — return as-is (already canonical)
+  if (window.isStructuredFeedingV1(mealVal)) {
+    return mealVal;
+  }
+  // Legacy string — comma-split + resolve defaults per item
+  if (typeof mealVal === 'string') {
+    var raw = mealVal.trim();
+    if (!raw) return { items: [] };
+    var items = raw.split(',').map(function(s) {
+      var name = s.trim().replace(/,+$/, '');
+      if (!name) return null;
+      var defaults = window._fdResolveQtyDefaults(name);
+      return {
+        name: name,
+        qty: defaults.qty,
+        unit: defaults.unit,
+        source: 'legacy-parse',
+        nutritionRef: name.toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim()
+      };
+    }).filter(function(x) { return x; });
+    return { items: items, _parsedFrom: 'legacy-string' };
+  }
+  // Unknown — return empty
+  return { items: [] };
+};
+// Keep the F-1 stub as an alias so any caller bound to the stub name still works.
+window.parseFeedingV1Stub = window.parseFeedingV1;
+
+// ═══════════════════════════════════════════════════════════════════════
+// Skip-state helpers (ratification #6)
+// Mark a meal slot as intentionally-skipped. Skipped slots render as
+// muted "Skipped" pills and are excluded from nutrition-snapshot diversity
+// penalties. Reversible — writing a real entry overwrites the skip.
+// ═══════════════════════════════════════════════════════════════════════
+window._fdMarkMealSkipped = function(dateKey, meal) {
+  if (!dateKey || !meal) return false;
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+  if (!fd[dateKey]) fd[dateKey] = { breakfast: '', lunch: '', dinner: '', snack: '' };
+  fd[dateKey][meal] = { skipped: true, skippedAt: Date.now(), items: [] };
+  if (typeof save === 'function' && typeof KEYS !== 'undefined' && KEYS.feeding) {
+    save(KEYS.feeding, fd);
+  }
+  if (typeof feedingData !== 'undefined') feedingData = fd;
+  if (typeof _islMarkDirty === 'function') _islMarkDirty('diet');
+  return true;
+};
+
+window._fdIsMealSkipped = function(dateKey, meal) {
+  if (!dateKey || !meal) return false;
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+  var day = fd[dateKey];
+  if (!day) return false;
+  var mv = day[meal];
+  return !!(mv && typeof mv === 'object' && mv.skipped === true);
+};
+
+// ═══════════════════════════════════════════════════════════════════════
+// _fdWriteStructuredMeal — canonical writer for the F-2 FOB Feed sheet.
+// Writes the structured shape under feedingData[dateKey][meal] AND
+// auto-generates legacy compat fields (text, {meal}_time, {meal}_intake)
+// so existing readers (home.js Today's Meals summary, diet stats, combo
+// intelligence, parseMealNutrition) continue working unchanged until
+// F-5 lands the read-side normalizer.
+//
+// payload: { items: [{name, qty, unit, nutritionRef}], time, overallIntake, note, sourceFlow }
+// Returns the structured shape that was written.
+// ═══════════════════════════════════════════════════════════════════════
+window._fdWriteStructuredMeal = function(dateKey, meal, payload) {
+  if (!dateKey || !meal || !payload) return null;
+  payload = payload || {};
+  var items = Array.isArray(payload.items) ? payload.items.slice() : [];
+  // Legacy compat: comma-joined text for downstream readers (Today's Meals
+  // summary, diet combos, parseMealNutrition). Trailing comma kept off.
+  var textCompat = items.map(function(it) { return it.name; }).join(', ');
+
+  var structured = {
+    items: items,
+    time: payload.time || null,
+    overallIntake: (typeof payload.overallIntake === 'number') ? payload.overallIntake : 0.75,  // ratified DEFAULT "Most"
+    note: payload.note || '',
+    sourceFlow: payload.sourceFlow || 'fob-feed',  // telemetry: fob-repeat | fob-combo | fob-novel | fob-feed | diet-tab
+    schemaVersion: window._FEEDING_V1_SCHEMA_VERSION,
+    text: textCompat,
+  };
+
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+  if (!fd[dateKey]) fd[dateKey] = { breakfast: '', lunch: '', dinner: '', snack: '' };
+  fd[dateKey][meal] = structured;
+  // Legacy compat fields at the day level (existing readers reach for these)
+  if (structured.time) fd[dateKey][meal + '_time'] = structured.time;
+  fd[dateKey][meal + '_intake'] = structured.overallIntake;
+
+  if (typeof save === 'function' && typeof KEYS !== 'undefined' && KEYS.feeding) {
+    save(KEYS.feeding, fd);
+  }
+  if (typeof feedingData !== 'undefined') feedingData = fd;
+  return structured;
+};
+
 // @@DATA_BLOCK_20_START@@ MILESTONE_STANDARDS
 
 // MILESTONE_SOURCE — controlled vocabulary for per-row clinical-band source
@@ -62869,6 +63164,351 @@ function _qlPredict() {
 
   return predictions;
 }
+
+// ═══════════════════════════════════════════════════════════════
+// F-2 — Autofill intelligence layers (L1 Repeat / L2 Combo / L3 Next-item / L4 Typeahead)
+// Spec: docs/specs/food-sub-tab-v1.md §F-2; ratifications #1/#2/#6.
+// All four helpers read window.feedingData; all return shape-stable
+// arrays so the FOB Feed sheet renderer is decoupled from the source
+// data layout. parseFeedingV1 (data.js) normalizes legacy + structured
+// rows on the way in so the helpers operate on a canonical shape.
+// ═══════════════════════════════════════════════════════════════
+
+// _fdGetMealSlotByTime — thin wrapper around detectMealType() for
+// readability + decoupling. Ratification #1: existing adaptive 14d
+// window logic in _qlComputeMealWindow is BETTER than fixed bands —
+// reuse it. Returns 'breakfast' | 'lunch' | 'dinner' | 'snack'.
+window._fdGetMealSlotByTime = function() {
+  return detectMealType();
+};
+
+// L1 — Repeat candidates. Returns up to `n` (default 3) recent meals
+// for the given slot, formatted for one-tap apply. For dinner, the
+// FIRST candidate is "Same as lunch (today)" if today's lunch is logged
+// (ratification #6 — 46% lunch=dinner match in observed data).
+//
+// Each candidate: { id, label, sub, items[], itemsText, ageRel, source }
+// label  — short chip text ("Yesterday's breakfast" / "Same as lunch today")
+// sub    — items preview (truncated, comma-separated)
+// items  — array of {name, qty, unit, nutritionRef} ready to apply
+// source — 'today-lunch' | 'yesterday' | 'recent' (telemetry)
+window._fdGetRepeatCandidates = function(meal, n) {
+  n = n || 3;
+  var out = [];
+  var todayStr = today();
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+
+  function dayLabel(daysAgo) {
+    if (daysAgo === 0) return 'Today';
+    if (daysAgo === 1) return 'Yesterday';
+    if (daysAgo < 7)  return daysAgo + ' days ago';
+    return 'Last week';
+  }
+
+  function structuredItemsFromMeal(mealVal) {
+    var parsed = window.parseFeedingV1(mealVal);
+    if (!parsed || !parsed.items || parsed.items.length === 0) return null;
+    if (parsed.skipped) return null;
+    // Hydrate any items missing qty/unit via the defaults resolver
+    var items = parsed.items.map(function(it) {
+      if (it.qty !== undefined && it.unit) return it;
+      var d = window._fdResolveQtyDefaults(it.name);
+      return Object.assign({}, it, { qty: d.qty, unit: d.unit });
+    });
+    return items;
+  }
+
+  // Ratification #6 — for dinner, surface today's lunch FIRST if logged.
+  if (meal === 'dinner' && fd[todayStr] && fd[todayStr].lunch) {
+    var lunchItems = structuredItemsFromMeal(fd[todayStr].lunch);
+    if (lunchItems && lunchItems.length) {
+      out.push({
+        id: 'today-lunch',
+        label: 'Same as today\'s lunch',
+        sub: lunchItems.map(function(it){return it.name;}).join(', '),
+        items: lunchItems,
+        itemsText: lunchItems.map(function(it){return it.name;}).join(', '),
+        ageRel: 'today',
+        source: 'today-lunch',
+      });
+    }
+  }
+
+  // Walk back up to 14 days; collect candidates for the same slot.
+  for (var d = 1; d <= 14 && out.length < n; d++) {
+    var dd = new Date(); dd.setDate(dd.getDate() - d);
+    var ds = toDateStr(dd);
+    var day = fd[ds];
+    if (!day) continue;
+    var items = structuredItemsFromMeal(day[meal]);
+    if (!items) continue;
+    out.push({
+      id: 'repeat-' + ds,
+      label: (d === 1 ? 'Yesterday\'s ' : dayLabel(d).toLowerCase() + ' ') + meal,
+      sub: items.map(function(it){return it.name;}).join(', '),
+      items: items,
+      itemsText: items.map(function(it){return it.name;}).join(', '),
+      ageRel: dayLabel(d),
+      source: d === 1 ? 'yesterday' : 'recent',
+    });
+  }
+
+  return out;
+};
+
+// L2 — Combo templates. Rolling 14d window: find combos (item-sets) that
+// repeat >= 2x in the same slot. Sort by frequency desc; break ties by
+// recency. Cold-start fallback to CURATED_COMBOS when <7 days of signal.
+//
+// Each combo: { id, label, items[], freq, source }
+// label  — "Your usual breakfast" (or "Pediatrician-suggested" for curated)
+// items  — array with default qty/unit hydrated via _fdResolveQtyDefaults
+// freq   — N× (observed frequency in window) or null (curated)
+// source — '14d-rolling' | 'curated'
+window._fdGetCombosForMeal = function(meal, opts) {
+  opts = opts || {};
+  var maxResults = opts.maxResults || 3;
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+  var todayStr = today();
+  var cutoff = new Date(); cutoff.setDate(cutoff.getDate() - 14);
+  var cutoffStr = toDateStr(cutoff);
+
+  // Collect (sorted-item-set → freq + lastDate) over 14d
+  var comboMap = {};
+  var daysWithSignal = 0;
+
+  Object.keys(fd).forEach(function(ds) {
+    if (ds < cutoffStr || ds > todayStr) return;
+    var day = fd[ds];
+    if (!day) return;
+    var parsed = window.parseFeedingV1(day[meal]);
+    if (!parsed || !parsed.items || parsed.items.length === 0 || parsed.skipped) return;
+    daysWithSignal++;
+    var names = parsed.items.map(function(it){ return String(it.name || '').toLowerCase().trim(); })
+                            .filter(function(n){ return n.length > 1; });
+    if (names.length < 2) return;
+    var sig = names.slice().sort().join('|');
+    if (!comboMap[sig]) comboMap[sig] = { items: parsed.items, freq: 0, lastDate: ds, names: names };
+    comboMap[sig].freq++;
+    if (ds > comboMap[sig].lastDate) {
+      comboMap[sig].lastDate = ds;
+      comboMap[sig].items = parsed.items;  // refresh with most-recent qty/unit
+    }
+  });
+
+  // Cold start — fall through to curated if <7 days of data for this slot
+  if (daysWithSignal < 7) {
+    var ageMonths = (typeof _zivaAgeMonths === 'function') ? _zivaAgeMonths() : null;
+    var curated = window._fdGetCuratedCombosForMeal(meal, ageMonths);
+    return curated.slice(0, maxResults).map(function(c, i) {
+      var items = c.items.map(function(name) {
+        var d = window._fdResolveQtyDefaults(name);
+        return { name: name, qty: d.qty, unit: d.unit, nutritionRef: name.toLowerCase().replace(/\s*\([^)]*\)\s*/g,'').trim(), source: 'curated' };
+      });
+      return {
+        id: 'curated-' + meal + '-' + i,
+        label: i === 0 ? 'Pediatrician-suggested' : 'Another suggestion',
+        items: items,
+        itemsText: items.map(function(it){return it.name;}).join(', '),
+        freq: null,
+        source: 'curated',
+        rationale: c.rationale,
+      };
+    });
+  }
+
+  // Rolling window — surface top combos with freq >= 2
+  var sorted = Object.keys(comboMap)
+    .map(function(sig){ return comboMap[sig]; })
+    .filter(function(c){ return c.freq >= 2; })
+    .sort(function(a, b){ return b.freq - a.freq || (b.lastDate > a.lastDate ? 1 : -1); });
+
+  if (sorted.length === 0) {
+    // No combos hit 2x — fall through to curated
+    var ageMonths2 = (typeof _zivaAgeMonths === 'function') ? _zivaAgeMonths() : null;
+    var curated2 = window._fdGetCuratedCombosForMeal(meal, ageMonths2);
+    return curated2.slice(0, maxResults).map(function(c, i) {
+      var items = c.items.map(function(name) {
+        var d = window._fdResolveQtyDefaults(name);
+        return { name: name, qty: d.qty, unit: d.unit, nutritionRef: name.toLowerCase().replace(/\s*\([^)]*\)\s*/g,'').trim(), source: 'curated' };
+      });
+      return {
+        id: 'curated-fallback-' + meal + '-' + i,
+        label: 'Pediatrician-suggested',
+        items: items,
+        itemsText: items.map(function(it){return it.name;}).join(', '),
+        freq: null,
+        source: 'curated',
+        rationale: c.rationale,
+      };
+    });
+  }
+
+  return sorted.slice(0, maxResults).map(function(c, i) {
+    // Hydrate items with default qty/unit if missing
+    var items = c.items.map(function(it){
+      if (it.qty !== undefined && it.unit) return it;
+      var d = window._fdResolveQtyDefaults(it.name);
+      return Object.assign({}, it, { qty: d.qty, unit: d.unit });
+    });
+    return {
+      id: 'combo-' + i,
+      label: i === 0 ? 'Your usual ' + meal : 'Another usual',
+      items: items,
+      itemsText: items.map(function(it){return it.name;}).join(', '),
+      freq: c.freq,
+      source: '14d-rolling',
+    };
+  });
+};
+
+// L3 — Next-item prediction. Given a set of items already in the current
+// meal, return the top `n` foods that co-occur with them in the rolling
+// 14d window of the same slot. Each prediction carries an honest
+// confidence % (CV3-006 Honesty axis — parents see WHY a suggestion is
+// surfaced). Excludes foods already in currentItems.
+//
+// Each prediction: { name, confidence, freq, denom }
+//   confidence: rounded percentage (0-100)
+//   freq:       count of co-occurrences with currentItems set
+//   denom:      total observations of the anchor item(s)
+window._fdGetNextItemPredictions = function(currentItems, meal, n) {
+  n = n || 4;
+  if (!Array.isArray(currentItems) || currentItems.length === 0) return [];
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+  var todayStr = today();
+  var cutoff = new Date(); cutoff.setDate(cutoff.getDate() - 14);
+  var cutoffStr = toDateStr(cutoff);
+
+  // Normalize current items to lowercase base names
+  var currentSet = {};
+  var anchorNames = currentItems.map(function(it) {
+    var name = String(it.name || it || '').toLowerCase().trim();
+    currentSet[name] = true;
+    return name;
+  });
+
+  // Walk 14d; for each day's same-slot entry that contains AT LEAST ONE
+  // anchor item, count co-occurrences of every other item in that meal.
+  var coCount = {};   // candidate name → co-occurrence count
+  var anchorDenom = 0;  // total days where any anchor item appears in slot
+
+  Object.keys(fd).forEach(function(ds) {
+    if (ds < cutoffStr || ds > todayStr) return;
+    var day = fd[ds];
+    if (!day) return;
+    var parsed = window.parseFeedingV1(day[meal]);
+    if (!parsed || !parsed.items || parsed.items.length === 0 || parsed.skipped) return;
+    var names = parsed.items.map(function(it){ return String(it.name || '').toLowerCase().trim(); });
+    // Does this day contain any anchor item?
+    var hasAnchor = anchorNames.some(function(a) { return names.indexOf(a) >= 0; });
+    if (!hasAnchor) return;
+    anchorDenom++;
+    // Count every non-anchor item that appears
+    names.forEach(function(n) {
+      if (currentSet[n]) return;  // skip items already in current meal
+      if (!coCount[n]) coCount[n] = { name: parsed.items.find(function(it) { return String(it.name).toLowerCase().trim() === n; }).name, freq: 0 };
+      coCount[n].freq++;
+    });
+  });
+
+  if (anchorDenom < 2) return [];  // not enough signal yet
+
+  var ranked = Object.keys(coCount).map(function(k) {
+    var c = coCount[k];
+    return {
+      name: c.name,
+      freq: c.freq,
+      denom: anchorDenom,
+      confidence: Math.round((c.freq / anchorDenom) * 100),
+    };
+  }).filter(function(p) { return p.confidence >= 20; })  // floor — don't surface noisy 1/14 hits
+    .sort(function(a, b) { return b.confidence - a.confidence; });
+
+  return ranked.slice(0, n);
+};
+
+// L4 — Typeahead. As-you-type match against NUTRITION + ziva_foods
+// (parent-introduced foods). Returns matches with default qty/unit
+// inlined so the dropdown can render the qty hint without an extra
+// resolver call per row.
+//
+// Each match: { name, source: 'nutrition' | 'introduced' | 'recent', qty, unit, step }
+window._fdSearchNutrition = function(query, opts) {
+  opts = opts || {};
+  var max = opts.max || 8;
+  if (!query || typeof query !== 'string') return [];
+  var q = query.toLowerCase().trim();
+  if (q.length < 1) return [];
+
+  var seen = {};
+  var matches = [];
+
+  function pushMatch(name, src) {
+    var key = String(name).toLowerCase().trim();
+    if (seen[key]) return;
+    seen[key] = true;
+    var d = window._fdResolveQtyDefaults(name);
+    matches.push({
+      name: name,
+      source: src,
+      qty: d.qty,
+      unit: d.unit,
+      step: d.step,
+    });
+  }
+
+  // 1. NUTRITION — base lookup (canonical food names)
+  if (typeof NUTRITION === 'object' && NUTRITION) {
+    Object.keys(NUTRITION).forEach(function(k) {
+      if (matches.length >= max * 2) return;
+      if (k.indexOf(q) === 0) pushMatch(k.charAt(0).toUpperCase() + k.slice(1), 'nutrition');
+    });
+    // Looser match — name contains query (after exact-prefix matches)
+    Object.keys(NUTRITION).forEach(function(k) {
+      if (matches.length >= max * 2) return;
+      if (k.indexOf(q) > 0) pushMatch(k.charAt(0).toUpperCase() + k.slice(1), 'nutrition');
+    });
+  }
+
+  // 2. Parent-introduced foods (ziva_foods list)
+  try {
+    var introduced = (typeof load === 'function') ? load(KEYS && KEYS.foods, []) || [] : [];
+    if (Array.isArray(introduced)) {
+      introduced.forEach(function(entry) {
+        if (matches.length >= max * 2) return;
+        var nm = entry && entry.name ? String(entry.name) : '';
+        if (!nm) return;
+        if (nm.toLowerCase().indexOf(q) >= 0) pushMatch(nm, 'introduced');
+      });
+    }
+  } catch(e) { /* introduced list is best-effort */ }
+
+  // 3. Recent items from feedingData (last 14 days, any slot) — surfaces
+  // foods the parent has actually been using (catches typeahead matches
+  // for foods that exist in their flow but not yet in NUTRITION).
+  try {
+    var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+    var cutoff = new Date(); cutoff.setDate(cutoff.getDate() - 14);
+    var cutoffStr = toDateStr(cutoff);
+    Object.keys(fd).forEach(function(ds) {
+      if (matches.length >= max * 2) return;
+      if (ds < cutoffStr) return;
+      ['breakfast','lunch','dinner','snack'].forEach(function(m) {
+        if (matches.length >= max * 2) return;
+        var parsed = window.parseFeedingV1(fd[ds][m]);
+        if (!parsed || !parsed.items) return;
+        parsed.items.forEach(function(it) {
+          if (matches.length >= max * 2) return;
+          var nm = it.name || '';
+          if (nm.toLowerCase().indexOf(q) >= 0) pushMatch(nm, 'recent');
+        });
+      });
+    });
+  } catch(e) { /* best-effort */ }
+
+  return matches.slice(0, max);
+};
 
 // ═══════════════════════════════════════════════════════════════
 // SMART QUICK LOG — Suggest Card Rendering

--- a/index.html
+++ b/index.html
@@ -6746,6 +6746,255 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 .ql-save-nap   { background:linear-gradient(135deg, #7e66b4, #7060a8); }
 .ql-save-poop  { background:linear-gradient(135deg, #8a6520, #946225); }
 
+/* ═══════════════════════════════════════════════════════════════
+   F-2 — FOB Feed sheet (autofill-first redesign)
+   Spec: docs/specs/food-sub-tab-v1.md §F-2
+   Four rail surfaces (L1 repeat / L2 combo / items / L3 next-item)
+   + per-food qty steppers + skip-meal button. Tokens-only per HR-4.
+   ═══════════════════════════════════════════════════════════════ */
+
+/* Rail wrapper — same vertical rhythm as other ql-form sections */
+.ql-feed-rail-wrap { display:flex; flex-direction:column; gap:var(--sp-4); }
+.ql-feed-rail { display:flex; flex-direction:column; gap:var(--sp-6); }
+
+/* L1 Repeat chips — sage outlined; primary chip emphasized */
+.ql-feed-repeat-chip {
+  background:var(--white);
+  border:1.5px solid var(--sage);
+  border-radius:var(--r-xl);
+  padding:var(--sp-10) var(--sp-12);
+  cursor:pointer;
+  min-height:36px;
+  transition:transform var(--ease-fast), background-color var(--ease-fast);
+  box-shadow:0 1px 3px rgba(60,40,40,0.04);
+}
+.ql-feed-repeat-chip:active { transform:scale(0.985); }
+.ql-feed-repeat-chip.primary {
+  background:var(--sage-light);
+  border-width:2px;
+}
+.ql-feed-repeat-head {
+  display:flex; align-items:center; gap:var(--sp-6);
+  font-weight:700; color:var(--tc-sage);
+  font-size:var(--fs-sm);
+}
+.ql-feed-repeat-head .zi { width:var(--icon-base); height:var(--icon-base); }
+.ql-feed-repeat-sub {
+  font-size:var(--fs-xs);
+  color:var(--mid);
+  margin-top:var(--sp-4);
+  font-weight:500;
+  line-height:var(--lh-snug);
+}
+
+/* L2 Combo chips — lavender outlined; freq badge inline */
+.ql-feed-combo-chip {
+  background:var(--lav-light);
+  border:1.5px solid var(--lavender);
+  border-radius:var(--r-xl);
+  padding:var(--sp-10) var(--sp-12);
+  cursor:pointer;
+  min-height:36px;
+  transition:transform var(--ease-fast);
+}
+.ql-feed-combo-chip:active { transform:scale(0.985); }
+.ql-feed-combo-head {
+  display:flex; align-items:center; gap:var(--sp-6);
+  font-weight:700; color:var(--tc-lav);
+  font-size:var(--fs-sm);
+}
+.ql-feed-combo-head .zi { width:var(--icon-base); height:var(--icon-base); }
+.ql-feed-combo-conf {
+  margin-left:auto;
+  font-size:var(--fs-2xs);
+  background:var(--lavender); color:var(--text);
+  padding:var(--sp-2) var(--sp-6);
+  border-radius:var(--r-full);
+  font-weight:700;
+}
+.ql-feed-combo-sub {
+  font-size:var(--fs-xs);
+  color:var(--mid);
+  margin-top:var(--sp-4);
+  font-weight:500;
+  line-height:var(--lh-snug);
+}
+
+/* Items list — current meal being built */
+.ql-feed-items-list {
+  background:var(--white);
+  border:1px solid #ece4dd;
+  border-radius:var(--r-xl);
+  overflow:hidden;
+}
+.ql-feed-items-empty {
+  text-align:center;
+  color:var(--light);
+  padding:var(--sp-16);
+  font-style:italic;
+  font-size:var(--fs-sm);
+}
+.ql-feed-item-row {
+  display:flex; align-items:center; gap:var(--sp-8);
+  padding:var(--sp-8) var(--sp-10);
+  border-bottom:1px solid #f4ece6;
+  min-height:48px;
+}
+.ql-feed-item-row:last-of-type { border-bottom:none; }
+.ql-feed-item-icon {
+  width:28px; height:28px;
+  background:var(--sage-light); color:var(--tc-sage);
+  border-radius:var(--r-full);
+  display:inline-flex; align-items:center; justify-content:center;
+  font-size:var(--fs-sm); font-weight:700;
+  flex-shrink:0;
+}
+.ql-feed-item-name {
+  flex:1; font-weight:600; font-size:var(--fs-base);
+  display:flex; flex-direction:column;
+  line-height:var(--lh-snug);
+}
+.ql-feed-item-meta {
+  font-size:var(--fs-2xs);
+  color:var(--light);
+  text-transform:uppercase;
+  letter-spacing:var(--ls-wide);
+  font-weight:500;
+  margin-top:var(--sp-2);
+}
+.ql-feed-item-x {
+  width:32px; height:32px;
+  display:inline-flex; align-items:center; justify-content:center;
+  border-radius:var(--r-full);
+  background:var(--rose-light); color:var(--tc-rose);
+  font-weight:700; font-size:var(--fs-md);
+  border:none; cursor:pointer;
+  flex-shrink:0;
+  margin-left:var(--sp-2);
+  transition:transform var(--ease-fast);
+}
+.ql-feed-item-x:active { transform:scale(0.9); }
+
+/* Per-food quantity stepper — [− qty unit +] */
+.ql-feed-qty-stepper {
+  display:inline-flex; align-items:center;
+  background:var(--warm);
+  border-radius:var(--r-full);
+  padding:var(--sp-2);
+  flex-shrink:0;
+}
+.ql-feed-qty-step {
+  width:32px; height:32px;
+  display:inline-flex; align-items:center; justify-content:center;
+  border-radius:var(--r-full);
+  background:var(--white); color:var(--tc-sage);
+  font-weight:700; font-size:var(--fs-base);
+  border:1px solid #ece4dd;
+  cursor:pointer;
+  font-family:'Nunito', sans-serif;
+  transition:transform var(--ease-fast);
+}
+.ql-feed-qty-step:active { transform:scale(0.92); background:var(--sage-light); }
+.ql-feed-qty-val {
+  padding:0 var(--sp-8);
+  font-weight:700;
+  min-width:52px; text-align:center;
+  font-size:var(--fs-sm);
+  color:var(--text);
+}
+.ql-feed-qty-unit {
+  font-size:var(--fs-2xs);
+  color:var(--mid);
+  letter-spacing:0;
+  font-weight:500;
+}
+
+/* L3 Next-item ribbon — horizontal scroll; confidence % per chip */
+.ql-feed-next-ribbon {
+  display:flex; gap:var(--sp-6);
+  overflow-x:auto;
+  padding:var(--sp-4) 0;
+  -webkit-overflow-scrolling:touch;
+}
+.ql-feed-next-chip {
+  display:inline-flex; align-items:center; gap:var(--sp-4);
+  background:var(--sage-light);
+  color:var(--tc-sage);
+  font-weight:700; font-size:var(--fs-sm);
+  padding:var(--sp-6) var(--sp-12);
+  border-radius:var(--r-full);
+  border:1px solid var(--sage);
+  flex-shrink:0;
+  min-height:36px;
+  cursor:pointer;
+  font-family:'Nunito', sans-serif;
+  transition:transform var(--ease-fast);
+}
+.ql-feed-next-chip:active { transform:scale(0.94); }
+.ql-feed-next-conf {
+  font-size:9px;
+  background:var(--white); color:var(--tc-sage);
+  border-radius:var(--r-full);
+  padding:1px var(--sp-6);
+  margin-left:var(--sp-2);
+  font-weight:700;
+  letter-spacing:0;
+}
+
+/* L4 Typeahead dropdown rows — qty hint inlined */
+.ql-feed-ta-row {
+  display:flex; align-items:center; gap:var(--sp-8);
+  padding:var(--sp-8) var(--sp-10);
+  border-bottom:1px solid #f4ece6;
+  cursor:pointer;
+  min-height:36px;
+}
+.ql-feed-ta-row:last-of-type { border-bottom:none; }
+.ql-feed-ta-row:active { background:var(--sage-light); }
+.ql-feed-ta-name {
+  flex:1;
+  font-weight:600; font-size:var(--fs-base);
+  color:var(--text);
+}
+.ql-feed-ta-meta {
+  font-size:var(--fs-2xs);
+  color:var(--mid);
+  text-transform:uppercase;
+  letter-spacing:var(--ls-wide);
+  font-weight:500;
+}
+
+/* Skip meal button — neutral chrome; pairs visually with Save Feed */
+.ql-save-skip {
+  background:var(--warm);
+  color:var(--mid);
+  border:1.5px solid #d8ccc4;
+  border-radius:var(--r-full);
+  padding:var(--sp-10) var(--sp-16);
+  font-weight:600; font-size:var(--fs-sm);
+  font-family:'Nunito', sans-serif;
+  cursor:pointer;
+  min-height:44px;
+  transition:transform var(--ease-fast), background-color var(--ease-fast);
+}
+.ql-save-skip:active { transform:scale(0.97); background:#f0e8e0; }
+.ql-save-skip:hover { background:#f8f0e8; }
+
+/* Dark mode — preserve domain identity; deepen backgrounds */
+[data-theme="dark"] .ql-feed-repeat-chip { background:var(--surface-alt); border-color:var(--tc-sage); }
+[data-theme="dark"] .ql-feed-repeat-chip.primary { background:#1e3028; }
+[data-theme="dark"] .ql-feed-repeat-head { color:#7ac0a0; }
+[data-theme="dark"] .ql-feed-combo-chip { background:#2a2240; border-color:var(--tc-lav); }
+[data-theme="dark"] .ql-feed-combo-head { color:#b8a8e0; }
+[data-theme="dark"] .ql-feed-combo-conf { background:var(--lavender); color:var(--text); }
+[data-theme="dark"] .ql-feed-items-list { background:var(--surface); border-color:#3a2e3e; }
+[data-theme="dark"] .ql-feed-item-row { border-bottom-color:#3a2e3e; }
+[data-theme="dark"] .ql-feed-qty-stepper { background:#221c28; }
+[data-theme="dark"] .ql-feed-qty-step { background:var(--surface); border-color:#3a2e3e; color:#7ac0a0; }
+[data-theme="dark"] .ql-feed-next-chip { background:#1e3028; color:#7ac0a0; border-color:var(--tc-sage); }
+[data-theme="dark"] .ql-feed-next-conf { background:var(--surface); color:#7ac0a0; }
+[data-theme="dark"] .ql-save-skip { background:#221c28; color:var(--mid); border-color:#3a2e3e; }
+
 /* ── Quick Log Toast ── */
 .ql-toast {
   position:fixed; bottom:90px; left:50%; transform:translateX(-50%) translateY(20px);
@@ -12827,7 +13076,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
   </div>
 </div>
 
-<!-- Quick Log Modal: Feed -->
+<!-- Quick Log Modal: Feed (F-2 redesign — autofill-first; spec: docs/specs/food-sub-tab-v1.md §F-2) -->
 <div class="ql-modal-overlay" id="qlModal-feed" data-action="closeQuickModalSelf">
   <div class="ql-modal">
     <div class="ql-modal-header">
@@ -12848,14 +13097,33 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
         <label class="micro-label">Date</label>
         <div class="ql-bf-row" id="qlBackfillPills"></div>
       </div>
-      <div id="qlFreqWrap" style="display:none;">
-        <label class="micro-label">Frequent</label>
-        <div class="ql-freq-row" id="qlFreqPills"></div>
+      <!-- F-2: L1 Repeat rail — "Same as yesterday's B" / "Same as today's lunch" (dinner only, ratification #6) -->
+      <div id="qlFeedRepeatWrap" class="ql-feed-rail-wrap" style="display:none;">
+        <label class="micro-label">Your usual</label>
+        <div class="ql-feed-rail" id="qlFeedRepeatRail"></div>
       </div>
+      <!-- F-2: L2 Combo template rail — "Your usual breakfast" rolling-14d or curated cold-start -->
+      <div id="qlFeedCombosWrap" class="ql-feed-rail-wrap" style="display:none;">
+        <label class="micro-label" id="qlFeedCombosLabel">Suggested combos</label>
+        <div class="ql-feed-rail" id="qlFeedCombosRail"></div>
+      </div>
+      <!-- F-2: Items list — populated as items added; qty steppers per row -->
+      <div id="qlFeedItemsWrap">
+        <label class="micro-label">Items</label>
+        <div class="ql-feed-items-list" id="qlFeedItemsList">
+          <div class="ql-feed-items-empty">Tap a combo above, or type an item below</div>
+        </div>
+      </div>
+      <!-- F-2: L3 Next-item prediction ribbon — appears after first item; co-occurrence ranked -->
+      <div id="qlFeedNextWrap" class="ql-feed-rail-wrap" style="display:none;">
+        <label class="micro-label" id="qlFeedNextLabel">You usually add</label>
+        <div class="ql-feed-next-ribbon" id="qlFeedNextRibbon"></div>
+      </div>
+      <!-- F-2: L4 Typeahead input — NUTRITION + introduced foods + recent; default qty/unit inlined -->
       <div>
-        <label class="micro-label">What did Ziva eat?</label>
+        <label class="micro-label">Add item</label>
         <div class="meal-input-wrap">
-          <input type="text" id="qlFeedInput" class="form-input input-ctx-peach" placeholder="e.g. ragi porridge, dal rice..." autocomplete="off" oninput="updateQLFeedDropdown()">
+          <input type="text" id="qlFeedInput" class="form-input input-ctx-peach" placeholder="Type to add (e.g. 'av' for avocado mash)" autocomplete="off" data-action="qlFeedTypeaheadInput" data-action-on="input">
           <div class="meal-dropdown" id="qlFeedDropdown"></div>
         </div>
       </div>
@@ -12864,12 +13132,8 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
         <input type="time" id="qlFeedTime" class="form-input input-ctx-peach" style="width:90px;padding:5px 8px;font-size:var(--fs-sm);">
         <span class="t-xs t-light">optional</span>
       </div>
-      <div id="qlSameAsWrap" style="display:none;">
-        <label class="micro-label">Quick repeat</label>
-        <div class="d-flex gap-8 flex-wrap" id="qlSameAsPills"></div>
-      </div>
       <div>
-        <label class="micro-label">How much?</label>
+        <label class="micro-label">How much overall?</label>
         <div class="ql-meal-pills" id="qlIntakePills">
           <div class="ql-intake-pill" data-mi-qlval="0.25"><svg class="zi"><use href="#zi-spoon"/></svg> Few bites</div>
           <div class="ql-intake-pill" data-mi-qlval="0.5"><svg class="zi"><use href="#zi-halfcircle"/></svg> Half</div>
@@ -12877,7 +13141,10 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
           <div class="ql-intake-pill" data-mi-qlval="1.0"><svg class="zi"><use href="#zi-star"/></svg> All</div>
         </div>
       </div>
-      <button class="ql-save ql-save-feed">Save Feed <svg class="zi"><use href="#zi-check"/></svg></button>
+      <div class="d-flex gap-8" style="align-items:stretch;">
+        <button class="ql-save-skip" data-action="qlFeedSkipMeal" type="button" title="Mark this meal as intentionally skipped">Skip this meal</button>
+        <button class="ql-save ql-save-feed flex-1-min100">Save Feed <svg class="zi"><use href="#zi-check"/></svg></button>
+      </div>
     </div>
   </div>
 </div>
@@ -19634,6 +19901,13 @@ function init() {
     else if (action === 'qlOpenPoop') { _qlSuggestUsed = true; openQuickModal('poop'); }
     else if (action === 'qlOpenActivity') { _qlSuggestUsed = true; openQuickModal('activity'); }
     else if (action === 'qlSwitchSuggest') _qlSwitchSuggest(arg);
+    // ── F-2 FOB Feed sheet handlers (spec: docs/specs/food-sub-tab-v1.md §F-2) ──
+    else if (action === 'qlFeedApplyRepeat' && typeof qlFeedApplyRepeat === 'function') qlFeedApplyRepeat(arg);
+    else if (action === 'qlFeedApplyCombo' && typeof qlFeedApplyCombo === 'function') qlFeedApplyCombo(arg);
+    else if (action === 'qlFeedAddItem' && typeof qlFeedAddItem === 'function') qlFeedAddItem(arg, arg2);
+    else if (action === 'qlFeedAdjustQty' && typeof qlFeedAdjustQty === 'function') qlFeedAdjustQty(arg, arg2);
+    else if (action === 'qlFeedRemoveItem' && typeof qlFeedRemoveItem === 'function') qlFeedRemoveItem(arg);
+    else if (action === 'qlFeedSkipMeal' && typeof qlFeedSkipMeal === 'function') qlFeedSkipMeal();
     // ── Food Favorites ──
     else if (action === 'foodToggleFavorite') {
       toggleFoodFavorite(arg);
@@ -19705,6 +19979,7 @@ function init() {
     const action = el.dataset.action;
     if (action === 'checkVaccDateShift') checkVaccDateShift();
     else if (action === 'ctInputAnswer' && typeof ctInputAnswer === 'function') ctInputAnswer(el.dataset.arg);
+    else if (action === 'qlFeedTypeaheadInput' && typeof qlFeedTypeaheadInput === 'function') qlFeedTypeaheadInput();
   });
 
   // ── Checkbox delegation (vacc completion multi-check) ──
@@ -61573,13 +61848,12 @@ function openQuickModal(type) {
     document.querySelectorAll('.ql-meal-pill').forEach(p => {
       p.classList.toggle('active', p.dataset.meal === _qlMeal);
     });
-    document.getElementById('qlFeedInput').value = '';
     const qlTimeEl = document.getElementById('qlFeedTime');
     if (qlTimeEl) qlTimeEl.value = '';
-    const qlDD = document.getElementById('qlFeedDropdown');
-    if (qlDD) qlDD.classList.remove('open');
-    renderQLSameAsPills();
-    renderQLFreqPills();
+    // F-2: reset items list state + render the four autofill regions
+    // (L1 repeat / L2 combo / items list / L3 next-item ribbon).
+    if (typeof _qlFeedReset === 'function') _qlFeedReset();
+    if (typeof _qlRenderFeedSheet === 'function') _qlRenderFeedSheet();
     // Reset intake pills to default (Most)
     _miWireQLIntakePills();
     // Hide backfill UI unless in backfill mode
@@ -63761,6 +64035,8 @@ function qaAnswerFavoriteFoods() {
 function setQLMeal(meal) {
   _qlMeal = meal;
   document.querySelectorAll('.ql-meal-pill').forEach(p => p.classList.toggle('active', p.dataset.meal === meal));
+  // F-2: refresh autofill regions on meal change — repeats + combos differ per slot.
+  if (typeof _qlRenderFeedSheet === 'function') _qlRenderFeedSheet();
 }
 
 function adjQLWake(delta) {
@@ -63809,32 +64085,339 @@ function undoLastQL() {
   }
 }
 
+// ═══════════════════════════════════════════════════════════════
+// F-2 — FOB Feed sheet render + handlers
+// Spec: docs/specs/food-sub-tab-v1.md §F-2
+// State: _qlFeedItems is the current items array being built. Stays in
+// sync with the rendered Items list via _qlRenderItemsList. Save writes
+// structured shape via _fdWriteStructuredMeal (data.js).
+// ═══════════════════════════════════════════════════════════════
+
+var _qlFeedItems = [];
+var _qlFeedSourceFlow = 'fob-feed';  // 'fob-repeat' | 'fob-combo' | 'fob-novel' | 'fob-feed'
+
+function _qlFeedReset() {
+  _qlFeedItems = [];
+  _qlFeedSourceFlow = 'fob-feed';
+  var inp = document.getElementById('qlFeedInput');
+  if (inp) inp.value = '';
+  var dd = document.getElementById('qlFeedDropdown');
+  if (dd) { dd.innerHTML = ''; dd.classList.remove('open'); }
+}
+
+// Render all dynamic regions of the FOB Feed sheet. Called on open + after
+// every state change (item add/remove/qty adjust, meal slot change).
+function _qlRenderFeedSheet() {
+  _qlRenderRepeatRail();
+  _qlRenderCombosRail();
+  _qlRenderItemsList();
+  _qlRenderNextItemRibbon();
+}
+
+// L1 — Repeat rail. Surfaces yesterday's/recent matching-slot meals as
+// one-tap apply chips. For dinner, "Same as today's lunch" leads if logged.
+function _qlRenderRepeatRail() {
+  var wrap = document.getElementById('qlFeedRepeatWrap');
+  var rail = document.getElementById('qlFeedRepeatRail');
+  if (!wrap || !rail) return;
+  var candidates = window._fdGetRepeatCandidates(_qlMeal, 3);
+  if (!candidates || candidates.length === 0) {
+    wrap.style.display = 'none';
+    rail.innerHTML = '';
+    return;
+  }
+  wrap.style.display = '';
+  rail.innerHTML = candidates.map(function(c, i) {
+    return '<div class="ql-feed-repeat-chip' + (i === 0 ? ' primary' : '') + '"' +
+           ' data-action="qlFeedApplyRepeat" data-arg="' + escAttr(c.id) + '">' +
+           '<div class="ql-feed-repeat-head">' +
+             '<svg class="zi"><use href="#zi-rainbow"/></svg> ' + escHtml(c.label) +
+           '</div>' +
+           '<div class="ql-feed-repeat-sub">' + escHtml(c.itemsText) + '</div>' +
+           '</div>';
+  }).join('');
+}
+
+// L2 — Combo template rail. Hidden once items present (parent has
+// committed to building manually; offering full-replace combos would
+// confuse). Shows rolling-14d top combos OR curated cold-start fallback.
+function _qlRenderCombosRail() {
+  var wrap = document.getElementById('qlFeedCombosWrap');
+  var rail = document.getElementById('qlFeedCombosRail');
+  var label = document.getElementById('qlFeedCombosLabel');
+  if (!wrap || !rail) return;
+  if (_qlFeedItems.length > 0) {
+    wrap.style.display = 'none';
+    rail.innerHTML = '';
+    return;
+  }
+  var combos = window._fdGetCombosForMeal(_qlMeal, { maxResults: 3 });
+  if (!combos || combos.length === 0) {
+    wrap.style.display = 'none';
+    rail.innerHTML = '';
+    return;
+  }
+  wrap.style.display = '';
+  if (label) {
+    label.textContent = combos[0].source === 'curated'
+      ? 'Suggested combos'
+      : 'Your usual ' + _qlMeal;
+  }
+  rail.innerHTML = combos.map(function(c) {
+    var freq = c.freq ? '<span class="ql-feed-combo-conf">' + c.freq + '×</span>' : '';
+    return '<div class="ql-feed-combo-chip" data-action="qlFeedApplyCombo" data-arg="' + escAttr(c.id) + '">' +
+           '<div class="ql-feed-combo-head">' +
+             '<svg class="zi"><use href="#zi-bowl"/></svg> ' + escHtml(c.label) + freq +
+           '</div>' +
+           '<div class="ql-feed-combo-sub">' + escHtml(c.itemsText) + '</div>' +
+           '</div>';
+  }).join('');
+}
+
+// Items list — current meal items with qty stepper + remove.
+function _qlRenderItemsList() {
+  var list = document.getElementById('qlFeedItemsList');
+  if (!list) return;
+  if (_qlFeedItems.length === 0) {
+    list.innerHTML = '<div class="ql-feed-items-empty">Tap a combo above, or type an item below</div>';
+    return;
+  }
+  list.innerHTML = _qlFeedItems.map(function(item, idx) {
+    var initial = (item.name || '?').charAt(0).toUpperCase();
+    var qtyDisplay = _qlFormatQty(item.qty);
+    return '<div class="ql-feed-item-row">' +
+           '<span class="ql-feed-item-icon">' + escHtml(initial) + '</span>' +
+           '<div class="ql-feed-item-name">' + escHtml(item.name) +
+             '<span class="ql-feed-item-meta">' + escHtml(item.source || 'manual') + '</span>' +
+           '</div>' +
+           '<div class="ql-feed-qty-stepper">' +
+             '<button class="ql-feed-qty-step" data-action="qlFeedAdjustQty" data-arg="' + idx + '" data-arg2="dec" type="button" aria-label="Decrease quantity">−</button>' +
+             '<span class="ql-feed-qty-val">' + qtyDisplay +
+               '<span class="ql-feed-qty-unit"> ' + escHtml(item.unit || '') + '</span>' +
+             '</span>' +
+             '<button class="ql-feed-qty-step" data-action="qlFeedAdjustQty" data-arg="' + idx + '" data-arg2="inc" type="button" aria-label="Increase quantity">+</button>' +
+           '</div>' +
+           '<button class="ql-feed-item-x" data-action="qlFeedRemoveItem" data-arg="' + idx + '" type="button" aria-label="Remove ' + escAttr(item.name) + '">×</button>' +
+           '</div>';
+  }).join('');
+}
+
+// Format qty as a unicode vulgar fraction when possible (¼ ½ ¾) plus
+// mixed numbers (1¼, 1½, 2¾). Outside the common set, falls back to
+// decimal with 2dp rounding.
+function _qlFormatQty(q) {
+  if (typeof q !== 'number' || isNaN(q)) return '1';
+  if (q === 0.25) return '¼';
+  if (q === 0.5)  return '½';
+  if (q === 0.75) return '¾';
+  var whole = Math.floor(q);
+  var frac = Math.round((q - whole) * 100) / 100;
+  if (frac === 0) return String(whole);
+  if (frac === 0.25) return whole + '¼';
+  if (frac === 0.5)  return whole + '½';
+  if (frac === 0.75) return whole + '¾';
+  return (Math.round(q * 100) / 100).toString();
+}
+
+// L3 — Next-item ribbon. Only appears after first item added. Confidence
+// % surfaced per chip (CV3-006 Honesty axis: parent sees WHY suggested).
+function _qlRenderNextItemRibbon() {
+  var wrap = document.getElementById('qlFeedNextWrap');
+  var ribbon = document.getElementById('qlFeedNextRibbon');
+  var label = document.getElementById('qlFeedNextLabel');
+  if (!wrap || !ribbon) return;
+  if (_qlFeedItems.length === 0) {
+    wrap.style.display = 'none';
+    ribbon.innerHTML = '';
+    return;
+  }
+  var predictions = window._fdGetNextItemPredictions(_qlFeedItems, _qlMeal, 4);
+  if (!predictions || predictions.length === 0) {
+    wrap.style.display = 'none';
+    ribbon.innerHTML = '';
+    return;
+  }
+  wrap.style.display = '';
+  if (label) {
+    var anchorName = _qlFeedItems[_qlFeedItems.length - 1].name;
+    label.textContent = _qlFeedItems.length === 1
+      ? 'You usually add (with ' + anchorName + ')'
+      : 'You usually add';
+  }
+  ribbon.innerHTML = predictions.map(function(p) {
+    return '<button class="ql-feed-next-chip" data-action="qlFeedAddItem"' +
+           ' data-arg="' + escAttr(p.name) + '" data-arg2="next" type="button">' +
+           '+ ' + escHtml(p.name) +
+           '<span class="ql-feed-next-conf">' + p.confidence + '%</span>' +
+           '</button>';
+  }).join('');
+}
+
+// ── F-2 handlers ──
+
+function qlFeedApplyRepeat(id) {
+  var cands = window._fdGetRepeatCandidates(_qlMeal, 6);
+  var found = cands.find(function(c) { return c.id === id; });
+  if (!found) return;
+  _qlFeedItems = found.items.slice().map(function(it) { return Object.assign({}, it); });
+  _qlFeedSourceFlow = 'fob-repeat';
+  _qlRenderFeedSheet();
+}
+
+function qlFeedApplyCombo(id) {
+  var combos = window._fdGetCombosForMeal(_qlMeal, { maxResults: 6 });
+  var found = combos.find(function(c) { return c.id === id; });
+  if (!found) return;
+  _qlFeedItems = found.items.slice().map(function(it) { return Object.assign({}, it); });
+  _qlFeedSourceFlow = 'fob-combo';
+  _qlRenderFeedSheet();
+}
+
+function qlFeedAddItem(name, source) {
+  if (!name) return;
+  var defaults = window._fdResolveQtyDefaults(name);
+  _qlFeedItems.push({
+    name: name,
+    qty: defaults.qty,
+    unit: defaults.unit,
+    nutritionRef: String(name).toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim(),
+    source: source || 'manual',
+  });
+  if (source === 'next' || source === 'typeahead') {
+    if (_qlFeedSourceFlow === 'fob-feed') _qlFeedSourceFlow = 'fob-novel';
+  }
+  // Clear typeahead input + dropdown
+  var inp = document.getElementById('qlFeedInput');
+  if (inp) inp.value = '';
+  var dd = document.getElementById('qlFeedDropdown');
+  if (dd) { dd.innerHTML = ''; dd.classList.remove('open'); }
+  _qlRenderFeedSheet();
+}
+
+function qlFeedAdjustQty(idxStr, dir) {
+  var idx = parseInt(idxStr, 10);
+  if (isNaN(idx) || !_qlFeedItems[idx]) return;
+  var item = _qlFeedItems[idx];
+  var defaults = window._fdResolveQtyDefaults(item.name);
+  var step = defaults.step || 0.25;
+  var delta = (dir === 'inc') ? step : -step;
+  var newQty = item.qty + delta;
+  if (newQty <= 0) return;  // don't allow zero — use × to remove
+  item.qty = Math.round(newQty * 100) / 100;
+  _qlRenderItemsList();
+}
+
+function qlFeedRemoveItem(idxStr) {
+  var idx = parseInt(idxStr, 10);
+  if (isNaN(idx) || !_qlFeedItems[idx]) return;
+  _qlFeedItems.splice(idx, 1);
+  _qlRenderFeedSheet();
+}
+
+function qlFeedTypeaheadInput() {
+  var inp = document.getElementById('qlFeedInput');
+  if (!inp) return;
+  var q = inp.value.trim();
+  var dd = document.getElementById('qlFeedDropdown');
+  if (!dd) return;
+  if (q.length < 1) {
+    dd.classList.remove('open');
+    dd.innerHTML = '';
+    return;
+  }
+  var matches = window._fdSearchNutrition(q, { max: 8 });
+  if (matches.length === 0) {
+    dd.innerHTML = '<div class="meal-dropdown-empty">No match. Press Enter to add as new food.</div>';
+    dd.classList.add('open');
+    return;
+  }
+  dd.innerHTML = matches.map(function(m) {
+    return '<div class="meal-dropdown-row ql-feed-ta-row"' +
+           ' data-action="qlFeedAddItem" data-arg="' + escAttr(m.name) + '" data-arg2="typeahead">' +
+           '<span class="ql-feed-ta-name">' + escHtml(m.name) + '</span>' +
+           '<span class="ql-feed-ta-meta">' + escHtml(m.source) + ' · ' +
+             _qlFormatQty(m.qty) + ' ' + escHtml(m.unit) +
+           '</span>' +
+           '</div>';
+  }).join('');
+  dd.classList.add('open');
+}
+
+function qlFeedSkipMeal() {
+  var dateStr = _qlBackfillDate || today();
+  if (!_qlMeal) return;
+  // Capture prev value for undo
+  var fd = load(KEYS.feeding, {}) || {};
+  var prevVal = fd[dateStr] ? fd[dateStr][_qlMeal] : '';
+  window._fdMarkMealSkipped(dateStr, _qlMeal);
+  var meal = _qlMeal;
+  var undoFn = function() {
+    var f = load(KEYS.feeding, {}) || {};
+    if (f[dateStr]) { f[dateStr][meal] = prevVal || ''; save(KEYS.feeding, f); feedingData = f; }
+    if (typeof _islMarkDirty === 'function') _islMarkDirty('diet');
+    var curTab2 = TAB_ORDER.find(function(t) { return document.getElementById('tab-' + t) && document.getElementById('tab-' + t).classList.contains('active'); });
+    if (curTab2 === 'diet') { if (typeof initFeeding === 'function') initFeeding(); if (typeof renderDietStats === 'function') renderDietStats(); }
+    if (curTab2 === 'home') renderHome();
+  };
+  closeQuickLogAll();
+  showQLToast(capitalize(meal) + ' marked as skipped', 4000, undoFn);
+  var curTab = TAB_ORDER.find(function(t) { return document.getElementById('tab-' + t) && document.getElementById('tab-' + t).classList.contains('active'); });
+  if (curTab === 'diet') { if (typeof initFeeding === 'function') initFeeding(); if (typeof renderDietStats === 'function') renderDietStats(); }
+  if (curTab === 'home') renderHome();
+}
+
 // ── Quick Log Save Functions ──
 
 function saveQLFeed() {
-  const food = document.getElementById('qlFeedInput').value.trim();
-  if (!food) { document.getElementById('qlFeedInput').focus(); return; }
   const dateStr = _qlBackfillDate || today();
 
-  // Load feeding data and merge into the correct day
-  const feeding = load(KEYS.feeding, {}) || {};
-  if (!feeding[dateStr]) feeding[dateStr] = { breakfast:'', lunch:'', dinner:'', snack:'' };
-  const day = feeding[dateStr];
+  // F-2: Fold any unsubmitted typed text in qlFeedInput as a final item
+  // (covers the "typed without picking typeahead → pressed Save" case).
+  // Comma-split for parents who paste a multi-item line.
+  const typedRaw = (document.getElementById('qlFeedInput')?.value || '').trim();
+  if (typedRaw) {
+    typedRaw.split(',').map(function(s) { return s.trim(); }).filter(Boolean).forEach(function(nm) {
+      const defaults = window._fdResolveQtyDefaults(nm);
+      _qlFeedItems.push({
+        name: nm,
+        qty: defaults.qty,
+        unit: defaults.unit,
+        nutritionRef: String(nm).toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim(),
+        source: 'typed',
+      });
+    });
+    if (_qlFeedSourceFlow === 'fob-feed') _qlFeedSourceFlow = 'fob-novel';
+    document.getElementById('qlFeedInput').value = '';
+  }
+
+  // Guard: must have at least one item to save.
+  if (_qlFeedItems.length === 0) {
+    document.getElementById('qlFeedInput')?.focus();
+    return;
+  }
 
   // Capture prev value for undo BEFORE mutation
+  const feedingPrev = load(KEYS.feeding, {}) || {};
   const undoMealKey = _qlMeal;
-  const prevMealValue = day[undoMealKey] || '';
+  const prevMealValue = (feedingPrev[dateStr] && feedingPrev[dateStr][undoMealKey]) || '';
 
-  day[_qlMeal] = day[_qlMeal] ? day[_qlMeal] + ', ' + food : food;
-  // Save meal time if entered
-  const qlTime = document.getElementById('qlFeedTime')?.value;
-  if (qlTime) day[_qlMeal + '_time'] = qlTime;
-  // Save intake level from QL pills
-  if (_qlSelectedIntake && _qlMeal !== 'snack') {
-    day[_qlMeal + '_intake'] = _qlSelectedIntake;
-  }
-  save(KEYS.feeding, feeding);
-  feedingData = feeding;
+  // Build the structured payload + write via the canonical F-2 writer.
+  const qlTime = (document.getElementById('qlFeedTime')?.value) || null;
+  const overallIntake = (typeof _qlSelectedIntake === 'number' && _qlSelectedIntake > 0)
+    ? _qlSelectedIntake
+    : 0.75;  // ratified default "Most"
+  const payload = {
+    items: _qlFeedItems.slice(),
+    time: qlTime,
+    overallIntake: overallIntake,
+    sourceFlow: _qlFeedSourceFlow,
+  };
+  window._fdWriteStructuredMeal(dateStr, _qlMeal, payload);
+
+  // Build legacy `food` string for downstream callers (toast nutrient flash,
+  // autoIntroduceFoodsFromDay, _qlFeedInsight). Comma-joined item names.
+  const food = _qlFeedItems.map(function(it) { return it.name; }).join(', ');
+
   _tsfMarkDirty();
 
   _islMarkDirty('diet');

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.28-4",
+  "version": "2026.05.28-5",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.28-10",
+  "version": "2026.05.28-11",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.28-5",
+  "version": "2026.05.28-6",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.28-9",
+  "version": "2026.05.28-10",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.28-7",
+  "version": "2026.05.28-9",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.28-6",
+  "version": "2026.05.28-7",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/audit-feed-sheet-wiring-v1.sh
+++ b/split/audit-feed-sheet-wiring-v1.sh
@@ -127,9 +127,45 @@ else:
     if missing_slots:
         FAILS.append(('curated-combos', f'CURATED_COMBOS missing slot coverage for: {sorted(missing_slots)}'))
 
+# ── 7. NUTRITION join-integrity (V-K-203) ──
+# The qty-defaults registry and curated-combo items are only load-bearing if
+# they join to a real NUTRITION row — F-5 nutrient compute keys off
+# nutritionRef, and the qty resolver's explicit override depends on the key
+# existing. This enforces the contract the nutritionRef comment claims but
+# the gate never actually checked (a typo'd or suffix-only food would ship
+# green, contributing zero nutrient signal). Ref derivation mirrors
+# _fdNutritionRef in data.js: paren-strip, then prep-suffix-stripped stem.
+nutr_block = re.search(r'const NUTRITION\s*=\s*\{(.*?)^\};', data, re.S | re.M)
+if not nutr_block:
+    FAILS.append(('nutrition-join', 'NUTRITION knowledge base not found in data.js'))
+else:
+    nutr_keys = set(re.findall(r"^\s+'([^']+)'\s*:\s*\{", nutr_block.group(1), re.M))
+    def _nutrition_ref(name):
+        base = re.sub(r"\s*\([^)]*\)\s*", "", name.lower()).strip()
+        if base in nutr_keys:
+            return base
+        stem = re.sub(r"\s+", " ", re.sub(r"\b(porridge|mash|puree|pure|sauce|roti|chapati|paratha)\b", "", base)).strip()
+        if stem and stem != base and stem in nutr_keys:
+            return stem
+        return base
+    # 7a. every explicit qty-default key resolves to a NUTRITION row
+    if qty_block:
+        qty_keys = re.findall(r"^\s*'([^']+)'\s*:\s*\{", qty_block.group(1), re.M)
+        orphan_qty = [k for k in qty_keys if k not in nutr_keys]
+        if orphan_qty:
+            FAILS.append(('nutrition-join', f'NUTRITION_QTY_DEFAULTS keys with no NUTRITION row: {orphan_qty}'))
+    # 7b. every curated-combo item's derived nutritionRef resolves to NUTRITION
+    if combos_block:
+        combo_items = []
+        for grp in re.findall(r"items:\s*\[([^\]]*)\]", combos_block.group(1)):
+            combo_items += re.findall(r"'([^']+)'", grp)
+        orphan_combo = sorted({it for it in set(combo_items) if _nutrition_ref(it) not in nutr_keys})
+        if orphan_combo:
+            FAILS.append(('nutrition-join', f'CURATED_COMBOS items whose nutritionRef misses NUTRITION: {orphan_combo}'))
+
 # ── Report ──
 if not FAILS:
-    print(f'audit-feed-sheet-wiring-v1: PASS (4 template wraps + 1 writer call + 7 handlers + 7 dispatchers + 30+ qty defaults + 10+ curated combos with full slot coverage)')
+    print(f'audit-feed-sheet-wiring-v1: PASS (4 template wraps + 1 writer call + 7 handlers + 7 dispatchers + 30+ qty defaults + 10+ curated combos with full slot coverage + NUTRITION join-integrity)')
     sys.exit(0)
 
 print(f'audit-feed-sheet-wiring-v1: FAIL ({len(FAILS)} structural assertion(s) failed)')
@@ -143,6 +179,7 @@ print('  • handlers        — add/restore the F-2 handler functions in intell
 print('  • dispatcher      — wire each handler in core.js click delegation block')
 print('  • nutrition-qty-defaults — keep ≥30 explicit per-food qty entries (top-used floor)')
 print('  • curated-combos  — keep ≥10 entries with all 4 slots represented')
+print('  • nutrition-join  — every qty-default key + curated-combo nutritionRef must resolve to a NUTRITION row')
 print()
 print('Spec: docs/specs/food-sub-tab-v1.md §F-2 / ratification #5 hard tap-budget')
 sys.exit(1)

--- a/split/audit-feed-sheet-wiring-v1.sh
+++ b/split/audit-feed-sheet-wiring-v1.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# audit-feed-sheet-wiring-v1.sh — F-2 structural wiring guard.
+# Spec: docs/specs/food-sub-tab-v1.md §F-2 (ratification #5 — hard tap-budget).
+#
+# Unlike the banned-pattern audits (chip taxonomy, card priority, activity
+# categories, no-personalised-prediction), this is a REQUIRED-PRESENCE
+# audit: it asserts that the wiring enabling the 3-tap-repeat / 4-tap-
+# combo / 6-tap-novel tap budgets stays connected. If a refactor silently
+# unwires the autofill rails or the structured-shape writer, the parent's
+# tap-count for the common case explodes from 4 → 12+ and the build fails
+# loud rather than shipping a regression.
+#
+# Six structural assertions:
+#
+#   1. TEMPLATE WRAPS — qlModal-feed contains the four F-2 wrap IDs
+#      (qlFeedRepeatWrap / qlFeedCombosWrap / qlFeedItemsWrap /
+#      qlFeedNextWrap). Removing any silently kills its rail surface.
+#
+#   2. WRITER CALL — saveQLFeed routes through _fdWriteStructuredMeal.
+#      A regression that reverts to direct day[meal] = string writes
+#      loses qty/unit/sourceFlow on disk + breaks F-3 review surface.
+#
+#   3. HANDLERS — the seven F-2 handlers exist:
+#      qlFeedApplyRepeat / qlFeedApplyCombo / qlFeedAddItem /
+#      qlFeedAdjustQty / qlFeedRemoveItem / qlFeedSkipMeal /
+#      qlFeedTypeaheadInput.
+#
+#   4. DISPATCHER — core.js routes each of the 7 actions. Missing
+#      dispatcher line = tappable element is dead.
+#
+#   5. NUTRITION_QTY_DEFAULTS — ≥30 entries (the top-used floor per
+#      ratification #4). Drops below this and the qty stepper falls
+#      through to category-resolver defaults for foods that should have
+#      explicit values.
+#
+#   6. CURATED_COMBOS — ≥10 entries spanning all four slots (breakfast/
+#      lunch/dinner/snack). L2 cold-start fallback requires variety per
+#      slot; below the floor, new parents see thin combo surface.
+#
+# Usage:   bash split/audit-feed-sheet-wiring-v1.sh   (0 = pass)
+
+set -e
+cd "$(dirname "$0")/.."
+
+python3 - <<'PYEOF'
+import re
+import sys
+
+FAILS = []
+
+# ── 1. Template wraps ──
+# The 4 F-2 wrap IDs are F-2-specific + appear nowhere else in the
+# codebase, so a file-wide grep is sufficient (avoids brittle balanced-
+# brace template parsing). The qlModal-feed block they live inside is
+# the only consumer.
+with open('split/template.html') as f:
+    template = f.read()
+if 'id="qlModal-feed"' not in template:
+    FAILS.append(('template-wraps', 'qlModal-feed block not found in template.html'))
+else:
+    required_wraps = ['qlFeedRepeatWrap', 'qlFeedCombosWrap', 'qlFeedItemsWrap', 'qlFeedNextWrap']
+    missing = [w for w in required_wraps if 'id="' + w + '"' not in template]
+    if missing:
+        FAILS.append(('template-wraps', f'missing required F-2 wrap IDs in template: {missing}'))
+
+# ── 2. Writer call ──
+with open('split/intelligence-quicklog.js') as f:
+    qlog = f.read()
+save_match = re.search(r'function saveQLFeed\(\)\s*\{(.*?)^\}', qlog, re.S | re.M)
+if not save_match:
+    FAILS.append(('writer-call', 'saveQLFeed function not found in intelligence-quicklog.js'))
+elif '_fdWriteStructuredMeal' not in save_match.group(1):
+    FAILS.append(('writer-call', 'saveQLFeed does not call _fdWriteStructuredMeal — structured shape would not persist'))
+
+# ── 3. Handlers ──
+required_handlers = [
+    'qlFeedApplyRepeat',
+    'qlFeedApplyCombo',
+    'qlFeedAddItem',
+    'qlFeedAdjustQty',
+    'qlFeedRemoveItem',
+    'qlFeedSkipMeal',
+    'qlFeedTypeaheadInput',
+]
+missing_handlers = []
+for h in required_handlers:
+    if not re.search(r'function\s+' + re.escape(h) + r'\s*\(', qlog):
+        missing_handlers.append(h)
+if missing_handlers:
+    FAILS.append(('handlers', f'missing F-2 handler function(s) in intelligence-quicklog.js: {missing_handlers}'))
+
+# ── 4. Dispatcher ──
+with open('split/core.js') as f:
+    core = f.read()
+missing_dispatch = []
+for h in required_handlers:
+    # Match either: action === 'handlerName'  OR  routes through handlerName
+    if not re.search(r"action\s*===\s*['\"]" + re.escape(h) + r"['\"]", core):
+        missing_dispatch.append(h)
+if missing_dispatch:
+    FAILS.append(('dispatcher', f'core.js dispatcher missing route(s) for: {missing_dispatch}'))
+
+# ── 5. NUTRITION_QTY_DEFAULTS count ──
+with open('split/data.js') as f:
+    data = f.read()
+qty_block = re.search(r'window\.NUTRITION_QTY_DEFAULTS\s*=\s*\{(.*?)^\};', data, re.S | re.M)
+if not qty_block:
+    FAILS.append(('nutrition-qty-defaults', 'NUTRITION_QTY_DEFAULTS registry not found in data.js'))
+else:
+    entry_count = len(re.findall(r"^\s*'[^']+':\s*\{", qty_block.group(1), re.M))
+    if entry_count < 30:
+        FAILS.append(('nutrition-qty-defaults', f'NUTRITION_QTY_DEFAULTS has {entry_count} entries (floor: 30)'))
+
+# ── 6. CURATED_COMBOS count + slot coverage ──
+combos_block = re.search(r'window\.CURATED_COMBOS\s*=\s*\[(.*?)\];', data, re.S)
+if not combos_block:
+    FAILS.append(('curated-combos', 'CURATED_COMBOS registry not found in data.js'))
+else:
+    combos_text = combos_block.group(1)
+    combo_count = len(re.findall(r"slot:\s*'[^']+'", combos_text))
+    if combo_count < 10:
+        FAILS.append(('curated-combos', f'CURATED_COMBOS has {combo_count} entries (floor: 10)'))
+    # Slot coverage
+    slots_in_combos = set(re.findall(r"slot:\s*'([^']+)'", combos_text))
+    expected_slots = {'breakfast', 'lunch', 'dinner', 'snack'}
+    missing_slots = expected_slots - slots_in_combos
+    if missing_slots:
+        FAILS.append(('curated-combos', f'CURATED_COMBOS missing slot coverage for: {sorted(missing_slots)}'))
+
+# ── Report ──
+if not FAILS:
+    print(f'audit-feed-sheet-wiring-v1: PASS (4 template wraps + 1 writer call + 7 handlers + 7 dispatchers + 30+ qty defaults + 10+ curated combos with full slot coverage)')
+    sys.exit(0)
+
+print(f'audit-feed-sheet-wiring-v1: FAIL ({len(FAILS)} structural assertion(s) failed)')
+for axis, msg in FAILS:
+    print(f'  [{axis}] {msg}')
+print()
+print('Resolution:')
+print('  • template-wraps  — restore the 4 F-2 wrap IDs in qlModal-feed (template.html)')
+print('  • writer-call     — saveQLFeed must call _fdWriteStructuredMeal(dateStr, meal, payload)')
+print('  • handlers        — add/restore the F-2 handler functions in intelligence-quicklog.js')
+print('  • dispatcher      — wire each handler in core.js click delegation block')
+print('  • nutrition-qty-defaults — keep ≥30 explicit per-food qty entries (top-used floor)')
+print('  • curated-combos  — keep ≥10 entries with all 4 slots represented')
+print()
+print('Spec: docs/specs/food-sub-tab-v1.md §F-2 / ratification #5 hard tap-budget')
+sys.exit(1)
+PYEOF

--- a/split/build.sh
+++ b/split/build.sh
@@ -96,6 +96,20 @@ if ! bash audit-activity-categories-v1.sh >&2; then
   echo "BUILD ABORTED: milestones-tab-v1 audit failed. Consume ACTIVITY_CATEGORIES; never fork the registry." >&2
   exit 1
 fi
+# food-sub-tab-v1 F-2 ship-gate (10th audit gate): audit-feed-sheet-wiring-v1.sh
+# blocks regressions that silently unwire the autofill rails or the
+# structured-shape writer in the FOB → FEED Log Feed sheet. Six required-
+# presence assertions: 4 template wraps (qlFeedRepeat/Combos/Items/Next),
+# the _fdWriteStructuredMeal call in saveQLFeed, 7 F-2 handlers, 7 core.js
+# dispatcher routes, ≥30 NUTRITION_QTY_DEFAULTS entries, ≥10 CURATED_COMBOS
+# with all 4 slots covered. Together these enforce ratification #5's hard
+# tap-budget (3-tap repeat / 4-tap combo / 6-tap novel) by guaranteeing the
+# wiring that enables those budgets stays intact. Spec: docs/specs/food-
+# sub-tab-v1.md §F-2. Charter CV3-006 warmth axis (friction reduction).
+if ! bash audit-feed-sheet-wiring-v1.sh >&2; then
+  echo "BUILD ABORTED: food-sub-tab-v1 F-2 wiring audit failed. Restore the FOB Feed sheet structural surface." >&2
+  exit 1
+fi
 # Phase 2 PR-3: bump manifest.json version (date-stamp + same-day counter)
 # before HTML concat. Errors here go to stderr so stdout (HTML) stays clean.
 node bump-version.mjs ../manifest.json

--- a/split/core.js
+++ b/split/core.js
@@ -801,7 +801,7 @@ function init() {
     else if (action === 'navFeedDay') { document.getElementById('feedingDate').value = arg; loadFeedingDay(); switchTab('diet'); }
     else if (action === 'navTabSub') { switchTab(arg); setTimeout(() => switchTrackSub(arg2), 100); }
     else if (action === 'closeScoreAndNav') { closeScorePopup(); setTimeout(() => switchTab(arg), 350); }
-    else if (action === 'qlMealAndOpen') { _qlMeal = arg; openQuickModal(arg2); }
+    else if (action === 'qlMealAndOpen') { _qlMeal = arg; _qlMealExplicit = true; openQuickModal(arg2); }
     else if (action === 'showHeatmapDetail') showHeatmapDetail(arg, parseInt(arg2), arg3);
     else if (action === 'openDoctorModal') { const a = arg; if (a) openDoctorModal(parseInt(a)); else openDoctorModal(); }
     else if (action === 'openFoodCatModal') openFoodCatModal(arg);
@@ -972,7 +972,7 @@ function init() {
     else if (action === 'deleteFoodAndRender') { deleteFood(arg); renderFoodCatSubContent(arg2); }
     else if (action === 'navTabSub') { switchTab(arg); setTimeout(() => switchTrackSub(arg2), 100); }
     else if (action === 'closeScoreAndNav') { closeScorePopup(); setTimeout(() => switchTab(arg), 350); }
-    else if (action === 'qlMealAndOpen') { _qlMeal = arg; openQuickModal(arg2); }
+    else if (action === 'qlMealAndOpen') { _qlMeal = arg; _qlMealExplicit = true; openQuickModal(arg2); }
     else if (action === 'closeAndPromptFever') { closeHomeSymptomChecker(); promptFeverTrack(); }
     else if (action === 'closeAndPromptDiarrhoea') { closeHomeSymptomChecker(); promptDiarrhoeaTrack(); }
     else if (action === 'closeAndPromptVomiting') { closeHomeSymptomChecker(); promptVomitingTrack(); }
@@ -1054,8 +1054,9 @@ function init() {
       } else if (arg === 'afternoon-poop') {
         openQuickModal('poop');
       } else if (arg2) {
-        // Feed nudge — pre-select meal type
+        // Feed nudge — pre-select meal type (F-2 fix C1: set explicit flag)
         _qlMeal = arg2;
+        _qlMealExplicit = true;
         openQuickModal('feed');
         setTimeout(function() {
           document.querySelectorAll('.ql-meal-pill').forEach(function(p) { p.classList.toggle('active', p.dataset.meal === arg2); });

--- a/split/core.js
+++ b/split/core.js
@@ -995,6 +995,13 @@ function init() {
     else if (action === 'qlOpenPoop') { _qlSuggestUsed = true; openQuickModal('poop'); }
     else if (action === 'qlOpenActivity') { _qlSuggestUsed = true; openQuickModal('activity'); }
     else if (action === 'qlSwitchSuggest') _qlSwitchSuggest(arg);
+    // ── F-2 FOB Feed sheet handlers (spec: docs/specs/food-sub-tab-v1.md §F-2) ──
+    else if (action === 'qlFeedApplyRepeat' && typeof qlFeedApplyRepeat === 'function') qlFeedApplyRepeat(arg);
+    else if (action === 'qlFeedApplyCombo' && typeof qlFeedApplyCombo === 'function') qlFeedApplyCombo(arg);
+    else if (action === 'qlFeedAddItem' && typeof qlFeedAddItem === 'function') qlFeedAddItem(arg, arg2);
+    else if (action === 'qlFeedAdjustQty' && typeof qlFeedAdjustQty === 'function') qlFeedAdjustQty(arg, arg2);
+    else if (action === 'qlFeedRemoveItem' && typeof qlFeedRemoveItem === 'function') qlFeedRemoveItem(arg);
+    else if (action === 'qlFeedSkipMeal' && typeof qlFeedSkipMeal === 'function') qlFeedSkipMeal();
     // ── Food Favorites ──
     else if (action === 'foodToggleFavorite') {
       toggleFoodFavorite(arg);
@@ -1066,6 +1073,7 @@ function init() {
     const action = el.dataset.action;
     if (action === 'checkVaccDateShift') checkVaccDateShift();
     else if (action === 'ctInputAnswer' && typeof ctInputAnswer === 'function') ctInputAnswer(el.dataset.arg);
+    else if (action === 'qlFeedTypeaheadInput' && typeof qlFeedTypeaheadInput === 'function') qlFeedTypeaheadInput();
   });
 
   // ── Checkbox delegation (vacc completion multi-check) ──

--- a/split/data.js
+++ b/split/data.js
@@ -2779,6 +2779,301 @@ window.isStructuredFeedingV1 = function(mealVal) {
   return mealVal && typeof mealVal === 'object' && Array.isArray(mealVal.items);
 };
 
+// ═══════════════════════════════════════════════════════════════════════
+// F-2 — per-food quantity defaults, CURATED_COMBOS, skip state, write helper
+// Spec: docs/specs/food-sub-tab-v1.md §F-2; ratifications #2 + #4 + #6.
+// Sidecar registry `NUTRITION_QTY_DEFAULTS` carries explicit qty/unit/step
+// for the top-used foods (the ones the 79-day feeding-data sample shows
+// parents actually log). Foods without an explicit override fall through
+// `_fdResolveQtyDefaults` to a category-based default. Kept as a sidecar
+// (not inline NUTRITION fields) so the qty data is discoverable in one
+// block — same intent as ratification #4 ("extend NUTRITION rows") with
+// edit-locality + maintainability preserved.
+// ═══════════════════════════════════════════════════════════════════════
+
+// Per-food explicit qty defaults. Keys MUST exist in NUTRITION (the
+// audit gate verifies). qty is a number (fractional allowed); unit is a
+// short display string ('pc' / 'tsp' / 'bowl' / 'cup' / 'piece'); step
+// is the +/- increment a single qty-stepper tap applies.
+window.NUTRITION_QTY_DEFAULTS = {
+  // ── GRAINS & STAPLES ──
+  'khichdi':        { qty: 1,    unit: 'bowl', step: 0.25 },
+  'ragi':           { qty: 1,    unit: 'cup',  step: 0.25 },   // porridge form
+  'rice':           { qty: 0.5,  unit: 'bowl', step: 0.25 },
+  'suji':           { qty: 1,    unit: 'cup',  step: 0.25 },
+  'oats':           { qty: 1,    unit: 'cup',  step: 0.25 },
+  'bajra':          { qty: 1,    unit: 'pc',   step: 0.5 },    // roti form
+  'jowar':          { qty: 1,    unit: 'pc',   step: 0.5 },
+  'idli':           { qty: 1,    unit: 'pc',   step: 1 },
+  'dosa':           { qty: 1,    unit: 'pc',   step: 0.5 },
+  'roti':           { qty: 1,    unit: 'pc',   step: 0.5 },
+  'paratha':        { qty: 1,    unit: 'pc',   step: 0.5 },
+  'poha':           { qty: 0.5,  unit: 'bowl', step: 0.25 },
+  // ── LENTILS ──
+  'moong dal':      { qty: 0.5,  unit: 'bowl', step: 0.25 },
+  'masoor dal':     { qty: 0.5,  unit: 'bowl', step: 0.25 },
+  'toor dal':       { qty: 0.5,  unit: 'bowl', step: 0.25 },
+  // ── VEGETABLES ──
+  'carrot':         { qty: 0.25, unit: 'cup',  step: 0.25 },   // mashed/puree form
+  'beetroot':       { qty: 0.25, unit: 'cup',  step: 0.25 },
+  'bottle gourd':   { qty: 0.25, unit: 'cup',  step: 0.25 },
+  'spinach':        { qty: 0.25, unit: 'cup',  step: 0.25 },
+  'tomato':         { qty: 0.5,  unit: 'pc',   step: 0.5 },
+  'cucumber':       { qty: 0.5,  unit: 'pc',   step: 0.25 },
+  'beans':          { qty: 0.25, unit: 'cup',  step: 0.25 },
+  // ── FRUITS ──
+  'apple':          { qty: 0.5,  unit: 'pc',   step: 0.25 },
+  'banana':         { qty: 0.5,  unit: 'pc',   step: 0.25 },
+  'mango':          { qty: 0.25, unit: 'pc',   step: 0.25 },   // small pieces typical
+  'avocado':        { qty: 0.5,  unit: 'pc',   step: 0.25 },
+  'blueberry':      { qty: 5,    unit: 'pc',   step: 2 },
+  'pear':           { qty: 0.5,  unit: 'pc',   step: 0.25 },
+  'papaya':         { qty: 0.25, unit: 'pc',   step: 0.25 },
+  'watermelon':     { qty: 1,    unit: 'cup',  step: 0.5 },    // cubed
+  'pomegranate':    { qty: 0.25, unit: 'cup',  step: 0.25 },   // seeds
+  'date':           { qty: 1,    unit: 'pc',   step: 1 },
+  'chiku':          { qty: 0.5,  unit: 'pc',   step: 0.25 },
+  // ── DAIRY & FATS ──
+  'ghee':           { qty: 1,    unit: 'tsp',  step: 0.5 },
+  'curd':           { qty: 0.25, unit: 'cup',  step: 0.25 },
+  'paneer':         { qty: 1,    unit: 'tbsp', step: 0.5 },    // crumbled
+  // ── NUTS & SEEDS (powdered/soaked) ──
+  'almonds':        { qty: 2,    unit: 'pc',   step: 1 },
+  'walnut':         { qty: 1,    unit: 'pc',   step: 1 },
+  'cashew':         { qty: 2,    unit: 'pc',   step: 1 },
+  'flaxseed':       { qty: 0.5,  unit: 'tsp',  step: 0.5 },
+  'chia seeds':     { qty: 0.5,  unit: 'tsp',  step: 0.5 },
+  // ── SPICES (trace amounts for babies) ──
+  'jeera':          { qty: 0.25, unit: 'tsp',  step: 0.25 },
+  'cumin':          { qty: 0.25, unit: 'tsp',  step: 0.25 },
+  'turmeric':       { qty: 0.25, unit: 'tsp',  step: 0.25 },
+  // ── LIQUIDS ──
+  'coconut water':  { qty: 0.5,  unit: 'cup',  step: 0.25 },
+  'lemon':          { qty: 1,    unit: 'tsp',  step: 0.5 },    // juice
+};
+
+// Category-based fallback for any NUTRITION row without an explicit qty
+// override. `_fdResolveQtyDefaults` walks the food name + NUTRITION tags
+// to pick the best-fitting category. Foods that mismatch all heuristics
+// fall through to the 'fallback' bucket.
+window._FOOD_QTY_CATEGORY_DEFAULTS = {
+  'porridge':       { qty: 1,    unit: 'cup',     step: 0.25 },
+  'roti-flatbread': { qty: 1,    unit: 'pc',      step: 0.5  },
+  'grain-staple':   { qty: 0.5,  unit: 'bowl',    step: 0.25 },
+  'dal-legume':     { qty: 0.5,  unit: 'bowl',    step: 0.25 },
+  'veg-piece':      { qty: 0.5,  unit: 'pc',      step: 0.25 },
+  'veg-mashed':     { qty: 0.25, unit: 'cup',     step: 0.25 },
+  'fruit-piece':    { qty: 0.5,  unit: 'pc',      step: 0.25 },
+  'fruit-berry':    { qty: 5,    unit: 'pc',      step: 2    },
+  'fruit-mash':     { qty: 0.5,  unit: 'pc',      step: 0.25 },
+  'nut-piece':      { qty: 1,    unit: 'pc',      step: 1    },
+  'fat-cooking':    { qty: 1,    unit: 'tsp',     step: 0.5  },
+  'spice':          { qty: 0.25, unit: 'tsp',     step: 0.25 },
+  'liquid-drink':   { qty: 0.5,  unit: 'cup',     step: 0.25 },
+  'fallback':       { qty: 1,    unit: 'serving', step: 1    },
+};
+
+// Resolver — explicit override wins; category fallback otherwise.
+// Returns { qty, unit, step }; never null.
+window._fdResolveQtyDefaults = function(foodName) {
+  if (!foodName) return _FOOD_QTY_CATEGORY_DEFAULTS.fallback;
+  var key = String(foodName).toLowerCase().trim();
+  // Strip parenthetical variants ("ghee (cow)" → "ghee"; "khichdi (masoor dal)" → "khichdi")
+  var base = key.replace(/\s*\([^)]*\)\s*/g, '').trim();
+  // 1. Explicit per-food override
+  if (NUTRITION_QTY_DEFAULTS[base]) return NUTRITION_QTY_DEFAULTS[base];
+  if (NUTRITION_QTY_DEFAULTS[key])  return NUTRITION_QTY_DEFAULTS[key];
+  // 2. Category resolver — name heuristics first
+  if (/porridge|upma|halwa/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['porridge'];
+  if (/\b(roti|chapati|paratha|naan|puri)\b/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['roti-flatbread'];
+  if (/\bdal\b|chickpeas|rajma|chole|peas/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['dal-legume'];
+  if (/\b(berry|cherry|grape|raisin)\b/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['fruit-berry'];
+  if (/mash|puree|sauce/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['fruit-mash'];
+  if (/(juice|water|coconut water|milk)/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['liquid-drink'];
+  if (/(seed|sesame|flax|chia)/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['spice'];
+  // 3. Tag-based fallback from NUTRITION
+  var n = (typeof NUTRITION !== 'undefined' && NUTRITION[base]) || (typeof NUTRITION !== 'undefined' && NUTRITION[key]);
+  if (n && n.tags) {
+    if (n.tags.indexOf('healthy-fats') >= 0 && /oil|ghee|butter/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['fat-cooking'];
+    if (n.tags.indexOf('iron-rich') >= 0 && n.tags.indexOf('protein-rich') >= 0) return _FOOD_QTY_CATEGORY_DEFAULTS['dal-legume'];
+    if (n.tags.indexOf('energy') >= 0 && !n.tags.indexOf('digestive') >= 0) return _FOOD_QTY_CATEGORY_DEFAULTS['grain-staple'];
+  }
+  // 4. Heuristic by nutrient profile
+  if (n && n.nutrients) {
+    if (n.nutrients.indexOf('water') >= 0) return _FOOD_QTY_CATEGORY_DEFAULTS['liquid-drink'];
+  }
+  return _FOOD_QTY_CATEGORY_DEFAULTS['veg-piece'];
+};
+
+// ═══════════════════════════════════════════════════════════════════════
+// CURATED_COMBOS — L2 autofill cold-start fallback (ratification #2 + #4)
+// 12 seed entries: 4 breakfast / 5 lunch+dinner / 3 snack. Age-gated via
+// minAgeMonths; surfaced when rolling-14d window has <7 days of signal.
+// Future curation arc (deferred) can expand from pediatrician guidelines.
+// ═══════════════════════════════════════════════════════════════════════
+window.CURATED_COMBOS = [
+  // ── BREAKFAST (4) ──
+  { slot: 'breakfast', items: ['Ragi porridge', 'Ghee (cow)', 'Banana mash'],
+    rationale: 'iron-base breakfast — ragi for iron, ghee for calorie density, banana for sweetness',
+    minAgeMonths: 6 },
+  { slot: 'breakfast', items: ['Avocado mash', 'Blueberry', 'Mango puree'],
+    rationale: 'good-fat + vitamin-C breakfast',
+    minAgeMonths: 6 },
+  { slot: 'breakfast', items: ['Suji', 'Ghee (cow)', 'Apple puree'],
+    rationale: 'soft-grain breakfast — gentle on stomach + cooked fruit pairing',
+    minAgeMonths: 6 },
+  { slot: 'breakfast', items: ['Oats porridge', 'Ghee (cow)', 'Banana mash'],
+    rationale: 'cereal-fruit breakfast — fibre + slow carbs',
+    minAgeMonths: 7 },
+  // ── LUNCH / DINNER (5) ──
+  { slot: 'lunch', items: ['Khichdi (masoor dal)', 'Ghee (cow)', 'Carrot', 'Bottle gourd'],
+    rationale: 'staple khichdi — protein + ghee + 2 veggies',
+    minAgeMonths: 6 },
+  { slot: 'lunch', items: ['Bajra roti', 'Masoor dal', 'Ghee (cow)', 'Spinach'],
+    rationale: 'millet-roti lunch — bajra for variety + iron-rich spinach',
+    minAgeMonths: 8 },
+  { slot: 'dinner', items: ['Khichdi (moong dal)', 'Ghee (cow)', 'Beetroot', 'Carrot'],
+    rationale: 'lighter moong dal dinner — easier overnight digestion',
+    minAgeMonths: 6 },
+  { slot: 'dinner', items: ['Rice', 'Masoor dal', 'Ghee (cow)'],
+    rationale: 'simple rice + dal dinner — fall-back when kitchen is light',
+    minAgeMonths: 6 },
+  { slot: 'lunch', items: ['Idli', 'Ghee (cow)', 'Tomato'],
+    rationale: 'south-Indian lunch — fermented + gut-friendly',
+    minAgeMonths: 7 },
+  // ── SNACK (3) ──
+  { slot: 'snack', items: ['Cucumber', 'Mango'],
+    rationale: 'hydration + sweet snack',
+    minAgeMonths: 7 },
+  { slot: 'snack', items: ['Coconut water', 'Cucumber'],
+    rationale: 'hot-day hydration — electrolytes + cooling',
+    minAgeMonths: 7 },
+  { slot: 'snack', items: ['Banana', 'Almonds'],
+    rationale: 'calorie-dense snack — fruit + nut for sustained energy',
+    minAgeMonths: 8 },
+];
+
+// Curated combo lookup — returns entries matching slot + Ziva's current age.
+window._fdGetCuratedCombosForMeal = function(meal, ageMonths) {
+  if (!meal || !Array.isArray(CURATED_COMBOS)) return [];
+  return CURATED_COMBOS.filter(function(c) {
+    if (c.slot !== meal) return false;
+    if (typeof ageMonths === 'number' && c.minAgeMonths > ageMonths) return false;
+    return true;
+  });
+};
+
+// ═══════════════════════════════════════════════════════════════════════
+// parseFeedingV1 — read-side normalizer (F-2 ships partial; F-5 ships
+// the full v3-8 parseFeeding tolerating ALL three shapes).
+// Returns: { items: [{name, qty, unit, ...}], time, overallIntake, ... }
+// regardless of input shape. Legacy strings parse via comma-split + qty
+// resolver. Skipped slots return { skipped: true, items: [] }.
+// ═══════════════════════════════════════════════════════════════════════
+window.parseFeedingV1 = function(mealVal) {
+  // Skipped state
+  if (mealVal && typeof mealVal === 'object' && mealVal.skipped === true) {
+    return { items: [], skipped: true, skippedAt: mealVal.skippedAt || null };
+  }
+  // Structured shape — return as-is (already canonical)
+  if (window.isStructuredFeedingV1(mealVal)) {
+    return mealVal;
+  }
+  // Legacy string — comma-split + resolve defaults per item
+  if (typeof mealVal === 'string') {
+    var raw = mealVal.trim();
+    if (!raw) return { items: [] };
+    var items = raw.split(',').map(function(s) {
+      var name = s.trim().replace(/,+$/, '');
+      if (!name) return null;
+      var defaults = window._fdResolveQtyDefaults(name);
+      return {
+        name: name,
+        qty: defaults.qty,
+        unit: defaults.unit,
+        source: 'legacy-parse',
+        nutritionRef: name.toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim()
+      };
+    }).filter(function(x) { return x; });
+    return { items: items, _parsedFrom: 'legacy-string' };
+  }
+  // Unknown — return empty
+  return { items: [] };
+};
+// Keep the F-1 stub as an alias so any caller bound to the stub name still works.
+window.parseFeedingV1Stub = window.parseFeedingV1;
+
+// ═══════════════════════════════════════════════════════════════════════
+// Skip-state helpers (ratification #6)
+// Mark a meal slot as intentionally-skipped. Skipped slots render as
+// muted "Skipped" pills and are excluded from nutrition-snapshot diversity
+// penalties. Reversible — writing a real entry overwrites the skip.
+// ═══════════════════════════════════════════════════════════════════════
+window._fdMarkMealSkipped = function(dateKey, meal) {
+  if (!dateKey || !meal) return false;
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+  if (!fd[dateKey]) fd[dateKey] = { breakfast: '', lunch: '', dinner: '', snack: '' };
+  fd[dateKey][meal] = { skipped: true, skippedAt: Date.now(), items: [] };
+  if (typeof save === 'function' && typeof KEYS !== 'undefined' && KEYS.feeding) {
+    save(KEYS.feeding, fd);
+  }
+  if (typeof feedingData !== 'undefined') feedingData = fd;
+  if (typeof _islMarkDirty === 'function') _islMarkDirty('diet');
+  return true;
+};
+
+window._fdIsMealSkipped = function(dateKey, meal) {
+  if (!dateKey || !meal) return false;
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+  var day = fd[dateKey];
+  if (!day) return false;
+  var mv = day[meal];
+  return !!(mv && typeof mv === 'object' && mv.skipped === true);
+};
+
+// ═══════════════════════════════════════════════════════════════════════
+// _fdWriteStructuredMeal — canonical writer for the F-2 FOB Feed sheet.
+// Writes the structured shape under feedingData[dateKey][meal] AND
+// auto-generates legacy compat fields (text, {meal}_time, {meal}_intake)
+// so existing readers (home.js Today's Meals summary, diet stats, combo
+// intelligence, parseMealNutrition) continue working unchanged until
+// F-5 lands the read-side normalizer.
+//
+// payload: { items: [{name, qty, unit, nutritionRef}], time, overallIntake, note, sourceFlow }
+// Returns the structured shape that was written.
+// ═══════════════════════════════════════════════════════════════════════
+window._fdWriteStructuredMeal = function(dateKey, meal, payload) {
+  if (!dateKey || !meal || !payload) return null;
+  payload = payload || {};
+  var items = Array.isArray(payload.items) ? payload.items.slice() : [];
+  // Legacy compat: comma-joined text for downstream readers (Today's Meals
+  // summary, diet combos, parseMealNutrition). Trailing comma kept off.
+  var textCompat = items.map(function(it) { return it.name; }).join(', ');
+
+  var structured = {
+    items: items,
+    time: payload.time || null,
+    overallIntake: (typeof payload.overallIntake === 'number') ? payload.overallIntake : 0.75,  // ratified DEFAULT "Most"
+    note: payload.note || '',
+    sourceFlow: payload.sourceFlow || 'fob-feed',  // telemetry: fob-repeat | fob-combo | fob-novel | fob-feed | diet-tab
+    schemaVersion: window._FEEDING_V1_SCHEMA_VERSION,
+    text: textCompat,
+  };
+
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+  if (!fd[dateKey]) fd[dateKey] = { breakfast: '', lunch: '', dinner: '', snack: '' };
+  fd[dateKey][meal] = structured;
+  // Legacy compat fields at the day level (existing readers reach for these)
+  if (structured.time) fd[dateKey][meal + '_time'] = structured.time;
+  fd[dateKey][meal + '_intake'] = structured.overallIntake;
+
+  if (typeof save === 'function' && typeof KEYS !== 'undefined' && KEYS.feeding) {
+    save(KEYS.feeding, fd);
+  }
+  if (typeof feedingData !== 'undefined') feedingData = fd;
+  return structured;
+};
+
 // @@DATA_BLOCK_20_START@@ MILESTONE_STANDARDS
 
 // MILESTONE_SOURCE — controlled vocabulary for per-row clinical-band source

--- a/split/data.js
+++ b/split/data.js
@@ -3009,11 +3009,17 @@ window.parseFeedingV1Stub = window.parseFeedingV1;
 // muted "Skipped" pills and are excluded from nutrition-snapshot diversity
 // penalties. Reversible — writing a real entry overwrites the skip.
 // ═══════════════════════════════════════════════════════════════════════
+// Writes the canonical SKIPPED_MEAL sentinel at the legacy [meal] field
+// (matches existing app-wide pattern at core.js:3119; consumers in
+// home.js Today's Meals + diet.js stats + intelligence-cards.js + isl
+// all key off this sentinel — there's no reason to invent a new one).
+// Also clears any v1 sidecar from prior structured writes.
 window._fdMarkMealSkipped = function(dateKey, meal) {
   if (!dateKey || !meal) return false;
   var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
   if (!fd[dateKey]) fd[dateKey] = { breakfast: '', lunch: '', dinner: '', snack: '' };
-  fd[dateKey][meal] = { skipped: true, skippedAt: Date.now(), items: [] };
+  fd[dateKey][meal] = (typeof SKIPPED_MEAL !== 'undefined') ? SKIPPED_MEAL : '—skipped—';
+  delete fd[dateKey][meal + '_v1'];
   if (typeof save === 'function' && typeof KEYS !== 'undefined' && KEYS.feeding) {
     save(KEYS.feeding, fd);
   }
@@ -3028,26 +3034,35 @@ window._fdIsMealSkipped = function(dateKey, meal) {
   var day = fd[dateKey];
   if (!day) return false;
   var mv = day[meal];
-  return !!(mv && typeof mv === 'object' && mv.skipped === true);
+  var sentinel = (typeof SKIPPED_MEAL !== 'undefined') ? SKIPPED_MEAL : '—skipped—';
+  if (mv === sentinel) return true;
+  if (mv && typeof mv === 'object' && mv.skipped === true) return true;  // legacy F-2-prerelease shape
+  return false;
 };
 
 // ═══════════════════════════════════════════════════════════════════════
 // _fdWriteStructuredMeal — canonical writer for the F-2 FOB Feed sheet.
-// Writes the structured shape under feedingData[dateKey][meal] AND
-// auto-generates legacy compat fields (text, {meal}_time, {meal}_intake)
-// so existing readers (home.js Today's Meals summary, diet stats, combo
-// intelligence, parseMealNutrition) continue working unchanged until
-// F-5 lands the read-side normalizer.
+//
+// Backward-compat doctrine (load-bearing): existing readers across
+// home.js Today's Meals, diet.js stats + combos, intelligence-cards.js,
+// intelligence-isl.js, medical.js all assume `feedingData[date][meal]`
+// is a STRING. Writing an object there breaks every legacy reader.
+//
+// So this writer keeps the legacy string at [meal] (comma-joined item
+// names) AND tucks the rich structured shape into a [meal + '_v1']
+// SIDECAR field. F-2 readers (L1-L4 helpers, saveQLFeed, diet Log
+// sub-tab review) reach for the sidecar via _fdReadDayMeal; legacy
+// readers continue reading the comma-string at [meal] unchanged.
+// F-5's parseFeeding normalizer will eventually unify the reads.
 //
 // payload: { items: [{name, qty, unit, nutritionRef}], time, overallIntake, note, sourceFlow }
-// Returns the structured shape that was written.
+// Returns the structured shape that was written to the sidecar.
 // ═══════════════════════════════════════════════════════════════════════
 window._fdWriteStructuredMeal = function(dateKey, meal, payload) {
   if (!dateKey || !meal || !payload) return null;
   payload = payload || {};
   var items = Array.isArray(payload.items) ? payload.items.slice() : [];
-  // Legacy compat: comma-joined text for downstream readers (Today's Meals
-  // summary, diet combos, parseMealNutrition). Trailing comma kept off.
+  // Legacy comma-joined text — what existing readers expect at [meal].
   var textCompat = items.map(function(it) { return it.name; }).join(', ');
 
   var structured = {
@@ -3055,15 +3070,19 @@ window._fdWriteStructuredMeal = function(dateKey, meal, payload) {
     time: payload.time || null,
     overallIntake: (typeof payload.overallIntake === 'number') ? payload.overallIntake : 0.75,  // ratified DEFAULT "Most"
     note: payload.note || '',
-    sourceFlow: payload.sourceFlow || 'fob-feed',  // telemetry: fob-repeat | fob-combo | fob-novel | fob-feed | diet-tab
+    sourceFlow: payload.sourceFlow || 'fob-feed',
     schemaVersion: window._FEEDING_V1_SCHEMA_VERSION,
-    text: textCompat,
+    writtenAt: Date.now(),
   };
 
   var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
   if (!fd[dateKey]) fd[dateKey] = { breakfast: '', lunch: '', dinner: '', snack: '' };
-  fd[dateKey][meal] = structured;
-  // Legacy compat fields at the day level (existing readers reach for these)
+  // Legacy string at the canonical slot (load-bearing for existing readers).
+  fd[dateKey][meal] = textCompat;
+  // Structured shape in sidecar — F-2 readers (L1-L4 helpers + diet Log
+  // review surface) reach here for qty + sourceFlow + overallIntake.
+  fd[dateKey][meal + '_v1'] = structured;
+  // Legacy time + intake at the day level (existing readers reach for these).
   if (structured.time) fd[dateKey][meal + '_time'] = structured.time;
   fd[dateKey][meal + '_intake'] = structured.overallIntake;
 
@@ -3072,6 +3091,57 @@ window._fdWriteStructuredMeal = function(dateKey, meal, payload) {
   }
   if (typeof feedingData !== 'undefined') feedingData = fd;
   return structured;
+};
+
+// _fdReadDayMeal — canonical reader. Returns the F-2 view of a meal slot
+// regardless of which shape sits on disk. Reads the [meal + '_v1']
+// sidecar first; falls back to parsing the legacy string at [meal].
+// Returns: { items[], time, overallIntake, skipped, sourceFlow, legacyText }
+window._fdReadDayMeal = function(dayObj, mealKey) {
+  if (!dayObj || !mealKey) return { items: [], skipped: false };
+  var sentinel = (typeof SKIPPED_MEAL !== 'undefined') ? SKIPPED_MEAL : '—skipped—';
+  var legacy = dayObj[mealKey];
+  // Skip sentinel — both forms
+  if (legacy === sentinel) {
+    return { items: [], skipped: true, legacyText: sentinel };
+  }
+  // Sidecar present — return the structured shape
+  var sidecar = dayObj[mealKey + '_v1'];
+  if (sidecar && Array.isArray(sidecar.items)) {
+    return {
+      items: sidecar.items,
+      time: sidecar.time || dayObj[mealKey + '_time'] || null,
+      overallIntake: typeof sidecar.overallIntake === 'number' ? sidecar.overallIntake : (dayObj[mealKey + '_intake'] || 0.75),
+      sourceFlow: sidecar.sourceFlow || 'fob-feed',
+      skipped: false,
+      legacyText: typeof legacy === 'string' ? legacy : (sidecar.items.map(function(it){return it.name;}).join(', ')),
+    };
+  }
+  // Legacy F-2-prerelease structured-at-[meal] shape (early-development
+  // fixtures may carry this; treat as canonical and migrate-on-read).
+  if (legacy && typeof legacy === 'object' && Array.isArray(legacy.items)) {
+    return {
+      items: legacy.items,
+      time: legacy.time || dayObj[mealKey + '_time'] || null,
+      overallIntake: typeof legacy.overallIntake === 'number' ? legacy.overallIntake : 0.75,
+      sourceFlow: legacy.sourceFlow || 'fob-feed',
+      skipped: legacy.skipped === true,
+      legacyText: legacy.items.map(function(it){return it.name;}).join(', '),
+    };
+  }
+  // Pure legacy string — parse via comma-split + qty resolver
+  if (typeof legacy === 'string' && legacy.trim()) {
+    var parsed = window.parseFeedingV1(legacy);
+    return {
+      items: parsed.items || [],
+      time: dayObj[mealKey + '_time'] || null,
+      overallIntake: dayObj[mealKey + '_intake'] || 0.75,
+      sourceFlow: 'legacy-string',
+      skipped: false,
+      legacyText: legacy,
+    };
+  }
+  return { items: [], skipped: false, legacyText: '' };
 };
 
 // @@DATA_BLOCK_20_START@@ MILESTONE_STANDARDS

--- a/split/data.js
+++ b/split/data.js
@@ -2896,13 +2896,13 @@ window._fdResolveQtyDefaults = function(foodName) {
   if (n && n.tags) {
     if (n.tags.indexOf('healthy-fats') >= 0 && /oil|ghee|butter/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['fat-cooking'];
     if (n.tags.indexOf('iron-rich') >= 0 && n.tags.indexOf('protein-rich') >= 0) return _FOOD_QTY_CATEGORY_DEFAULTS['dal-legume'];
-    if (n.tags.indexOf('energy') >= 0 && !n.tags.indexOf('digestive') >= 0) return _FOOD_QTY_CATEGORY_DEFAULTS['grain-staple'];
+    if (n.tags.indexOf('energy') >= 0 && n.tags.indexOf('digestive') < 0) return _FOOD_QTY_CATEGORY_DEFAULTS['grain-staple'];
   }
   // 4. Heuristic by nutrient profile
   if (n && n.nutrients) {
     if (n.nutrients.indexOf('water') >= 0) return _FOOD_QTY_CATEGORY_DEFAULTS['liquid-drink'];
   }
-  return _FOOD_QTY_CATEGORY_DEFAULTS['veg-piece'];
+  return _FOOD_QTY_CATEGORY_DEFAULTS['fallback'];
 };
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -3013,13 +3013,17 @@ window.parseFeedingV1Stub = window.parseFeedingV1;
 // (matches existing app-wide pattern at core.js:3119; consumers in
 // home.js Today's Meals + diet.js stats + intelligence-cards.js + isl
 // all key off this sentinel — there's no reason to invent a new one).
-// Also clears any v1 sidecar from prior structured writes.
+// Clears the v1 sidecar AND the legacy [meal+'_time']/[meal+'_intake']
+// fields so a skip is atomic — Today So Far + diet stats don't render
+// stale time/intake for what the parent just marked as skipped.
 window._fdMarkMealSkipped = function(dateKey, meal) {
   if (!dateKey || !meal) return false;
   var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
   if (!fd[dateKey]) fd[dateKey] = { breakfast: '', lunch: '', dinner: '', snack: '' };
   fd[dateKey][meal] = (typeof SKIPPED_MEAL !== 'undefined') ? SKIPPED_MEAL : '—skipped—';
   delete fd[dateKey][meal + '_v1'];
+  delete fd[dateKey][meal + '_time'];
+  delete fd[dateKey][meal + '_intake'];
   if (typeof save === 'function' && typeof KEYS !== 'undefined' && KEYS.feeding) {
     save(KEYS.feeding, fd);
   }
@@ -3082,9 +3086,23 @@ window._fdWriteStructuredMeal = function(dateKey, meal, payload) {
   // Structured shape in sidecar — F-2 readers (L1-L4 helpers + diet Log
   // review surface) reach here for qty + sourceFlow + overallIntake.
   fd[dateKey][meal + '_v1'] = structured;
-  // Legacy time + intake at the day level (existing readers reach for these).
+  // Legacy time at the day level (existing readers reach for this).
+  // Unconditionally write — if structured.time is null, clear the legacy
+  // field so undo/re-save flows don't leave a phantom time from a prior
+  // write attached to a different food.
   if (structured.time) fd[dateKey][meal + '_time'] = structured.time;
-  fd[dateKey][meal + '_intake'] = structured.overallIntake;
+  else delete fd[dateKey][meal + '_time'];
+  // Legacy intake at the day level — only for B/L/D. Snack has the
+  // chip in the F-2 UI but the legacy invariant (pre-F-2 saveQLFeed
+  // guard `_qlMeal !== 'snack'`) was that snack carries no intake at
+  // the day level. Existing readers (intelligence-cards.js, isl, diet
+  // stats) assume snack_intake is undefined for snacks; preserve that.
+  // F-2 readers reach structured.overallIntake via _fdReadDayMeal.
+  if (meal !== 'snack') {
+    fd[dateKey][meal + '_intake'] = structured.overallIntake;
+  } else {
+    delete fd[dateKey][meal + '_intake'];
+  }
 
   if (typeof save === 'function' && typeof KEYS !== 'undefined' && KEYS.feeding) {
     save(KEYS.feeding, fd);

--- a/split/data.js
+++ b/split/data.js
@@ -2865,12 +2865,40 @@ window._FOOD_QTY_CATEGORY_DEFAULTS = {
   'veg-mashed':     { qty: 0.25, unit: 'cup',     step: 0.25 },
   'fruit-piece':    { qty: 0.5,  unit: 'pc',      step: 0.25 },
   'fruit-berry':    { qty: 5,    unit: 'pc',      step: 2    },
-  'fruit-mash':     { qty: 0.5,  unit: 'pc',      step: 0.25 },
+  'fruit-mash':     { qty: 2,    unit: 'tbsp',    step: 1    },
   'nut-piece':      { qty: 1,    unit: 'pc',      step: 1    },
   'fat-cooking':    { qty: 1,    unit: 'tsp',     step: 0.5  },
   'spice':          { qty: 0.25, unit: 'tsp',     step: 0.25 },
   'liquid-drink':   { qty: 0.5,  unit: 'cup',     step: 0.25 },
   'fallback':       { qty: 1,    unit: 'serving', step: 1    },
+};
+
+// Strip a prep-form word ("ragi porridge"→"ragi", "banana mash"→"banana",
+// "bajra roti"→"bajra") so a curated explicit override / NUTRITION row can
+// be matched before the broad category fallthrough. Returns '' when
+// stripping would empty the string (the food name IS the prep word, e.g.
+// "porridge", "roti") so callers fall back to the original base. (V-K-201)
+window._fdStripPrepSuffix = function(base) {
+  if (!base) return '';
+  return String(base)
+    .replace(/\b(porridge|mash|puree|pure|sauce|roti|chapati|paratha)\b/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
+// Resolve a food name to its best NUTRITION key for the nutrient join:
+// paren-strip, and if that isn't a NUTRITION row, try the prep-suffix-
+// stripped stem ("ragi porridge"→"ragi"). Falls back to the paren-stripped
+// base when neither matches, preserving legacy behavior. (V-K-200)
+window._fdNutritionRef = function(name) {
+  if (!name) return '';
+  var base = String(name).toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim();
+  if (typeof NUTRITION !== 'undefined' && NUTRITION) {
+    if (NUTRITION[base]) return base;
+    var stem = window._fdStripPrepSuffix(base);
+    if (stem && stem !== base && NUTRITION[stem]) return stem;
+  }
+  return base;
 };
 
 // Resolver — explicit override wins; category fallback otherwise.
@@ -2883,6 +2911,12 @@ window._fdResolveQtyDefaults = function(foodName) {
   // 1. Explicit per-food override
   if (NUTRITION_QTY_DEFAULTS[base]) return NUTRITION_QTY_DEFAULTS[base];
   if (NUTRITION_QTY_DEFAULTS[key])  return NUTRITION_QTY_DEFAULTS[key];
+  // 1b. Prep-suffix-stripped stem ("banana mash"→"banana") so a curated
+  //     explicit qty wins over the broad category catch below. Category
+  //     heuristics still run on the un-stripped base, so unnamed mashes
+  //     ("papaya puree") keep their fruit-mash default. (V-K-201)
+  var stem = window._fdStripPrepSuffix(base);
+  if (stem && stem !== base && NUTRITION_QTY_DEFAULTS[stem]) return NUTRITION_QTY_DEFAULTS[stem];
   // 2. Category resolver — name heuristics first
   if (/porridge|upma|halwa/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['porridge'];
   if (/\b(roti|chapati|paratha|naan|puri)\b/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['roti-flatbread'];
@@ -2983,6 +3017,11 @@ window.parseFeedingV1 = function(mealVal) {
   if (typeof mealVal === 'string') {
     var raw = mealVal.trim();
     if (!raw) return { items: [] };
+    // Skip sentinel reaching the normalizer directly (the live read path
+    // guards this in _fdReadDayMeal, but F-5 callers may invoke parseFeedingV1
+    // on the raw string) — must not emit a phantom "—skipped—" food. (V-K-202)
+    var sentinel = (typeof SKIPPED_MEAL !== 'undefined') ? SKIPPED_MEAL : '—skipped—';
+    if (raw === sentinel) return { items: [], skipped: true };
     var items = raw.split(',').map(function(s) {
       var name = s.trim().replace(/,+$/, '');
       if (!name) return null;
@@ -2992,7 +3031,7 @@ window.parseFeedingV1 = function(mealVal) {
         qty: defaults.qty,
         unit: defaults.unit,
         source: 'legacy-parse',
-        nutritionRef: name.toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim()
+        nutritionRef: window._fdNutritionRef(name)
       };
     }).filter(function(x) { return x; });
     return { items: items, _parsedFrom: 'legacy-string' };

--- a/split/diet.js
+++ b/split/diet.js
@@ -4036,20 +4036,6 @@ function getTopMeals(n) {
     .map(m => ({ name: m.display.charAt(0).toUpperCase() + m.display.slice(1), count: m.count }));
 }
 
-function renderQLFreqPills() {
-  const wrap = document.getElementById('qlFreqWrap');
-  const el = document.getElementById('qlFreqPills');
-  if (!wrap || !el) return;
-
-  const top = getTopMeals(5);
-  if (top.length === 0) { wrap.style.display = 'none'; return; }
-
-  wrap.style.display = '';
-  el.innerHTML = top.map(m =>
-    `<div class="ql-freq-pill" onclick="document.getElementById('qlFeedInput').value='${escHtml(m.name).replace(/'/g, "\\'")}';document.getElementById('qlFeedInput').focus();" title="${m.count}× logged">${escHtml(m.name)}</div>`
-  ).join('');
-}
-
 // ── Meal progress on Home ──
 
 // ── MEAL DIVERSITY INDEX ──

--- a/split/diet.js
+++ b/split/diet.js
@@ -2444,6 +2444,15 @@ function _miGetIntake(dateStr, meal) {
 function _miSetIntake(dateStr, meal, value) {
   if (!feedingData[dateStr]) return;
   feedingData[dateStr][meal + '_intake'] = value;
+  // F-2 fix (E_b): sync the structured sidecar's overallIntake too.
+  // Otherwise _fdReadDayMeal returns the stale sidecar value while
+  // legacy _miGetIntake returns the updated value — two surfaces
+  // disagree about the same meal's intake (FOB Feed L1 repeat shows
+  // old; home Today's Meals + diet stats show new).
+  var sidecar = feedingData[dateStr][meal + '_v1'];
+  if (sidecar && typeof sidecar === 'object') {
+    sidecar.overallIntake = value;
+  }
   save(KEYS.feeding, feedingData);
   _islMarkDirty('diet');
   // V-M-70: intake adjustment alone doesn't change meal content (so withFat won't flip),

--- a/split/home.js
+++ b/split/home.js
@@ -9351,7 +9351,7 @@ function computeAlerts() {
           title: loggedMeals.length === 0 ? 'No meals logged today' : missingLabels + ' not logged today',
           body: bodyMsg,
           tip: 'Logging every meal — even "skipped" or "just breastmilk" — helps build an accurate picture of intake patterns.',
-          action: { label: 'Log ' + firstMissing.charAt(0).toUpperCase() + firstMissing.slice(1), fn: '_qlMeal="' + firstMissing + '";openQuickModal("feed")' },
+          action: { label: 'Log ' + firstMissing.charAt(0).toUpperCase() + firstMissing.slice(1), fn: '_qlMeal="' + firstMissing + '";_qlMealExplicit=true;openQuickModal("feed")' },
           tab: 'diet'        });
       }
     }
@@ -10072,7 +10072,7 @@ function renderTodayPlan() {
     time: '8–9', icon: zi('sun'), title: 'Breakfast',
     detail: bfDone ? iconText('check', todayEntry.breakfast) : bfSuggestion,
     tag: 'food', done: bfDone, htmlDetail: bfDone,
-    action: bfDone ? null : '_qlMeal="breakfast";openQuickModal("feed")'
+    action: bfDone ? null : '_qlMeal="breakfast";_qlMealExplicit=true;openQuickModal("feed")'
   });
 
   // Morning nap
@@ -10142,7 +10142,7 @@ function renderTodayPlan() {
     time: '12–1', icon: zi('sun'), title: 'Lunch',
     detail: lnDone ? iconText('check', todayEntry.lunch) : lnSuggestion,
     tag: 'food', done: lnDone, htmlDetail: lnDone,
-    action: lnDone ? null : '_qlMeal="lunch";openQuickModal("feed")'
+    action: lnDone ? null : '_qlMeal="lunch";_qlMealExplicit=true;openQuickModal("feed")'
   });
 
   // Afternoon nap
@@ -10216,7 +10216,7 @@ function renderTodayPlan() {
     time: '6–7', icon: zi('moon'), title: 'Dinner',
     detail: dnDone ? iconText('check', todayEntry.dinner) : dnSuggestion,
     tag: 'food', done: dnDone, htmlDetail: dnDone,
-    action: dnDone ? null : '_qlMeal="dinner";openQuickModal("feed")'
+    action: dnDone ? null : '_qlMeal="dinner";_qlMealExplicit=true;openQuickModal("feed")'
   });
 
   // Snack
@@ -10225,7 +10225,7 @@ function renderTodayPlan() {
     time: '10–4', icon: zi('spoon'), title: 'Snack',
     detail: skDone ? iconText('check', todayEntry.snack) : 'A quick bite between meals — fruit mash, ragi biscuit, or curd',
     tag: 'food', done: skDone, htmlDetail: skDone,
-    action: skDone ? null : '_qlMeal="snack";openQuickModal("feed")'
+    action: skDone ? null : '_qlMeal="snack";_qlMealExplicit=true;openQuickModal("feed")'
   });
 
   // Bedtime routine

--- a/split/intelligence-illness.js
+++ b/split/intelligence-illness.js
@@ -2046,7 +2046,7 @@ function saveFeedingDay() {
     dinner:    document.getElementById('meal-dinner').disabled ? (existing.dinner || '') : document.getElementById('meal-dinner').value,
     snack:     document.getElementById('meal-snack').disabled ? (existing.snack || '') : document.getElementById('meal-snack').value,
   };
-  // Save optional meal times
+  // Save optional meal times + preserve F-2 sidecar when text unchanged
   ['breakfast','lunch','dinner','snack'].forEach(m => {
     const timeVal = document.getElementById('mealtime-' + m)?.value || '';
     if (timeVal) {
@@ -2058,6 +2058,18 @@ function saveFeedingDay() {
     if (existing[m + '_intake'] !== undefined) {
       feedingData[d][m + '_intake'] = existing[m + '_intake'];
     }
+    // F-2 fix (E_a): preserve the [meal + '_v1'] structured sidecar when
+    // the meal text didn't change. Without this, every Diet tab editor
+    // save silently drops the rich shape (items[], qty/unit, sourceFlow,
+    // overallIntake) that the FOB Feed sheet had written — Today So Far
+    // + L1-L4 helpers + future F-3 review surface all degrade to legacy
+    // comma-split with synthesized default qty.
+    if (existing[m + '_v1'] && feedingData[d][m] === (existing[m] || '')) {
+      feedingData[d][m + '_v1'] = existing[m + '_v1'];
+    }
+    // If text changed, the sidecar is intentionally dropped — the legacy
+    // string is now the source of truth post-edit (matches the pre-F-2
+    // behavior that this writer used to maintain implicitly).
   });
   save(KEYS.feeding, feedingData);
   _tsfMarkDirty();
@@ -2352,6 +2364,13 @@ function changeDate(dir) {
 // ─────────────────────────────────────────
 let _qlOpen = false;
 let _qlMeal = 'breakfast';
+// F-2 fix (C1): explicit-meal flag. Callers that pre-set _qlMeal before
+// openQuickModal('feed') set this to true so openQuickModal preserves
+// their intent instead of clobbering with detectMealType(). One-shot —
+// consumed (reset to false) inside openQuickModal. Without this guard,
+// every "Log Breakfast" home alert at 8 PM would silently re-route to
+// the dinner slot (detected by time-of-day) and load wrong-slot rails.
+let _qlMealExplicit = false;
 let _qlWake = 0;
 let _qlColor = 'yellow';
 let _qlCon = 'normal';
@@ -2411,7 +2430,14 @@ function openQuickModal(type) {
 
   // Pre-fill defaults
   if (type === 'feed') {
-    _qlMeal = detectMealType();
+    // F-2 fix (C1): preserve _qlMeal when a caller explicitly set it
+    // (via the _qlMealExplicit flag). Without this guard, callers like
+    // home-tab "Log Breakfast" alerts at 8 PM would have their intent
+    // clobbered to detectMealType()='dinner' and load wrong-slot rails.
+    if (!_qlMealExplicit) {
+      _qlMeal = detectMealType();
+    }
+    _qlMealExplicit = false;  // one-shot — consume the flag
     if (!_qlBackfillDate) _qlBackfillDate = null; // ensure reset for non-backfill
     document.querySelectorAll('.ql-meal-pill').forEach(p => {
       p.classList.toggle('active', p.dataset.meal === _qlMeal);

--- a/split/intelligence-illness.js
+++ b/split/intelligence-illness.js
@@ -2416,13 +2416,12 @@ function openQuickModal(type) {
     document.querySelectorAll('.ql-meal-pill').forEach(p => {
       p.classList.toggle('active', p.dataset.meal === _qlMeal);
     });
-    document.getElementById('qlFeedInput').value = '';
     const qlTimeEl = document.getElementById('qlFeedTime');
     if (qlTimeEl) qlTimeEl.value = '';
-    const qlDD = document.getElementById('qlFeedDropdown');
-    if (qlDD) qlDD.classList.remove('open');
-    renderQLSameAsPills();
-    renderQLFreqPills();
+    // F-2: reset items list state + render the four autofill regions
+    // (L1 repeat / L2 combo / items list / L3 next-item ribbon).
+    if (typeof _qlFeedReset === 'function') _qlFeedReset();
+    if (typeof _qlRenderFeedSheet === 'function') _qlRenderFeedSheet();
     // Reset intake pills to default (Most)
     _miWireQLIntakePills();
     // Hide backfill UI unless in backfill mode

--- a/split/intelligence-qa-handlers.js
+++ b/split/intelligence-qa-handlers.js
@@ -3306,21 +3306,23 @@ function sgTapChip(food) {
     showQLToast('All meals are filled for today');
     return;
   }
+  // F-2 fix (C1): set _qlMeal + explicit flag BEFORE openQuickModal so
+  // the modal preserves intent (was: openQuickModal clobbered _qlMeal
+  // to detectMealType() then a setTimeout re-set it AFTER the rails had
+  // already rendered for the wrong slot).
+  _qlMeal = nextMeal;
+  _qlMealExplicit = true;
   openQuickLog();
   openQuickModal('feed');
-  // Set meal + prefill after modal opens (openQuickModal resets _qlMeal via detectMealType)
+  // F-2 fix (B2/C4): push the suggested food directly into _qlFeedItems
+  // via the canonical handler so it appears in the Items list (not just
+  // the typeahead input). Old code used updateQLFeedDropdown +
+  // pickQLFood which write to input only — bypassing the structured
+  // shape and leaving the Items list misleadingly empty.
   setTimeout(function() {
-    _qlMeal = nextMeal;
-    const inp = document.getElementById('qlFeedInput');
-    if (inp) {
-      inp.value = food;
-      inp.focus();
-      updateQLFeedDropdown();
+    if (typeof qlFeedAddItem === 'function' && food) {
+      qlFeedAddItem(food, 'typeahead');
     }
-    // Select correct meal pill
-    document.querySelectorAll('.ql-meal-pill').forEach(p => {
-      p.classList.toggle('active', p.dataset.meal === nextMeal);
-    });
   }, 50);
 }
 

--- a/split/intelligence-quicklog.js
+++ b/split/intelligence-quicklog.js
@@ -1237,7 +1237,7 @@ window._fdGetCombosForMeal = function(meal, opts) {
     return curated.slice(0, maxResults).map(function(c, i) {
       var items = c.items.map(function(name) {
         var d = window._fdResolveQtyDefaults(name);
-        return { name: name, qty: d.qty, unit: d.unit, nutritionRef: name.toLowerCase().replace(/\s*\([^)]*\)\s*/g,'').trim(), source: 'curated' };
+        return { name: name, qty: d.qty, unit: d.unit, nutritionRef: window._fdNutritionRef(name), source: 'curated' };
       });
       return {
         id: 'curated-' + meal + '-' + i,
@@ -1264,7 +1264,7 @@ window._fdGetCombosForMeal = function(meal, opts) {
     return curated2.slice(0, maxResults).map(function(c, i) {
       var items = c.items.map(function(name) {
         var d = window._fdResolveQtyDefaults(name);
-        return { name: name, qty: d.qty, unit: d.unit, nutritionRef: name.toLowerCase().replace(/\s*\([^)]*\)\s*/g,'').trim(), source: 'curated' };
+        return { name: name, qty: d.qty, unit: d.unit, nutritionRef: window._fdNutritionRef(name), source: 'curated' };
       });
       return {
         id: 'curated-fallback-' + meal + '-' + i,
@@ -1816,7 +1816,22 @@ function _qlRenderFeedSheet() {
 // F-2 fix (A6): hidden once items are present (mirror the combos-rail
 // behavior). Otherwise an accidental tap on a still-visible repeat chip
 // silently wipes the parent's in-progress items with no undo affordance.
+// L1↔L2 dedup: the repeat rail (your actual history) and the combo rail
+// (templates / curated cold-start) can surface the identical food-set as two
+// differently-coloured chips. The repeat rail stashes its signatures here so
+// the combo rail can drop the duplicate and keep the more-authoritative
+// history chip. Reset at the top of every repeat-rail render. (V-V-204)
+var _qlRepeatSigs = [];
+function _qlFeedRailSig(itemsText) {
+  return String(itemsText || '').toLowerCase().split(',')
+    .map(function(s) { return s.trim(); })
+    .filter(function(s) { return s; })
+    .sort()
+    .join('|');
+}
+
 function _qlRenderRepeatRail() {
+  _qlRepeatSigs = [];
   var wrap = document.getElementById('qlFeedRepeatWrap');
   var rail = document.getElementById('qlFeedRepeatRail');
   if (!wrap || !rail) return;
@@ -1831,6 +1846,7 @@ function _qlRenderRepeatRail() {
     rail.innerHTML = '';
     return;
   }
+  _qlRepeatSigs = candidates.map(function(c) { return _qlFeedRailSig(c.itemsText); });
   wrap.style.display = '';
   rail.innerHTML = candidates.map(function(c, i) {
     return '<div class="ql-feed-repeat-chip' + (i === 0 ? ' primary' : '') + '"' +
@@ -1857,6 +1873,13 @@ function _qlRenderCombosRail() {
     return;
   }
   var combos = window._fdGetCombosForMeal(_qlMeal, { maxResults: 3 });
+  // Drop any combo whose food-set duplicates a repeat-rail chip already shown
+  // above (the history chip is more authoritative). (V-V-204)
+  if (combos && combos.length && _qlRepeatSigs.length) {
+    combos = combos.filter(function(c) {
+      return _qlRepeatSigs.indexOf(_qlFeedRailSig(c.itemsText)) === -1;
+    });
+  }
   if (!combos || combos.length === 0) {
     wrap.style.display = 'none';
     rail.innerHTML = '';
@@ -1887,14 +1910,19 @@ function _qlRenderItemsList() {
     list.innerHTML = '<div class="ql-feed-items-empty">Tap a combo above, or type an item below</div>';
     return;
   }
+  // Stable alphabetical order so the list has a fixed scan position across
+  // the four entry rails (combo-replace, repeat-replace, next/typeahead push)
+  // — sorting the array in place keeps the data-arg idx consistent with the
+  // qty-stepper / remove handlers. (V-V-202)
+  _qlFeedItems.sort(function(a, b) {
+    return String(a.name || '').toLowerCase().localeCompare(String(b.name || '').toLowerCase());
+  });
   list.innerHTML = _qlFeedItems.map(function(item, idx) {
     var initial = (item.name || '?').charAt(0).toUpperCase();
     var qtyDisplay = _qlFormatQty(item.qty);
     return '<div class="ql-feed-item-row">' +
            '<span class="ql-feed-item-icon">' + escHtml(initial) + '</span>' +
-           '<div class="ql-feed-item-name">' + escHtml(item.name) +
-             '<span class="ql-feed-item-meta">' + escHtml(item.source || 'manual') + '</span>' +
-           '</div>' +
+           '<div class="ql-feed-item-name">' + escHtml(item.name) + '</div>' +
            '<div class="ql-feed-qty-stepper">' +
              '<button class="ql-feed-qty-step" data-action="qlFeedAdjustQty" data-arg="' + idx + '" data-arg2="dec" type="button" aria-label="Decrease quantity">−</button>' +
              '<span class="ql-feed-qty-val">' + qtyDisplay +
@@ -2004,7 +2032,7 @@ function qlFeedAddItem(name, source) {
     name: name,
     qty: defaults.qty,
     unit: defaults.unit,
-    nutritionRef: normalized,
+    nutritionRef: window._fdNutritionRef(name),
     source: source || 'manual',
   });
   if (source === 'next' || source === 'typeahead') {
@@ -3877,43 +3905,6 @@ function updateMealSkipButtons() {
       if (input) { input.disabled = false; input.placeholder = 'Type to search foods...'; }
     }
   });
-}
-
-// ── Expanded same-as pills (yesterday's all meals) ──
-function renderQLSameAsPills() {
-  const wrap = document.getElementById('qlSameAsWrap');
-  const pills = document.getElementById('qlSameAsPills');
-  if (!wrap || !pills) return;
-
-  const todayEntry = feedingData[today()] || {};
-  const meals = [];
-  const seen = new Set();
-  function add(label, value) {
-    if (value && !seen.has(value)) { meals.push({ label, value }); seen.add(value); }
-  }
-
-  // Today's meals
-  add(zi('sun')+' Today B', todayEntry.breakfast);
-  add(zi('sun')+' Today L', todayEntry.lunch);
-  add(zi('moon')+' Today D', todayEntry.dinner);
-  add(zi('spoon')+' Today S', todayEntry.snack);
-
-  // Yesterday's meals (all three)
-  const yd = new Date(); yd.setDate(yd.getDate() - 1);
-  const ydEntry = feedingData[toDateStr(yd)] || {};
-  add(zi('clock')+' Yd B', ydEntry.breakfast);
-  add(zi('clock')+' Yd L', ydEntry.lunch);
-  add(zi('clock')+' Yd D', ydEntry.dinner);
-
-  if (meals.length === 0) {
-    wrap.style.display = 'none';
-    return;
-  }
-
-  wrap.style.display = '';
-  pills.innerHTML = meals.map(m =>
-    `<button class="btn-ghost" style="font-size:var(--fs-xs);padding:5px 10px;border-radius:var(--r-2xl);" onclick="document.getElementById('qlFeedInput').value='${escHtml(m.value).replace(/'/g, "\\'")}';this.closest('#qlSameAsWrap').style.display='none';">${m.label}</button>`
-  ).join('');
 }
 
 // Close QL dropdown on blur

--- a/split/intelligence-quicklog.js
+++ b/split/intelligence-quicklog.js
@@ -1688,6 +1688,8 @@ function qaAnswerFavoriteFoods() {
 function setQLMeal(meal) {
   _qlMeal = meal;
   document.querySelectorAll('.ql-meal-pill').forEach(p => p.classList.toggle('active', p.dataset.meal === meal));
+  // F-2: refresh autofill regions on meal change — repeats + combos differ per slot.
+  if (typeof _qlRenderFeedSheet === 'function') _qlRenderFeedSheet();
 }
 
 function adjQLWake(delta) {
@@ -1736,32 +1738,339 @@ function undoLastQL() {
   }
 }
 
+// ═══════════════════════════════════════════════════════════════
+// F-2 — FOB Feed sheet render + handlers
+// Spec: docs/specs/food-sub-tab-v1.md §F-2
+// State: _qlFeedItems is the current items array being built. Stays in
+// sync with the rendered Items list via _qlRenderItemsList. Save writes
+// structured shape via _fdWriteStructuredMeal (data.js).
+// ═══════════════════════════════════════════════════════════════
+
+var _qlFeedItems = [];
+var _qlFeedSourceFlow = 'fob-feed';  // 'fob-repeat' | 'fob-combo' | 'fob-novel' | 'fob-feed'
+
+function _qlFeedReset() {
+  _qlFeedItems = [];
+  _qlFeedSourceFlow = 'fob-feed';
+  var inp = document.getElementById('qlFeedInput');
+  if (inp) inp.value = '';
+  var dd = document.getElementById('qlFeedDropdown');
+  if (dd) { dd.innerHTML = ''; dd.classList.remove('open'); }
+}
+
+// Render all dynamic regions of the FOB Feed sheet. Called on open + after
+// every state change (item add/remove/qty adjust, meal slot change).
+function _qlRenderFeedSheet() {
+  _qlRenderRepeatRail();
+  _qlRenderCombosRail();
+  _qlRenderItemsList();
+  _qlRenderNextItemRibbon();
+}
+
+// L1 — Repeat rail. Surfaces yesterday's/recent matching-slot meals as
+// one-tap apply chips. For dinner, "Same as today's lunch" leads if logged.
+function _qlRenderRepeatRail() {
+  var wrap = document.getElementById('qlFeedRepeatWrap');
+  var rail = document.getElementById('qlFeedRepeatRail');
+  if (!wrap || !rail) return;
+  var candidates = window._fdGetRepeatCandidates(_qlMeal, 3);
+  if (!candidates || candidates.length === 0) {
+    wrap.style.display = 'none';
+    rail.innerHTML = '';
+    return;
+  }
+  wrap.style.display = '';
+  rail.innerHTML = candidates.map(function(c, i) {
+    return '<div class="ql-feed-repeat-chip' + (i === 0 ? ' primary' : '') + '"' +
+           ' data-action="qlFeedApplyRepeat" data-arg="' + escAttr(c.id) + '">' +
+           '<div class="ql-feed-repeat-head">' +
+             '<svg class="zi"><use href="#zi-rainbow"/></svg> ' + escHtml(c.label) +
+           '</div>' +
+           '<div class="ql-feed-repeat-sub">' + escHtml(c.itemsText) + '</div>' +
+           '</div>';
+  }).join('');
+}
+
+// L2 — Combo template rail. Hidden once items present (parent has
+// committed to building manually; offering full-replace combos would
+// confuse). Shows rolling-14d top combos OR curated cold-start fallback.
+function _qlRenderCombosRail() {
+  var wrap = document.getElementById('qlFeedCombosWrap');
+  var rail = document.getElementById('qlFeedCombosRail');
+  var label = document.getElementById('qlFeedCombosLabel');
+  if (!wrap || !rail) return;
+  if (_qlFeedItems.length > 0) {
+    wrap.style.display = 'none';
+    rail.innerHTML = '';
+    return;
+  }
+  var combos = window._fdGetCombosForMeal(_qlMeal, { maxResults: 3 });
+  if (!combos || combos.length === 0) {
+    wrap.style.display = 'none';
+    rail.innerHTML = '';
+    return;
+  }
+  wrap.style.display = '';
+  if (label) {
+    label.textContent = combos[0].source === 'curated'
+      ? 'Suggested combos'
+      : 'Your usual ' + _qlMeal;
+  }
+  rail.innerHTML = combos.map(function(c) {
+    var freq = c.freq ? '<span class="ql-feed-combo-conf">' + c.freq + '×</span>' : '';
+    return '<div class="ql-feed-combo-chip" data-action="qlFeedApplyCombo" data-arg="' + escAttr(c.id) + '">' +
+           '<div class="ql-feed-combo-head">' +
+             '<svg class="zi"><use href="#zi-bowl"/></svg> ' + escHtml(c.label) + freq +
+           '</div>' +
+           '<div class="ql-feed-combo-sub">' + escHtml(c.itemsText) + '</div>' +
+           '</div>';
+  }).join('');
+}
+
+// Items list — current meal items with qty stepper + remove.
+function _qlRenderItemsList() {
+  var list = document.getElementById('qlFeedItemsList');
+  if (!list) return;
+  if (_qlFeedItems.length === 0) {
+    list.innerHTML = '<div class="ql-feed-items-empty">Tap a combo above, or type an item below</div>';
+    return;
+  }
+  list.innerHTML = _qlFeedItems.map(function(item, idx) {
+    var initial = (item.name || '?').charAt(0).toUpperCase();
+    var qtyDisplay = _qlFormatQty(item.qty);
+    return '<div class="ql-feed-item-row">' +
+           '<span class="ql-feed-item-icon">' + escHtml(initial) + '</span>' +
+           '<div class="ql-feed-item-name">' + escHtml(item.name) +
+             '<span class="ql-feed-item-meta">' + escHtml(item.source || 'manual') + '</span>' +
+           '</div>' +
+           '<div class="ql-feed-qty-stepper">' +
+             '<button class="ql-feed-qty-step" data-action="qlFeedAdjustQty" data-arg="' + idx + '" data-arg2="dec" type="button" aria-label="Decrease quantity">−</button>' +
+             '<span class="ql-feed-qty-val">' + qtyDisplay +
+               '<span class="ql-feed-qty-unit"> ' + escHtml(item.unit || '') + '</span>' +
+             '</span>' +
+             '<button class="ql-feed-qty-step" data-action="qlFeedAdjustQty" data-arg="' + idx + '" data-arg2="inc" type="button" aria-label="Increase quantity">+</button>' +
+           '</div>' +
+           '<button class="ql-feed-item-x" data-action="qlFeedRemoveItem" data-arg="' + idx + '" type="button" aria-label="Remove ' + escAttr(item.name) + '">×</button>' +
+           '</div>';
+  }).join('');
+}
+
+// Format qty as a unicode vulgar fraction when possible (¼ ½ ¾) plus
+// mixed numbers (1¼, 1½, 2¾). Outside the common set, falls back to
+// decimal with 2dp rounding.
+function _qlFormatQty(q) {
+  if (typeof q !== 'number' || isNaN(q)) return '1';
+  if (q === 0.25) return '¼';
+  if (q === 0.5)  return '½';
+  if (q === 0.75) return '¾';
+  var whole = Math.floor(q);
+  var frac = Math.round((q - whole) * 100) / 100;
+  if (frac === 0) return String(whole);
+  if (frac === 0.25) return whole + '¼';
+  if (frac === 0.5)  return whole + '½';
+  if (frac === 0.75) return whole + '¾';
+  return (Math.round(q * 100) / 100).toString();
+}
+
+// L3 — Next-item ribbon. Only appears after first item added. Confidence
+// % surfaced per chip (CV3-006 Honesty axis: parent sees WHY suggested).
+function _qlRenderNextItemRibbon() {
+  var wrap = document.getElementById('qlFeedNextWrap');
+  var ribbon = document.getElementById('qlFeedNextRibbon');
+  var label = document.getElementById('qlFeedNextLabel');
+  if (!wrap || !ribbon) return;
+  if (_qlFeedItems.length === 0) {
+    wrap.style.display = 'none';
+    ribbon.innerHTML = '';
+    return;
+  }
+  var predictions = window._fdGetNextItemPredictions(_qlFeedItems, _qlMeal, 4);
+  if (!predictions || predictions.length === 0) {
+    wrap.style.display = 'none';
+    ribbon.innerHTML = '';
+    return;
+  }
+  wrap.style.display = '';
+  if (label) {
+    var anchorName = _qlFeedItems[_qlFeedItems.length - 1].name;
+    label.textContent = _qlFeedItems.length === 1
+      ? 'You usually add (with ' + anchorName + ')'
+      : 'You usually add';
+  }
+  ribbon.innerHTML = predictions.map(function(p) {
+    return '<button class="ql-feed-next-chip" data-action="qlFeedAddItem"' +
+           ' data-arg="' + escAttr(p.name) + '" data-arg2="next" type="button">' +
+           '+ ' + escHtml(p.name) +
+           '<span class="ql-feed-next-conf">' + p.confidence + '%</span>' +
+           '</button>';
+  }).join('');
+}
+
+// ── F-2 handlers ──
+
+function qlFeedApplyRepeat(id) {
+  var cands = window._fdGetRepeatCandidates(_qlMeal, 6);
+  var found = cands.find(function(c) { return c.id === id; });
+  if (!found) return;
+  _qlFeedItems = found.items.slice().map(function(it) { return Object.assign({}, it); });
+  _qlFeedSourceFlow = 'fob-repeat';
+  _qlRenderFeedSheet();
+}
+
+function qlFeedApplyCombo(id) {
+  var combos = window._fdGetCombosForMeal(_qlMeal, { maxResults: 6 });
+  var found = combos.find(function(c) { return c.id === id; });
+  if (!found) return;
+  _qlFeedItems = found.items.slice().map(function(it) { return Object.assign({}, it); });
+  _qlFeedSourceFlow = 'fob-combo';
+  _qlRenderFeedSheet();
+}
+
+function qlFeedAddItem(name, source) {
+  if (!name) return;
+  var defaults = window._fdResolveQtyDefaults(name);
+  _qlFeedItems.push({
+    name: name,
+    qty: defaults.qty,
+    unit: defaults.unit,
+    nutritionRef: String(name).toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim(),
+    source: source || 'manual',
+  });
+  if (source === 'next' || source === 'typeahead') {
+    if (_qlFeedSourceFlow === 'fob-feed') _qlFeedSourceFlow = 'fob-novel';
+  }
+  // Clear typeahead input + dropdown
+  var inp = document.getElementById('qlFeedInput');
+  if (inp) inp.value = '';
+  var dd = document.getElementById('qlFeedDropdown');
+  if (dd) { dd.innerHTML = ''; dd.classList.remove('open'); }
+  _qlRenderFeedSheet();
+}
+
+function qlFeedAdjustQty(idxStr, dir) {
+  var idx = parseInt(idxStr, 10);
+  if (isNaN(idx) || !_qlFeedItems[idx]) return;
+  var item = _qlFeedItems[idx];
+  var defaults = window._fdResolveQtyDefaults(item.name);
+  var step = defaults.step || 0.25;
+  var delta = (dir === 'inc') ? step : -step;
+  var newQty = item.qty + delta;
+  if (newQty <= 0) return;  // don't allow zero — use × to remove
+  item.qty = Math.round(newQty * 100) / 100;
+  _qlRenderItemsList();
+}
+
+function qlFeedRemoveItem(idxStr) {
+  var idx = parseInt(idxStr, 10);
+  if (isNaN(idx) || !_qlFeedItems[idx]) return;
+  _qlFeedItems.splice(idx, 1);
+  _qlRenderFeedSheet();
+}
+
+function qlFeedTypeaheadInput() {
+  var inp = document.getElementById('qlFeedInput');
+  if (!inp) return;
+  var q = inp.value.trim();
+  var dd = document.getElementById('qlFeedDropdown');
+  if (!dd) return;
+  if (q.length < 1) {
+    dd.classList.remove('open');
+    dd.innerHTML = '';
+    return;
+  }
+  var matches = window._fdSearchNutrition(q, { max: 8 });
+  if (matches.length === 0) {
+    dd.innerHTML = '<div class="meal-dropdown-empty">No match. Press Enter to add as new food.</div>';
+    dd.classList.add('open');
+    return;
+  }
+  dd.innerHTML = matches.map(function(m) {
+    return '<div class="meal-dropdown-row ql-feed-ta-row"' +
+           ' data-action="qlFeedAddItem" data-arg="' + escAttr(m.name) + '" data-arg2="typeahead">' +
+           '<span class="ql-feed-ta-name">' + escHtml(m.name) + '</span>' +
+           '<span class="ql-feed-ta-meta">' + escHtml(m.source) + ' · ' +
+             _qlFormatQty(m.qty) + ' ' + escHtml(m.unit) +
+           '</span>' +
+           '</div>';
+  }).join('');
+  dd.classList.add('open');
+}
+
+function qlFeedSkipMeal() {
+  var dateStr = _qlBackfillDate || today();
+  if (!_qlMeal) return;
+  // Capture prev value for undo
+  var fd = load(KEYS.feeding, {}) || {};
+  var prevVal = fd[dateStr] ? fd[dateStr][_qlMeal] : '';
+  window._fdMarkMealSkipped(dateStr, _qlMeal);
+  var meal = _qlMeal;
+  var undoFn = function() {
+    var f = load(KEYS.feeding, {}) || {};
+    if (f[dateStr]) { f[dateStr][meal] = prevVal || ''; save(KEYS.feeding, f); feedingData = f; }
+    if (typeof _islMarkDirty === 'function') _islMarkDirty('diet');
+    var curTab2 = TAB_ORDER.find(function(t) { return document.getElementById('tab-' + t) && document.getElementById('tab-' + t).classList.contains('active'); });
+    if (curTab2 === 'diet') { if (typeof initFeeding === 'function') initFeeding(); if (typeof renderDietStats === 'function') renderDietStats(); }
+    if (curTab2 === 'home') renderHome();
+  };
+  closeQuickLogAll();
+  showQLToast(capitalize(meal) + ' marked as skipped', 4000, undoFn);
+  var curTab = TAB_ORDER.find(function(t) { return document.getElementById('tab-' + t) && document.getElementById('tab-' + t).classList.contains('active'); });
+  if (curTab === 'diet') { if (typeof initFeeding === 'function') initFeeding(); if (typeof renderDietStats === 'function') renderDietStats(); }
+  if (curTab === 'home') renderHome();
+}
+
 // ── Quick Log Save Functions ──
 
 function saveQLFeed() {
-  const food = document.getElementById('qlFeedInput').value.trim();
-  if (!food) { document.getElementById('qlFeedInput').focus(); return; }
   const dateStr = _qlBackfillDate || today();
 
-  // Load feeding data and merge into the correct day
-  const feeding = load(KEYS.feeding, {}) || {};
-  if (!feeding[dateStr]) feeding[dateStr] = { breakfast:'', lunch:'', dinner:'', snack:'' };
-  const day = feeding[dateStr];
+  // F-2: Fold any unsubmitted typed text in qlFeedInput as a final item
+  // (covers the "typed without picking typeahead → pressed Save" case).
+  // Comma-split for parents who paste a multi-item line.
+  const typedRaw = (document.getElementById('qlFeedInput')?.value || '').trim();
+  if (typedRaw) {
+    typedRaw.split(',').map(function(s) { return s.trim(); }).filter(Boolean).forEach(function(nm) {
+      const defaults = window._fdResolveQtyDefaults(nm);
+      _qlFeedItems.push({
+        name: nm,
+        qty: defaults.qty,
+        unit: defaults.unit,
+        nutritionRef: String(nm).toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim(),
+        source: 'typed',
+      });
+    });
+    if (_qlFeedSourceFlow === 'fob-feed') _qlFeedSourceFlow = 'fob-novel';
+    document.getElementById('qlFeedInput').value = '';
+  }
+
+  // Guard: must have at least one item to save.
+  if (_qlFeedItems.length === 0) {
+    document.getElementById('qlFeedInput')?.focus();
+    return;
+  }
 
   // Capture prev value for undo BEFORE mutation
+  const feedingPrev = load(KEYS.feeding, {}) || {};
   const undoMealKey = _qlMeal;
-  const prevMealValue = day[undoMealKey] || '';
+  const prevMealValue = (feedingPrev[dateStr] && feedingPrev[dateStr][undoMealKey]) || '';
 
-  day[_qlMeal] = day[_qlMeal] ? day[_qlMeal] + ', ' + food : food;
-  // Save meal time if entered
-  const qlTime = document.getElementById('qlFeedTime')?.value;
-  if (qlTime) day[_qlMeal + '_time'] = qlTime;
-  // Save intake level from QL pills
-  if (_qlSelectedIntake && _qlMeal !== 'snack') {
-    day[_qlMeal + '_intake'] = _qlSelectedIntake;
-  }
-  save(KEYS.feeding, feeding);
-  feedingData = feeding;
+  // Build the structured payload + write via the canonical F-2 writer.
+  const qlTime = (document.getElementById('qlFeedTime')?.value) || null;
+  const overallIntake = (typeof _qlSelectedIntake === 'number' && _qlSelectedIntake > 0)
+    ? _qlSelectedIntake
+    : 0.75;  // ratified default "Most"
+  const payload = {
+    items: _qlFeedItems.slice(),
+    time: qlTime,
+    overallIntake: overallIntake,
+    sourceFlow: _qlFeedSourceFlow,
+  };
+  window._fdWriteStructuredMeal(dateStr, _qlMeal, payload);
+
+  // Build legacy `food` string for downstream callers (toast nutrient flash,
+  // autoIntroduceFoodsFromDay, _qlFeedInsight). Comma-joined item names.
+  const food = _qlFeedItems.map(function(it) { return it.name; }).join(', ');
+
   _tsfMarkDirty();
 
   _islMarkDirty('diet');

--- a/split/intelligence-quicklog.js
+++ b/split/intelligence-quicklog.js
@@ -1093,6 +1093,351 @@ function _qlPredict() {
 }
 
 // ═══════════════════════════════════════════════════════════════
+// F-2 — Autofill intelligence layers (L1 Repeat / L2 Combo / L3 Next-item / L4 Typeahead)
+// Spec: docs/specs/food-sub-tab-v1.md §F-2; ratifications #1/#2/#6.
+// All four helpers read window.feedingData; all return shape-stable
+// arrays so the FOB Feed sheet renderer is decoupled from the source
+// data layout. parseFeedingV1 (data.js) normalizes legacy + structured
+// rows on the way in so the helpers operate on a canonical shape.
+// ═══════════════════════════════════════════════════════════════
+
+// _fdGetMealSlotByTime — thin wrapper around detectMealType() for
+// readability + decoupling. Ratification #1: existing adaptive 14d
+// window logic in _qlComputeMealWindow is BETTER than fixed bands —
+// reuse it. Returns 'breakfast' | 'lunch' | 'dinner' | 'snack'.
+window._fdGetMealSlotByTime = function() {
+  return detectMealType();
+};
+
+// L1 — Repeat candidates. Returns up to `n` (default 3) recent meals
+// for the given slot, formatted for one-tap apply. For dinner, the
+// FIRST candidate is "Same as lunch (today)" if today's lunch is logged
+// (ratification #6 — 46% lunch=dinner match in observed data).
+//
+// Each candidate: { id, label, sub, items[], itemsText, ageRel, source }
+// label  — short chip text ("Yesterday's breakfast" / "Same as lunch today")
+// sub    — items preview (truncated, comma-separated)
+// items  — array of {name, qty, unit, nutritionRef} ready to apply
+// source — 'today-lunch' | 'yesterday' | 'recent' (telemetry)
+window._fdGetRepeatCandidates = function(meal, n) {
+  n = n || 3;
+  var out = [];
+  var todayStr = today();
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+
+  function dayLabel(daysAgo) {
+    if (daysAgo === 0) return 'Today';
+    if (daysAgo === 1) return 'Yesterday';
+    if (daysAgo < 7)  return daysAgo + ' days ago';
+    return 'Last week';
+  }
+
+  function structuredItemsFromMeal(mealVal) {
+    var parsed = window.parseFeedingV1(mealVal);
+    if (!parsed || !parsed.items || parsed.items.length === 0) return null;
+    if (parsed.skipped) return null;
+    // Hydrate any items missing qty/unit via the defaults resolver
+    var items = parsed.items.map(function(it) {
+      if (it.qty !== undefined && it.unit) return it;
+      var d = window._fdResolveQtyDefaults(it.name);
+      return Object.assign({}, it, { qty: d.qty, unit: d.unit });
+    });
+    return items;
+  }
+
+  // Ratification #6 — for dinner, surface today's lunch FIRST if logged.
+  if (meal === 'dinner' && fd[todayStr] && fd[todayStr].lunch) {
+    var lunchItems = structuredItemsFromMeal(fd[todayStr].lunch);
+    if (lunchItems && lunchItems.length) {
+      out.push({
+        id: 'today-lunch',
+        label: 'Same as today\'s lunch',
+        sub: lunchItems.map(function(it){return it.name;}).join(', '),
+        items: lunchItems,
+        itemsText: lunchItems.map(function(it){return it.name;}).join(', '),
+        ageRel: 'today',
+        source: 'today-lunch',
+      });
+    }
+  }
+
+  // Walk back up to 14 days; collect candidates for the same slot.
+  for (var d = 1; d <= 14 && out.length < n; d++) {
+    var dd = new Date(); dd.setDate(dd.getDate() - d);
+    var ds = toDateStr(dd);
+    var day = fd[ds];
+    if (!day) continue;
+    var items = structuredItemsFromMeal(day[meal]);
+    if (!items) continue;
+    out.push({
+      id: 'repeat-' + ds,
+      label: (d === 1 ? 'Yesterday\'s ' : dayLabel(d).toLowerCase() + ' ') + meal,
+      sub: items.map(function(it){return it.name;}).join(', '),
+      items: items,
+      itemsText: items.map(function(it){return it.name;}).join(', '),
+      ageRel: dayLabel(d),
+      source: d === 1 ? 'yesterday' : 'recent',
+    });
+  }
+
+  return out;
+};
+
+// L2 — Combo templates. Rolling 14d window: find combos (item-sets) that
+// repeat >= 2x in the same slot. Sort by frequency desc; break ties by
+// recency. Cold-start fallback to CURATED_COMBOS when <7 days of signal.
+//
+// Each combo: { id, label, items[], freq, source }
+// label  — "Your usual breakfast" (or "Pediatrician-suggested" for curated)
+// items  — array with default qty/unit hydrated via _fdResolveQtyDefaults
+// freq   — N× (observed frequency in window) or null (curated)
+// source — '14d-rolling' | 'curated'
+window._fdGetCombosForMeal = function(meal, opts) {
+  opts = opts || {};
+  var maxResults = opts.maxResults || 3;
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+  var todayStr = today();
+  var cutoff = new Date(); cutoff.setDate(cutoff.getDate() - 14);
+  var cutoffStr = toDateStr(cutoff);
+
+  // Collect (sorted-item-set → freq + lastDate) over 14d
+  var comboMap = {};
+  var daysWithSignal = 0;
+
+  Object.keys(fd).forEach(function(ds) {
+    if (ds < cutoffStr || ds > todayStr) return;
+    var day = fd[ds];
+    if (!day) return;
+    var parsed = window.parseFeedingV1(day[meal]);
+    if (!parsed || !parsed.items || parsed.items.length === 0 || parsed.skipped) return;
+    daysWithSignal++;
+    var names = parsed.items.map(function(it){ return String(it.name || '').toLowerCase().trim(); })
+                            .filter(function(n){ return n.length > 1; });
+    if (names.length < 2) return;
+    var sig = names.slice().sort().join('|');
+    if (!comboMap[sig]) comboMap[sig] = { items: parsed.items, freq: 0, lastDate: ds, names: names };
+    comboMap[sig].freq++;
+    if (ds > comboMap[sig].lastDate) {
+      comboMap[sig].lastDate = ds;
+      comboMap[sig].items = parsed.items;  // refresh with most-recent qty/unit
+    }
+  });
+
+  // Cold start — fall through to curated if <7 days of data for this slot
+  if (daysWithSignal < 7) {
+    var ageMonths = (typeof _zivaAgeMonths === 'function') ? _zivaAgeMonths() : null;
+    var curated = window._fdGetCuratedCombosForMeal(meal, ageMonths);
+    return curated.slice(0, maxResults).map(function(c, i) {
+      var items = c.items.map(function(name) {
+        var d = window._fdResolveQtyDefaults(name);
+        return { name: name, qty: d.qty, unit: d.unit, nutritionRef: name.toLowerCase().replace(/\s*\([^)]*\)\s*/g,'').trim(), source: 'curated' };
+      });
+      return {
+        id: 'curated-' + meal + '-' + i,
+        label: i === 0 ? 'Pediatrician-suggested' : 'Another suggestion',
+        items: items,
+        itemsText: items.map(function(it){return it.name;}).join(', '),
+        freq: null,
+        source: 'curated',
+        rationale: c.rationale,
+      };
+    });
+  }
+
+  // Rolling window — surface top combos with freq >= 2
+  var sorted = Object.keys(comboMap)
+    .map(function(sig){ return comboMap[sig]; })
+    .filter(function(c){ return c.freq >= 2; })
+    .sort(function(a, b){ return b.freq - a.freq || (b.lastDate > a.lastDate ? 1 : -1); });
+
+  if (sorted.length === 0) {
+    // No combos hit 2x — fall through to curated
+    var ageMonths2 = (typeof _zivaAgeMonths === 'function') ? _zivaAgeMonths() : null;
+    var curated2 = window._fdGetCuratedCombosForMeal(meal, ageMonths2);
+    return curated2.slice(0, maxResults).map(function(c, i) {
+      var items = c.items.map(function(name) {
+        var d = window._fdResolveQtyDefaults(name);
+        return { name: name, qty: d.qty, unit: d.unit, nutritionRef: name.toLowerCase().replace(/\s*\([^)]*\)\s*/g,'').trim(), source: 'curated' };
+      });
+      return {
+        id: 'curated-fallback-' + meal + '-' + i,
+        label: 'Pediatrician-suggested',
+        items: items,
+        itemsText: items.map(function(it){return it.name;}).join(', '),
+        freq: null,
+        source: 'curated',
+        rationale: c.rationale,
+      };
+    });
+  }
+
+  return sorted.slice(0, maxResults).map(function(c, i) {
+    // Hydrate items with default qty/unit if missing
+    var items = c.items.map(function(it){
+      if (it.qty !== undefined && it.unit) return it;
+      var d = window._fdResolveQtyDefaults(it.name);
+      return Object.assign({}, it, { qty: d.qty, unit: d.unit });
+    });
+    return {
+      id: 'combo-' + i,
+      label: i === 0 ? 'Your usual ' + meal : 'Another usual',
+      items: items,
+      itemsText: items.map(function(it){return it.name;}).join(', '),
+      freq: c.freq,
+      source: '14d-rolling',
+    };
+  });
+};
+
+// L3 — Next-item prediction. Given a set of items already in the current
+// meal, return the top `n` foods that co-occur with them in the rolling
+// 14d window of the same slot. Each prediction carries an honest
+// confidence % (CV3-006 Honesty axis — parents see WHY a suggestion is
+// surfaced). Excludes foods already in currentItems.
+//
+// Each prediction: { name, confidence, freq, denom }
+//   confidence: rounded percentage (0-100)
+//   freq:       count of co-occurrences with currentItems set
+//   denom:      total observations of the anchor item(s)
+window._fdGetNextItemPredictions = function(currentItems, meal, n) {
+  n = n || 4;
+  if (!Array.isArray(currentItems) || currentItems.length === 0) return [];
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+  var todayStr = today();
+  var cutoff = new Date(); cutoff.setDate(cutoff.getDate() - 14);
+  var cutoffStr = toDateStr(cutoff);
+
+  // Normalize current items to lowercase base names
+  var currentSet = {};
+  var anchorNames = currentItems.map(function(it) {
+    var name = String(it.name || it || '').toLowerCase().trim();
+    currentSet[name] = true;
+    return name;
+  });
+
+  // Walk 14d; for each day's same-slot entry that contains AT LEAST ONE
+  // anchor item, count co-occurrences of every other item in that meal.
+  var coCount = {};   // candidate name → co-occurrence count
+  var anchorDenom = 0;  // total days where any anchor item appears in slot
+
+  Object.keys(fd).forEach(function(ds) {
+    if (ds < cutoffStr || ds > todayStr) return;
+    var day = fd[ds];
+    if (!day) return;
+    var parsed = window.parseFeedingV1(day[meal]);
+    if (!parsed || !parsed.items || parsed.items.length === 0 || parsed.skipped) return;
+    var names = parsed.items.map(function(it){ return String(it.name || '').toLowerCase().trim(); });
+    // Does this day contain any anchor item?
+    var hasAnchor = anchorNames.some(function(a) { return names.indexOf(a) >= 0; });
+    if (!hasAnchor) return;
+    anchorDenom++;
+    // Count every non-anchor item that appears
+    names.forEach(function(n) {
+      if (currentSet[n]) return;  // skip items already in current meal
+      if (!coCount[n]) coCount[n] = { name: parsed.items.find(function(it) { return String(it.name).toLowerCase().trim() === n; }).name, freq: 0 };
+      coCount[n].freq++;
+    });
+  });
+
+  if (anchorDenom < 2) return [];  // not enough signal yet
+
+  var ranked = Object.keys(coCount).map(function(k) {
+    var c = coCount[k];
+    return {
+      name: c.name,
+      freq: c.freq,
+      denom: anchorDenom,
+      confidence: Math.round((c.freq / anchorDenom) * 100),
+    };
+  }).filter(function(p) { return p.confidence >= 20; })  // floor — don't surface noisy 1/14 hits
+    .sort(function(a, b) { return b.confidence - a.confidence; });
+
+  return ranked.slice(0, n);
+};
+
+// L4 — Typeahead. As-you-type match against NUTRITION + ziva_foods
+// (parent-introduced foods). Returns matches with default qty/unit
+// inlined so the dropdown can render the qty hint without an extra
+// resolver call per row.
+//
+// Each match: { name, source: 'nutrition' | 'introduced' | 'recent', qty, unit, step }
+window._fdSearchNutrition = function(query, opts) {
+  opts = opts || {};
+  var max = opts.max || 8;
+  if (!query || typeof query !== 'string') return [];
+  var q = query.toLowerCase().trim();
+  if (q.length < 1) return [];
+
+  var seen = {};
+  var matches = [];
+
+  function pushMatch(name, src) {
+    var key = String(name).toLowerCase().trim();
+    if (seen[key]) return;
+    seen[key] = true;
+    var d = window._fdResolveQtyDefaults(name);
+    matches.push({
+      name: name,
+      source: src,
+      qty: d.qty,
+      unit: d.unit,
+      step: d.step,
+    });
+  }
+
+  // 1. NUTRITION — base lookup (canonical food names)
+  if (typeof NUTRITION === 'object' && NUTRITION) {
+    Object.keys(NUTRITION).forEach(function(k) {
+      if (matches.length >= max * 2) return;
+      if (k.indexOf(q) === 0) pushMatch(k.charAt(0).toUpperCase() + k.slice(1), 'nutrition');
+    });
+    // Looser match — name contains query (after exact-prefix matches)
+    Object.keys(NUTRITION).forEach(function(k) {
+      if (matches.length >= max * 2) return;
+      if (k.indexOf(q) > 0) pushMatch(k.charAt(0).toUpperCase() + k.slice(1), 'nutrition');
+    });
+  }
+
+  // 2. Parent-introduced foods (ziva_foods list)
+  try {
+    var introduced = (typeof load === 'function') ? load(KEYS && KEYS.foods, []) || [] : [];
+    if (Array.isArray(introduced)) {
+      introduced.forEach(function(entry) {
+        if (matches.length >= max * 2) return;
+        var nm = entry && entry.name ? String(entry.name) : '';
+        if (!nm) return;
+        if (nm.toLowerCase().indexOf(q) >= 0) pushMatch(nm, 'introduced');
+      });
+    }
+  } catch(e) { /* introduced list is best-effort */ }
+
+  // 3. Recent items from feedingData (last 14 days, any slot) — surfaces
+  // foods the parent has actually been using (catches typeahead matches
+  // for foods that exist in their flow but not yet in NUTRITION).
+  try {
+    var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+    var cutoff = new Date(); cutoff.setDate(cutoff.getDate() - 14);
+    var cutoffStr = toDateStr(cutoff);
+    Object.keys(fd).forEach(function(ds) {
+      if (matches.length >= max * 2) return;
+      if (ds < cutoffStr) return;
+      ['breakfast','lunch','dinner','snack'].forEach(function(m) {
+        if (matches.length >= max * 2) return;
+        var parsed = window.parseFeedingV1(fd[ds][m]);
+        if (!parsed || !parsed.items) return;
+        parsed.items.forEach(function(it) {
+          if (matches.length >= max * 2) return;
+          var nm = it.name || '';
+          if (nm.toLowerCase().indexOf(q) >= 0) pushMatch(nm, 'recent');
+        });
+      });
+    });
+  } catch(e) { /* best-effort */ }
+
+  return matches.slice(0, max);
+};
+
+// ═══════════════════════════════════════════════════════════════
 // SMART QUICK LOG — Suggest Card Rendering
 // ═══════════════════════════════════════════════════════════════
 

--- a/split/intelligence-quicklog.js
+++ b/split/intelligence-quicklog.js
@@ -1132,22 +1132,21 @@ window._fdGetRepeatCandidates = function(meal, n) {
     return 'Last week';
   }
 
-  function structuredItemsFromMeal(mealVal) {
-    var parsed = window.parseFeedingV1(mealVal);
-    if (!parsed || !parsed.items || parsed.items.length === 0) return null;
-    if (parsed.skipped) return null;
-    // Hydrate any items missing qty/unit via the defaults resolver
-    var items = parsed.items.map(function(it) {
+  function itemsFromDay(day, mealKey) {
+    if (!day) return null;
+    var rec = window._fdReadDayMeal(day, mealKey);
+    if (!rec || rec.skipped || !rec.items || rec.items.length === 0) return null;
+    // Hydrate any items missing qty/unit (legacy-string-parsed records lack them).
+    return rec.items.map(function(it) {
       if (it.qty !== undefined && it.unit) return it;
-      var d = window._fdResolveQtyDefaults(it.name);
-      return Object.assign({}, it, { qty: d.qty, unit: d.unit });
+      var defaults = window._fdResolveQtyDefaults(it.name);
+      return Object.assign({}, it, { qty: defaults.qty, unit: defaults.unit });
     });
-    return items;
   }
 
   // Ratification #6 — for dinner, surface today's lunch FIRST if logged.
-  if (meal === 'dinner' && fd[todayStr] && fd[todayStr].lunch) {
-    var lunchItems = structuredItemsFromMeal(fd[todayStr].lunch);
+  if (meal === 'dinner' && fd[todayStr]) {
+    var lunchItems = itemsFromDay(fd[todayStr], 'lunch');
     if (lunchItems && lunchItems.length) {
       out.push({
         id: 'today-lunch',
@@ -1165,9 +1164,7 @@ window._fdGetRepeatCandidates = function(meal, n) {
   for (var d = 1; d <= 14 && out.length < n; d++) {
     var dd = new Date(); dd.setDate(dd.getDate() - d);
     var ds = toDateStr(dd);
-    var day = fd[ds];
-    if (!day) continue;
-    var items = structuredItemsFromMeal(day[meal]);
+    var items = itemsFromDay(fd[ds], meal);
     if (!items) continue;
     out.push({
       id: 'repeat-' + ds,
@@ -1208,18 +1205,18 @@ window._fdGetCombosForMeal = function(meal, opts) {
     if (ds < cutoffStr || ds > todayStr) return;
     var day = fd[ds];
     if (!day) return;
-    var parsed = window.parseFeedingV1(day[meal]);
-    if (!parsed || !parsed.items || parsed.items.length === 0 || parsed.skipped) return;
+    var rec = window._fdReadDayMeal(day, meal);
+    if (!rec || rec.skipped || !rec.items || rec.items.length === 0) return;
     daysWithSignal++;
-    var names = parsed.items.map(function(it){ return String(it.name || '').toLowerCase().trim(); })
-                            .filter(function(n){ return n.length > 1; });
+    var names = rec.items.map(function(it){ return String(it.name || '').toLowerCase().trim(); })
+                         .filter(function(n){ return n.length > 1; });
     if (names.length < 2) return;
     var sig = names.slice().sort().join('|');
-    if (!comboMap[sig]) comboMap[sig] = { items: parsed.items, freq: 0, lastDate: ds, names: names };
+    if (!comboMap[sig]) comboMap[sig] = { items: rec.items, freq: 0, lastDate: ds, names: names };
     comboMap[sig].freq++;
     if (ds > comboMap[sig].lastDate) {
       comboMap[sig].lastDate = ds;
-      comboMap[sig].items = parsed.items;  // refresh with most-recent qty/unit
+      comboMap[sig].items = rec.items;  // refresh with most-recent qty/unit
     }
   });
 
@@ -1324,9 +1321,9 @@ window._fdGetNextItemPredictions = function(currentItems, meal, n) {
     if (ds < cutoffStr || ds > todayStr) return;
     var day = fd[ds];
     if (!day) return;
-    var parsed = window.parseFeedingV1(day[meal]);
-    if (!parsed || !parsed.items || parsed.items.length === 0 || parsed.skipped) return;
-    var names = parsed.items.map(function(it){ return String(it.name || '').toLowerCase().trim(); });
+    var rec = window._fdReadDayMeal(day, meal);
+    if (!rec || rec.skipped || !rec.items || rec.items.length === 0) return;
+    var names = rec.items.map(function(it){ return String(it.name || '').toLowerCase().trim(); });
     // Does this day contain any anchor item?
     var hasAnchor = anchorNames.some(function(a) { return names.indexOf(a) >= 0; });
     if (!hasAnchor) return;
@@ -1334,7 +1331,7 @@ window._fdGetNextItemPredictions = function(currentItems, meal, n) {
     // Count every non-anchor item that appears
     names.forEach(function(n) {
       if (currentSet[n]) return;  // skip items already in current meal
-      if (!coCount[n]) coCount[n] = { name: parsed.items.find(function(it) { return String(it.name).toLowerCase().trim() === n; }).name, freq: 0 };
+      if (!coCount[n]) coCount[n] = { name: rec.items.find(function(it) { return String(it.name).toLowerCase().trim() === n; }).name, freq: 0 };
       coCount[n].freq++;
     });
   });
@@ -1423,9 +1420,9 @@ window._fdSearchNutrition = function(query, opts) {
       if (ds < cutoffStr) return;
       ['breakfast','lunch','dinner','snack'].forEach(function(m) {
         if (matches.length >= max * 2) return;
-        var parsed = window.parseFeedingV1(fd[ds][m]);
-        if (!parsed || !parsed.items) return;
-        parsed.items.forEach(function(it) {
+        var rec = window._fdReadDayMeal(fd[ds], m);
+        if (!rec || rec.skipped || !rec.items) return;
+        rec.items.forEach(function(it) {
           if (matches.length >= max * 2) return;
           var nm = it.name || '';
           if (nm.toLowerCase().indexOf(q) >= 0) pushMatch(nm, 'recent');
@@ -2112,11 +2109,18 @@ function saveQLFeed() {
   // Accuracy tracking
   _qlLogAction('feed:' + _qlMeal, _qlSuggestUsed);
 
-  // Build undo function
+  // Build undo function — restore prev legacy value AND clear the v1 sidecar
+  // (otherwise stale structured data lingers after undo).
   const undoDateStr = dateStr;
   const undoFn = () => {
     const f = load(KEYS.feeding, {}) || {};
-    if (f[undoDateStr]) { f[undoDateStr][undoMealKey] = prevMealValue; save(KEYS.feeding, f); feedingData = f; _islMarkDirty('diet'); }
+    if (f[undoDateStr]) {
+      f[undoDateStr][undoMealKey] = prevMealValue;
+      delete f[undoDateStr][undoMealKey + '_v1'];
+      save(KEYS.feeding, f);
+      feedingData = f;
+      _islMarkDirty('diet');
+    }
   };
 
   closeQuickLogAll();

--- a/split/intelligence-quicklog.js
+++ b/split/intelligence-quicklog.js
@@ -1119,10 +1119,16 @@ window._fdGetMealSlotByTime = function() {
 // sub    — items preview (truncated, comma-separated)
 // items  — array of {name, qty, unit, nutritionRef} ready to apply
 // source — 'today-lunch' | 'yesterday' | 'recent' (telemetry)
-window._fdGetRepeatCandidates = function(meal, n) {
+window._fdGetRepeatCandidates = function(meal, n, opts) {
   n = n || 3;
+  opts = opts || {};
   var out = [];
-  var todayStr = today();
+  // F-2 fix (A2): use opts.fromDate (caller's active date — typically
+  // _qlBackfillDate || today()) so backfill flows walk back from the
+  // RIGHT date. Without this, backfilling dinner for 2026-05-15
+  // surfaces today's lunch as "Same as today's lunch" + applying the
+  // chip writes today's items to the May 15 slot.
+  var todayStr = opts.fromDate || today();
   var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
 
   function dayLabel(daysAgo) {
@@ -1160,9 +1166,13 @@ window._fdGetRepeatCandidates = function(meal, n) {
     }
   }
 
-  // Walk back up to 14 days; collect candidates for the same slot.
+  // Walk back up to 14 days FROM the active date (todayStr; may be
+  // _qlBackfillDate). HR-12-safe: parse with explicit y/m/d construction.
+  var anchorParts = todayStr.split('-');
+  var anchorDate = new Date(parseInt(anchorParts[0]), parseInt(anchorParts[1]) - 1, parseInt(anchorParts[2]));  // HR-12-safe
   for (var d = 1; d <= 14 && out.length < n; d++) {
-    var dd = new Date(); dd.setDate(dd.getDate() - d);
+    var dd = new Date(anchorDate.getTime());
+    dd.setDate(dd.getDate() - d);
     var ds = toDateStr(dd);
     var items = itemsFromDay(fd[ds], meal);
     if (!items) continue;
@@ -1501,13 +1511,21 @@ function _qlConfirmSuggest() {
   _qlSuggestUsed = true;
   var pred = _qlActivePredictions.find(function(p) { return p.type === 'feed'; });
   if (!pred) return;
+  // F-2 fix (C1): mark meal explicit so openQuickModal preserves intent
   _qlMeal = pred.meal;
+  _qlMealExplicit = true;
   openQuickModal('feed');
+  // F-2 fix (C2): push predicted foods directly into _qlFeedItems so the
+  // Items list reflects what will be saved, not just the typeahead input
+  // (which would leave the Items list misleadingly empty until typed-text
+  // fold-in at Save time — and the items would route via 'fob-typed'
+  // bypassing the structured-shape clean-data gate).
   setTimeout(function() {
-    document.querySelectorAll('.ql-meal-pill').forEach(function(p) { p.classList.toggle('active', p.dataset.meal === pred.meal); });
-    if (pred.foods) {
-      var inp = document.getElementById('qlFeedInput');
-      if (inp) inp.value = pred.foods;
+    if (pred.foods && typeof qlFeedAddItem === 'function') {
+      String(pred.foods).split(/\s*\+\s*|,\s*/).forEach(function(name) {
+        var trimmed = name.trim();
+        if (trimmed) qlFeedAddItem(trimmed, 'typeahead');
+      });
     }
   }, 50);
 }
@@ -1516,18 +1534,17 @@ function _qlEditSuggest() {
   _qlSuggestUsed = true;
   var pred = _qlActivePredictions.find(function(p) { return p.type === 'feed'; });
   var meal = pred ? pred.meal : detectMealType();
+  // F-2 fix (C1): mark meal explicit so openQuickModal preserves intent
   _qlMeal = meal;
+  _qlMealExplicit = true;
   openQuickModal('feed');
-  setTimeout(function() {
-    document.querySelectorAll('.ql-meal-pill').forEach(function(p) { p.classList.toggle('active', p.dataset.meal === meal); });
-  }, 50);
 }
 
 // ═══════════════════════════════════════════════════════════════
 // SMART QUICK LOG — Post-Save Micro-Insights
 // ═══════════════════════════════════════════════════════════════
 
-function _qlFeedInsight() {
+function _qlFeedInsight(foodArg) {
   try {
     var todayStr = today();
     var day = feedingData[todayStr];
@@ -1535,7 +1552,11 @@ function _qlFeedInsight() {
     var mealCount = ['breakfast', 'lunch', 'dinner'].filter(function(m) { return day[m] && day[m].trim(); }).length;
     if (mealCount >= 3) return '3rd meal today \u2014 great variety!';
 
-    var food = document.getElementById('qlFeedInput')?.value?.trim() || '';
+    // F-2 fix (C3/E_e): saveQLFeed now clears qlFeedInput AFTER folding
+    // typed text into _qlFeedItems but BEFORE calling _qlFeedInsight.
+    // The legacy input-read path returns '' and the 'New food!' branch
+    // dies silently. Prefer the food arg (built from items by caller).
+    var food = (typeof foodArg === 'string' && foodArg) ? foodArg : (document.getElementById('qlFeedInput')?.value?.trim() || '');
     if (food) {
       var base = _baseFoodName(food);
       var isNew = !foods.some(function(f) { return _baseFoodName(f.name) === base; });
@@ -1683,9 +1704,13 @@ function qaAnswerFavoriteFoods() {
 }
 
 function setQLMeal(meal) {
+  // F-2 fix (C1): user-driven meal pill tap is explicit by intent
   _qlMeal = meal;
+  _qlMealExplicit = true;
   document.querySelectorAll('.ql-meal-pill').forEach(p => p.classList.toggle('active', p.dataset.meal === meal));
-  // F-2: refresh autofill regions on meal change — repeats + combos differ per slot.
+  // F-2: re-hydrate items from the new meal slot (preserves multi-save flow
+  // when parent switches B→L→D) + refresh autofill regions.
+  if (typeof _qlFeedReset === 'function') _qlFeedReset();
   if (typeof _qlRenderFeedSheet === 'function') _qlRenderFeedSheet();
 }
 
@@ -1753,6 +1778,28 @@ function _qlFeedReset() {
   if (inp) inp.value = '';
   var dd = document.getElementById('qlFeedDropdown');
   if (dd) { dd.innerHTML = ''; dd.classList.remove('open'); }
+  // F-2 fix (B1): if the slot is already logged for the active date,
+  // hydrate _qlFeedItems from the existing meal so re-opening the FOB
+  // Feed sheet on an already-logged meal preserves prior items. Without
+  // this, the historical "log a few items, come back, add more" flow
+  // silently destroys the prior save (REPLACE semantic + empty Items
+  // list on reopen). Skipped meals don't hydrate — parent re-opening
+  // a skipped slot is intentionally starting fresh.
+  var dateStr = _qlBackfillDate || today();
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+  if (fd[dateStr] && _qlMeal && typeof window._fdReadDayMeal === 'function') {
+    var rec = window._fdReadDayMeal(fd[dateStr], _qlMeal);
+    if (rec && !rec.skipped && rec.items && rec.items.length > 0) {
+      _qlFeedItems = rec.items.map(function(it) {
+        if (it.qty !== undefined && it.unit) return Object.assign({}, it);
+        var defaults = window._fdResolveQtyDefaults(it.name);
+        return Object.assign({}, it, { qty: defaults.qty, unit: defaults.unit });
+      });
+      // Preserve the original sourceFlow so re-save doesn't downgrade
+      // a 'fob-combo' meal to 'fob-feed' on an unchanged re-save.
+      _qlFeedSourceFlow = rec.sourceFlow || 'fob-feed';
+    }
+  }
 }
 
 // Render all dynamic regions of the FOB Feed sheet. Called on open + after
@@ -1766,11 +1813,19 @@ function _qlRenderFeedSheet() {
 
 // L1 — Repeat rail. Surfaces yesterday's/recent matching-slot meals as
 // one-tap apply chips. For dinner, "Same as today's lunch" leads if logged.
+// F-2 fix (A6): hidden once items are present (mirror the combos-rail
+// behavior). Otherwise an accidental tap on a still-visible repeat chip
+// silently wipes the parent's in-progress items with no undo affordance.
 function _qlRenderRepeatRail() {
   var wrap = document.getElementById('qlFeedRepeatWrap');
   var rail = document.getElementById('qlFeedRepeatRail');
   if (!wrap || !rail) return;
-  var candidates = window._fdGetRepeatCandidates(_qlMeal, 3);
+  if (_qlFeedItems.length > 0) {
+    wrap.style.display = 'none';
+    rail.innerHTML = '';
+    return;
+  }
+  var candidates = window._fdGetRepeatCandidates(_qlMeal, 3, { fromDate: _qlBackfillDate || today() });
   if (!candidates || candidates.length === 0) {
     wrap.style.display = 'none';
     rail.innerHTML = '';
@@ -1906,7 +1961,7 @@ function _qlRenderNextItemRibbon() {
 // ── F-2 handlers ──
 
 function qlFeedApplyRepeat(id) {
-  var cands = window._fdGetRepeatCandidates(_qlMeal, 6);
+  var cands = window._fdGetRepeatCandidates(_qlMeal, 6, { fromDate: _qlBackfillDate || today() });
   var found = cands.find(function(c) { return c.id === id; });
   if (!found) return;
   _qlFeedItems = found.items.slice().map(function(it) { return Object.assign({}, it); });
@@ -1925,22 +1980,36 @@ function qlFeedApplyCombo(id) {
 
 function qlFeedAddItem(name, source) {
   if (!name) return;
+  // F-2 fix (B4): dedup by base name. Same food added via L3 next-item +
+  // L4 typeahead would otherwise produce duplicate rows in _qlFeedItems,
+  // each with its own qty stepper, and double-count in the post-save
+  // nutrient flash + autoIntroduceFoodsFromDay. For F-2 a meal entry
+  // carries one item per food; quantity adjustments use the stepper.
+  var normalized = String(name).toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim();
+  var alreadyPresent = _qlFeedItems.some(function(it) {
+    var n = String(it.name).toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim();
+    return n === normalized;
+  });
+  // Clear typeahead input + dropdown regardless (parent's input was consumed)
+  var inp = document.getElementById('qlFeedInput');
+  if (inp) inp.value = '';
+  var dd = document.getElementById('qlFeedDropdown');
+  if (dd) { dd.innerHTML = ''; dd.classList.remove('open'); }
+  if (alreadyPresent) {
+    if (typeof showQLToast === 'function') showQLToast(name + ' already added — adjust qty with +/-', 2000);
+    return;
+  }
   var defaults = window._fdResolveQtyDefaults(name);
   _qlFeedItems.push({
     name: name,
     qty: defaults.qty,
     unit: defaults.unit,
-    nutritionRef: String(name).toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim(),
+    nutritionRef: normalized,
     source: source || 'manual',
   });
   if (source === 'next' || source === 'typeahead') {
     if (_qlFeedSourceFlow === 'fob-feed') _qlFeedSourceFlow = 'fob-novel';
   }
-  // Clear typeahead input + dropdown
-  var inp = document.getElementById('qlFeedInput');
-  if (inp) inp.value = '';
-  var dd = document.getElementById('qlFeedDropdown');
-  if (dd) { dd.innerHTML = ''; dd.classList.remove('open'); }
   _qlRenderFeedSheet();
 }
 
@@ -1996,21 +2065,42 @@ function qlFeedTypeaheadInput() {
 function qlFeedSkipMeal() {
   var dateStr = _qlBackfillDate || today();
   if (!_qlMeal) return;
-  // Capture prev value for undo
+  // F-2 fix (A3 + B3): capture FULL prev state for atomic undo —
+  // legacy [meal] string + [meal+'_v1'] sidecar + [meal+'_time'] +
+  // [meal+'_intake']. Otherwise undo restores only the legacy string
+  // and leaves a phantom time/intake or loses the structured shape.
   var fd = load(KEYS.feeding, {}) || {};
-  var prevVal = fd[dateStr] ? fd[dateStr][_qlMeal] : '';
+  var prevDay = fd[dateStr] || {};
+  var prevVal = prevDay[_qlMeal];
+  var prevSidecar = prevDay[_qlMeal + '_v1'];
+  var prevTime = prevDay[_qlMeal + '_time'];
+  var prevIntake = prevDay[_qlMeal + '_intake'];
   window._fdMarkMealSkipped(dateStr, _qlMeal);
   var meal = _qlMeal;
   var undoFn = function() {
     var f = load(KEYS.feeding, {}) || {};
-    if (f[dateStr]) { f[dateStr][meal] = prevVal || ''; save(KEYS.feeding, f); feedingData = f; }
+    if (!f[dateStr]) f[dateStr] = { breakfast: '', lunch: '', dinner: '', snack: '' };
+    if (prevVal !== undefined) f[dateStr][meal] = prevVal; else f[dateStr][meal] = '';
+    if (prevSidecar !== undefined) f[dateStr][meal + '_v1'] = prevSidecar; else delete f[dateStr][meal + '_v1'];
+    if (prevTime !== undefined) f[dateStr][meal + '_time'] = prevTime; else delete f[dateStr][meal + '_time'];
+    if (prevIntake !== undefined) f[dateStr][meal + '_intake'] = prevIntake; else delete f[dateStr][meal + '_intake'];
+    save(KEYS.feeding, f);
+    feedingData = f;
     if (typeof _islMarkDirty === 'function') _islMarkDirty('diet');
+    if (typeof updateMealSkipButtons === 'function') updateMealSkipButtons();
     var curTab2 = TAB_ORDER.find(function(t) { return document.getElementById('tab-' + t) && document.getElementById('tab-' + t).classList.contains('active'); });
     if (curTab2 === 'diet') { if (typeof initFeeding === 'function') initFeeding(); if (typeof renderDietStats === 'function') renderDietStats(); }
     if (curTab2 === 'home') renderHome();
   };
+  // F-2 fix (A4): reset _qlBackfillDate so subsequent QL opens (sleep/nap/poop/etc.)
+  // don't inherit stale backfill state across modal types.
+  _qlBackfillDate = null;
   closeQuickLogAll();
   showQLToast(capitalize(meal) + ' marked as skipped', 4000, undoFn);
+  // F-2 fix (R1): updateMealSkipButtons refreshes the Diet tab's per-meal
+  // Skip toggles so a subsequent tap on the now-stale legacy Skip button
+  // doesn't silently UNSKIP the meal we just skipped via FOB.
+  if (typeof updateMealSkipButtons === 'function') updateMealSkipButtons();
   var curTab = TAB_ORDER.find(function(t) { return document.getElementById('tab-' + t) && document.getElementById('tab-' + t).classList.contains('active'); });
   if (curTab === 'diet') { if (typeof initFeeding === 'function') initFeeding(); if (typeof renderDietStats === 'function') renderDietStats(); }
   if (curTab === 'home') renderHome();
@@ -2046,10 +2136,18 @@ function saveQLFeed() {
     return;
   }
 
-  // Capture prev value for undo BEFORE mutation
-  const feedingPrev = load(KEYS.feeding, {}) || {};
+  // Capture FULL prev state for atomic undo BEFORE mutation —
+  // legacy [meal] string + [meal+'_v1'] sidecar + [meal+'_time'] +
+  // [meal+'_intake']. Otherwise undo would restore only the legacy
+  // string and leave phantom time/intake from this save attached to
+  // the now-restored prior meal name (F-2 fix B3/D4/E_c/C5).
+  // In-memory read instead of disk reload (efficiency E6).
   const undoMealKey = _qlMeal;
-  const prevMealValue = (feedingPrev[dateStr] && feedingPrev[dateStr][undoMealKey]) || '';
+  const prevDay = (typeof feedingData !== 'undefined' && feedingData && feedingData[dateStr]) || {};
+  const prevMealValue = prevDay[undoMealKey] || '';
+  const prevSidecar = prevDay[undoMealKey + '_v1'];
+  const prevTime = prevDay[undoMealKey + '_time'];
+  const prevIntake = prevDay[undoMealKey + '_intake'];
 
   // Build the structured payload + write via the canonical F-2 writer.
   const qlTime = (document.getElementById('qlFeedTime')?.value) || null;
@@ -2104,23 +2202,32 @@ function saveQLFeed() {
 
   _qlBackfillDate = null; // reset backfill
 
-  // Smart QL: compute insight BEFORE closing modal
-  var qlInsight = _qlFeedInsight();
+  // Smart QL: compute insight BEFORE closing modal. Pass food string built
+  // from _qlFeedItems above (F-2 fix C3/E_e — the input was cleared after
+  // typed-text fold-in, so reading qlFeedInput.value would return '').
+  var qlInsight = _qlFeedInsight(food);
   // Accuracy tracking
   _qlLogAction('feed:' + _qlMeal, _qlSuggestUsed);
 
-  // Build undo function — restore prev legacy value AND clear the v1 sidecar
-  // (otherwise stale structured data lingers after undo).
+  // Build undo function — restore the FULL prev state atomically
+  // (legacy [meal] + [meal+'_v1'] sidecar + [meal+'_time'] +
+  // [meal+'_intake']). Each field uses prev-was-undefined →
+  // delete-the-key semantic so undo doesn't silently re-introduce
+  // a default 0.75 intake on a meal that had no intake set.
   const undoDateStr = dateStr;
   const undoFn = () => {
     const f = load(KEYS.feeding, {}) || {};
-    if (f[undoDateStr]) {
-      f[undoDateStr][undoMealKey] = prevMealValue;
-      delete f[undoDateStr][undoMealKey + '_v1'];
-      save(KEYS.feeding, f);
-      feedingData = f;
-      _islMarkDirty('diet');
-    }
+    if (!f[undoDateStr]) f[undoDateStr] = { breakfast: '', lunch: '', dinner: '', snack: '' };
+    f[undoDateStr][undoMealKey] = prevMealValue;
+    if (prevSidecar !== undefined) f[undoDateStr][undoMealKey + '_v1'] = prevSidecar;
+    else delete f[undoDateStr][undoMealKey + '_v1'];
+    if (prevTime !== undefined) f[undoDateStr][undoMealKey + '_time'] = prevTime;
+    else delete f[undoDateStr][undoMealKey + '_time'];
+    if (prevIntake !== undefined) f[undoDateStr][undoMealKey + '_intake'] = prevIntake;
+    else delete f[undoDateStr][undoMealKey + '_intake'];
+    save(KEYS.feeding, f);
+    feedingData = f;
+    _islMarkDirty('diet');
   };
 
   closeQuickLogAll();
@@ -3315,7 +3422,7 @@ function renderHomeMealProgress() {
         <div class="mi-prog-row">${_miRenderBar(_miVal)} <span class="mi-prog-label">${escHtml(_miLv.label)}</span></div>
       </div>`;
     } else {
-      html += `<div class="meal-prog-slot mps-empty" onclick="_qlMeal='${m.full}';openQuickModal('feed')">
+      html += `<div class="meal-prog-slot mps-empty" onclick="_qlMeal='${m.full}';_qlMealExplicit=true;openQuickModal('feed')">
         <div class="meal-prog-icon">${zi('target')}</div>
         <div class="meal-prog-label">${m.label}</div>
         <div class="meal-prog-food t-light" >tap to log</div>
@@ -3679,7 +3786,16 @@ function skipMeals(mealKeys) {
   const dateStr = today();
   if (!feedingData[dateStr]) feedingData[dateStr] = { breakfast:'', lunch:'', dinner:'', snack:'' };
   mealKeys.forEach(m => {
-    if (!feedingData[dateStr][m]) feedingData[dateStr][m] = '—skipped—';
+    if (!feedingData[dateStr][m]) {
+      feedingData[dateStr][m] = '—skipped—';
+      // F-2 fix (Alt1): clear the structured sidecar + legacy _time/_intake
+      // so a skip is atomic. Without this, a meal previously logged via
+      // FOB (sidecar present) then skipped via this home-tab "Skip
+      // remaining" path leaves the stale sidecar alongside the sentinel.
+      delete feedingData[dateStr][m + '_v1'];
+      delete feedingData[dateStr][m + '_time'];
+      delete feedingData[dateStr][m + '_intake'];
+    }
   });
   save(KEYS.feeding, feedingData);
   // V-M-70: complete the _refreshTodayMedWithFat contract on every feedingData mutation.
@@ -3701,6 +3817,11 @@ function skipSingleMeal(mealKey) {
 
   if (feedingData[dateStr][mealKey] && feedingData[dateStr][mealKey] !== '—skipped—') return; // already has food
   feedingData[dateStr][mealKey] = '—skipped—';
+  // F-2 fix (Alt1): clear the structured sidecar + legacy _time/_intake
+  // so a skip is atomic. Matches _fdMarkMealSkipped contract.
+  delete feedingData[dateStr][mealKey + '_v1'];
+  delete feedingData[dateStr][mealKey + '_time'];
+  delete feedingData[dateStr][mealKey + '_intake'];
   save(KEYS.feeding, feedingData);
   // V-M-70: complete the _refreshTodayMedWithFat contract.
   if (dateStr === today() && typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();

--- a/split/styles.css
+++ b/split/styles.css
@@ -6643,16 +6643,6 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 .ql-modal-close:hover { background:var(--rose-light); color:var(--tc-rose); }
 
 .ql-form { display:flex; flex-direction:column; gap:var(--sp-12); }
-/* Frequent meals pills */
-.ql-freq-row { display:flex; flex-wrap:wrap; gap:var(--sp-4); }
-.ql-freq-pill {
-  font-size:var(--fs-xs); padding:var(--sp-4) var(--sp-10); border-radius:var(--r-full);
-  background:var(--sage-light); border:1px solid rgba(181,213,197,0.4);
-  color:var(--tc-sage); cursor:pointer; white-space:nowrap;
-  max-width:140px;
-  transition:transform var(--ease-fast), background var(--ease-fast);
-}
-.ql-freq-pill:active { transform:scale(0.95); background:var(--accent-sage-deep); color:white; }
 /* Backfill date pills */
 .ql-bf-row { display:flex; gap:var(--sp-4); flex-wrap:wrap; }
 .ql-bf-pill {
@@ -6925,7 +6915,7 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 }
 .ql-feed-next-chip:active { transform:scale(0.94); }
 .ql-feed-next-conf {
-  font-size:9px;
+  font-size:var(--fs-2xs);
   background:var(--white); color:var(--tc-sage);
   border-radius:var(--r-full);
   padding:1px var(--sp-6);
@@ -6979,7 +6969,10 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 [data-theme="dark"] .ql-feed-repeat-head { color:#7ac0a0; }
 [data-theme="dark"] .ql-feed-combo-chip { background:#2a2240; border-color:var(--tc-lav); }
 [data-theme="dark"] .ql-feed-combo-head { color:#b8a8e0; }
-[data-theme="dark"] .ql-feed-combo-conf { background:var(--lavender); color:var(--text); }
+/* Deep-lavender badge with light text so the combo frequency/confidence
+   number stays legible in dark mode — the prior var(--text) flipped light
+   over the unchanged light-lavender fill (~1.42:1). (V-M-210 / V-V-210) */
+[data-theme="dark"] .ql-feed-combo-conf { background:#3a2f55; color:#e6dcf5; }
 [data-theme="dark"] .ql-feed-items-list { background:var(--surface); border-color:#3a2e3e; }
 [data-theme="dark"] .ql-feed-item-row { border-bottom-color:#3a2e3e; }
 [data-theme="dark"] .ql-feed-qty-stepper { background:#221c28; }
@@ -7388,8 +7381,6 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 @media (prefers-reduced-motion: reduce) {
   .sc-disclosure-toggle { transition:none; }
 }
-[data-theme="dark"] .ql-freq-pill { background:rgba(58,112,96,0.12); border-color:rgba(181,213,197,0.15); color:var(--tc-sage); }
-[data-theme="dark"] .ql-freq-pill:active { background:var(--accent-sage-deep); color:var(--body-bg); }
 [data-theme="dark"] .ql-bf-pill { background:rgba(201,184,232,0.1); border-color:rgba(201,184,232,0.15); }
 [data-theme="dark"] .ql-bf-pill.active { background:rgba(184,168,224,0.2); color:var(--tc-lav); border-color:rgba(184,168,224,0.35); }
 [data-theme="dark"] .meal-prog-slot { background:var(--card-bg); border-color:var(--card-border); }

--- a/split/styles.css
+++ b/split/styles.css
@@ -6739,6 +6739,255 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 .ql-save-nap   { background:linear-gradient(135deg, #7e66b4, #7060a8); }
 .ql-save-poop  { background:linear-gradient(135deg, #8a6520, #946225); }
 
+/* ═══════════════════════════════════════════════════════════════
+   F-2 — FOB Feed sheet (autofill-first redesign)
+   Spec: docs/specs/food-sub-tab-v1.md §F-2
+   Four rail surfaces (L1 repeat / L2 combo / items / L3 next-item)
+   + per-food qty steppers + skip-meal button. Tokens-only per HR-4.
+   ═══════════════════════════════════════════════════════════════ */
+
+/* Rail wrapper — same vertical rhythm as other ql-form sections */
+.ql-feed-rail-wrap { display:flex; flex-direction:column; gap:var(--sp-4); }
+.ql-feed-rail { display:flex; flex-direction:column; gap:var(--sp-6); }
+
+/* L1 Repeat chips — sage outlined; primary chip emphasized */
+.ql-feed-repeat-chip {
+  background:var(--white);
+  border:1.5px solid var(--sage);
+  border-radius:var(--r-xl);
+  padding:var(--sp-10) var(--sp-12);
+  cursor:pointer;
+  min-height:36px;
+  transition:transform var(--ease-fast), background-color var(--ease-fast);
+  box-shadow:0 1px 3px rgba(60,40,40,0.04);
+}
+.ql-feed-repeat-chip:active { transform:scale(0.985); }
+.ql-feed-repeat-chip.primary {
+  background:var(--sage-light);
+  border-width:2px;
+}
+.ql-feed-repeat-head {
+  display:flex; align-items:center; gap:var(--sp-6);
+  font-weight:700; color:var(--tc-sage);
+  font-size:var(--fs-sm);
+}
+.ql-feed-repeat-head .zi { width:var(--icon-base); height:var(--icon-base); }
+.ql-feed-repeat-sub {
+  font-size:var(--fs-xs);
+  color:var(--mid);
+  margin-top:var(--sp-4);
+  font-weight:500;
+  line-height:var(--lh-snug);
+}
+
+/* L2 Combo chips — lavender outlined; freq badge inline */
+.ql-feed-combo-chip {
+  background:var(--lav-light);
+  border:1.5px solid var(--lavender);
+  border-radius:var(--r-xl);
+  padding:var(--sp-10) var(--sp-12);
+  cursor:pointer;
+  min-height:36px;
+  transition:transform var(--ease-fast);
+}
+.ql-feed-combo-chip:active { transform:scale(0.985); }
+.ql-feed-combo-head {
+  display:flex; align-items:center; gap:var(--sp-6);
+  font-weight:700; color:var(--tc-lav);
+  font-size:var(--fs-sm);
+}
+.ql-feed-combo-head .zi { width:var(--icon-base); height:var(--icon-base); }
+.ql-feed-combo-conf {
+  margin-left:auto;
+  font-size:var(--fs-2xs);
+  background:var(--lavender); color:var(--text);
+  padding:var(--sp-2) var(--sp-6);
+  border-radius:var(--r-full);
+  font-weight:700;
+}
+.ql-feed-combo-sub {
+  font-size:var(--fs-xs);
+  color:var(--mid);
+  margin-top:var(--sp-4);
+  font-weight:500;
+  line-height:var(--lh-snug);
+}
+
+/* Items list — current meal being built */
+.ql-feed-items-list {
+  background:var(--white);
+  border:1px solid #ece4dd;
+  border-radius:var(--r-xl);
+  overflow:hidden;
+}
+.ql-feed-items-empty {
+  text-align:center;
+  color:var(--light);
+  padding:var(--sp-16);
+  font-style:italic;
+  font-size:var(--fs-sm);
+}
+.ql-feed-item-row {
+  display:flex; align-items:center; gap:var(--sp-8);
+  padding:var(--sp-8) var(--sp-10);
+  border-bottom:1px solid #f4ece6;
+  min-height:48px;
+}
+.ql-feed-item-row:last-of-type { border-bottom:none; }
+.ql-feed-item-icon {
+  width:28px; height:28px;
+  background:var(--sage-light); color:var(--tc-sage);
+  border-radius:var(--r-full);
+  display:inline-flex; align-items:center; justify-content:center;
+  font-size:var(--fs-sm); font-weight:700;
+  flex-shrink:0;
+}
+.ql-feed-item-name {
+  flex:1; font-weight:600; font-size:var(--fs-base);
+  display:flex; flex-direction:column;
+  line-height:var(--lh-snug);
+}
+.ql-feed-item-meta {
+  font-size:var(--fs-2xs);
+  color:var(--light);
+  text-transform:uppercase;
+  letter-spacing:var(--ls-wide);
+  font-weight:500;
+  margin-top:var(--sp-2);
+}
+.ql-feed-item-x {
+  width:32px; height:32px;
+  display:inline-flex; align-items:center; justify-content:center;
+  border-radius:var(--r-full);
+  background:var(--rose-light); color:var(--tc-rose);
+  font-weight:700; font-size:var(--fs-md);
+  border:none; cursor:pointer;
+  flex-shrink:0;
+  margin-left:var(--sp-2);
+  transition:transform var(--ease-fast);
+}
+.ql-feed-item-x:active { transform:scale(0.9); }
+
+/* Per-food quantity stepper — [− qty unit +] */
+.ql-feed-qty-stepper {
+  display:inline-flex; align-items:center;
+  background:var(--warm);
+  border-radius:var(--r-full);
+  padding:var(--sp-2);
+  flex-shrink:0;
+}
+.ql-feed-qty-step {
+  width:32px; height:32px;
+  display:inline-flex; align-items:center; justify-content:center;
+  border-radius:var(--r-full);
+  background:var(--white); color:var(--tc-sage);
+  font-weight:700; font-size:var(--fs-base);
+  border:1px solid #ece4dd;
+  cursor:pointer;
+  font-family:'Nunito', sans-serif;
+  transition:transform var(--ease-fast);
+}
+.ql-feed-qty-step:active { transform:scale(0.92); background:var(--sage-light); }
+.ql-feed-qty-val {
+  padding:0 var(--sp-8);
+  font-weight:700;
+  min-width:52px; text-align:center;
+  font-size:var(--fs-sm);
+  color:var(--text);
+}
+.ql-feed-qty-unit {
+  font-size:var(--fs-2xs);
+  color:var(--mid);
+  letter-spacing:0;
+  font-weight:500;
+}
+
+/* L3 Next-item ribbon — horizontal scroll; confidence % per chip */
+.ql-feed-next-ribbon {
+  display:flex; gap:var(--sp-6);
+  overflow-x:auto;
+  padding:var(--sp-4) 0;
+  -webkit-overflow-scrolling:touch;
+}
+.ql-feed-next-chip {
+  display:inline-flex; align-items:center; gap:var(--sp-4);
+  background:var(--sage-light);
+  color:var(--tc-sage);
+  font-weight:700; font-size:var(--fs-sm);
+  padding:var(--sp-6) var(--sp-12);
+  border-radius:var(--r-full);
+  border:1px solid var(--sage);
+  flex-shrink:0;
+  min-height:36px;
+  cursor:pointer;
+  font-family:'Nunito', sans-serif;
+  transition:transform var(--ease-fast);
+}
+.ql-feed-next-chip:active { transform:scale(0.94); }
+.ql-feed-next-conf {
+  font-size:9px;
+  background:var(--white); color:var(--tc-sage);
+  border-radius:var(--r-full);
+  padding:1px var(--sp-6);
+  margin-left:var(--sp-2);
+  font-weight:700;
+  letter-spacing:0;
+}
+
+/* L4 Typeahead dropdown rows — qty hint inlined */
+.ql-feed-ta-row {
+  display:flex; align-items:center; gap:var(--sp-8);
+  padding:var(--sp-8) var(--sp-10);
+  border-bottom:1px solid #f4ece6;
+  cursor:pointer;
+  min-height:36px;
+}
+.ql-feed-ta-row:last-of-type { border-bottom:none; }
+.ql-feed-ta-row:active { background:var(--sage-light); }
+.ql-feed-ta-name {
+  flex:1;
+  font-weight:600; font-size:var(--fs-base);
+  color:var(--text);
+}
+.ql-feed-ta-meta {
+  font-size:var(--fs-2xs);
+  color:var(--mid);
+  text-transform:uppercase;
+  letter-spacing:var(--ls-wide);
+  font-weight:500;
+}
+
+/* Skip meal button — neutral chrome; pairs visually with Save Feed */
+.ql-save-skip {
+  background:var(--warm);
+  color:var(--mid);
+  border:1.5px solid #d8ccc4;
+  border-radius:var(--r-full);
+  padding:var(--sp-10) var(--sp-16);
+  font-weight:600; font-size:var(--fs-sm);
+  font-family:'Nunito', sans-serif;
+  cursor:pointer;
+  min-height:44px;
+  transition:transform var(--ease-fast), background-color var(--ease-fast);
+}
+.ql-save-skip:active { transform:scale(0.97); background:#f0e8e0; }
+.ql-save-skip:hover { background:#f8f0e8; }
+
+/* Dark mode — preserve domain identity; deepen backgrounds */
+[data-theme="dark"] .ql-feed-repeat-chip { background:var(--surface-alt); border-color:var(--tc-sage); }
+[data-theme="dark"] .ql-feed-repeat-chip.primary { background:#1e3028; }
+[data-theme="dark"] .ql-feed-repeat-head { color:#7ac0a0; }
+[data-theme="dark"] .ql-feed-combo-chip { background:#2a2240; border-color:var(--tc-lav); }
+[data-theme="dark"] .ql-feed-combo-head { color:#b8a8e0; }
+[data-theme="dark"] .ql-feed-combo-conf { background:var(--lavender); color:var(--text); }
+[data-theme="dark"] .ql-feed-items-list { background:var(--surface); border-color:#3a2e3e; }
+[data-theme="dark"] .ql-feed-item-row { border-bottom-color:#3a2e3e; }
+[data-theme="dark"] .ql-feed-qty-stepper { background:#221c28; }
+[data-theme="dark"] .ql-feed-qty-step { background:var(--surface); border-color:#3a2e3e; color:#7ac0a0; }
+[data-theme="dark"] .ql-feed-next-chip { background:#1e3028; color:#7ac0a0; border-color:var(--tc-sage); }
+[data-theme="dark"] .ql-feed-next-conf { background:var(--surface); color:#7ac0a0; }
+[data-theme="dark"] .ql-save-skip { background:#221c28; color:var(--mid); border-color:#3a2e3e; }
+
 /* ── Quick Log Toast ── */
 .ql-toast {
   position:fixed; bottom:90px; left:50%; transform:translateX(-50%) translateY(20px);

--- a/split/template.html
+++ b/split/template.html
@@ -2421,7 +2421,7 @@
   </div>
 </div>
 
-<!-- Quick Log Modal: Feed -->
+<!-- Quick Log Modal: Feed (F-2 redesign — autofill-first; spec: docs/specs/food-sub-tab-v1.md §F-2) -->
 <div class="ql-modal-overlay" id="qlModal-feed" data-action="closeQuickModalSelf">
   <div class="ql-modal">
     <div class="ql-modal-header">
@@ -2442,14 +2442,33 @@
         <label class="micro-label">Date</label>
         <div class="ql-bf-row" id="qlBackfillPills"></div>
       </div>
-      <div id="qlFreqWrap" style="display:none;">
-        <label class="micro-label">Frequent</label>
-        <div class="ql-freq-row" id="qlFreqPills"></div>
+      <!-- F-2: L1 Repeat rail — "Same as yesterday's B" / "Same as today's lunch" (dinner only, ratification #6) -->
+      <div id="qlFeedRepeatWrap" class="ql-feed-rail-wrap" style="display:none;">
+        <label class="micro-label">Your usual</label>
+        <div class="ql-feed-rail" id="qlFeedRepeatRail"></div>
       </div>
+      <!-- F-2: L2 Combo template rail — "Your usual breakfast" rolling-14d or curated cold-start -->
+      <div id="qlFeedCombosWrap" class="ql-feed-rail-wrap" style="display:none;">
+        <label class="micro-label" id="qlFeedCombosLabel">Suggested combos</label>
+        <div class="ql-feed-rail" id="qlFeedCombosRail"></div>
+      </div>
+      <!-- F-2: Items list — populated as items added; qty steppers per row -->
+      <div id="qlFeedItemsWrap">
+        <label class="micro-label">Items</label>
+        <div class="ql-feed-items-list" id="qlFeedItemsList">
+          <div class="ql-feed-items-empty">Tap a combo above, or type an item below</div>
+        </div>
+      </div>
+      <!-- F-2: L3 Next-item prediction ribbon — appears after first item; co-occurrence ranked -->
+      <div id="qlFeedNextWrap" class="ql-feed-rail-wrap" style="display:none;">
+        <label class="micro-label" id="qlFeedNextLabel">You usually add</label>
+        <div class="ql-feed-next-ribbon" id="qlFeedNextRibbon"></div>
+      </div>
+      <!-- F-2: L4 Typeahead input — NUTRITION + introduced foods + recent; default qty/unit inlined -->
       <div>
-        <label class="micro-label">What did Ziva eat?</label>
+        <label class="micro-label">Add item</label>
         <div class="meal-input-wrap">
-          <input type="text" id="qlFeedInput" class="form-input input-ctx-peach" placeholder="e.g. ragi porridge, dal rice..." autocomplete="off" oninput="updateQLFeedDropdown()">
+          <input type="text" id="qlFeedInput" class="form-input input-ctx-peach" placeholder="Type to add (e.g. 'av' for avocado mash)" autocomplete="off" data-action="qlFeedTypeaheadInput" data-action-on="input">
           <div class="meal-dropdown" id="qlFeedDropdown"></div>
         </div>
       </div>
@@ -2458,12 +2477,8 @@
         <input type="time" id="qlFeedTime" class="form-input input-ctx-peach" style="width:90px;padding:5px 8px;font-size:var(--fs-sm);">
         <span class="t-xs t-light">optional</span>
       </div>
-      <div id="qlSameAsWrap" style="display:none;">
-        <label class="micro-label">Quick repeat</label>
-        <div class="d-flex gap-8 flex-wrap" id="qlSameAsPills"></div>
-      </div>
       <div>
-        <label class="micro-label">How much?</label>
+        <label class="micro-label">How much overall?</label>
         <div class="ql-meal-pills" id="qlIntakePills">
           <div class="ql-intake-pill" data-mi-qlval="0.25"><svg class="zi"><use href="#zi-spoon"/></svg> Few bites</div>
           <div class="ql-intake-pill" data-mi-qlval="0.5"><svg class="zi"><use href="#zi-halfcircle"/></svg> Half</div>
@@ -2471,7 +2486,10 @@
           <div class="ql-intake-pill" data-mi-qlval="1.0"><svg class="zi"><use href="#zi-star"/></svg> All</div>
         </div>
       </div>
-      <button class="ql-save ql-save-feed">Save Feed <svg class="zi"><use href="#zi-check"/></svg></button>
+      <div class="d-flex gap-8" style="align-items:stretch;">
+        <button class="ql-save-skip" data-action="qlFeedSkipMeal" type="button" title="Mark this meal as intentionally skipped">Skip this meal</button>
+        <button class="ql-save ql-save-feed flex-1-min100">Save Feed <svg class="zi"><use href="#zi-check"/></svg></button>
+      </div>
     </div>
   </div>
 </div>

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -16949,11 +16949,17 @@ window.parseFeedingV1Stub = window.parseFeedingV1;
 // muted "Skipped" pills and are excluded from nutrition-snapshot diversity
 // penalties. Reversible — writing a real entry overwrites the skip.
 // ═══════════════════════════════════════════════════════════════════════
+// Writes the canonical SKIPPED_MEAL sentinel at the legacy [meal] field
+// (matches existing app-wide pattern at core.js:3119; consumers in
+// home.js Today's Meals + diet.js stats + intelligence-cards.js + isl
+// all key off this sentinel — there's no reason to invent a new one).
+// Also clears any v1 sidecar from prior structured writes.
 window._fdMarkMealSkipped = function(dateKey, meal) {
   if (!dateKey || !meal) return false;
   var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
   if (!fd[dateKey]) fd[dateKey] = { breakfast: '', lunch: '', dinner: '', snack: '' };
-  fd[dateKey][meal] = { skipped: true, skippedAt: Date.now(), items: [] };
+  fd[dateKey][meal] = (typeof SKIPPED_MEAL !== 'undefined') ? SKIPPED_MEAL : '—skipped—';
+  delete fd[dateKey][meal + '_v1'];
   if (typeof save === 'function' && typeof KEYS !== 'undefined' && KEYS.feeding) {
     save(KEYS.feeding, fd);
   }
@@ -16968,26 +16974,35 @@ window._fdIsMealSkipped = function(dateKey, meal) {
   var day = fd[dateKey];
   if (!day) return false;
   var mv = day[meal];
-  return !!(mv && typeof mv === 'object' && mv.skipped === true);
+  var sentinel = (typeof SKIPPED_MEAL !== 'undefined') ? SKIPPED_MEAL : '—skipped—';
+  if (mv === sentinel) return true;
+  if (mv && typeof mv === 'object' && mv.skipped === true) return true;  // legacy F-2-prerelease shape
+  return false;
 };
 
 // ═══════════════════════════════════════════════════════════════════════
 // _fdWriteStructuredMeal — canonical writer for the F-2 FOB Feed sheet.
-// Writes the structured shape under feedingData[dateKey][meal] AND
-// auto-generates legacy compat fields (text, {meal}_time, {meal}_intake)
-// so existing readers (home.js Today's Meals summary, diet stats, combo
-// intelligence, parseMealNutrition) continue working unchanged until
-// F-5 lands the read-side normalizer.
+//
+// Backward-compat doctrine (load-bearing): existing readers across
+// home.js Today's Meals, diet.js stats + combos, intelligence-cards.js,
+// intelligence-isl.js, medical.js all assume `feedingData[date][meal]`
+// is a STRING. Writing an object there breaks every legacy reader.
+//
+// So this writer keeps the legacy string at [meal] (comma-joined item
+// names) AND tucks the rich structured shape into a [meal + '_v1']
+// SIDECAR field. F-2 readers (L1-L4 helpers, saveQLFeed, diet Log
+// sub-tab review) reach for the sidecar via _fdReadDayMeal; legacy
+// readers continue reading the comma-string at [meal] unchanged.
+// F-5's parseFeeding normalizer will eventually unify the reads.
 //
 // payload: { items: [{name, qty, unit, nutritionRef}], time, overallIntake, note, sourceFlow }
-// Returns the structured shape that was written.
+// Returns the structured shape that was written to the sidecar.
 // ═══════════════════════════════════════════════════════════════════════
 window._fdWriteStructuredMeal = function(dateKey, meal, payload) {
   if (!dateKey || !meal || !payload) return null;
   payload = payload || {};
   var items = Array.isArray(payload.items) ? payload.items.slice() : [];
-  // Legacy compat: comma-joined text for downstream readers (Today's Meals
-  // summary, diet combos, parseMealNutrition). Trailing comma kept off.
+  // Legacy comma-joined text — what existing readers expect at [meal].
   var textCompat = items.map(function(it) { return it.name; }).join(', ');
 
   var structured = {
@@ -16995,15 +17010,19 @@ window._fdWriteStructuredMeal = function(dateKey, meal, payload) {
     time: payload.time || null,
     overallIntake: (typeof payload.overallIntake === 'number') ? payload.overallIntake : 0.75,  // ratified DEFAULT "Most"
     note: payload.note || '',
-    sourceFlow: payload.sourceFlow || 'fob-feed',  // telemetry: fob-repeat | fob-combo | fob-novel | fob-feed | diet-tab
+    sourceFlow: payload.sourceFlow || 'fob-feed',
     schemaVersion: window._FEEDING_V1_SCHEMA_VERSION,
-    text: textCompat,
+    writtenAt: Date.now(),
   };
 
   var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
   if (!fd[dateKey]) fd[dateKey] = { breakfast: '', lunch: '', dinner: '', snack: '' };
-  fd[dateKey][meal] = structured;
-  // Legacy compat fields at the day level (existing readers reach for these)
+  // Legacy string at the canonical slot (load-bearing for existing readers).
+  fd[dateKey][meal] = textCompat;
+  // Structured shape in sidecar — F-2 readers (L1-L4 helpers + diet Log
+  // review surface) reach here for qty + sourceFlow + overallIntake.
+  fd[dateKey][meal + '_v1'] = structured;
+  // Legacy time + intake at the day level (existing readers reach for these).
   if (structured.time) fd[dateKey][meal + '_time'] = structured.time;
   fd[dateKey][meal + '_intake'] = structured.overallIntake;
 
@@ -17012,6 +17031,57 @@ window._fdWriteStructuredMeal = function(dateKey, meal, payload) {
   }
   if (typeof feedingData !== 'undefined') feedingData = fd;
   return structured;
+};
+
+// _fdReadDayMeal — canonical reader. Returns the F-2 view of a meal slot
+// regardless of which shape sits on disk. Reads the [meal + '_v1']
+// sidecar first; falls back to parsing the legacy string at [meal].
+// Returns: { items[], time, overallIntake, skipped, sourceFlow, legacyText }
+window._fdReadDayMeal = function(dayObj, mealKey) {
+  if (!dayObj || !mealKey) return { items: [], skipped: false };
+  var sentinel = (typeof SKIPPED_MEAL !== 'undefined') ? SKIPPED_MEAL : '—skipped—';
+  var legacy = dayObj[mealKey];
+  // Skip sentinel — both forms
+  if (legacy === sentinel) {
+    return { items: [], skipped: true, legacyText: sentinel };
+  }
+  // Sidecar present — return the structured shape
+  var sidecar = dayObj[mealKey + '_v1'];
+  if (sidecar && Array.isArray(sidecar.items)) {
+    return {
+      items: sidecar.items,
+      time: sidecar.time || dayObj[mealKey + '_time'] || null,
+      overallIntake: typeof sidecar.overallIntake === 'number' ? sidecar.overallIntake : (dayObj[mealKey + '_intake'] || 0.75),
+      sourceFlow: sidecar.sourceFlow || 'fob-feed',
+      skipped: false,
+      legacyText: typeof legacy === 'string' ? legacy : (sidecar.items.map(function(it){return it.name;}).join(', ')),
+    };
+  }
+  // Legacy F-2-prerelease structured-at-[meal] shape (early-development
+  // fixtures may carry this; treat as canonical and migrate-on-read).
+  if (legacy && typeof legacy === 'object' && Array.isArray(legacy.items)) {
+    return {
+      items: legacy.items,
+      time: legacy.time || dayObj[mealKey + '_time'] || null,
+      overallIntake: typeof legacy.overallIntake === 'number' ? legacy.overallIntake : 0.75,
+      sourceFlow: legacy.sourceFlow || 'fob-feed',
+      skipped: legacy.skipped === true,
+      legacyText: legacy.items.map(function(it){return it.name;}).join(', '),
+    };
+  }
+  // Pure legacy string — parse via comma-split + qty resolver
+  if (typeof legacy === 'string' && legacy.trim()) {
+    var parsed = window.parseFeedingV1(legacy);
+    return {
+      items: parsed.items || [],
+      time: dayObj[mealKey + '_time'] || null,
+      overallIntake: dayObj[mealKey + '_intake'] || 0.75,
+      sourceFlow: 'legacy-string',
+      skipped: false,
+      legacyText: legacy,
+    };
+  }
+  return { items: [], skipped: false, legacyText: '' };
 };
 
 // @@DATA_BLOCK_20_START@@ MILESTONE_STANDARDS
@@ -63479,22 +63549,21 @@ window._fdGetRepeatCandidates = function(meal, n) {
     return 'Last week';
   }
 
-  function structuredItemsFromMeal(mealVal) {
-    var parsed = window.parseFeedingV1(mealVal);
-    if (!parsed || !parsed.items || parsed.items.length === 0) return null;
-    if (parsed.skipped) return null;
-    // Hydrate any items missing qty/unit via the defaults resolver
-    var items = parsed.items.map(function(it) {
+  function itemsFromDay(day, mealKey) {
+    if (!day) return null;
+    var rec = window._fdReadDayMeal(day, mealKey);
+    if (!rec || rec.skipped || !rec.items || rec.items.length === 0) return null;
+    // Hydrate any items missing qty/unit (legacy-string-parsed records lack them).
+    return rec.items.map(function(it) {
       if (it.qty !== undefined && it.unit) return it;
-      var d = window._fdResolveQtyDefaults(it.name);
-      return Object.assign({}, it, { qty: d.qty, unit: d.unit });
+      var defaults = window._fdResolveQtyDefaults(it.name);
+      return Object.assign({}, it, { qty: defaults.qty, unit: defaults.unit });
     });
-    return items;
   }
 
   // Ratification #6 — for dinner, surface today's lunch FIRST if logged.
-  if (meal === 'dinner' && fd[todayStr] && fd[todayStr].lunch) {
-    var lunchItems = structuredItemsFromMeal(fd[todayStr].lunch);
+  if (meal === 'dinner' && fd[todayStr]) {
+    var lunchItems = itemsFromDay(fd[todayStr], 'lunch');
     if (lunchItems && lunchItems.length) {
       out.push({
         id: 'today-lunch',
@@ -63512,9 +63581,7 @@ window._fdGetRepeatCandidates = function(meal, n) {
   for (var d = 1; d <= 14 && out.length < n; d++) {
     var dd = new Date(); dd.setDate(dd.getDate() - d);
     var ds = toDateStr(dd);
-    var day = fd[ds];
-    if (!day) continue;
-    var items = structuredItemsFromMeal(day[meal]);
+    var items = itemsFromDay(fd[ds], meal);
     if (!items) continue;
     out.push({
       id: 'repeat-' + ds,
@@ -63555,18 +63622,18 @@ window._fdGetCombosForMeal = function(meal, opts) {
     if (ds < cutoffStr || ds > todayStr) return;
     var day = fd[ds];
     if (!day) return;
-    var parsed = window.parseFeedingV1(day[meal]);
-    if (!parsed || !parsed.items || parsed.items.length === 0 || parsed.skipped) return;
+    var rec = window._fdReadDayMeal(day, meal);
+    if (!rec || rec.skipped || !rec.items || rec.items.length === 0) return;
     daysWithSignal++;
-    var names = parsed.items.map(function(it){ return String(it.name || '').toLowerCase().trim(); })
-                            .filter(function(n){ return n.length > 1; });
+    var names = rec.items.map(function(it){ return String(it.name || '').toLowerCase().trim(); })
+                         .filter(function(n){ return n.length > 1; });
     if (names.length < 2) return;
     var sig = names.slice().sort().join('|');
-    if (!comboMap[sig]) comboMap[sig] = { items: parsed.items, freq: 0, lastDate: ds, names: names };
+    if (!comboMap[sig]) comboMap[sig] = { items: rec.items, freq: 0, lastDate: ds, names: names };
     comboMap[sig].freq++;
     if (ds > comboMap[sig].lastDate) {
       comboMap[sig].lastDate = ds;
-      comboMap[sig].items = parsed.items;  // refresh with most-recent qty/unit
+      comboMap[sig].items = rec.items;  // refresh with most-recent qty/unit
     }
   });
 
@@ -63671,9 +63738,9 @@ window._fdGetNextItemPredictions = function(currentItems, meal, n) {
     if (ds < cutoffStr || ds > todayStr) return;
     var day = fd[ds];
     if (!day) return;
-    var parsed = window.parseFeedingV1(day[meal]);
-    if (!parsed || !parsed.items || parsed.items.length === 0 || parsed.skipped) return;
-    var names = parsed.items.map(function(it){ return String(it.name || '').toLowerCase().trim(); });
+    var rec = window._fdReadDayMeal(day, meal);
+    if (!rec || rec.skipped || !rec.items || rec.items.length === 0) return;
+    var names = rec.items.map(function(it){ return String(it.name || '').toLowerCase().trim(); });
     // Does this day contain any anchor item?
     var hasAnchor = anchorNames.some(function(a) { return names.indexOf(a) >= 0; });
     if (!hasAnchor) return;
@@ -63681,7 +63748,7 @@ window._fdGetNextItemPredictions = function(currentItems, meal, n) {
     // Count every non-anchor item that appears
     names.forEach(function(n) {
       if (currentSet[n]) return;  // skip items already in current meal
-      if (!coCount[n]) coCount[n] = { name: parsed.items.find(function(it) { return String(it.name).toLowerCase().trim() === n; }).name, freq: 0 };
+      if (!coCount[n]) coCount[n] = { name: rec.items.find(function(it) { return String(it.name).toLowerCase().trim() === n; }).name, freq: 0 };
       coCount[n].freq++;
     });
   });
@@ -63770,9 +63837,9 @@ window._fdSearchNutrition = function(query, opts) {
       if (ds < cutoffStr) return;
       ['breakfast','lunch','dinner','snack'].forEach(function(m) {
         if (matches.length >= max * 2) return;
-        var parsed = window.parseFeedingV1(fd[ds][m]);
-        if (!parsed || !parsed.items) return;
-        parsed.items.forEach(function(it) {
+        var rec = window._fdReadDayMeal(fd[ds], m);
+        if (!rec || rec.skipped || !rec.items) return;
+        rec.items.forEach(function(it) {
           if (matches.length >= max * 2) return;
           var nm = it.name || '';
           if (nm.toLowerCase().indexOf(q) >= 0) pushMatch(nm, 'recent');
@@ -64459,11 +64526,18 @@ function saveQLFeed() {
   // Accuracy tracking
   _qlLogAction('feed:' + _qlMeal, _qlSuggestUsed);
 
-  // Build undo function
+  // Build undo function — restore prev legacy value AND clear the v1 sidecar
+  // (otherwise stale structured data lingers after undo).
   const undoDateStr = dateStr;
   const undoFn = () => {
     const f = load(KEYS.feeding, {}) || {};
-    if (f[undoDateStr]) { f[undoDateStr][undoMealKey] = prevMealValue; save(KEYS.feeding, f); feedingData = f; _islMarkDirty('diet'); }
+    if (f[undoDateStr]) {
+      f[undoDateStr][undoMealKey] = prevMealValue;
+      delete f[undoDateStr][undoMealKey + '_v1'];
+      save(KEYS.feeding, f);
+      feedingData = f;
+      _islMarkDirty('diet');
+    }
   };
 
   closeQuickLogAll();

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -16836,13 +16836,13 @@ window._fdResolveQtyDefaults = function(foodName) {
   if (n && n.tags) {
     if (n.tags.indexOf('healthy-fats') >= 0 && /oil|ghee|butter/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['fat-cooking'];
     if (n.tags.indexOf('iron-rich') >= 0 && n.tags.indexOf('protein-rich') >= 0) return _FOOD_QTY_CATEGORY_DEFAULTS['dal-legume'];
-    if (n.tags.indexOf('energy') >= 0 && !n.tags.indexOf('digestive') >= 0) return _FOOD_QTY_CATEGORY_DEFAULTS['grain-staple'];
+    if (n.tags.indexOf('energy') >= 0 && n.tags.indexOf('digestive') < 0) return _FOOD_QTY_CATEGORY_DEFAULTS['grain-staple'];
   }
   // 4. Heuristic by nutrient profile
   if (n && n.nutrients) {
     if (n.nutrients.indexOf('water') >= 0) return _FOOD_QTY_CATEGORY_DEFAULTS['liquid-drink'];
   }
-  return _FOOD_QTY_CATEGORY_DEFAULTS['veg-piece'];
+  return _FOOD_QTY_CATEGORY_DEFAULTS['fallback'];
 };
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -16953,13 +16953,17 @@ window.parseFeedingV1Stub = window.parseFeedingV1;
 // (matches existing app-wide pattern at core.js:3119; consumers in
 // home.js Today's Meals + diet.js stats + intelligence-cards.js + isl
 // all key off this sentinel — there's no reason to invent a new one).
-// Also clears any v1 sidecar from prior structured writes.
+// Clears the v1 sidecar AND the legacy [meal+'_time']/[meal+'_intake']
+// fields so a skip is atomic — Today So Far + diet stats don't render
+// stale time/intake for what the parent just marked as skipped.
 window._fdMarkMealSkipped = function(dateKey, meal) {
   if (!dateKey || !meal) return false;
   var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
   if (!fd[dateKey]) fd[dateKey] = { breakfast: '', lunch: '', dinner: '', snack: '' };
   fd[dateKey][meal] = (typeof SKIPPED_MEAL !== 'undefined') ? SKIPPED_MEAL : '—skipped—';
   delete fd[dateKey][meal + '_v1'];
+  delete fd[dateKey][meal + '_time'];
+  delete fd[dateKey][meal + '_intake'];
   if (typeof save === 'function' && typeof KEYS !== 'undefined' && KEYS.feeding) {
     save(KEYS.feeding, fd);
   }
@@ -17022,9 +17026,23 @@ window._fdWriteStructuredMeal = function(dateKey, meal, payload) {
   // Structured shape in sidecar — F-2 readers (L1-L4 helpers + diet Log
   // review surface) reach here for qty + sourceFlow + overallIntake.
   fd[dateKey][meal + '_v1'] = structured;
-  // Legacy time + intake at the day level (existing readers reach for these).
+  // Legacy time at the day level (existing readers reach for this).
+  // Unconditionally write — if structured.time is null, clear the legacy
+  // field so undo/re-save flows don't leave a phantom time from a prior
+  // write attached to a different food.
   if (structured.time) fd[dateKey][meal + '_time'] = structured.time;
-  fd[dateKey][meal + '_intake'] = structured.overallIntake;
+  else delete fd[dateKey][meal + '_time'];
+  // Legacy intake at the day level — only for B/L/D. Snack has the
+  // chip in the F-2 UI but the legacy invariant (pre-F-2 saveQLFeed
+  // guard `_qlMeal !== 'snack'`) was that snack carries no intake at
+  // the day level. Existing readers (intelligence-cards.js, isl, diet
+  // stats) assume snack_intake is undefined for snacks; preserve that.
+  // F-2 readers reach structured.overallIntake via _fdReadDayMeal.
+  if (meal !== 'snack') {
+    fd[dateKey][meal + '_intake'] = structured.overallIntake;
+  } else {
+    delete fd[dateKey][meal + '_intake'];
+  }
 
   if (typeof save === 'function' && typeof KEYS !== 'undefined' && KEYS.feeding) {
     save(KEYS.feeding, fd);
@@ -19777,7 +19795,7 @@ function init() {
     else if (action === 'navFeedDay') { document.getElementById('feedingDate').value = arg; loadFeedingDay(); switchTab('diet'); }
     else if (action === 'navTabSub') { switchTab(arg); setTimeout(() => switchTrackSub(arg2), 100); }
     else if (action === 'closeScoreAndNav') { closeScorePopup(); setTimeout(() => switchTab(arg), 350); }
-    else if (action === 'qlMealAndOpen') { _qlMeal = arg; openQuickModal(arg2); }
+    else if (action === 'qlMealAndOpen') { _qlMeal = arg; _qlMealExplicit = true; openQuickModal(arg2); }
     else if (action === 'showHeatmapDetail') showHeatmapDetail(arg, parseInt(arg2), arg3);
     else if (action === 'openDoctorModal') { const a = arg; if (a) openDoctorModal(parseInt(a)); else openDoctorModal(); }
     else if (action === 'openFoodCatModal') openFoodCatModal(arg);
@@ -19948,7 +19966,7 @@ function init() {
     else if (action === 'deleteFoodAndRender') { deleteFood(arg); renderFoodCatSubContent(arg2); }
     else if (action === 'navTabSub') { switchTab(arg); setTimeout(() => switchTrackSub(arg2), 100); }
     else if (action === 'closeScoreAndNav') { closeScorePopup(); setTimeout(() => switchTab(arg), 350); }
-    else if (action === 'qlMealAndOpen') { _qlMeal = arg; openQuickModal(arg2); }
+    else if (action === 'qlMealAndOpen') { _qlMeal = arg; _qlMealExplicit = true; openQuickModal(arg2); }
     else if (action === 'closeAndPromptFever') { closeHomeSymptomChecker(); promptFeverTrack(); }
     else if (action === 'closeAndPromptDiarrhoea') { closeHomeSymptomChecker(); promptDiarrhoeaTrack(); }
     else if (action === 'closeAndPromptVomiting') { closeHomeSymptomChecker(); promptVomitingTrack(); }
@@ -20030,8 +20048,9 @@ function init() {
       } else if (arg === 'afternoon-poop') {
         openQuickModal('poop');
       } else if (arg2) {
-        // Feed nudge — pre-select meal type
+        // Feed nudge — pre-select meal type (F-2 fix C1: set explicit flag)
         _qlMeal = arg2;
+        _qlMealExplicit = true;
         openQuickModal('feed');
         setTimeout(function() {
           document.querySelectorAll('.ql-meal-pill').forEach(function(p) { p.classList.toggle('active', p.dataset.meal === arg2); });
@@ -35209,7 +35228,7 @@ function computeAlerts() {
           title: loggedMeals.length === 0 ? 'No meals logged today' : missingLabels + ' not logged today',
           body: bodyMsg,
           tip: 'Logging every meal — even "skipped" or "just breastmilk" — helps build an accurate picture of intake patterns.',
-          action: { label: 'Log ' + firstMissing.charAt(0).toUpperCase() + firstMissing.slice(1), fn: '_qlMeal="' + firstMissing + '";openQuickModal("feed")' },
+          action: { label: 'Log ' + firstMissing.charAt(0).toUpperCase() + firstMissing.slice(1), fn: '_qlMeal="' + firstMissing + '";_qlMealExplicit=true;openQuickModal("feed")' },
           tab: 'diet'        });
       }
     }
@@ -35930,7 +35949,7 @@ function renderTodayPlan() {
     time: '8–9', icon: zi('sun'), title: 'Breakfast',
     detail: bfDone ? iconText('check', todayEntry.breakfast) : bfSuggestion,
     tag: 'food', done: bfDone, htmlDetail: bfDone,
-    action: bfDone ? null : '_qlMeal="breakfast";openQuickModal("feed")'
+    action: bfDone ? null : '_qlMeal="breakfast";_qlMealExplicit=true;openQuickModal("feed")'
   });
 
   // Morning nap
@@ -36000,7 +36019,7 @@ function renderTodayPlan() {
     time: '12–1', icon: zi('sun'), title: 'Lunch',
     detail: lnDone ? iconText('check', todayEntry.lunch) : lnSuggestion,
     tag: 'food', done: lnDone, htmlDetail: lnDone,
-    action: lnDone ? null : '_qlMeal="lunch";openQuickModal("feed")'
+    action: lnDone ? null : '_qlMeal="lunch";_qlMealExplicit=true;openQuickModal("feed")'
   });
 
   // Afternoon nap
@@ -36074,7 +36093,7 @@ function renderTodayPlan() {
     time: '6–7', icon: zi('moon'), title: 'Dinner',
     detail: dnDone ? iconText('check', todayEntry.dinner) : dnSuggestion,
     tag: 'food', done: dnDone, htmlDetail: dnDone,
-    action: dnDone ? null : '_qlMeal="dinner";openQuickModal("feed")'
+    action: dnDone ? null : '_qlMeal="dinner";_qlMealExplicit=true;openQuickModal("feed")'
   });
 
   // Snack
@@ -36083,7 +36102,7 @@ function renderTodayPlan() {
     time: '10–4', icon: zi('spoon'), title: 'Snack',
     detail: skDone ? iconText('check', todayEntry.snack) : 'A quick bite between meals — fruit mash, ragi biscuit, or curd',
     tag: 'food', done: skDone, htmlDetail: skDone,
-    action: skDone ? null : '_qlMeal="snack";openQuickModal("feed")'
+    action: skDone ? null : '_qlMeal="snack";_qlMealExplicit=true;openQuickModal("feed")'
   });
 
   // Bedtime routine
@@ -39966,6 +39985,15 @@ function _miGetIntake(dateStr, meal) {
 function _miSetIntake(dateStr, meal, value) {
   if (!feedingData[dateStr]) return;
   feedingData[dateStr][meal + '_intake'] = value;
+  // F-2 fix (E_b): sync the structured sidecar's overallIntake too.
+  // Otherwise _fdReadDayMeal returns the stale sidecar value while
+  // legacy _miGetIntake returns the updated value — two surfaces
+  // disagree about the same meal's intake (FOB Feed L1 repeat shows
+  // old; home Today's Meals + diet stats show new).
+  var sidecar = feedingData[dateStr][meal + '_v1'];
+  if (sidecar && typeof sidecar === 'object') {
+    sidecar.overallIntake = value;
+  }
   save(KEYS.feeding, feedingData);
   _islMarkDirty('diet');
   // V-M-70: intake adjustment alone doesn't change meal content (so withFat won't flip),
@@ -59154,21 +59182,23 @@ function sgTapChip(food) {
     showQLToast('All meals are filled for today');
     return;
   }
+  // F-2 fix (C1): set _qlMeal + explicit flag BEFORE openQuickModal so
+  // the modal preserves intent (was: openQuickModal clobbered _qlMeal
+  // to detectMealType() then a setTimeout re-set it AFTER the rails had
+  // already rendered for the wrong slot).
+  _qlMeal = nextMeal;
+  _qlMealExplicit = true;
   openQuickLog();
   openQuickModal('feed');
-  // Set meal + prefill after modal opens (openQuickModal resets _qlMeal via detectMealType)
+  // F-2 fix (B2/C4): push the suggested food directly into _qlFeedItems
+  // via the canonical handler so it appears in the Items list (not just
+  // the typeahead input). Old code used updateQLFeedDropdown +
+  // pickQLFood which write to input only — bypassing the structured
+  // shape and leaving the Items list misleadingly empty.
   setTimeout(function() {
-    _qlMeal = nextMeal;
-    const inp = document.getElementById('qlFeedInput');
-    if (inp) {
-      inp.value = food;
-      inp.focus();
-      updateQLFeedDropdown();
+    if (typeof qlFeedAddItem === 'function' && food) {
+      qlFeedAddItem(food, 'typeahead');
     }
-    // Select correct meal pill
-    document.querySelectorAll('.ql-meal-pill').forEach(p => {
-      p.classList.toggle('active', p.dataset.meal === nextMeal);
-    });
   }, 50);
 }
 
@@ -61548,7 +61578,7 @@ function saveFeedingDay() {
     dinner:    document.getElementById('meal-dinner').disabled ? (existing.dinner || '') : document.getElementById('meal-dinner').value,
     snack:     document.getElementById('meal-snack').disabled ? (existing.snack || '') : document.getElementById('meal-snack').value,
   };
-  // Save optional meal times
+  // Save optional meal times + preserve F-2 sidecar when text unchanged
   ['breakfast','lunch','dinner','snack'].forEach(m => {
     const timeVal = document.getElementById('mealtime-' + m)?.value || '';
     if (timeVal) {
@@ -61560,6 +61590,18 @@ function saveFeedingDay() {
     if (existing[m + '_intake'] !== undefined) {
       feedingData[d][m + '_intake'] = existing[m + '_intake'];
     }
+    // F-2 fix (E_a): preserve the [meal + '_v1'] structured sidecar when
+    // the meal text didn't change. Without this, every Diet tab editor
+    // save silently drops the rich shape (items[], qty/unit, sourceFlow,
+    // overallIntake) that the FOB Feed sheet had written — Today So Far
+    // + L1-L4 helpers + future F-3 review surface all degrade to legacy
+    // comma-split with synthesized default qty.
+    if (existing[m + '_v1'] && feedingData[d][m] === (existing[m] || '')) {
+      feedingData[d][m + '_v1'] = existing[m + '_v1'];
+    }
+    // If text changed, the sidecar is intentionally dropped — the legacy
+    // string is now the source of truth post-edit (matches the pre-F-2
+    // behavior that this writer used to maintain implicitly).
   });
   save(KEYS.feeding, feedingData);
   _tsfMarkDirty();
@@ -61854,6 +61896,13 @@ function changeDate(dir) {
 // ─────────────────────────────────────────
 let _qlOpen = false;
 let _qlMeal = 'breakfast';
+// F-2 fix (C1): explicit-meal flag. Callers that pre-set _qlMeal before
+// openQuickModal('feed') set this to true so openQuickModal preserves
+// their intent instead of clobbering with detectMealType(). One-shot —
+// consumed (reset to false) inside openQuickModal. Without this guard,
+// every "Log Breakfast" home alert at 8 PM would silently re-route to
+// the dinner slot (detected by time-of-day) and load wrong-slot rails.
+let _qlMealExplicit = false;
 let _qlWake = 0;
 let _qlColor = 'yellow';
 let _qlCon = 'normal';
@@ -61913,7 +61962,14 @@ function openQuickModal(type) {
 
   // Pre-fill defaults
   if (type === 'feed') {
-    _qlMeal = detectMealType();
+    // F-2 fix (C1): preserve _qlMeal when a caller explicitly set it
+    // (via the _qlMealExplicit flag). Without this guard, callers like
+    // home-tab "Log Breakfast" alerts at 8 PM would have their intent
+    // clobbered to detectMealType()='dinner' and load wrong-slot rails.
+    if (!_qlMealExplicit) {
+      _qlMeal = detectMealType();
+    }
+    _qlMealExplicit = false;  // one-shot — consume the flag
     if (!_qlBackfillDate) _qlBackfillDate = null; // ensure reset for non-backfill
     document.querySelectorAll('.ql-meal-pill').forEach(p => {
       p.classList.toggle('active', p.dataset.meal === _qlMeal);
@@ -63536,10 +63592,16 @@ window._fdGetMealSlotByTime = function() {
 // sub    — items preview (truncated, comma-separated)
 // items  — array of {name, qty, unit, nutritionRef} ready to apply
 // source — 'today-lunch' | 'yesterday' | 'recent' (telemetry)
-window._fdGetRepeatCandidates = function(meal, n) {
+window._fdGetRepeatCandidates = function(meal, n, opts) {
   n = n || 3;
+  opts = opts || {};
   var out = [];
-  var todayStr = today();
+  // F-2 fix (A2): use opts.fromDate (caller's active date — typically
+  // _qlBackfillDate || today()) so backfill flows walk back from the
+  // RIGHT date. Without this, backfilling dinner for 2026-05-15
+  // surfaces today's lunch as "Same as today's lunch" + applying the
+  // chip writes today's items to the May 15 slot.
+  var todayStr = opts.fromDate || today();
   var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
 
   function dayLabel(daysAgo) {
@@ -63577,9 +63639,13 @@ window._fdGetRepeatCandidates = function(meal, n) {
     }
   }
 
-  // Walk back up to 14 days; collect candidates for the same slot.
+  // Walk back up to 14 days FROM the active date (todayStr; may be
+  // _qlBackfillDate). HR-12-safe: parse with explicit y/m/d construction.
+  var anchorParts = todayStr.split('-');
+  var anchorDate = new Date(parseInt(anchorParts[0]), parseInt(anchorParts[1]) - 1, parseInt(anchorParts[2]));  // HR-12-safe
   for (var d = 1; d <= 14 && out.length < n; d++) {
-    var dd = new Date(); dd.setDate(dd.getDate() - d);
+    var dd = new Date(anchorDate.getTime());
+    dd.setDate(dd.getDate() - d);
     var ds = toDateStr(dd);
     var items = itemsFromDay(fd[ds], meal);
     if (!items) continue;
@@ -63918,13 +63984,21 @@ function _qlConfirmSuggest() {
   _qlSuggestUsed = true;
   var pred = _qlActivePredictions.find(function(p) { return p.type === 'feed'; });
   if (!pred) return;
+  // F-2 fix (C1): mark meal explicit so openQuickModal preserves intent
   _qlMeal = pred.meal;
+  _qlMealExplicit = true;
   openQuickModal('feed');
+  // F-2 fix (C2): push predicted foods directly into _qlFeedItems so the
+  // Items list reflects what will be saved, not just the typeahead input
+  // (which would leave the Items list misleadingly empty until typed-text
+  // fold-in at Save time — and the items would route via 'fob-typed'
+  // bypassing the structured-shape clean-data gate).
   setTimeout(function() {
-    document.querySelectorAll('.ql-meal-pill').forEach(function(p) { p.classList.toggle('active', p.dataset.meal === pred.meal); });
-    if (pred.foods) {
-      var inp = document.getElementById('qlFeedInput');
-      if (inp) inp.value = pred.foods;
+    if (pred.foods && typeof qlFeedAddItem === 'function') {
+      String(pred.foods).split(/\s*\+\s*|,\s*/).forEach(function(name) {
+        var trimmed = name.trim();
+        if (trimmed) qlFeedAddItem(trimmed, 'typeahead');
+      });
     }
   }, 50);
 }
@@ -63933,18 +64007,17 @@ function _qlEditSuggest() {
   _qlSuggestUsed = true;
   var pred = _qlActivePredictions.find(function(p) { return p.type === 'feed'; });
   var meal = pred ? pred.meal : detectMealType();
+  // F-2 fix (C1): mark meal explicit so openQuickModal preserves intent
   _qlMeal = meal;
+  _qlMealExplicit = true;
   openQuickModal('feed');
-  setTimeout(function() {
-    document.querySelectorAll('.ql-meal-pill').forEach(function(p) { p.classList.toggle('active', p.dataset.meal === meal); });
-  }, 50);
 }
 
 // ═══════════════════════════════════════════════════════════════
 // SMART QUICK LOG — Post-Save Micro-Insights
 // ═══════════════════════════════════════════════════════════════
 
-function _qlFeedInsight() {
+function _qlFeedInsight(foodArg) {
   try {
     var todayStr = today();
     var day = feedingData[todayStr];
@@ -63952,7 +64025,11 @@ function _qlFeedInsight() {
     var mealCount = ['breakfast', 'lunch', 'dinner'].filter(function(m) { return day[m] && day[m].trim(); }).length;
     if (mealCount >= 3) return '3rd meal today \u2014 great variety!';
 
-    var food = document.getElementById('qlFeedInput')?.value?.trim() || '';
+    // F-2 fix (C3/E_e): saveQLFeed now clears qlFeedInput AFTER folding
+    // typed text into _qlFeedItems but BEFORE calling _qlFeedInsight.
+    // The legacy input-read path returns '' and the 'New food!' branch
+    // dies silently. Prefer the food arg (built from items by caller).
+    var food = (typeof foodArg === 'string' && foodArg) ? foodArg : (document.getElementById('qlFeedInput')?.value?.trim() || '');
     if (food) {
       var base = _baseFoodName(food);
       var isNew = !foods.some(function(f) { return _baseFoodName(f.name) === base; });
@@ -64100,9 +64177,13 @@ function qaAnswerFavoriteFoods() {
 }
 
 function setQLMeal(meal) {
+  // F-2 fix (C1): user-driven meal pill tap is explicit by intent
   _qlMeal = meal;
+  _qlMealExplicit = true;
   document.querySelectorAll('.ql-meal-pill').forEach(p => p.classList.toggle('active', p.dataset.meal === meal));
-  // F-2: refresh autofill regions on meal change — repeats + combos differ per slot.
+  // F-2: re-hydrate items from the new meal slot (preserves multi-save flow
+  // when parent switches B→L→D) + refresh autofill regions.
+  if (typeof _qlFeedReset === 'function') _qlFeedReset();
   if (typeof _qlRenderFeedSheet === 'function') _qlRenderFeedSheet();
 }
 
@@ -64170,6 +64251,28 @@ function _qlFeedReset() {
   if (inp) inp.value = '';
   var dd = document.getElementById('qlFeedDropdown');
   if (dd) { dd.innerHTML = ''; dd.classList.remove('open'); }
+  // F-2 fix (B1): if the slot is already logged for the active date,
+  // hydrate _qlFeedItems from the existing meal so re-opening the FOB
+  // Feed sheet on an already-logged meal preserves prior items. Without
+  // this, the historical "log a few items, come back, add more" flow
+  // silently destroys the prior save (REPLACE semantic + empty Items
+  // list on reopen). Skipped meals don't hydrate — parent re-opening
+  // a skipped slot is intentionally starting fresh.
+  var dateStr = _qlBackfillDate || today();
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+  if (fd[dateStr] && _qlMeal && typeof window._fdReadDayMeal === 'function') {
+    var rec = window._fdReadDayMeal(fd[dateStr], _qlMeal);
+    if (rec && !rec.skipped && rec.items && rec.items.length > 0) {
+      _qlFeedItems = rec.items.map(function(it) {
+        if (it.qty !== undefined && it.unit) return Object.assign({}, it);
+        var defaults = window._fdResolveQtyDefaults(it.name);
+        return Object.assign({}, it, { qty: defaults.qty, unit: defaults.unit });
+      });
+      // Preserve the original sourceFlow so re-save doesn't downgrade
+      // a 'fob-combo' meal to 'fob-feed' on an unchanged re-save.
+      _qlFeedSourceFlow = rec.sourceFlow || 'fob-feed';
+    }
+  }
 }
 
 // Render all dynamic regions of the FOB Feed sheet. Called on open + after
@@ -64183,11 +64286,19 @@ function _qlRenderFeedSheet() {
 
 // L1 — Repeat rail. Surfaces yesterday's/recent matching-slot meals as
 // one-tap apply chips. For dinner, "Same as today's lunch" leads if logged.
+// F-2 fix (A6): hidden once items are present (mirror the combos-rail
+// behavior). Otherwise an accidental tap on a still-visible repeat chip
+// silently wipes the parent's in-progress items with no undo affordance.
 function _qlRenderRepeatRail() {
   var wrap = document.getElementById('qlFeedRepeatWrap');
   var rail = document.getElementById('qlFeedRepeatRail');
   if (!wrap || !rail) return;
-  var candidates = window._fdGetRepeatCandidates(_qlMeal, 3);
+  if (_qlFeedItems.length > 0) {
+    wrap.style.display = 'none';
+    rail.innerHTML = '';
+    return;
+  }
+  var candidates = window._fdGetRepeatCandidates(_qlMeal, 3, { fromDate: _qlBackfillDate || today() });
   if (!candidates || candidates.length === 0) {
     wrap.style.display = 'none';
     rail.innerHTML = '';
@@ -64323,7 +64434,7 @@ function _qlRenderNextItemRibbon() {
 // ── F-2 handlers ──
 
 function qlFeedApplyRepeat(id) {
-  var cands = window._fdGetRepeatCandidates(_qlMeal, 6);
+  var cands = window._fdGetRepeatCandidates(_qlMeal, 6, { fromDate: _qlBackfillDate || today() });
   var found = cands.find(function(c) { return c.id === id; });
   if (!found) return;
   _qlFeedItems = found.items.slice().map(function(it) { return Object.assign({}, it); });
@@ -64342,22 +64453,36 @@ function qlFeedApplyCombo(id) {
 
 function qlFeedAddItem(name, source) {
   if (!name) return;
+  // F-2 fix (B4): dedup by base name. Same food added via L3 next-item +
+  // L4 typeahead would otherwise produce duplicate rows in _qlFeedItems,
+  // each with its own qty stepper, and double-count in the post-save
+  // nutrient flash + autoIntroduceFoodsFromDay. For F-2 a meal entry
+  // carries one item per food; quantity adjustments use the stepper.
+  var normalized = String(name).toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim();
+  var alreadyPresent = _qlFeedItems.some(function(it) {
+    var n = String(it.name).toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim();
+    return n === normalized;
+  });
+  // Clear typeahead input + dropdown regardless (parent's input was consumed)
+  var inp = document.getElementById('qlFeedInput');
+  if (inp) inp.value = '';
+  var dd = document.getElementById('qlFeedDropdown');
+  if (dd) { dd.innerHTML = ''; dd.classList.remove('open'); }
+  if (alreadyPresent) {
+    if (typeof showQLToast === 'function') showQLToast(name + ' already added — adjust qty with +/-', 2000);
+    return;
+  }
   var defaults = window._fdResolveQtyDefaults(name);
   _qlFeedItems.push({
     name: name,
     qty: defaults.qty,
     unit: defaults.unit,
-    nutritionRef: String(name).toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim(),
+    nutritionRef: normalized,
     source: source || 'manual',
   });
   if (source === 'next' || source === 'typeahead') {
     if (_qlFeedSourceFlow === 'fob-feed') _qlFeedSourceFlow = 'fob-novel';
   }
-  // Clear typeahead input + dropdown
-  var inp = document.getElementById('qlFeedInput');
-  if (inp) inp.value = '';
-  var dd = document.getElementById('qlFeedDropdown');
-  if (dd) { dd.innerHTML = ''; dd.classList.remove('open'); }
   _qlRenderFeedSheet();
 }
 
@@ -64413,21 +64538,42 @@ function qlFeedTypeaheadInput() {
 function qlFeedSkipMeal() {
   var dateStr = _qlBackfillDate || today();
   if (!_qlMeal) return;
-  // Capture prev value for undo
+  // F-2 fix (A3 + B3): capture FULL prev state for atomic undo —
+  // legacy [meal] string + [meal+'_v1'] sidecar + [meal+'_time'] +
+  // [meal+'_intake']. Otherwise undo restores only the legacy string
+  // and leaves a phantom time/intake or loses the structured shape.
   var fd = load(KEYS.feeding, {}) || {};
-  var prevVal = fd[dateStr] ? fd[dateStr][_qlMeal] : '';
+  var prevDay = fd[dateStr] || {};
+  var prevVal = prevDay[_qlMeal];
+  var prevSidecar = prevDay[_qlMeal + '_v1'];
+  var prevTime = prevDay[_qlMeal + '_time'];
+  var prevIntake = prevDay[_qlMeal + '_intake'];
   window._fdMarkMealSkipped(dateStr, _qlMeal);
   var meal = _qlMeal;
   var undoFn = function() {
     var f = load(KEYS.feeding, {}) || {};
-    if (f[dateStr]) { f[dateStr][meal] = prevVal || ''; save(KEYS.feeding, f); feedingData = f; }
+    if (!f[dateStr]) f[dateStr] = { breakfast: '', lunch: '', dinner: '', snack: '' };
+    if (prevVal !== undefined) f[dateStr][meal] = prevVal; else f[dateStr][meal] = '';
+    if (prevSidecar !== undefined) f[dateStr][meal + '_v1'] = prevSidecar; else delete f[dateStr][meal + '_v1'];
+    if (prevTime !== undefined) f[dateStr][meal + '_time'] = prevTime; else delete f[dateStr][meal + '_time'];
+    if (prevIntake !== undefined) f[dateStr][meal + '_intake'] = prevIntake; else delete f[dateStr][meal + '_intake'];
+    save(KEYS.feeding, f);
+    feedingData = f;
     if (typeof _islMarkDirty === 'function') _islMarkDirty('diet');
+    if (typeof updateMealSkipButtons === 'function') updateMealSkipButtons();
     var curTab2 = TAB_ORDER.find(function(t) { return document.getElementById('tab-' + t) && document.getElementById('tab-' + t).classList.contains('active'); });
     if (curTab2 === 'diet') { if (typeof initFeeding === 'function') initFeeding(); if (typeof renderDietStats === 'function') renderDietStats(); }
     if (curTab2 === 'home') renderHome();
   };
+  // F-2 fix (A4): reset _qlBackfillDate so subsequent QL opens (sleep/nap/poop/etc.)
+  // don't inherit stale backfill state across modal types.
+  _qlBackfillDate = null;
   closeQuickLogAll();
   showQLToast(capitalize(meal) + ' marked as skipped', 4000, undoFn);
+  // F-2 fix (R1): updateMealSkipButtons refreshes the Diet tab's per-meal
+  // Skip toggles so a subsequent tap on the now-stale legacy Skip button
+  // doesn't silently UNSKIP the meal we just skipped via FOB.
+  if (typeof updateMealSkipButtons === 'function') updateMealSkipButtons();
   var curTab = TAB_ORDER.find(function(t) { return document.getElementById('tab-' + t) && document.getElementById('tab-' + t).classList.contains('active'); });
   if (curTab === 'diet') { if (typeof initFeeding === 'function') initFeeding(); if (typeof renderDietStats === 'function') renderDietStats(); }
   if (curTab === 'home') renderHome();
@@ -64463,10 +64609,18 @@ function saveQLFeed() {
     return;
   }
 
-  // Capture prev value for undo BEFORE mutation
-  const feedingPrev = load(KEYS.feeding, {}) || {};
+  // Capture FULL prev state for atomic undo BEFORE mutation —
+  // legacy [meal] string + [meal+'_v1'] sidecar + [meal+'_time'] +
+  // [meal+'_intake']. Otherwise undo would restore only the legacy
+  // string and leave phantom time/intake from this save attached to
+  // the now-restored prior meal name (F-2 fix B3/D4/E_c/C5).
+  // In-memory read instead of disk reload (efficiency E6).
   const undoMealKey = _qlMeal;
-  const prevMealValue = (feedingPrev[dateStr] && feedingPrev[dateStr][undoMealKey]) || '';
+  const prevDay = (typeof feedingData !== 'undefined' && feedingData && feedingData[dateStr]) || {};
+  const prevMealValue = prevDay[undoMealKey] || '';
+  const prevSidecar = prevDay[undoMealKey + '_v1'];
+  const prevTime = prevDay[undoMealKey + '_time'];
+  const prevIntake = prevDay[undoMealKey + '_intake'];
 
   // Build the structured payload + write via the canonical F-2 writer.
   const qlTime = (document.getElementById('qlFeedTime')?.value) || null;
@@ -64521,23 +64675,32 @@ function saveQLFeed() {
 
   _qlBackfillDate = null; // reset backfill
 
-  // Smart QL: compute insight BEFORE closing modal
-  var qlInsight = _qlFeedInsight();
+  // Smart QL: compute insight BEFORE closing modal. Pass food string built
+  // from _qlFeedItems above (F-2 fix C3/E_e — the input was cleared after
+  // typed-text fold-in, so reading qlFeedInput.value would return '').
+  var qlInsight = _qlFeedInsight(food);
   // Accuracy tracking
   _qlLogAction('feed:' + _qlMeal, _qlSuggestUsed);
 
-  // Build undo function — restore prev legacy value AND clear the v1 sidecar
-  // (otherwise stale structured data lingers after undo).
+  // Build undo function — restore the FULL prev state atomically
+  // (legacy [meal] + [meal+'_v1'] sidecar + [meal+'_time'] +
+  // [meal+'_intake']). Each field uses prev-was-undefined →
+  // delete-the-key semantic so undo doesn't silently re-introduce
+  // a default 0.75 intake on a meal that had no intake set.
   const undoDateStr = dateStr;
   const undoFn = () => {
     const f = load(KEYS.feeding, {}) || {};
-    if (f[undoDateStr]) {
-      f[undoDateStr][undoMealKey] = prevMealValue;
-      delete f[undoDateStr][undoMealKey + '_v1'];
-      save(KEYS.feeding, f);
-      feedingData = f;
-      _islMarkDirty('diet');
-    }
+    if (!f[undoDateStr]) f[undoDateStr] = { breakfast: '', lunch: '', dinner: '', snack: '' };
+    f[undoDateStr][undoMealKey] = prevMealValue;
+    if (prevSidecar !== undefined) f[undoDateStr][undoMealKey + '_v1'] = prevSidecar;
+    else delete f[undoDateStr][undoMealKey + '_v1'];
+    if (prevTime !== undefined) f[undoDateStr][undoMealKey + '_time'] = prevTime;
+    else delete f[undoDateStr][undoMealKey + '_time'];
+    if (prevIntake !== undefined) f[undoDateStr][undoMealKey + '_intake'] = prevIntake;
+    else delete f[undoDateStr][undoMealKey + '_intake'];
+    save(KEYS.feeding, f);
+    feedingData = f;
+    _islMarkDirty('diet');
   };
 
   closeQuickLogAll();
@@ -65732,7 +65895,7 @@ function renderHomeMealProgress() {
         <div class="mi-prog-row">${_miRenderBar(_miVal)} <span class="mi-prog-label">${escHtml(_miLv.label)}</span></div>
       </div>`;
     } else {
-      html += `<div class="meal-prog-slot mps-empty" onclick="_qlMeal='${m.full}';openQuickModal('feed')">
+      html += `<div class="meal-prog-slot mps-empty" onclick="_qlMeal='${m.full}';_qlMealExplicit=true;openQuickModal('feed')">
         <div class="meal-prog-icon">${zi('target')}</div>
         <div class="meal-prog-label">${m.label}</div>
         <div class="meal-prog-food t-light" >tap to log</div>
@@ -66096,7 +66259,16 @@ function skipMeals(mealKeys) {
   const dateStr = today();
   if (!feedingData[dateStr]) feedingData[dateStr] = { breakfast:'', lunch:'', dinner:'', snack:'' };
   mealKeys.forEach(m => {
-    if (!feedingData[dateStr][m]) feedingData[dateStr][m] = '—skipped—';
+    if (!feedingData[dateStr][m]) {
+      feedingData[dateStr][m] = '—skipped—';
+      // F-2 fix (Alt1): clear the structured sidecar + legacy _time/_intake
+      // so a skip is atomic. Without this, a meal previously logged via
+      // FOB (sidecar present) then skipped via this home-tab "Skip
+      // remaining" path leaves the stale sidecar alongside the sentinel.
+      delete feedingData[dateStr][m + '_v1'];
+      delete feedingData[dateStr][m + '_time'];
+      delete feedingData[dateStr][m + '_intake'];
+    }
   });
   save(KEYS.feeding, feedingData);
   // V-M-70: complete the _refreshTodayMedWithFat contract on every feedingData mutation.
@@ -66118,6 +66290,11 @@ function skipSingleMeal(mealKey) {
 
   if (feedingData[dateStr][mealKey] && feedingData[dateStr][mealKey] !== '—skipped—') return; // already has food
   feedingData[dateStr][mealKey] = '—skipped—';
+  // F-2 fix (Alt1): clear the structured sidecar + legacy _time/_intake
+  // so a skip is atomic. Matches _fdMarkMealSkipped contract.
+  delete feedingData[dateStr][mealKey + '_v1'];
+  delete feedingData[dateStr][mealKey + '_time'];
+  delete feedingData[dateStr][mealKey + '_intake'];
   save(KEYS.feeding, feedingData);
   // V-M-70: complete the _refreshTodayMedWithFat contract.
   if (dateStr === today() && typeof _refreshTodayMedWithFat === 'function') _refreshTodayMedWithFat();

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -6650,16 +6650,6 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 .ql-modal-close:hover { background:var(--rose-light); color:var(--tc-rose); }
 
 .ql-form { display:flex; flex-direction:column; gap:var(--sp-12); }
-/* Frequent meals pills */
-.ql-freq-row { display:flex; flex-wrap:wrap; gap:var(--sp-4); }
-.ql-freq-pill {
-  font-size:var(--fs-xs); padding:var(--sp-4) var(--sp-10); border-radius:var(--r-full);
-  background:var(--sage-light); border:1px solid rgba(181,213,197,0.4);
-  color:var(--tc-sage); cursor:pointer; white-space:nowrap;
-  max-width:140px;
-  transition:transform var(--ease-fast), background var(--ease-fast);
-}
-.ql-freq-pill:active { transform:scale(0.95); background:var(--accent-sage-deep); color:white; }
 /* Backfill date pills */
 .ql-bf-row { display:flex; gap:var(--sp-4); flex-wrap:wrap; }
 .ql-bf-pill {
@@ -6932,7 +6922,7 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 }
 .ql-feed-next-chip:active { transform:scale(0.94); }
 .ql-feed-next-conf {
-  font-size:9px;
+  font-size:var(--fs-2xs);
   background:var(--white); color:var(--tc-sage);
   border-radius:var(--r-full);
   padding:1px var(--sp-6);
@@ -6986,7 +6976,10 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 [data-theme="dark"] .ql-feed-repeat-head { color:#7ac0a0; }
 [data-theme="dark"] .ql-feed-combo-chip { background:#2a2240; border-color:var(--tc-lav); }
 [data-theme="dark"] .ql-feed-combo-head { color:#b8a8e0; }
-[data-theme="dark"] .ql-feed-combo-conf { background:var(--lavender); color:var(--text); }
+/* Deep-lavender badge with light text so the combo frequency/confidence
+   number stays legible in dark mode — the prior var(--text) flipped light
+   over the unchanged light-lavender fill (~1.42:1). (V-M-210 / V-V-210) */
+[data-theme="dark"] .ql-feed-combo-conf { background:#3a2f55; color:#e6dcf5; }
 [data-theme="dark"] .ql-feed-items-list { background:var(--surface); border-color:#3a2e3e; }
 [data-theme="dark"] .ql-feed-item-row { border-bottom-color:#3a2e3e; }
 [data-theme="dark"] .ql-feed-qty-stepper { background:#221c28; }
@@ -7395,8 +7388,6 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 @media (prefers-reduced-motion: reduce) {
   .sc-disclosure-toggle { transition:none; }
 }
-[data-theme="dark"] .ql-freq-pill { background:rgba(58,112,96,0.12); border-color:rgba(181,213,197,0.15); color:var(--tc-sage); }
-[data-theme="dark"] .ql-freq-pill:active { background:var(--accent-sage-deep); color:var(--body-bg); }
 [data-theme="dark"] .ql-bf-pill { background:rgba(201,184,232,0.1); border-color:rgba(201,184,232,0.15); }
 [data-theme="dark"] .ql-bf-pill.active { background:rgba(184,168,224,0.2); color:var(--tc-lav); border-color:rgba(184,168,224,0.35); }
 [data-theme="dark"] .meal-prog-slot { background:var(--card-bg); border-color:var(--card-border); }
@@ -16805,12 +16796,40 @@ window._FOOD_QTY_CATEGORY_DEFAULTS = {
   'veg-mashed':     { qty: 0.25, unit: 'cup',     step: 0.25 },
   'fruit-piece':    { qty: 0.5,  unit: 'pc',      step: 0.25 },
   'fruit-berry':    { qty: 5,    unit: 'pc',      step: 2    },
-  'fruit-mash':     { qty: 0.5,  unit: 'pc',      step: 0.25 },
+  'fruit-mash':     { qty: 2,    unit: 'tbsp',    step: 1    },
   'nut-piece':      { qty: 1,    unit: 'pc',      step: 1    },
   'fat-cooking':    { qty: 1,    unit: 'tsp',     step: 0.5  },
   'spice':          { qty: 0.25, unit: 'tsp',     step: 0.25 },
   'liquid-drink':   { qty: 0.5,  unit: 'cup',     step: 0.25 },
   'fallback':       { qty: 1,    unit: 'serving', step: 1    },
+};
+
+// Strip a prep-form word ("ragi porridge"→"ragi", "banana mash"→"banana",
+// "bajra roti"→"bajra") so a curated explicit override / NUTRITION row can
+// be matched before the broad category fallthrough. Returns '' when
+// stripping would empty the string (the food name IS the prep word, e.g.
+// "porridge", "roti") so callers fall back to the original base. (V-K-201)
+window._fdStripPrepSuffix = function(base) {
+  if (!base) return '';
+  return String(base)
+    .replace(/\b(porridge|mash|puree|pure|sauce|roti|chapati|paratha)\b/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
+// Resolve a food name to its best NUTRITION key for the nutrient join:
+// paren-strip, and if that isn't a NUTRITION row, try the prep-suffix-
+// stripped stem ("ragi porridge"→"ragi"). Falls back to the paren-stripped
+// base when neither matches, preserving legacy behavior. (V-K-200)
+window._fdNutritionRef = function(name) {
+  if (!name) return '';
+  var base = String(name).toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim();
+  if (typeof NUTRITION !== 'undefined' && NUTRITION) {
+    if (NUTRITION[base]) return base;
+    var stem = window._fdStripPrepSuffix(base);
+    if (stem && stem !== base && NUTRITION[stem]) return stem;
+  }
+  return base;
 };
 
 // Resolver — explicit override wins; category fallback otherwise.
@@ -16823,6 +16842,12 @@ window._fdResolveQtyDefaults = function(foodName) {
   // 1. Explicit per-food override
   if (NUTRITION_QTY_DEFAULTS[base]) return NUTRITION_QTY_DEFAULTS[base];
   if (NUTRITION_QTY_DEFAULTS[key])  return NUTRITION_QTY_DEFAULTS[key];
+  // 1b. Prep-suffix-stripped stem ("banana mash"→"banana") so a curated
+  //     explicit qty wins over the broad category catch below. Category
+  //     heuristics still run on the un-stripped base, so unnamed mashes
+  //     ("papaya puree") keep their fruit-mash default. (V-K-201)
+  var stem = window._fdStripPrepSuffix(base);
+  if (stem && stem !== base && NUTRITION_QTY_DEFAULTS[stem]) return NUTRITION_QTY_DEFAULTS[stem];
   // 2. Category resolver — name heuristics first
   if (/porridge|upma|halwa/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['porridge'];
   if (/\b(roti|chapati|paratha|naan|puri)\b/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['roti-flatbread'];
@@ -16923,6 +16948,11 @@ window.parseFeedingV1 = function(mealVal) {
   if (typeof mealVal === 'string') {
     var raw = mealVal.trim();
     if (!raw) return { items: [] };
+    // Skip sentinel reaching the normalizer directly (the live read path
+    // guards this in _fdReadDayMeal, but F-5 callers may invoke parseFeedingV1
+    // on the raw string) — must not emit a phantom "—skipped—" food. (V-K-202)
+    var sentinel = (typeof SKIPPED_MEAL !== 'undefined') ? SKIPPED_MEAL : '—skipped—';
+    if (raw === sentinel) return { items: [], skipped: true };
     var items = raw.split(',').map(function(s) {
       var name = s.trim().replace(/,+$/, '');
       if (!name) return null;
@@ -16932,7 +16962,7 @@ window.parseFeedingV1 = function(mealVal) {
         qty: defaults.qty,
         unit: defaults.unit,
         source: 'legacy-parse',
-        nutritionRef: name.toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim()
+        nutritionRef: window._fdNutritionRef(name)
       };
     }).filter(function(x) { return x; });
     return { items: items, _parsedFrom: 'legacy-string' };
@@ -41577,20 +41607,6 @@ function getTopMeals(n) {
     .map(m => ({ name: m.display.charAt(0).toUpperCase() + m.display.slice(1), count: m.count }));
 }
 
-function renderQLFreqPills() {
-  const wrap = document.getElementById('qlFreqWrap');
-  const el = document.getElementById('qlFreqPills');
-  if (!wrap || !el) return;
-
-  const top = getTopMeals(5);
-  if (top.length === 0) { wrap.style.display = 'none'; return; }
-
-  wrap.style.display = '';
-  el.innerHTML = top.map(m =>
-    `<div class="ql-freq-pill" onclick="document.getElementById('qlFeedInput').value='${escHtml(m.name).replace(/'/g, "\\'")}';document.getElementById('qlFeedInput').focus();" title="${m.count}× logged">${escHtml(m.name)}</div>`
-  ).join('');
-}
-
 // ── Meal progress on Home ──
 
 // ── MEAL DIVERSITY INDEX ──
@@ -63710,7 +63726,7 @@ window._fdGetCombosForMeal = function(meal, opts) {
     return curated.slice(0, maxResults).map(function(c, i) {
       var items = c.items.map(function(name) {
         var d = window._fdResolveQtyDefaults(name);
-        return { name: name, qty: d.qty, unit: d.unit, nutritionRef: name.toLowerCase().replace(/\s*\([^)]*\)\s*/g,'').trim(), source: 'curated' };
+        return { name: name, qty: d.qty, unit: d.unit, nutritionRef: window._fdNutritionRef(name), source: 'curated' };
       });
       return {
         id: 'curated-' + meal + '-' + i,
@@ -63737,7 +63753,7 @@ window._fdGetCombosForMeal = function(meal, opts) {
     return curated2.slice(0, maxResults).map(function(c, i) {
       var items = c.items.map(function(name) {
         var d = window._fdResolveQtyDefaults(name);
-        return { name: name, qty: d.qty, unit: d.unit, nutritionRef: name.toLowerCase().replace(/\s*\([^)]*\)\s*/g,'').trim(), source: 'curated' };
+        return { name: name, qty: d.qty, unit: d.unit, nutritionRef: window._fdNutritionRef(name), source: 'curated' };
       });
       return {
         id: 'curated-fallback-' + meal + '-' + i,
@@ -64289,7 +64305,22 @@ function _qlRenderFeedSheet() {
 // F-2 fix (A6): hidden once items are present (mirror the combos-rail
 // behavior). Otherwise an accidental tap on a still-visible repeat chip
 // silently wipes the parent's in-progress items with no undo affordance.
+// L1↔L2 dedup: the repeat rail (your actual history) and the combo rail
+// (templates / curated cold-start) can surface the identical food-set as two
+// differently-coloured chips. The repeat rail stashes its signatures here so
+// the combo rail can drop the duplicate and keep the more-authoritative
+// history chip. Reset at the top of every repeat-rail render. (V-V-204)
+var _qlRepeatSigs = [];
+function _qlFeedRailSig(itemsText) {
+  return String(itemsText || '').toLowerCase().split(',')
+    .map(function(s) { return s.trim(); })
+    .filter(function(s) { return s; })
+    .sort()
+    .join('|');
+}
+
 function _qlRenderRepeatRail() {
+  _qlRepeatSigs = [];
   var wrap = document.getElementById('qlFeedRepeatWrap');
   var rail = document.getElementById('qlFeedRepeatRail');
   if (!wrap || !rail) return;
@@ -64304,6 +64335,7 @@ function _qlRenderRepeatRail() {
     rail.innerHTML = '';
     return;
   }
+  _qlRepeatSigs = candidates.map(function(c) { return _qlFeedRailSig(c.itemsText); });
   wrap.style.display = '';
   rail.innerHTML = candidates.map(function(c, i) {
     return '<div class="ql-feed-repeat-chip' + (i === 0 ? ' primary' : '') + '"' +
@@ -64330,6 +64362,13 @@ function _qlRenderCombosRail() {
     return;
   }
   var combos = window._fdGetCombosForMeal(_qlMeal, { maxResults: 3 });
+  // Drop any combo whose food-set duplicates a repeat-rail chip already shown
+  // above (the history chip is more authoritative). (V-V-204)
+  if (combos && combos.length && _qlRepeatSigs.length) {
+    combos = combos.filter(function(c) {
+      return _qlRepeatSigs.indexOf(_qlFeedRailSig(c.itemsText)) === -1;
+    });
+  }
   if (!combos || combos.length === 0) {
     wrap.style.display = 'none';
     rail.innerHTML = '';
@@ -64360,14 +64399,19 @@ function _qlRenderItemsList() {
     list.innerHTML = '<div class="ql-feed-items-empty">Tap a combo above, or type an item below</div>';
     return;
   }
+  // Stable alphabetical order so the list has a fixed scan position across
+  // the four entry rails (combo-replace, repeat-replace, next/typeahead push)
+  // — sorting the array in place keeps the data-arg idx consistent with the
+  // qty-stepper / remove handlers. (V-V-202)
+  _qlFeedItems.sort(function(a, b) {
+    return String(a.name || '').toLowerCase().localeCompare(String(b.name || '').toLowerCase());
+  });
   list.innerHTML = _qlFeedItems.map(function(item, idx) {
     var initial = (item.name || '?').charAt(0).toUpperCase();
     var qtyDisplay = _qlFormatQty(item.qty);
     return '<div class="ql-feed-item-row">' +
            '<span class="ql-feed-item-icon">' + escHtml(initial) + '</span>' +
-           '<div class="ql-feed-item-name">' + escHtml(item.name) +
-             '<span class="ql-feed-item-meta">' + escHtml(item.source || 'manual') + '</span>' +
-           '</div>' +
+           '<div class="ql-feed-item-name">' + escHtml(item.name) + '</div>' +
            '<div class="ql-feed-qty-stepper">' +
              '<button class="ql-feed-qty-step" data-action="qlFeedAdjustQty" data-arg="' + idx + '" data-arg2="dec" type="button" aria-label="Decrease quantity">−</button>' +
              '<span class="ql-feed-qty-val">' + qtyDisplay +
@@ -64477,7 +64521,7 @@ function qlFeedAddItem(name, source) {
     name: name,
     qty: defaults.qty,
     unit: defaults.unit,
-    nutritionRef: normalized,
+    nutritionRef: window._fdNutritionRef(name),
     source: source || 'manual',
   });
   if (source === 'next' || source === 'typeahead') {
@@ -66350,43 +66394,6 @@ function updateMealSkipButtons() {
       if (input) { input.disabled = false; input.placeholder = 'Type to search foods...'; }
     }
   });
-}
-
-// ── Expanded same-as pills (yesterday's all meals) ──
-function renderQLSameAsPills() {
-  const wrap = document.getElementById('qlSameAsWrap');
-  const pills = document.getElementById('qlSameAsPills');
-  if (!wrap || !pills) return;
-
-  const todayEntry = feedingData[today()] || {};
-  const meals = [];
-  const seen = new Set();
-  function add(label, value) {
-    if (value && !seen.has(value)) { meals.push({ label, value }); seen.add(value); }
-  }
-
-  // Today's meals
-  add(zi('sun')+' Today B', todayEntry.breakfast);
-  add(zi('sun')+' Today L', todayEntry.lunch);
-  add(zi('moon')+' Today D', todayEntry.dinner);
-  add(zi('spoon')+' Today S', todayEntry.snack);
-
-  // Yesterday's meals (all three)
-  const yd = new Date(); yd.setDate(yd.getDate() - 1);
-  const ydEntry = feedingData[toDateStr(yd)] || {};
-  add(zi('clock')+' Yd B', ydEntry.breakfast);
-  add(zi('clock')+' Yd L', ydEntry.lunch);
-  add(zi('clock')+' Yd D', ydEntry.dinner);
-
-  if (meals.length === 0) {
-    wrap.style.display = 'none';
-    return;
-  }
-
-  wrap.style.display = '';
-  pills.innerHTML = meals.map(m =>
-    `<button class="btn-ghost" style="font-size:var(--fs-xs);padding:5px 10px;border-radius:var(--r-2xl);" onclick="document.getElementById('qlFeedInput').value='${escHtml(m.value).replace(/'/g, "\\'")}';this.closest('#qlSameAsWrap').style.display='none';">${m.label}</button>`
-  ).join('');
 }
 
 // Close QL dropdown on blur

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -16452,6 +16452,301 @@ window.isStructuredFeedingV1 = function(mealVal) {
   return mealVal && typeof mealVal === 'object' && Array.isArray(mealVal.items);
 };
 
+// ═══════════════════════════════════════════════════════════════════════
+// F-2 — per-food quantity defaults, CURATED_COMBOS, skip state, write helper
+// Spec: docs/specs/food-sub-tab-v1.md §F-2; ratifications #2 + #4 + #6.
+// Sidecar registry `NUTRITION_QTY_DEFAULTS` carries explicit qty/unit/step
+// for the top-used foods (the ones the 79-day feeding-data sample shows
+// parents actually log). Foods without an explicit override fall through
+// `_fdResolveQtyDefaults` to a category-based default. Kept as a sidecar
+// (not inline NUTRITION fields) so the qty data is discoverable in one
+// block — same intent as ratification #4 ("extend NUTRITION rows") with
+// edit-locality + maintainability preserved.
+// ═══════════════════════════════════════════════════════════════════════
+
+// Per-food explicit qty defaults. Keys MUST exist in NUTRITION (the
+// audit gate verifies). qty is a number (fractional allowed); unit is a
+// short display string ('pc' / 'tsp' / 'bowl' / 'cup' / 'piece'); step
+// is the +/- increment a single qty-stepper tap applies.
+window.NUTRITION_QTY_DEFAULTS = {
+  // ── GRAINS & STAPLES ──
+  'khichdi':        { qty: 1,    unit: 'bowl', step: 0.25 },
+  'ragi':           { qty: 1,    unit: 'cup',  step: 0.25 },   // porridge form
+  'rice':           { qty: 0.5,  unit: 'bowl', step: 0.25 },
+  'suji':           { qty: 1,    unit: 'cup',  step: 0.25 },
+  'oats':           { qty: 1,    unit: 'cup',  step: 0.25 },
+  'bajra':          { qty: 1,    unit: 'pc',   step: 0.5 },    // roti form
+  'jowar':          { qty: 1,    unit: 'pc',   step: 0.5 },
+  'idli':           { qty: 1,    unit: 'pc',   step: 1 },
+  'dosa':           { qty: 1,    unit: 'pc',   step: 0.5 },
+  'roti':           { qty: 1,    unit: 'pc',   step: 0.5 },
+  'paratha':        { qty: 1,    unit: 'pc',   step: 0.5 },
+  'poha':           { qty: 0.5,  unit: 'bowl', step: 0.25 },
+  // ── LENTILS ──
+  'moong dal':      { qty: 0.5,  unit: 'bowl', step: 0.25 },
+  'masoor dal':     { qty: 0.5,  unit: 'bowl', step: 0.25 },
+  'toor dal':       { qty: 0.5,  unit: 'bowl', step: 0.25 },
+  // ── VEGETABLES ──
+  'carrot':         { qty: 0.25, unit: 'cup',  step: 0.25 },   // mashed/puree form
+  'beetroot':       { qty: 0.25, unit: 'cup',  step: 0.25 },
+  'bottle gourd':   { qty: 0.25, unit: 'cup',  step: 0.25 },
+  'spinach':        { qty: 0.25, unit: 'cup',  step: 0.25 },
+  'tomato':         { qty: 0.5,  unit: 'pc',   step: 0.5 },
+  'cucumber':       { qty: 0.5,  unit: 'pc',   step: 0.25 },
+  'beans':          { qty: 0.25, unit: 'cup',  step: 0.25 },
+  // ── FRUITS ──
+  'apple':          { qty: 0.5,  unit: 'pc',   step: 0.25 },
+  'banana':         { qty: 0.5,  unit: 'pc',   step: 0.25 },
+  'mango':          { qty: 0.25, unit: 'pc',   step: 0.25 },   // small pieces typical
+  'avocado':        { qty: 0.5,  unit: 'pc',   step: 0.25 },
+  'blueberry':      { qty: 5,    unit: 'pc',   step: 2 },
+  'pear':           { qty: 0.5,  unit: 'pc',   step: 0.25 },
+  'papaya':         { qty: 0.25, unit: 'pc',   step: 0.25 },
+  'watermelon':     { qty: 1,    unit: 'cup',  step: 0.5 },    // cubed
+  'pomegranate':    { qty: 0.25, unit: 'cup',  step: 0.25 },   // seeds
+  'date':           { qty: 1,    unit: 'pc',   step: 1 },
+  'chiku':          { qty: 0.5,  unit: 'pc',   step: 0.25 },
+  // ── DAIRY & FATS ──
+  'ghee':           { qty: 1,    unit: 'tsp',  step: 0.5 },
+  'curd':           { qty: 0.25, unit: 'cup',  step: 0.25 },
+  'paneer':         { qty: 1,    unit: 'tbsp', step: 0.5 },    // crumbled
+  // ── NUTS & SEEDS (powdered/soaked) ──
+  'almonds':        { qty: 2,    unit: 'pc',   step: 1 },
+  'walnut':         { qty: 1,    unit: 'pc',   step: 1 },
+  'cashew':         { qty: 2,    unit: 'pc',   step: 1 },
+  'flaxseed':       { qty: 0.5,  unit: 'tsp',  step: 0.5 },
+  'chia seeds':     { qty: 0.5,  unit: 'tsp',  step: 0.5 },
+  // ── SPICES (trace amounts for babies) ──
+  'jeera':          { qty: 0.25, unit: 'tsp',  step: 0.25 },
+  'cumin':          { qty: 0.25, unit: 'tsp',  step: 0.25 },
+  'turmeric':       { qty: 0.25, unit: 'tsp',  step: 0.25 },
+  // ── LIQUIDS ──
+  'coconut water':  { qty: 0.5,  unit: 'cup',  step: 0.25 },
+  'lemon':          { qty: 1,    unit: 'tsp',  step: 0.5 },    // juice
+};
+
+// Category-based fallback for any NUTRITION row without an explicit qty
+// override. `_fdResolveQtyDefaults` walks the food name + NUTRITION tags
+// to pick the best-fitting category. Foods that mismatch all heuristics
+// fall through to the 'fallback' bucket.
+window._FOOD_QTY_CATEGORY_DEFAULTS = {
+  'porridge':       { qty: 1,    unit: 'cup',     step: 0.25 },
+  'roti-flatbread': { qty: 1,    unit: 'pc',      step: 0.5  },
+  'grain-staple':   { qty: 0.5,  unit: 'bowl',    step: 0.25 },
+  'dal-legume':     { qty: 0.5,  unit: 'bowl',    step: 0.25 },
+  'veg-piece':      { qty: 0.5,  unit: 'pc',      step: 0.25 },
+  'veg-mashed':     { qty: 0.25, unit: 'cup',     step: 0.25 },
+  'fruit-piece':    { qty: 0.5,  unit: 'pc',      step: 0.25 },
+  'fruit-berry':    { qty: 5,    unit: 'pc',      step: 2    },
+  'fruit-mash':     { qty: 0.5,  unit: 'pc',      step: 0.25 },
+  'nut-piece':      { qty: 1,    unit: 'pc',      step: 1    },
+  'fat-cooking':    { qty: 1,    unit: 'tsp',     step: 0.5  },
+  'spice':          { qty: 0.25, unit: 'tsp',     step: 0.25 },
+  'liquid-drink':   { qty: 0.5,  unit: 'cup',     step: 0.25 },
+  'fallback':       { qty: 1,    unit: 'serving', step: 1    },
+};
+
+// Resolver — explicit override wins; category fallback otherwise.
+// Returns { qty, unit, step }; never null.
+window._fdResolveQtyDefaults = function(foodName) {
+  if (!foodName) return _FOOD_QTY_CATEGORY_DEFAULTS.fallback;
+  var key = String(foodName).toLowerCase().trim();
+  // Strip parenthetical variants ("ghee (cow)" → "ghee"; "khichdi (masoor dal)" → "khichdi")
+  var base = key.replace(/\s*\([^)]*\)\s*/g, '').trim();
+  // 1. Explicit per-food override
+  if (NUTRITION_QTY_DEFAULTS[base]) return NUTRITION_QTY_DEFAULTS[base];
+  if (NUTRITION_QTY_DEFAULTS[key])  return NUTRITION_QTY_DEFAULTS[key];
+  // 2. Category resolver — name heuristics first
+  if (/porridge|upma|halwa/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['porridge'];
+  if (/\b(roti|chapati|paratha|naan|puri)\b/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['roti-flatbread'];
+  if (/\bdal\b|chickpeas|rajma|chole|peas/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['dal-legume'];
+  if (/\b(berry|cherry|grape|raisin)\b/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['fruit-berry'];
+  if (/mash|puree|sauce/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['fruit-mash'];
+  if (/(juice|water|coconut water|milk)/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['liquid-drink'];
+  if (/(seed|sesame|flax|chia)/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['spice'];
+  // 3. Tag-based fallback from NUTRITION
+  var n = (typeof NUTRITION !== 'undefined' && NUTRITION[base]) || (typeof NUTRITION !== 'undefined' && NUTRITION[key]);
+  if (n && n.tags) {
+    if (n.tags.indexOf('healthy-fats') >= 0 && /oil|ghee|butter/.test(base)) return _FOOD_QTY_CATEGORY_DEFAULTS['fat-cooking'];
+    if (n.tags.indexOf('iron-rich') >= 0 && n.tags.indexOf('protein-rich') >= 0) return _FOOD_QTY_CATEGORY_DEFAULTS['dal-legume'];
+    if (n.tags.indexOf('energy') >= 0 && !n.tags.indexOf('digestive') >= 0) return _FOOD_QTY_CATEGORY_DEFAULTS['grain-staple'];
+  }
+  // 4. Heuristic by nutrient profile
+  if (n && n.nutrients) {
+    if (n.nutrients.indexOf('water') >= 0) return _FOOD_QTY_CATEGORY_DEFAULTS['liquid-drink'];
+  }
+  return _FOOD_QTY_CATEGORY_DEFAULTS['veg-piece'];
+};
+
+// ═══════════════════════════════════════════════════════════════════════
+// CURATED_COMBOS — L2 autofill cold-start fallback (ratification #2 + #4)
+// 12 seed entries: 4 breakfast / 5 lunch+dinner / 3 snack. Age-gated via
+// minAgeMonths; surfaced when rolling-14d window has <7 days of signal.
+// Future curation arc (deferred) can expand from pediatrician guidelines.
+// ═══════════════════════════════════════════════════════════════════════
+window.CURATED_COMBOS = [
+  // ── BREAKFAST (4) ──
+  { slot: 'breakfast', items: ['Ragi porridge', 'Ghee (cow)', 'Banana mash'],
+    rationale: 'iron-base breakfast — ragi for iron, ghee for calorie density, banana for sweetness',
+    minAgeMonths: 6 },
+  { slot: 'breakfast', items: ['Avocado mash', 'Blueberry', 'Mango puree'],
+    rationale: 'good-fat + vitamin-C breakfast',
+    minAgeMonths: 6 },
+  { slot: 'breakfast', items: ['Suji', 'Ghee (cow)', 'Apple puree'],
+    rationale: 'soft-grain breakfast — gentle on stomach + cooked fruit pairing',
+    minAgeMonths: 6 },
+  { slot: 'breakfast', items: ['Oats porridge', 'Ghee (cow)', 'Banana mash'],
+    rationale: 'cereal-fruit breakfast — fibre + slow carbs',
+    minAgeMonths: 7 },
+  // ── LUNCH / DINNER (5) ──
+  { slot: 'lunch', items: ['Khichdi (masoor dal)', 'Ghee (cow)', 'Carrot', 'Bottle gourd'],
+    rationale: 'staple khichdi — protein + ghee + 2 veggies',
+    minAgeMonths: 6 },
+  { slot: 'lunch', items: ['Bajra roti', 'Masoor dal', 'Ghee (cow)', 'Spinach'],
+    rationale: 'millet-roti lunch — bajra for variety + iron-rich spinach',
+    minAgeMonths: 8 },
+  { slot: 'dinner', items: ['Khichdi (moong dal)', 'Ghee (cow)', 'Beetroot', 'Carrot'],
+    rationale: 'lighter moong dal dinner — easier overnight digestion',
+    minAgeMonths: 6 },
+  { slot: 'dinner', items: ['Rice', 'Masoor dal', 'Ghee (cow)'],
+    rationale: 'simple rice + dal dinner — fall-back when kitchen is light',
+    minAgeMonths: 6 },
+  { slot: 'lunch', items: ['Idli', 'Ghee (cow)', 'Tomato'],
+    rationale: 'south-Indian lunch — fermented + gut-friendly',
+    minAgeMonths: 7 },
+  // ── SNACK (3) ──
+  { slot: 'snack', items: ['Cucumber', 'Mango'],
+    rationale: 'hydration + sweet snack',
+    minAgeMonths: 7 },
+  { slot: 'snack', items: ['Coconut water', 'Cucumber'],
+    rationale: 'hot-day hydration — electrolytes + cooling',
+    minAgeMonths: 7 },
+  { slot: 'snack', items: ['Banana', 'Almonds'],
+    rationale: 'calorie-dense snack — fruit + nut for sustained energy',
+    minAgeMonths: 8 },
+];
+
+// Curated combo lookup — returns entries matching slot + Ziva's current age.
+window._fdGetCuratedCombosForMeal = function(meal, ageMonths) {
+  if (!meal || !Array.isArray(CURATED_COMBOS)) return [];
+  return CURATED_COMBOS.filter(function(c) {
+    if (c.slot !== meal) return false;
+    if (typeof ageMonths === 'number' && c.minAgeMonths > ageMonths) return false;
+    return true;
+  });
+};
+
+// ═══════════════════════════════════════════════════════════════════════
+// parseFeedingV1 — read-side normalizer (F-2 ships partial; F-5 ships
+// the full v3-8 parseFeeding tolerating ALL three shapes).
+// Returns: { items: [{name, qty, unit, ...}], time, overallIntake, ... }
+// regardless of input shape. Legacy strings parse via comma-split + qty
+// resolver. Skipped slots return { skipped: true, items: [] }.
+// ═══════════════════════════════════════════════════════════════════════
+window.parseFeedingV1 = function(mealVal) {
+  // Skipped state
+  if (mealVal && typeof mealVal === 'object' && mealVal.skipped === true) {
+    return { items: [], skipped: true, skippedAt: mealVal.skippedAt || null };
+  }
+  // Structured shape — return as-is (already canonical)
+  if (window.isStructuredFeedingV1(mealVal)) {
+    return mealVal;
+  }
+  // Legacy string — comma-split + resolve defaults per item
+  if (typeof mealVal === 'string') {
+    var raw = mealVal.trim();
+    if (!raw) return { items: [] };
+    var items = raw.split(',').map(function(s) {
+      var name = s.trim().replace(/,+$/, '');
+      if (!name) return null;
+      var defaults = window._fdResolveQtyDefaults(name);
+      return {
+        name: name,
+        qty: defaults.qty,
+        unit: defaults.unit,
+        source: 'legacy-parse',
+        nutritionRef: name.toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim()
+      };
+    }).filter(function(x) { return x; });
+    return { items: items, _parsedFrom: 'legacy-string' };
+  }
+  // Unknown — return empty
+  return { items: [] };
+};
+// Keep the F-1 stub as an alias so any caller bound to the stub name still works.
+window.parseFeedingV1Stub = window.parseFeedingV1;
+
+// ═══════════════════════════════════════════════════════════════════════
+// Skip-state helpers (ratification #6)
+// Mark a meal slot as intentionally-skipped. Skipped slots render as
+// muted "Skipped" pills and are excluded from nutrition-snapshot diversity
+// penalties. Reversible — writing a real entry overwrites the skip.
+// ═══════════════════════════════════════════════════════════════════════
+window._fdMarkMealSkipped = function(dateKey, meal) {
+  if (!dateKey || !meal) return false;
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+  if (!fd[dateKey]) fd[dateKey] = { breakfast: '', lunch: '', dinner: '', snack: '' };
+  fd[dateKey][meal] = { skipped: true, skippedAt: Date.now(), items: [] };
+  if (typeof save === 'function' && typeof KEYS !== 'undefined' && KEYS.feeding) {
+    save(KEYS.feeding, fd);
+  }
+  if (typeof feedingData !== 'undefined') feedingData = fd;
+  if (typeof _islMarkDirty === 'function') _islMarkDirty('diet');
+  return true;
+};
+
+window._fdIsMealSkipped = function(dateKey, meal) {
+  if (!dateKey || !meal) return false;
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+  var day = fd[dateKey];
+  if (!day) return false;
+  var mv = day[meal];
+  return !!(mv && typeof mv === 'object' && mv.skipped === true);
+};
+
+// ═══════════════════════════════════════════════════════════════════════
+// _fdWriteStructuredMeal — canonical writer for the F-2 FOB Feed sheet.
+// Writes the structured shape under feedingData[dateKey][meal] AND
+// auto-generates legacy compat fields (text, {meal}_time, {meal}_intake)
+// so existing readers (home.js Today's Meals summary, diet stats, combo
+// intelligence, parseMealNutrition) continue working unchanged until
+// F-5 lands the read-side normalizer.
+//
+// payload: { items: [{name, qty, unit, nutritionRef}], time, overallIntake, note, sourceFlow }
+// Returns the structured shape that was written.
+// ═══════════════════════════════════════════════════════════════════════
+window._fdWriteStructuredMeal = function(dateKey, meal, payload) {
+  if (!dateKey || !meal || !payload) return null;
+  payload = payload || {};
+  var items = Array.isArray(payload.items) ? payload.items.slice() : [];
+  // Legacy compat: comma-joined text for downstream readers (Today's Meals
+  // summary, diet combos, parseMealNutrition). Trailing comma kept off.
+  var textCompat = items.map(function(it) { return it.name; }).join(', ');
+
+  var structured = {
+    items: items,
+    time: payload.time || null,
+    overallIntake: (typeof payload.overallIntake === 'number') ? payload.overallIntake : 0.75,  // ratified DEFAULT "Most"
+    note: payload.note || '',
+    sourceFlow: payload.sourceFlow || 'fob-feed',  // telemetry: fob-repeat | fob-combo | fob-novel | fob-feed | diet-tab
+    schemaVersion: window._FEEDING_V1_SCHEMA_VERSION,
+    text: textCompat,
+  };
+
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+  if (!fd[dateKey]) fd[dateKey] = { breakfast: '', lunch: '', dinner: '', snack: '' };
+  fd[dateKey][meal] = structured;
+  // Legacy compat fields at the day level (existing readers reach for these)
+  if (structured.time) fd[dateKey][meal + '_time'] = structured.time;
+  fd[dateKey][meal + '_intake'] = structured.overallIntake;
+
+  if (typeof save === 'function' && typeof KEYS !== 'undefined' && KEYS.feeding) {
+    save(KEYS.feeding, fd);
+  }
+  if (typeof feedingData !== 'undefined') feedingData = fd;
+  return structured;
+};
+
 // @@DATA_BLOCK_20_START@@ MILESTONE_STANDARDS
 
 // MILESTONE_SOURCE — controlled vocabulary for per-row clinical-band source
@@ -62869,6 +63164,351 @@ function _qlPredict() {
 
   return predictions;
 }
+
+// ═══════════════════════════════════════════════════════════════
+// F-2 — Autofill intelligence layers (L1 Repeat / L2 Combo / L3 Next-item / L4 Typeahead)
+// Spec: docs/specs/food-sub-tab-v1.md §F-2; ratifications #1/#2/#6.
+// All four helpers read window.feedingData; all return shape-stable
+// arrays so the FOB Feed sheet renderer is decoupled from the source
+// data layout. parseFeedingV1 (data.js) normalizes legacy + structured
+// rows on the way in so the helpers operate on a canonical shape.
+// ═══════════════════════════════════════════════════════════════
+
+// _fdGetMealSlotByTime — thin wrapper around detectMealType() for
+// readability + decoupling. Ratification #1: existing adaptive 14d
+// window logic in _qlComputeMealWindow is BETTER than fixed bands —
+// reuse it. Returns 'breakfast' | 'lunch' | 'dinner' | 'snack'.
+window._fdGetMealSlotByTime = function() {
+  return detectMealType();
+};
+
+// L1 — Repeat candidates. Returns up to `n` (default 3) recent meals
+// for the given slot, formatted for one-tap apply. For dinner, the
+// FIRST candidate is "Same as lunch (today)" if today's lunch is logged
+// (ratification #6 — 46% lunch=dinner match in observed data).
+//
+// Each candidate: { id, label, sub, items[], itemsText, ageRel, source }
+// label  — short chip text ("Yesterday's breakfast" / "Same as lunch today")
+// sub    — items preview (truncated, comma-separated)
+// items  — array of {name, qty, unit, nutritionRef} ready to apply
+// source — 'today-lunch' | 'yesterday' | 'recent' (telemetry)
+window._fdGetRepeatCandidates = function(meal, n) {
+  n = n || 3;
+  var out = [];
+  var todayStr = today();
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+
+  function dayLabel(daysAgo) {
+    if (daysAgo === 0) return 'Today';
+    if (daysAgo === 1) return 'Yesterday';
+    if (daysAgo < 7)  return daysAgo + ' days ago';
+    return 'Last week';
+  }
+
+  function structuredItemsFromMeal(mealVal) {
+    var parsed = window.parseFeedingV1(mealVal);
+    if (!parsed || !parsed.items || parsed.items.length === 0) return null;
+    if (parsed.skipped) return null;
+    // Hydrate any items missing qty/unit via the defaults resolver
+    var items = parsed.items.map(function(it) {
+      if (it.qty !== undefined && it.unit) return it;
+      var d = window._fdResolveQtyDefaults(it.name);
+      return Object.assign({}, it, { qty: d.qty, unit: d.unit });
+    });
+    return items;
+  }
+
+  // Ratification #6 — for dinner, surface today's lunch FIRST if logged.
+  if (meal === 'dinner' && fd[todayStr] && fd[todayStr].lunch) {
+    var lunchItems = structuredItemsFromMeal(fd[todayStr].lunch);
+    if (lunchItems && lunchItems.length) {
+      out.push({
+        id: 'today-lunch',
+        label: 'Same as today\'s lunch',
+        sub: lunchItems.map(function(it){return it.name;}).join(', '),
+        items: lunchItems,
+        itemsText: lunchItems.map(function(it){return it.name;}).join(', '),
+        ageRel: 'today',
+        source: 'today-lunch',
+      });
+    }
+  }
+
+  // Walk back up to 14 days; collect candidates for the same slot.
+  for (var d = 1; d <= 14 && out.length < n; d++) {
+    var dd = new Date(); dd.setDate(dd.getDate() - d);
+    var ds = toDateStr(dd);
+    var day = fd[ds];
+    if (!day) continue;
+    var items = structuredItemsFromMeal(day[meal]);
+    if (!items) continue;
+    out.push({
+      id: 'repeat-' + ds,
+      label: (d === 1 ? 'Yesterday\'s ' : dayLabel(d).toLowerCase() + ' ') + meal,
+      sub: items.map(function(it){return it.name;}).join(', '),
+      items: items,
+      itemsText: items.map(function(it){return it.name;}).join(', '),
+      ageRel: dayLabel(d),
+      source: d === 1 ? 'yesterday' : 'recent',
+    });
+  }
+
+  return out;
+};
+
+// L2 — Combo templates. Rolling 14d window: find combos (item-sets) that
+// repeat >= 2x in the same slot. Sort by frequency desc; break ties by
+// recency. Cold-start fallback to CURATED_COMBOS when <7 days of signal.
+//
+// Each combo: { id, label, items[], freq, source }
+// label  — "Your usual breakfast" (or "Pediatrician-suggested" for curated)
+// items  — array with default qty/unit hydrated via _fdResolveQtyDefaults
+// freq   — N× (observed frequency in window) or null (curated)
+// source — '14d-rolling' | 'curated'
+window._fdGetCombosForMeal = function(meal, opts) {
+  opts = opts || {};
+  var maxResults = opts.maxResults || 3;
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+  var todayStr = today();
+  var cutoff = new Date(); cutoff.setDate(cutoff.getDate() - 14);
+  var cutoffStr = toDateStr(cutoff);
+
+  // Collect (sorted-item-set → freq + lastDate) over 14d
+  var comboMap = {};
+  var daysWithSignal = 0;
+
+  Object.keys(fd).forEach(function(ds) {
+    if (ds < cutoffStr || ds > todayStr) return;
+    var day = fd[ds];
+    if (!day) return;
+    var parsed = window.parseFeedingV1(day[meal]);
+    if (!parsed || !parsed.items || parsed.items.length === 0 || parsed.skipped) return;
+    daysWithSignal++;
+    var names = parsed.items.map(function(it){ return String(it.name || '').toLowerCase().trim(); })
+                            .filter(function(n){ return n.length > 1; });
+    if (names.length < 2) return;
+    var sig = names.slice().sort().join('|');
+    if (!comboMap[sig]) comboMap[sig] = { items: parsed.items, freq: 0, lastDate: ds, names: names };
+    comboMap[sig].freq++;
+    if (ds > comboMap[sig].lastDate) {
+      comboMap[sig].lastDate = ds;
+      comboMap[sig].items = parsed.items;  // refresh with most-recent qty/unit
+    }
+  });
+
+  // Cold start — fall through to curated if <7 days of data for this slot
+  if (daysWithSignal < 7) {
+    var ageMonths = (typeof _zivaAgeMonths === 'function') ? _zivaAgeMonths() : null;
+    var curated = window._fdGetCuratedCombosForMeal(meal, ageMonths);
+    return curated.slice(0, maxResults).map(function(c, i) {
+      var items = c.items.map(function(name) {
+        var d = window._fdResolveQtyDefaults(name);
+        return { name: name, qty: d.qty, unit: d.unit, nutritionRef: name.toLowerCase().replace(/\s*\([^)]*\)\s*/g,'').trim(), source: 'curated' };
+      });
+      return {
+        id: 'curated-' + meal + '-' + i,
+        label: i === 0 ? 'Pediatrician-suggested' : 'Another suggestion',
+        items: items,
+        itemsText: items.map(function(it){return it.name;}).join(', '),
+        freq: null,
+        source: 'curated',
+        rationale: c.rationale,
+      };
+    });
+  }
+
+  // Rolling window — surface top combos with freq >= 2
+  var sorted = Object.keys(comboMap)
+    .map(function(sig){ return comboMap[sig]; })
+    .filter(function(c){ return c.freq >= 2; })
+    .sort(function(a, b){ return b.freq - a.freq || (b.lastDate > a.lastDate ? 1 : -1); });
+
+  if (sorted.length === 0) {
+    // No combos hit 2x — fall through to curated
+    var ageMonths2 = (typeof _zivaAgeMonths === 'function') ? _zivaAgeMonths() : null;
+    var curated2 = window._fdGetCuratedCombosForMeal(meal, ageMonths2);
+    return curated2.slice(0, maxResults).map(function(c, i) {
+      var items = c.items.map(function(name) {
+        var d = window._fdResolveQtyDefaults(name);
+        return { name: name, qty: d.qty, unit: d.unit, nutritionRef: name.toLowerCase().replace(/\s*\([^)]*\)\s*/g,'').trim(), source: 'curated' };
+      });
+      return {
+        id: 'curated-fallback-' + meal + '-' + i,
+        label: 'Pediatrician-suggested',
+        items: items,
+        itemsText: items.map(function(it){return it.name;}).join(', '),
+        freq: null,
+        source: 'curated',
+        rationale: c.rationale,
+      };
+    });
+  }
+
+  return sorted.slice(0, maxResults).map(function(c, i) {
+    // Hydrate items with default qty/unit if missing
+    var items = c.items.map(function(it){
+      if (it.qty !== undefined && it.unit) return it;
+      var d = window._fdResolveQtyDefaults(it.name);
+      return Object.assign({}, it, { qty: d.qty, unit: d.unit });
+    });
+    return {
+      id: 'combo-' + i,
+      label: i === 0 ? 'Your usual ' + meal : 'Another usual',
+      items: items,
+      itemsText: items.map(function(it){return it.name;}).join(', '),
+      freq: c.freq,
+      source: '14d-rolling',
+    };
+  });
+};
+
+// L3 — Next-item prediction. Given a set of items already in the current
+// meal, return the top `n` foods that co-occur with them in the rolling
+// 14d window of the same slot. Each prediction carries an honest
+// confidence % (CV3-006 Honesty axis — parents see WHY a suggestion is
+// surfaced). Excludes foods already in currentItems.
+//
+// Each prediction: { name, confidence, freq, denom }
+//   confidence: rounded percentage (0-100)
+//   freq:       count of co-occurrences with currentItems set
+//   denom:      total observations of the anchor item(s)
+window._fdGetNextItemPredictions = function(currentItems, meal, n) {
+  n = n || 4;
+  if (!Array.isArray(currentItems) || currentItems.length === 0) return [];
+  var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+  var todayStr = today();
+  var cutoff = new Date(); cutoff.setDate(cutoff.getDate() - 14);
+  var cutoffStr = toDateStr(cutoff);
+
+  // Normalize current items to lowercase base names
+  var currentSet = {};
+  var anchorNames = currentItems.map(function(it) {
+    var name = String(it.name || it || '').toLowerCase().trim();
+    currentSet[name] = true;
+    return name;
+  });
+
+  // Walk 14d; for each day's same-slot entry that contains AT LEAST ONE
+  // anchor item, count co-occurrences of every other item in that meal.
+  var coCount = {};   // candidate name → co-occurrence count
+  var anchorDenom = 0;  // total days where any anchor item appears in slot
+
+  Object.keys(fd).forEach(function(ds) {
+    if (ds < cutoffStr || ds > todayStr) return;
+    var day = fd[ds];
+    if (!day) return;
+    var parsed = window.parseFeedingV1(day[meal]);
+    if (!parsed || !parsed.items || parsed.items.length === 0 || parsed.skipped) return;
+    var names = parsed.items.map(function(it){ return String(it.name || '').toLowerCase().trim(); });
+    // Does this day contain any anchor item?
+    var hasAnchor = anchorNames.some(function(a) { return names.indexOf(a) >= 0; });
+    if (!hasAnchor) return;
+    anchorDenom++;
+    // Count every non-anchor item that appears
+    names.forEach(function(n) {
+      if (currentSet[n]) return;  // skip items already in current meal
+      if (!coCount[n]) coCount[n] = { name: parsed.items.find(function(it) { return String(it.name).toLowerCase().trim() === n; }).name, freq: 0 };
+      coCount[n].freq++;
+    });
+  });
+
+  if (anchorDenom < 2) return [];  // not enough signal yet
+
+  var ranked = Object.keys(coCount).map(function(k) {
+    var c = coCount[k];
+    return {
+      name: c.name,
+      freq: c.freq,
+      denom: anchorDenom,
+      confidence: Math.round((c.freq / anchorDenom) * 100),
+    };
+  }).filter(function(p) { return p.confidence >= 20; })  // floor — don't surface noisy 1/14 hits
+    .sort(function(a, b) { return b.confidence - a.confidence; });
+
+  return ranked.slice(0, n);
+};
+
+// L4 — Typeahead. As-you-type match against NUTRITION + ziva_foods
+// (parent-introduced foods). Returns matches with default qty/unit
+// inlined so the dropdown can render the qty hint without an extra
+// resolver call per row.
+//
+// Each match: { name, source: 'nutrition' | 'introduced' | 'recent', qty, unit, step }
+window._fdSearchNutrition = function(query, opts) {
+  opts = opts || {};
+  var max = opts.max || 8;
+  if (!query || typeof query !== 'string') return [];
+  var q = query.toLowerCase().trim();
+  if (q.length < 1) return [];
+
+  var seen = {};
+  var matches = [];
+
+  function pushMatch(name, src) {
+    var key = String(name).toLowerCase().trim();
+    if (seen[key]) return;
+    seen[key] = true;
+    var d = window._fdResolveQtyDefaults(name);
+    matches.push({
+      name: name,
+      source: src,
+      qty: d.qty,
+      unit: d.unit,
+      step: d.step,
+    });
+  }
+
+  // 1. NUTRITION — base lookup (canonical food names)
+  if (typeof NUTRITION === 'object' && NUTRITION) {
+    Object.keys(NUTRITION).forEach(function(k) {
+      if (matches.length >= max * 2) return;
+      if (k.indexOf(q) === 0) pushMatch(k.charAt(0).toUpperCase() + k.slice(1), 'nutrition');
+    });
+    // Looser match — name contains query (after exact-prefix matches)
+    Object.keys(NUTRITION).forEach(function(k) {
+      if (matches.length >= max * 2) return;
+      if (k.indexOf(q) > 0) pushMatch(k.charAt(0).toUpperCase() + k.slice(1), 'nutrition');
+    });
+  }
+
+  // 2. Parent-introduced foods (ziva_foods list)
+  try {
+    var introduced = (typeof load === 'function') ? load(KEYS && KEYS.foods, []) || [] : [];
+    if (Array.isArray(introduced)) {
+      introduced.forEach(function(entry) {
+        if (matches.length >= max * 2) return;
+        var nm = entry && entry.name ? String(entry.name) : '';
+        if (!nm) return;
+        if (nm.toLowerCase().indexOf(q) >= 0) pushMatch(nm, 'introduced');
+      });
+    }
+  } catch(e) { /* introduced list is best-effort */ }
+
+  // 3. Recent items from feedingData (last 14 days, any slot) — surfaces
+  // foods the parent has actually been using (catches typeahead matches
+  // for foods that exist in their flow but not yet in NUTRITION).
+  try {
+    var fd = (typeof feedingData !== 'undefined' && feedingData) || {};
+    var cutoff = new Date(); cutoff.setDate(cutoff.getDate() - 14);
+    var cutoffStr = toDateStr(cutoff);
+    Object.keys(fd).forEach(function(ds) {
+      if (matches.length >= max * 2) return;
+      if (ds < cutoffStr) return;
+      ['breakfast','lunch','dinner','snack'].forEach(function(m) {
+        if (matches.length >= max * 2) return;
+        var parsed = window.parseFeedingV1(fd[ds][m]);
+        if (!parsed || !parsed.items) return;
+        parsed.items.forEach(function(it) {
+          if (matches.length >= max * 2) return;
+          var nm = it.name || '';
+          if (nm.toLowerCase().indexOf(q) >= 0) pushMatch(nm, 'recent');
+        });
+      });
+    });
+  } catch(e) { /* best-effort */ }
+
+  return matches.slice(0, max);
+};
 
 // ═══════════════════════════════════════════════════════════════
 // SMART QUICK LOG — Suggest Card Rendering

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -6746,6 +6746,255 @@ body.ql-locked .dark-toggle { pointer-events:none; }
 .ql-save-nap   { background:linear-gradient(135deg, #7e66b4, #7060a8); }
 .ql-save-poop  { background:linear-gradient(135deg, #8a6520, #946225); }
 
+/* ═══════════════════════════════════════════════════════════════
+   F-2 — FOB Feed sheet (autofill-first redesign)
+   Spec: docs/specs/food-sub-tab-v1.md §F-2
+   Four rail surfaces (L1 repeat / L2 combo / items / L3 next-item)
+   + per-food qty steppers + skip-meal button. Tokens-only per HR-4.
+   ═══════════════════════════════════════════════════════════════ */
+
+/* Rail wrapper — same vertical rhythm as other ql-form sections */
+.ql-feed-rail-wrap { display:flex; flex-direction:column; gap:var(--sp-4); }
+.ql-feed-rail { display:flex; flex-direction:column; gap:var(--sp-6); }
+
+/* L1 Repeat chips — sage outlined; primary chip emphasized */
+.ql-feed-repeat-chip {
+  background:var(--white);
+  border:1.5px solid var(--sage);
+  border-radius:var(--r-xl);
+  padding:var(--sp-10) var(--sp-12);
+  cursor:pointer;
+  min-height:36px;
+  transition:transform var(--ease-fast), background-color var(--ease-fast);
+  box-shadow:0 1px 3px rgba(60,40,40,0.04);
+}
+.ql-feed-repeat-chip:active { transform:scale(0.985); }
+.ql-feed-repeat-chip.primary {
+  background:var(--sage-light);
+  border-width:2px;
+}
+.ql-feed-repeat-head {
+  display:flex; align-items:center; gap:var(--sp-6);
+  font-weight:700; color:var(--tc-sage);
+  font-size:var(--fs-sm);
+}
+.ql-feed-repeat-head .zi { width:var(--icon-base); height:var(--icon-base); }
+.ql-feed-repeat-sub {
+  font-size:var(--fs-xs);
+  color:var(--mid);
+  margin-top:var(--sp-4);
+  font-weight:500;
+  line-height:var(--lh-snug);
+}
+
+/* L2 Combo chips — lavender outlined; freq badge inline */
+.ql-feed-combo-chip {
+  background:var(--lav-light);
+  border:1.5px solid var(--lavender);
+  border-radius:var(--r-xl);
+  padding:var(--sp-10) var(--sp-12);
+  cursor:pointer;
+  min-height:36px;
+  transition:transform var(--ease-fast);
+}
+.ql-feed-combo-chip:active { transform:scale(0.985); }
+.ql-feed-combo-head {
+  display:flex; align-items:center; gap:var(--sp-6);
+  font-weight:700; color:var(--tc-lav);
+  font-size:var(--fs-sm);
+}
+.ql-feed-combo-head .zi { width:var(--icon-base); height:var(--icon-base); }
+.ql-feed-combo-conf {
+  margin-left:auto;
+  font-size:var(--fs-2xs);
+  background:var(--lavender); color:var(--text);
+  padding:var(--sp-2) var(--sp-6);
+  border-radius:var(--r-full);
+  font-weight:700;
+}
+.ql-feed-combo-sub {
+  font-size:var(--fs-xs);
+  color:var(--mid);
+  margin-top:var(--sp-4);
+  font-weight:500;
+  line-height:var(--lh-snug);
+}
+
+/* Items list — current meal being built */
+.ql-feed-items-list {
+  background:var(--white);
+  border:1px solid #ece4dd;
+  border-radius:var(--r-xl);
+  overflow:hidden;
+}
+.ql-feed-items-empty {
+  text-align:center;
+  color:var(--light);
+  padding:var(--sp-16);
+  font-style:italic;
+  font-size:var(--fs-sm);
+}
+.ql-feed-item-row {
+  display:flex; align-items:center; gap:var(--sp-8);
+  padding:var(--sp-8) var(--sp-10);
+  border-bottom:1px solid #f4ece6;
+  min-height:48px;
+}
+.ql-feed-item-row:last-of-type { border-bottom:none; }
+.ql-feed-item-icon {
+  width:28px; height:28px;
+  background:var(--sage-light); color:var(--tc-sage);
+  border-radius:var(--r-full);
+  display:inline-flex; align-items:center; justify-content:center;
+  font-size:var(--fs-sm); font-weight:700;
+  flex-shrink:0;
+}
+.ql-feed-item-name {
+  flex:1; font-weight:600; font-size:var(--fs-base);
+  display:flex; flex-direction:column;
+  line-height:var(--lh-snug);
+}
+.ql-feed-item-meta {
+  font-size:var(--fs-2xs);
+  color:var(--light);
+  text-transform:uppercase;
+  letter-spacing:var(--ls-wide);
+  font-weight:500;
+  margin-top:var(--sp-2);
+}
+.ql-feed-item-x {
+  width:32px; height:32px;
+  display:inline-flex; align-items:center; justify-content:center;
+  border-radius:var(--r-full);
+  background:var(--rose-light); color:var(--tc-rose);
+  font-weight:700; font-size:var(--fs-md);
+  border:none; cursor:pointer;
+  flex-shrink:0;
+  margin-left:var(--sp-2);
+  transition:transform var(--ease-fast);
+}
+.ql-feed-item-x:active { transform:scale(0.9); }
+
+/* Per-food quantity stepper — [− qty unit +] */
+.ql-feed-qty-stepper {
+  display:inline-flex; align-items:center;
+  background:var(--warm);
+  border-radius:var(--r-full);
+  padding:var(--sp-2);
+  flex-shrink:0;
+}
+.ql-feed-qty-step {
+  width:32px; height:32px;
+  display:inline-flex; align-items:center; justify-content:center;
+  border-radius:var(--r-full);
+  background:var(--white); color:var(--tc-sage);
+  font-weight:700; font-size:var(--fs-base);
+  border:1px solid #ece4dd;
+  cursor:pointer;
+  font-family:'Nunito', sans-serif;
+  transition:transform var(--ease-fast);
+}
+.ql-feed-qty-step:active { transform:scale(0.92); background:var(--sage-light); }
+.ql-feed-qty-val {
+  padding:0 var(--sp-8);
+  font-weight:700;
+  min-width:52px; text-align:center;
+  font-size:var(--fs-sm);
+  color:var(--text);
+}
+.ql-feed-qty-unit {
+  font-size:var(--fs-2xs);
+  color:var(--mid);
+  letter-spacing:0;
+  font-weight:500;
+}
+
+/* L3 Next-item ribbon — horizontal scroll; confidence % per chip */
+.ql-feed-next-ribbon {
+  display:flex; gap:var(--sp-6);
+  overflow-x:auto;
+  padding:var(--sp-4) 0;
+  -webkit-overflow-scrolling:touch;
+}
+.ql-feed-next-chip {
+  display:inline-flex; align-items:center; gap:var(--sp-4);
+  background:var(--sage-light);
+  color:var(--tc-sage);
+  font-weight:700; font-size:var(--fs-sm);
+  padding:var(--sp-6) var(--sp-12);
+  border-radius:var(--r-full);
+  border:1px solid var(--sage);
+  flex-shrink:0;
+  min-height:36px;
+  cursor:pointer;
+  font-family:'Nunito', sans-serif;
+  transition:transform var(--ease-fast);
+}
+.ql-feed-next-chip:active { transform:scale(0.94); }
+.ql-feed-next-conf {
+  font-size:9px;
+  background:var(--white); color:var(--tc-sage);
+  border-radius:var(--r-full);
+  padding:1px var(--sp-6);
+  margin-left:var(--sp-2);
+  font-weight:700;
+  letter-spacing:0;
+}
+
+/* L4 Typeahead dropdown rows — qty hint inlined */
+.ql-feed-ta-row {
+  display:flex; align-items:center; gap:var(--sp-8);
+  padding:var(--sp-8) var(--sp-10);
+  border-bottom:1px solid #f4ece6;
+  cursor:pointer;
+  min-height:36px;
+}
+.ql-feed-ta-row:last-of-type { border-bottom:none; }
+.ql-feed-ta-row:active { background:var(--sage-light); }
+.ql-feed-ta-name {
+  flex:1;
+  font-weight:600; font-size:var(--fs-base);
+  color:var(--text);
+}
+.ql-feed-ta-meta {
+  font-size:var(--fs-2xs);
+  color:var(--mid);
+  text-transform:uppercase;
+  letter-spacing:var(--ls-wide);
+  font-weight:500;
+}
+
+/* Skip meal button — neutral chrome; pairs visually with Save Feed */
+.ql-save-skip {
+  background:var(--warm);
+  color:var(--mid);
+  border:1.5px solid #d8ccc4;
+  border-radius:var(--r-full);
+  padding:var(--sp-10) var(--sp-16);
+  font-weight:600; font-size:var(--fs-sm);
+  font-family:'Nunito', sans-serif;
+  cursor:pointer;
+  min-height:44px;
+  transition:transform var(--ease-fast), background-color var(--ease-fast);
+}
+.ql-save-skip:active { transform:scale(0.97); background:#f0e8e0; }
+.ql-save-skip:hover { background:#f8f0e8; }
+
+/* Dark mode — preserve domain identity; deepen backgrounds */
+[data-theme="dark"] .ql-feed-repeat-chip { background:var(--surface-alt); border-color:var(--tc-sage); }
+[data-theme="dark"] .ql-feed-repeat-chip.primary { background:#1e3028; }
+[data-theme="dark"] .ql-feed-repeat-head { color:#7ac0a0; }
+[data-theme="dark"] .ql-feed-combo-chip { background:#2a2240; border-color:var(--tc-lav); }
+[data-theme="dark"] .ql-feed-combo-head { color:#b8a8e0; }
+[data-theme="dark"] .ql-feed-combo-conf { background:var(--lavender); color:var(--text); }
+[data-theme="dark"] .ql-feed-items-list { background:var(--surface); border-color:#3a2e3e; }
+[data-theme="dark"] .ql-feed-item-row { border-bottom-color:#3a2e3e; }
+[data-theme="dark"] .ql-feed-qty-stepper { background:#221c28; }
+[data-theme="dark"] .ql-feed-qty-step { background:var(--surface); border-color:#3a2e3e; color:#7ac0a0; }
+[data-theme="dark"] .ql-feed-next-chip { background:#1e3028; color:#7ac0a0; border-color:var(--tc-sage); }
+[data-theme="dark"] .ql-feed-next-conf { background:var(--surface); color:#7ac0a0; }
+[data-theme="dark"] .ql-save-skip { background:#221c28; color:var(--mid); border-color:#3a2e3e; }
+
 /* ── Quick Log Toast ── */
 .ql-toast {
   position:fixed; bottom:90px; left:50%; transform:translateX(-50%) translateY(20px);
@@ -12827,7 +13076,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
   </div>
 </div>
 
-<!-- Quick Log Modal: Feed -->
+<!-- Quick Log Modal: Feed (F-2 redesign — autofill-first; spec: docs/specs/food-sub-tab-v1.md §F-2) -->
 <div class="ql-modal-overlay" id="qlModal-feed" data-action="closeQuickModalSelf">
   <div class="ql-modal">
     <div class="ql-modal-header">
@@ -12848,14 +13097,33 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
         <label class="micro-label">Date</label>
         <div class="ql-bf-row" id="qlBackfillPills"></div>
       </div>
-      <div id="qlFreqWrap" style="display:none;">
-        <label class="micro-label">Frequent</label>
-        <div class="ql-freq-row" id="qlFreqPills"></div>
+      <!-- F-2: L1 Repeat rail — "Same as yesterday's B" / "Same as today's lunch" (dinner only, ratification #6) -->
+      <div id="qlFeedRepeatWrap" class="ql-feed-rail-wrap" style="display:none;">
+        <label class="micro-label">Your usual</label>
+        <div class="ql-feed-rail" id="qlFeedRepeatRail"></div>
       </div>
+      <!-- F-2: L2 Combo template rail — "Your usual breakfast" rolling-14d or curated cold-start -->
+      <div id="qlFeedCombosWrap" class="ql-feed-rail-wrap" style="display:none;">
+        <label class="micro-label" id="qlFeedCombosLabel">Suggested combos</label>
+        <div class="ql-feed-rail" id="qlFeedCombosRail"></div>
+      </div>
+      <!-- F-2: Items list — populated as items added; qty steppers per row -->
+      <div id="qlFeedItemsWrap">
+        <label class="micro-label">Items</label>
+        <div class="ql-feed-items-list" id="qlFeedItemsList">
+          <div class="ql-feed-items-empty">Tap a combo above, or type an item below</div>
+        </div>
+      </div>
+      <!-- F-2: L3 Next-item prediction ribbon — appears after first item; co-occurrence ranked -->
+      <div id="qlFeedNextWrap" class="ql-feed-rail-wrap" style="display:none;">
+        <label class="micro-label" id="qlFeedNextLabel">You usually add</label>
+        <div class="ql-feed-next-ribbon" id="qlFeedNextRibbon"></div>
+      </div>
+      <!-- F-2: L4 Typeahead input — NUTRITION + introduced foods + recent; default qty/unit inlined -->
       <div>
-        <label class="micro-label">What did Ziva eat?</label>
+        <label class="micro-label">Add item</label>
         <div class="meal-input-wrap">
-          <input type="text" id="qlFeedInput" class="form-input input-ctx-peach" placeholder="e.g. ragi porridge, dal rice..." autocomplete="off" oninput="updateQLFeedDropdown()">
+          <input type="text" id="qlFeedInput" class="form-input input-ctx-peach" placeholder="Type to add (e.g. 'av' for avocado mash)" autocomplete="off" data-action="qlFeedTypeaheadInput" data-action-on="input">
           <div class="meal-dropdown" id="qlFeedDropdown"></div>
         </div>
       </div>
@@ -12864,12 +13132,8 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
         <input type="time" id="qlFeedTime" class="form-input input-ctx-peach" style="width:90px;padding:5px 8px;font-size:var(--fs-sm);">
         <span class="t-xs t-light">optional</span>
       </div>
-      <div id="qlSameAsWrap" style="display:none;">
-        <label class="micro-label">Quick repeat</label>
-        <div class="d-flex gap-8 flex-wrap" id="qlSameAsPills"></div>
-      </div>
       <div>
-        <label class="micro-label">How much?</label>
+        <label class="micro-label">How much overall?</label>
         <div class="ql-meal-pills" id="qlIntakePills">
           <div class="ql-intake-pill" data-mi-qlval="0.25"><svg class="zi"><use href="#zi-spoon"/></svg> Few bites</div>
           <div class="ql-intake-pill" data-mi-qlval="0.5"><svg class="zi"><use href="#zi-halfcircle"/></svg> Half</div>
@@ -12877,7 +13141,10 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
           <div class="ql-intake-pill" data-mi-qlval="1.0"><svg class="zi"><use href="#zi-star"/></svg> All</div>
         </div>
       </div>
-      <button class="ql-save ql-save-feed">Save Feed <svg class="zi"><use href="#zi-check"/></svg></button>
+      <div class="d-flex gap-8" style="align-items:stretch;">
+        <button class="ql-save-skip" data-action="qlFeedSkipMeal" type="button" title="Mark this meal as intentionally skipped">Skip this meal</button>
+        <button class="ql-save ql-save-feed flex-1-min100">Save Feed <svg class="zi"><use href="#zi-check"/></svg></button>
+      </div>
     </div>
   </div>
 </div>
@@ -19634,6 +19901,13 @@ function init() {
     else if (action === 'qlOpenPoop') { _qlSuggestUsed = true; openQuickModal('poop'); }
     else if (action === 'qlOpenActivity') { _qlSuggestUsed = true; openQuickModal('activity'); }
     else if (action === 'qlSwitchSuggest') _qlSwitchSuggest(arg);
+    // ── F-2 FOB Feed sheet handlers (spec: docs/specs/food-sub-tab-v1.md §F-2) ──
+    else if (action === 'qlFeedApplyRepeat' && typeof qlFeedApplyRepeat === 'function') qlFeedApplyRepeat(arg);
+    else if (action === 'qlFeedApplyCombo' && typeof qlFeedApplyCombo === 'function') qlFeedApplyCombo(arg);
+    else if (action === 'qlFeedAddItem' && typeof qlFeedAddItem === 'function') qlFeedAddItem(arg, arg2);
+    else if (action === 'qlFeedAdjustQty' && typeof qlFeedAdjustQty === 'function') qlFeedAdjustQty(arg, arg2);
+    else if (action === 'qlFeedRemoveItem' && typeof qlFeedRemoveItem === 'function') qlFeedRemoveItem(arg);
+    else if (action === 'qlFeedSkipMeal' && typeof qlFeedSkipMeal === 'function') qlFeedSkipMeal();
     // ── Food Favorites ──
     else if (action === 'foodToggleFavorite') {
       toggleFoodFavorite(arg);
@@ -19705,6 +19979,7 @@ function init() {
     const action = el.dataset.action;
     if (action === 'checkVaccDateShift') checkVaccDateShift();
     else if (action === 'ctInputAnswer' && typeof ctInputAnswer === 'function') ctInputAnswer(el.dataset.arg);
+    else if (action === 'qlFeedTypeaheadInput' && typeof qlFeedTypeaheadInput === 'function') qlFeedTypeaheadInput();
   });
 
   // ── Checkbox delegation (vacc completion multi-check) ──
@@ -61573,13 +61848,12 @@ function openQuickModal(type) {
     document.querySelectorAll('.ql-meal-pill').forEach(p => {
       p.classList.toggle('active', p.dataset.meal === _qlMeal);
     });
-    document.getElementById('qlFeedInput').value = '';
     const qlTimeEl = document.getElementById('qlFeedTime');
     if (qlTimeEl) qlTimeEl.value = '';
-    const qlDD = document.getElementById('qlFeedDropdown');
-    if (qlDD) qlDD.classList.remove('open');
-    renderQLSameAsPills();
-    renderQLFreqPills();
+    // F-2: reset items list state + render the four autofill regions
+    // (L1 repeat / L2 combo / items list / L3 next-item ribbon).
+    if (typeof _qlFeedReset === 'function') _qlFeedReset();
+    if (typeof _qlRenderFeedSheet === 'function') _qlRenderFeedSheet();
     // Reset intake pills to default (Most)
     _miWireQLIntakePills();
     // Hide backfill UI unless in backfill mode
@@ -63761,6 +64035,8 @@ function qaAnswerFavoriteFoods() {
 function setQLMeal(meal) {
   _qlMeal = meal;
   document.querySelectorAll('.ql-meal-pill').forEach(p => p.classList.toggle('active', p.dataset.meal === meal));
+  // F-2: refresh autofill regions on meal change — repeats + combos differ per slot.
+  if (typeof _qlRenderFeedSheet === 'function') _qlRenderFeedSheet();
 }
 
 function adjQLWake(delta) {
@@ -63809,32 +64085,339 @@ function undoLastQL() {
   }
 }
 
+// ═══════════════════════════════════════════════════════════════
+// F-2 — FOB Feed sheet render + handlers
+// Spec: docs/specs/food-sub-tab-v1.md §F-2
+// State: _qlFeedItems is the current items array being built. Stays in
+// sync with the rendered Items list via _qlRenderItemsList. Save writes
+// structured shape via _fdWriteStructuredMeal (data.js).
+// ═══════════════════════════════════════════════════════════════
+
+var _qlFeedItems = [];
+var _qlFeedSourceFlow = 'fob-feed';  // 'fob-repeat' | 'fob-combo' | 'fob-novel' | 'fob-feed'
+
+function _qlFeedReset() {
+  _qlFeedItems = [];
+  _qlFeedSourceFlow = 'fob-feed';
+  var inp = document.getElementById('qlFeedInput');
+  if (inp) inp.value = '';
+  var dd = document.getElementById('qlFeedDropdown');
+  if (dd) { dd.innerHTML = ''; dd.classList.remove('open'); }
+}
+
+// Render all dynamic regions of the FOB Feed sheet. Called on open + after
+// every state change (item add/remove/qty adjust, meal slot change).
+function _qlRenderFeedSheet() {
+  _qlRenderRepeatRail();
+  _qlRenderCombosRail();
+  _qlRenderItemsList();
+  _qlRenderNextItemRibbon();
+}
+
+// L1 — Repeat rail. Surfaces yesterday's/recent matching-slot meals as
+// one-tap apply chips. For dinner, "Same as today's lunch" leads if logged.
+function _qlRenderRepeatRail() {
+  var wrap = document.getElementById('qlFeedRepeatWrap');
+  var rail = document.getElementById('qlFeedRepeatRail');
+  if (!wrap || !rail) return;
+  var candidates = window._fdGetRepeatCandidates(_qlMeal, 3);
+  if (!candidates || candidates.length === 0) {
+    wrap.style.display = 'none';
+    rail.innerHTML = '';
+    return;
+  }
+  wrap.style.display = '';
+  rail.innerHTML = candidates.map(function(c, i) {
+    return '<div class="ql-feed-repeat-chip' + (i === 0 ? ' primary' : '') + '"' +
+           ' data-action="qlFeedApplyRepeat" data-arg="' + escAttr(c.id) + '">' +
+           '<div class="ql-feed-repeat-head">' +
+             '<svg class="zi"><use href="#zi-rainbow"/></svg> ' + escHtml(c.label) +
+           '</div>' +
+           '<div class="ql-feed-repeat-sub">' + escHtml(c.itemsText) + '</div>' +
+           '</div>';
+  }).join('');
+}
+
+// L2 — Combo template rail. Hidden once items present (parent has
+// committed to building manually; offering full-replace combos would
+// confuse). Shows rolling-14d top combos OR curated cold-start fallback.
+function _qlRenderCombosRail() {
+  var wrap = document.getElementById('qlFeedCombosWrap');
+  var rail = document.getElementById('qlFeedCombosRail');
+  var label = document.getElementById('qlFeedCombosLabel');
+  if (!wrap || !rail) return;
+  if (_qlFeedItems.length > 0) {
+    wrap.style.display = 'none';
+    rail.innerHTML = '';
+    return;
+  }
+  var combos = window._fdGetCombosForMeal(_qlMeal, { maxResults: 3 });
+  if (!combos || combos.length === 0) {
+    wrap.style.display = 'none';
+    rail.innerHTML = '';
+    return;
+  }
+  wrap.style.display = '';
+  if (label) {
+    label.textContent = combos[0].source === 'curated'
+      ? 'Suggested combos'
+      : 'Your usual ' + _qlMeal;
+  }
+  rail.innerHTML = combos.map(function(c) {
+    var freq = c.freq ? '<span class="ql-feed-combo-conf">' + c.freq + '×</span>' : '';
+    return '<div class="ql-feed-combo-chip" data-action="qlFeedApplyCombo" data-arg="' + escAttr(c.id) + '">' +
+           '<div class="ql-feed-combo-head">' +
+             '<svg class="zi"><use href="#zi-bowl"/></svg> ' + escHtml(c.label) + freq +
+           '</div>' +
+           '<div class="ql-feed-combo-sub">' + escHtml(c.itemsText) + '</div>' +
+           '</div>';
+  }).join('');
+}
+
+// Items list — current meal items with qty stepper + remove.
+function _qlRenderItemsList() {
+  var list = document.getElementById('qlFeedItemsList');
+  if (!list) return;
+  if (_qlFeedItems.length === 0) {
+    list.innerHTML = '<div class="ql-feed-items-empty">Tap a combo above, or type an item below</div>';
+    return;
+  }
+  list.innerHTML = _qlFeedItems.map(function(item, idx) {
+    var initial = (item.name || '?').charAt(0).toUpperCase();
+    var qtyDisplay = _qlFormatQty(item.qty);
+    return '<div class="ql-feed-item-row">' +
+           '<span class="ql-feed-item-icon">' + escHtml(initial) + '</span>' +
+           '<div class="ql-feed-item-name">' + escHtml(item.name) +
+             '<span class="ql-feed-item-meta">' + escHtml(item.source || 'manual') + '</span>' +
+           '</div>' +
+           '<div class="ql-feed-qty-stepper">' +
+             '<button class="ql-feed-qty-step" data-action="qlFeedAdjustQty" data-arg="' + idx + '" data-arg2="dec" type="button" aria-label="Decrease quantity">−</button>' +
+             '<span class="ql-feed-qty-val">' + qtyDisplay +
+               '<span class="ql-feed-qty-unit"> ' + escHtml(item.unit || '') + '</span>' +
+             '</span>' +
+             '<button class="ql-feed-qty-step" data-action="qlFeedAdjustQty" data-arg="' + idx + '" data-arg2="inc" type="button" aria-label="Increase quantity">+</button>' +
+           '</div>' +
+           '<button class="ql-feed-item-x" data-action="qlFeedRemoveItem" data-arg="' + idx + '" type="button" aria-label="Remove ' + escAttr(item.name) + '">×</button>' +
+           '</div>';
+  }).join('');
+}
+
+// Format qty as a unicode vulgar fraction when possible (¼ ½ ¾) plus
+// mixed numbers (1¼, 1½, 2¾). Outside the common set, falls back to
+// decimal with 2dp rounding.
+function _qlFormatQty(q) {
+  if (typeof q !== 'number' || isNaN(q)) return '1';
+  if (q === 0.25) return '¼';
+  if (q === 0.5)  return '½';
+  if (q === 0.75) return '¾';
+  var whole = Math.floor(q);
+  var frac = Math.round((q - whole) * 100) / 100;
+  if (frac === 0) return String(whole);
+  if (frac === 0.25) return whole + '¼';
+  if (frac === 0.5)  return whole + '½';
+  if (frac === 0.75) return whole + '¾';
+  return (Math.round(q * 100) / 100).toString();
+}
+
+// L3 — Next-item ribbon. Only appears after first item added. Confidence
+// % surfaced per chip (CV3-006 Honesty axis: parent sees WHY suggested).
+function _qlRenderNextItemRibbon() {
+  var wrap = document.getElementById('qlFeedNextWrap');
+  var ribbon = document.getElementById('qlFeedNextRibbon');
+  var label = document.getElementById('qlFeedNextLabel');
+  if (!wrap || !ribbon) return;
+  if (_qlFeedItems.length === 0) {
+    wrap.style.display = 'none';
+    ribbon.innerHTML = '';
+    return;
+  }
+  var predictions = window._fdGetNextItemPredictions(_qlFeedItems, _qlMeal, 4);
+  if (!predictions || predictions.length === 0) {
+    wrap.style.display = 'none';
+    ribbon.innerHTML = '';
+    return;
+  }
+  wrap.style.display = '';
+  if (label) {
+    var anchorName = _qlFeedItems[_qlFeedItems.length - 1].name;
+    label.textContent = _qlFeedItems.length === 1
+      ? 'You usually add (with ' + anchorName + ')'
+      : 'You usually add';
+  }
+  ribbon.innerHTML = predictions.map(function(p) {
+    return '<button class="ql-feed-next-chip" data-action="qlFeedAddItem"' +
+           ' data-arg="' + escAttr(p.name) + '" data-arg2="next" type="button">' +
+           '+ ' + escHtml(p.name) +
+           '<span class="ql-feed-next-conf">' + p.confidence + '%</span>' +
+           '</button>';
+  }).join('');
+}
+
+// ── F-2 handlers ──
+
+function qlFeedApplyRepeat(id) {
+  var cands = window._fdGetRepeatCandidates(_qlMeal, 6);
+  var found = cands.find(function(c) { return c.id === id; });
+  if (!found) return;
+  _qlFeedItems = found.items.slice().map(function(it) { return Object.assign({}, it); });
+  _qlFeedSourceFlow = 'fob-repeat';
+  _qlRenderFeedSheet();
+}
+
+function qlFeedApplyCombo(id) {
+  var combos = window._fdGetCombosForMeal(_qlMeal, { maxResults: 6 });
+  var found = combos.find(function(c) { return c.id === id; });
+  if (!found) return;
+  _qlFeedItems = found.items.slice().map(function(it) { return Object.assign({}, it); });
+  _qlFeedSourceFlow = 'fob-combo';
+  _qlRenderFeedSheet();
+}
+
+function qlFeedAddItem(name, source) {
+  if (!name) return;
+  var defaults = window._fdResolveQtyDefaults(name);
+  _qlFeedItems.push({
+    name: name,
+    qty: defaults.qty,
+    unit: defaults.unit,
+    nutritionRef: String(name).toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim(),
+    source: source || 'manual',
+  });
+  if (source === 'next' || source === 'typeahead') {
+    if (_qlFeedSourceFlow === 'fob-feed') _qlFeedSourceFlow = 'fob-novel';
+  }
+  // Clear typeahead input + dropdown
+  var inp = document.getElementById('qlFeedInput');
+  if (inp) inp.value = '';
+  var dd = document.getElementById('qlFeedDropdown');
+  if (dd) { dd.innerHTML = ''; dd.classList.remove('open'); }
+  _qlRenderFeedSheet();
+}
+
+function qlFeedAdjustQty(idxStr, dir) {
+  var idx = parseInt(idxStr, 10);
+  if (isNaN(idx) || !_qlFeedItems[idx]) return;
+  var item = _qlFeedItems[idx];
+  var defaults = window._fdResolveQtyDefaults(item.name);
+  var step = defaults.step || 0.25;
+  var delta = (dir === 'inc') ? step : -step;
+  var newQty = item.qty + delta;
+  if (newQty <= 0) return;  // don't allow zero — use × to remove
+  item.qty = Math.round(newQty * 100) / 100;
+  _qlRenderItemsList();
+}
+
+function qlFeedRemoveItem(idxStr) {
+  var idx = parseInt(idxStr, 10);
+  if (isNaN(idx) || !_qlFeedItems[idx]) return;
+  _qlFeedItems.splice(idx, 1);
+  _qlRenderFeedSheet();
+}
+
+function qlFeedTypeaheadInput() {
+  var inp = document.getElementById('qlFeedInput');
+  if (!inp) return;
+  var q = inp.value.trim();
+  var dd = document.getElementById('qlFeedDropdown');
+  if (!dd) return;
+  if (q.length < 1) {
+    dd.classList.remove('open');
+    dd.innerHTML = '';
+    return;
+  }
+  var matches = window._fdSearchNutrition(q, { max: 8 });
+  if (matches.length === 0) {
+    dd.innerHTML = '<div class="meal-dropdown-empty">No match. Press Enter to add as new food.</div>';
+    dd.classList.add('open');
+    return;
+  }
+  dd.innerHTML = matches.map(function(m) {
+    return '<div class="meal-dropdown-row ql-feed-ta-row"' +
+           ' data-action="qlFeedAddItem" data-arg="' + escAttr(m.name) + '" data-arg2="typeahead">' +
+           '<span class="ql-feed-ta-name">' + escHtml(m.name) + '</span>' +
+           '<span class="ql-feed-ta-meta">' + escHtml(m.source) + ' · ' +
+             _qlFormatQty(m.qty) + ' ' + escHtml(m.unit) +
+           '</span>' +
+           '</div>';
+  }).join('');
+  dd.classList.add('open');
+}
+
+function qlFeedSkipMeal() {
+  var dateStr = _qlBackfillDate || today();
+  if (!_qlMeal) return;
+  // Capture prev value for undo
+  var fd = load(KEYS.feeding, {}) || {};
+  var prevVal = fd[dateStr] ? fd[dateStr][_qlMeal] : '';
+  window._fdMarkMealSkipped(dateStr, _qlMeal);
+  var meal = _qlMeal;
+  var undoFn = function() {
+    var f = load(KEYS.feeding, {}) || {};
+    if (f[dateStr]) { f[dateStr][meal] = prevVal || ''; save(KEYS.feeding, f); feedingData = f; }
+    if (typeof _islMarkDirty === 'function') _islMarkDirty('diet');
+    var curTab2 = TAB_ORDER.find(function(t) { return document.getElementById('tab-' + t) && document.getElementById('tab-' + t).classList.contains('active'); });
+    if (curTab2 === 'diet') { if (typeof initFeeding === 'function') initFeeding(); if (typeof renderDietStats === 'function') renderDietStats(); }
+    if (curTab2 === 'home') renderHome();
+  };
+  closeQuickLogAll();
+  showQLToast(capitalize(meal) + ' marked as skipped', 4000, undoFn);
+  var curTab = TAB_ORDER.find(function(t) { return document.getElementById('tab-' + t) && document.getElementById('tab-' + t).classList.contains('active'); });
+  if (curTab === 'diet') { if (typeof initFeeding === 'function') initFeeding(); if (typeof renderDietStats === 'function') renderDietStats(); }
+  if (curTab === 'home') renderHome();
+}
+
 // ── Quick Log Save Functions ──
 
 function saveQLFeed() {
-  const food = document.getElementById('qlFeedInput').value.trim();
-  if (!food) { document.getElementById('qlFeedInput').focus(); return; }
   const dateStr = _qlBackfillDate || today();
 
-  // Load feeding data and merge into the correct day
-  const feeding = load(KEYS.feeding, {}) || {};
-  if (!feeding[dateStr]) feeding[dateStr] = { breakfast:'', lunch:'', dinner:'', snack:'' };
-  const day = feeding[dateStr];
+  // F-2: Fold any unsubmitted typed text in qlFeedInput as a final item
+  // (covers the "typed without picking typeahead → pressed Save" case).
+  // Comma-split for parents who paste a multi-item line.
+  const typedRaw = (document.getElementById('qlFeedInput')?.value || '').trim();
+  if (typedRaw) {
+    typedRaw.split(',').map(function(s) { return s.trim(); }).filter(Boolean).forEach(function(nm) {
+      const defaults = window._fdResolveQtyDefaults(nm);
+      _qlFeedItems.push({
+        name: nm,
+        qty: defaults.qty,
+        unit: defaults.unit,
+        nutritionRef: String(nm).toLowerCase().replace(/\s*\([^)]*\)\s*/g, '').trim(),
+        source: 'typed',
+      });
+    });
+    if (_qlFeedSourceFlow === 'fob-feed') _qlFeedSourceFlow = 'fob-novel';
+    document.getElementById('qlFeedInput').value = '';
+  }
+
+  // Guard: must have at least one item to save.
+  if (_qlFeedItems.length === 0) {
+    document.getElementById('qlFeedInput')?.focus();
+    return;
+  }
 
   // Capture prev value for undo BEFORE mutation
+  const feedingPrev = load(KEYS.feeding, {}) || {};
   const undoMealKey = _qlMeal;
-  const prevMealValue = day[undoMealKey] || '';
+  const prevMealValue = (feedingPrev[dateStr] && feedingPrev[dateStr][undoMealKey]) || '';
 
-  day[_qlMeal] = day[_qlMeal] ? day[_qlMeal] + ', ' + food : food;
-  // Save meal time if entered
-  const qlTime = document.getElementById('qlFeedTime')?.value;
-  if (qlTime) day[_qlMeal + '_time'] = qlTime;
-  // Save intake level from QL pills
-  if (_qlSelectedIntake && _qlMeal !== 'snack') {
-    day[_qlMeal + '_intake'] = _qlSelectedIntake;
-  }
-  save(KEYS.feeding, feeding);
-  feedingData = feeding;
+  // Build the structured payload + write via the canonical F-2 writer.
+  const qlTime = (document.getElementById('qlFeedTime')?.value) || null;
+  const overallIntake = (typeof _qlSelectedIntake === 'number' && _qlSelectedIntake > 0)
+    ? _qlSelectedIntake
+    : 0.75;  // ratified default "Most"
+  const payload = {
+    items: _qlFeedItems.slice(),
+    time: qlTime,
+    overallIntake: overallIntake,
+    sourceFlow: _qlFeedSourceFlow,
+  };
+  window._fdWriteStructuredMeal(dateStr, _qlMeal, payload);
+
+  // Build legacy `food` string for downstream callers (toast nutrient flash,
+  // autoIntroduceFoodsFromDay, _qlFeedInsight). Comma-joined item names.
+  const food = _qlFeedItems.map(function(it) { return it.name; }).join(', ');
+
   _tsfMarkDirty();
 
   _islMarkDirty('diet');


### PR DESCRIPTION
## Summary

**food-sub-tab-v1 F-2 — structured "FOB Feed" log entry form.** Item builder + L1–L4 autofill intelligence (repeat rail / curated combos / next-item ribbon / NUTRITION typeahead) + qty/unit steppers + skip-meal, writing the canonical structured shape to a `feedingData[date][meal+'_v1']` sidecar alongside the legacy comma-joined string. UX policy = **Option A** (structured-only Diet Log) per Architect ratification.

**Status: canon-cc-008 chain discharged — ready for merge.**

## Phasing (per `docs/specs/food-sub-tab-v1.md`)
- **F-1 (done, #165)** sub-tab scaffold + structured shape schema
- **F-2 (this PR)** Log sub-tab structured entry form
- **F-3 / F-4 (queued)** Library consolidation / Patterns sub-tab
- **F-5 (queued, last)** `parseFeeding` normalizer — reads the qty/sidecar shape this PR writes. Until F-5, structured qty is **write-only by design** (the sidecar architecture; nothing reads qty for nutrition compute yet).

## Stages
1–4. data layer + autofill helpers, FOB Feed sheet rewrite, backward-compat sidecar, 10th audit gate + spec F-2 fold.
5. `/code-review xhigh` — 15 findings (4 catastrophic / 8 high / 3 medium), all fixed (`fc56730`).
6. **canon-cc-008 Governor chain** (`7672df1`) — see below.

## canon-cc-008 chain (release gate)
- **Maren** (Care, diet.js+home.js) — `clear-with-notes`
- **Kael** (Intelligence, data.js+core.js+illness+qa-handlers) — `clear-with-notes`
- **Vela** (Surfacing, intelligence-quicklog.js) — `amendments-required`
- **Sequential triple-jurisdiction** on styles.css + template.html (Maren → Kael → Vela)
- **Lyra synth + fold** under standing fold-authority
- **Cipher Edict V** — **LGTM** (CV3-006 three-axis; write-only qty acknowledged by-design; 4 fold-interaction risks trace clean)

### Folded (stage 6)
- **Convergent root-cause** (V-K-200/201 + V-V-203, three jurisdictions): prep-suffix normalization — "Banana mash" → explicit `banana` entry (not `fruit-mash` "½ pc"); 7 combo items now derive a real NUTRITION `nutritionRef`; `fruit-mash` unit pc→tbsp.
- V-K-202 `parseFeedingV1` skip-sentinel guard · V-K-203 audit-gate NUTRITION join-integrity · V-K-210 dead-code deletion
- V-V-200 drop engine telemetry label · V-V-202 alphabetical Items sort · V-V-204 L1↔L2 rail dedup
- V-M-210/V-V-210 dark combo-conf contrast (1.42:1 → legible) · V-M-211/V-V-211 9px → `var(--fs-2xs)`

**Architect-ratified non-folds:** V-V-201 (qty write-only until F-5, by-design) · V-M-200 (Maren: no-fix-for-F-2)

### F-5 carry-forward (not blockers)
Persist `nutritionRef` at write-time · add `schemaVersion` version-gate branch · name the `0.75` intake constant.

## CV3-006
- **Honesty** — source attribution on parse; write-only qty disclosed as by-design, closed at F-5.
- **Extensibility** — NUTRITION-driven; new join-integrity gate fails loud on orphan qty-keys / combo refs.
- **Warmth (primary)** — autofill rails cut input burden; fold sharpened the 2 AM surface (contrast, scan order, telemetry removal, zoom-tier rejoin).

Build clean; 7 audit gates pass.

https://claude.ai/code/session_01QMQk72WmE7ezu3mVB5BHwU