### PR TITLE
fix: HR-doctrine follow-ups (#108) — #109 / #110 / #111

### DIFF
--- a/docs/CARETICKET_STATE_MACHINE.html
+++ b/docs/CARETICKET_STATE_MACHINE.html
@@ -159,7 +159,7 @@ code { font-family: var(--mono); font-size: 12px; color: var(--ink); }
         <span class="state-chip" style="background:#f2a8b8">escalated</span>
       </td>
       <td class="cell-rationale">trigger — highest severity</td>
-      <td class="cell-impl"><code>ctHandleEscalation</code> @ <code>intelligence-caretickets.js:1521</code></td>
+      <td class="cell-impl"><code>ctHandleEscalation</code> @ <code>intelligence-caretickets.js:1524</code></td>
       <td class="cell-note">fires on highest-severity trigger</td>
     </tr>
   
@@ -171,7 +171,7 @@ code { font-family: var(--mono); font-size: 12px; color: var(--ink); }
         <span class="state-chip" style="background:#b5d5c5">resolved</span>
       </td>
       <td class="cell-rationale">criteria met + confirm, OR manual close after exhaustion</td>
-      <td class="cell-impl"><code>ctResolveTicket</code> @ <code>intelligence-caretickets.js:1537</code></td>
+      <td class="cell-impl"><code>ctResolveTicket</code> @ <code>intelligence-caretickets.js:1540</code></td>
       <td class="cell-note">criteria met + confirm, OR manual close</td>
     </tr>
   
@@ -183,7 +183,7 @@ code { font-family: var(--mono); font-size: 12px; color: var(--ink); }
         <span class="state-chip" style="background:#a8cfe0">active</span>
       </td>
       <td class="cell-rationale">clear check-in + confirm de-escalation</td>
-      <td class="cell-impl"><code>ctDeEscalate</code> @ <code>intelligence-caretickets.js:1579</code></td>
+      <td class="cell-impl"><code>ctDeEscalate</code> @ <code>intelligence-caretickets.js:1582</code></td>
       <td class="cell-note">clear check-in + confirm de-escalation</td>
     </tr>
   
@@ -195,7 +195,7 @@ code { font-family: var(--mono); font-size: 12px; color: var(--ink); }
         <span class="state-chip" style="background:#f2a8b8">escalated</span>
       </td>
       <td class="cell-rationale">different/higher trigger — upgrade action</td>
-      <td class="cell-impl"><code>ctHandleEscalation</code> @ <code>intelligence-caretickets.js:1521</code></td>
+      <td class="cell-impl"><code>ctHandleEscalation</code> @ <code>intelligence-caretickets.js:1524</code></td>
       <td class="cell-note">re-fires with different/higher trigger</td>
     </tr>
   
@@ -207,7 +207,7 @@ code { font-family: var(--mono); font-size: 12px; color: var(--ink); }
         <span class="state-chip" style="background:#b5d5c5">resolved</span>
       </td>
       <td class="cell-rationale">force-resolve with explicit confirmation + reason</td>
-      <td class="cell-impl"><code>ctResolveTicket</code> @ <code>intelligence-caretickets.js:1537</code></td>
+      <td class="cell-impl"><code>ctResolveTicket</code> @ <code>intelligence-caretickets.js:1540</code></td>
       <td class="cell-note">force=true path; explicit confirmation + reason</td>
     </tr>
   
@@ -219,7 +219,7 @@ code { font-family: var(--mono); font-size: 12px; color: var(--ink); }
         <span class="state-chip" style="background:#a8cfe0">active</span>
       </td>
       <td class="cell-rationale">reopen — suggest fresh ticket after 2 reopens</td>
-      <td class="cell-impl"><code>ctReopenTicket</code> @ <code>intelligence-caretickets.js:1553</code></td>
+      <td class="cell-impl"><code>ctReopenTicket</code> @ <code>intelligence-caretickets.js:1556</code></td>
       <td class="cell-note">reopen — suggest fresh ticket after 2 reopens</td>
     </tr>
   

--- a/docs/QA_GATE_SPEC.md
+++ b/docs/QA_GATE_SPEC.md
@@ -109,7 +109,7 @@ These checks are **run as bash commands**, not mental checks. The builder must e
 ```
 CHECKS:
 1. zi() icon validation     — every zi('name') cross-referenced against the 52-icon set
-2. Attribute escaping       — every data-arg with JSON uses _alAttrSafe (or equivalent), not bare escHtml
+2. Attribute escaping       — every data-arg with JSON uses escHtml (escapes " since #107; JSON.stringify neutralises \n before escHtml runs). The _alAttrSafe helper was retired in #109/V-K-47.
 3. XSS: escHtml             — all user-originated text in innerHTML passes through escHtml()
 4. No emojis                — Unicode range grep (U+1F300–1F9FF, U+2600–27BF)
 5. No inline onclick        — grep for onclick=, onchange=, oninput=, onfocus=, onblur=
@@ -261,7 +261,7 @@ grep -oP "zi\('\K[^']+" $FILE | sort -u | while read icon; do
 done
 
 echo "── 2. Attribute escaping (JSON in data-arg) ──"
-grep 'data-arg=.*JSON\|data-arg=.*stringify\|data-arg=.*payload' $FILE | grep -v '_alAttrSafe\|_attrSafe' && echo "  ✗ UNESCAPED JSON" || echo "  ✓ PASS"
+grep 'data-arg=.*JSON\|data-arg=.*stringify\|data-arg=.*payload' $FILE | grep -v '_alAttrSafe\|_attrSafe\|escHtml' && echo "  ✗ UNESCAPED JSON" || echo "  ✓ PASS"
 
 echo "── 3. escHtml on user text ──"
 # Manual review: check innerHTML assignments with user data

--- a/index.html
+++ b/index.html
@@ -63046,6 +63046,10 @@ function _alRenderYesterday() {
     var dom = (item.domains && item.domains[0]) ? item.domains[0] : '';
     var meta = AL_DOMAIN_META[dom] || { icon: zi('run'), label: '' };
     var durStr = item.duration ? ' · ' + item.duration + 'm' : '';
+    // V-K-47 (#109): item.text is textarea-sourced and may contain newlines, but
+    // JSON.stringify converts real \n into the two-char escape before escHtml runs,
+    // so escHtml's \n→<br> arm never fires on the stringified payload. Keep this
+    // stringify-before-escHtml order; do not hand-build the data-arg JSON.
     var payload = JSON.stringify({ text: item.text, duration: item.duration || null });
     html += '<button class="al-yesterday-item" data-domain="' + (dom || 'motor') + '" data-action="alTapYesterday" data-arg="' + escHtml(payload) + '">' +
       '<span class="al-yesterday-icon">' + meta.icon + '</span>' +

--- a/index.html
+++ b/index.html
@@ -19963,6 +19963,12 @@ function init() {
     else if (action === 'runHomeFoodQuery') runHomeFoodQuery();
     else if (action === 'closeHomeSymptomChecker') closeHomeSymptomChecker();
     else if (action === 'runHomeSymptomCheck') runHomeSymptomCheck();
+    else if (action === 'fillSymptomCheck') {
+      // HR-3 (issue #109): quick-chip fills #homeSymptomInput then runs the check.
+      var _hsi = document.getElementById('homeSymptomInput');
+      if (_hsi) _hsi.value = arg;
+      if (typeof runHomeSymptomCheck === 'function') runHomeSymptomCheck();
+    }
     else if (action === 'promptFeverTrack') promptFeverTrack();
     else if (action === 'promptDiarrhoeaTrack') promptDiarrhoeaTrack();
     else if (action === 'promptVomitingTrack') promptVomitingTrack();
@@ -22998,10 +23004,12 @@ function confirmAction(msg, callback, btnText) {
 // handlers.
 
 // vizArg — encode a detail object into a double-quoted HTML attribute.
-// escHtml is unsuitable here: it rewrites \n to <br> (corrupts JSON) and
-// leaves " unescaped (breaks the attribute). JSON.stringify already
-// escapes \, " and control chars within string values; we only need to
-// HTML-escape the quote and angle/amp glyphs so the attribute parses.
+// escHtml is unsuitable here because it rewrites \n to <br>, which corrupts the
+// JSON payload. (V-K-48, issue #109: escHtml DOES escape " since #107, so
+// quote-safety is no longer the distinguishing reason — the \n→<br> rewrite
+// is.) JSON.stringify already escapes \, " and control chars within string
+// values; we only need to HTML-escape the quote and angle/amp glyphs so the
+// attribute parses.
 function vizArg(detail) {
   return JSON.stringify(detail)
     .replace(/&/g, '&amp;')
@@ -44813,12 +44821,12 @@ function renderVacc() {
       if (isBooked) {
         const apptLabel = getVaccApptLabel(bookedData);
         if (apptLabel) {
-          bsEl.innerHTML = `<div class="vc-booked-pill" data-action="openVaccApptModal" data-arg="${escAttr(upcoming.name)}">
+          bsEl.innerHTML = `<div class="vc-booked-pill" data-action="openVaccApptModal" data-arg="${escHtml(upcoming.name)}">
             <span class="status-good-xs"><span class="zi-check-placeholder"></span> Booked</span>
             <span class="vc-booked-detail">${apptLabel}</span>
           </div>`;
         } else {
-          bsEl.innerHTML = `<div class="vc-booked-pill" data-action="openVaccApptModal" data-arg="${escAttr(upcoming.name)}">
+          bsEl.innerHTML = `<div class="vc-booked-pill" data-action="openVaccApptModal" data-arg="${escHtml(upcoming.name)}">
             <span class="status-good-xs"><span class="zi-check-placeholder"></span> Booked</span>
             <span class="vc-booked-detail-light">Tap to add date & time</span>
           </div>`;
@@ -44826,7 +44834,7 @@ function renderVacc() {
         bsEl.style.display = '';
       } else {
         if (safeD <= 14) {
-          bsEl.innerHTML = `<button class="btn btn-sage vc-book-btn" data-action="markVaccBooked" data-arg="${escAttr(upcoming.name)}">${zi('clock')} Book appointment</button>`;
+          bsEl.innerHTML = `<button class="btn btn-sage vc-book-btn" data-action="markVaccBooked" data-arg="${escHtml(upcoming.name)}">${zi('clock')} Book appointment</button>`;
           bsEl.style.display = '';
         } else {
           bsEl.style.display = 'none';
@@ -44981,7 +44989,7 @@ function _vaccRenderCompletionCard(dueVaccines) {
         <div class="vc-complete-q">Was the vaccination given?</div>
       </div>
       <div class="vc-complete-actions">
-        <button class="btn btn-sage" data-action="vaccMarkDone" data-arg="${escAttr(v.name)}" data-arg2="${escAttr(dueDate)}">Yes, done today</button>
+        <button class="btn btn-sage" data-action="vaccMarkDone" data-arg="${escHtml(v.name)}" data-arg2="${escAttr(dueDate)}">Yes, done today</button>
         <button class="btn btn-ghost" data-action="vaccShowDelay" data-arg="${escAttr(dueDate)}">Not yet</button>
       </div>
     </div>`;
@@ -46011,7 +46019,7 @@ function renderVaccItem(v, status) {
       const apptLabel = getVaccApptLabel(bookedData);
       bookingHtml = apptLabel
         ? `<div style="margin-top:4px;display:inline-flex;align-items:center;gap:var(--sp-4);padding:2px 8px;border-radius:var(--r-full);background:var(--surface-sage);font-size:var(--fs-xs);"><span style="font-weight:600;color:var(--tc-sage);">${zi('check')} Booked</span><span style="font-weight:400;color:var(--mid);">${apptLabel}</span></div>`
-        : `<div style="margin-top:4px;display:inline-flex;align-items:center;gap:var(--sp-4);padding:2px 8px;border-radius:var(--r-full);background:var(--surface-sage);font-size:var(--fs-xs);cursor:pointer;" data-action="openVaccApptModal" data-arg="${escAttr(v.name)}"><span style="font-weight:600;color:var(--tc-sage);">${zi('check')} Booked</span><span style="font-weight:400;color:var(--light);">Add date</span></div>`;
+        : `<div style="margin-top:4px;display:inline-flex;align-items:center;gap:var(--sp-4);padding:2px 8px;border-radius:var(--r-full);background:var(--surface-sage);font-size:var(--fs-xs);cursor:pointer;" data-action="openVaccApptModal" data-arg="${escHtml(v.name)}"><span style="font-weight:600;color:var(--tc-sage);">${zi('check')} Booked</span><span style="font-weight:400;color:var(--light);">Add date</span></div>`;
     }
   }
   return `<div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:8px 10px;border-radius:var(--r-lg);background:${c.bg};border-left:var(--accent-w) solid ${c.border};margin-bottom:4px;">
@@ -46622,11 +46630,11 @@ function renderUpcomingItem(item) {
   if (isDone) {
     actionsHtml = '<span class="upcoming-badge achieved-badge">' + zi('check') + ' Achieved</span>';
   } else if (isIP) {
-    actionsHtml = `<button class="ms-action-btn" data-action="upcomingToMilestoneDone" data-stop="1" data-arg="${escAttr(item.text)}" data-arg2="${item.advanced ? 'true' : 'false'}" data-arg3="${escAttr(catVal)}">${zi('check')} Done</button>`;
+    actionsHtml = `<button class="ms-action-btn" data-action="upcomingToMilestoneDone" data-stop="1" data-arg="${escHtml(item.text)}" data-arg2="${item.advanced ? 'true' : 'false'}" data-arg3="${escAttr(catVal)}">${zi('check')} Done</button>`;
   } else {
     actionsHtml = `
-      <button class="ms-action-btn" data-action="upcomingToMilestoneInProgress" data-stop="1" data-arg="${escAttr(item.text)}" data-arg2="${item.advanced ? 'true' : 'false'}" data-arg3="${escAttr(catVal)}">${zi('target')} Started</button>
-      <button class="ms-action-btn" data-action="upcomingToMilestoneDone" data-stop="1" data-arg="${escAttr(item.text)}" data-arg2="${item.advanced ? 'true' : 'false'}" data-arg3="${escAttr(catVal)}">${zi('check')} Done</button>
+      <button class="ms-action-btn" data-action="upcomingToMilestoneInProgress" data-stop="1" data-arg="${escHtml(item.text)}" data-arg2="${item.advanced ? 'true' : 'false'}" data-arg3="${escAttr(catVal)}">${zi('target')} Started</button>
+      <button class="ms-action-btn" data-action="upcomingToMilestoneDone" data-stop="1" data-arg="${escHtml(item.text)}" data-arg2="${item.advanced ? 'true' : 'false'}" data-arg3="${escAttr(catVal)}">${zi('check')} Done</button>
     `;
   }
 
@@ -62802,10 +62810,9 @@ let _alUpgradePrompted = {};
 let _alSuggestInjected = false;
 var _alUpgradeTimerId = null;
 
-// escHtml doesn't escape " — this helper does, for safe JSON in data-arg attributes
-function _alAttrSafe(s) {
-  return escHtml(s).replace(/"/g, '&quot;');
-}
+// V-K-47 (issue #109): the former _alAttrSafe helper was escHtml(s) +
+// a redundant .replace(/"/g,'&quot;') — a no-op since #107 made escHtml escape
+// " itself. Call sites now use escHtml(payload) directly; helper removed.
 
 // ── Step 4: Active milestone → suggestion matching ──
 
@@ -62909,7 +62916,7 @@ function _alRenderSuggestions() {
     html += '<div class="al-suggest-cards">';
     g.activities.forEach(function(act) {
       var payload = JSON.stringify({ keyword: g.keyword, text: act.text, duration: act.duration, tip: act.tip || '', icon: act.icon || 'run' });
-      html += '<button class="al-suggest-card" data-action="alTapSuggestion" data-arg="' + _alAttrSafe(payload) + '">' +
+      html += '<button class="al-suggest-card" data-action="alTapSuggestion" data-arg="' + escHtml(payload) + '">' +
         '<span class="al-suggest-icon">' + zi(act.icon || 'run') + '</span>' +
         '<span class="al-suggest-text">' + escHtml(act.text) + '</span>' +
         '<span class="al-suggest-dur">' + act.duration + ' min</span>' +
@@ -63040,7 +63047,7 @@ function _alRenderYesterday() {
     var meta = AL_DOMAIN_META[dom] || { icon: zi('run'), label: '' };
     var durStr = item.duration ? ' · ' + item.duration + 'm' : '';
     var payload = JSON.stringify({ text: item.text, duration: item.duration || null });
-    html += '<button class="al-yesterday-item" data-domain="' + (dom || 'motor') + '" data-action="alTapYesterday" data-arg="' + _alAttrSafe(payload) + '">' +
+    html += '<button class="al-yesterday-item" data-domain="' + (dom || 'motor') + '" data-action="alTapYesterday" data-arg="' + escHtml(payload) + '">' +
       '<span class="al-yesterday-icon">' + meta.icon + '</span>' +
       '<span class="al-yesterday-text">' + escHtml(item.text) + durStr + '</span></button>';
   });
@@ -63241,7 +63248,7 @@ function _alRenderDomainNudge() {
     nudge.suggestions.forEach(function(s, i) {
       if (i > 0) html += ' · ';
       var payload = JSON.stringify({ keyword: s.keyword, text: s.text, duration: s.duration, tip: s.tip, icon: s.icon });
-      html += '<button class="al-nudge-link" data-action="alTapSuggestion" data-arg="' + _alAttrSafe(payload) + '">' + escHtml(s.text) + '</button>';
+      html += '<button class="al-nudge-link" data-action="alTapSuggestion" data-arg="' + escHtml(payload) + '">' + escHtml(s.text) + '</button>';
     });
     html += '</div>';
   }
@@ -66060,8 +66067,11 @@ function openHomeSymptomChecker() {
   overlay.style.overscrollBehavior = 'contain';
 
   // Build quick chips HTML
+  // HR-3 (issue #109): data-action delegation, not inline onclick. The
+  // dispatcher (core.js: fillSymptomCheck) sets #homeSymptomInput then runs the
+  // check. escHtml at the data-arg + text render boundary (HR-4).
   const chipsHtml = SYMPTOM_QUICK_CHIPS.map(s =>
-    '<span class="sc-quick-chip" onclick="document.getElementById(\'homeSymptomInput\').value=\'' + s + '\';runHomeSymptomCheck()">' + s + '</span>'
+    '<span class="sc-quick-chip" data-action="fillSymptomCheck" data-arg="' + escHtml(s) + '">' + escHtml(s) + '</span>'
   ).join('');
 
   overlay.innerHTML = `
@@ -71640,24 +71650,27 @@ function ctValidateTickets() {
 }
 
 // ── Notification Text ──
-
+// HR-4 (issue #110, V-K-44): this returns PLAIN TEXT for a Notification.body
+// sink (see _ctSystemNotify), which does NOT decode HTML entities. Pass
+// ticket.title RAW — escaping here renders literal &#39;/&quot; in the system
+// notification. Escape only at HTML render boundaries, never at this producer.
 function ctNotificationText(ticket) {
   var tpl = CT_TEMPLATES[ticket.category];
   if (ticket.status === 'escalated') {
-    return 'Urgent: ' + escHtml(ticket.title) + ' needs attention';
+    return 'Urgent: ' + ticket.title + ' needs attention';
   }
   if (ticket.type === 'incident') {
     var elapsed = ctTimeAgo(ticket.createdAt);
-    return escHtml(ticket.title) + ' \u2014 time for a quick check (' + elapsed + ')';
+    return ticket.title + ' \u2014 time for a quick check (' + elapsed + ')';
   }
   // Goal
   var goalTexts = {
     sleep_improve: 'How was last night? Quick check on sleep progress',
     weight_gain: 'Time for a weight check-in',
     feeding_variety: 'Any new foods today? Quick food variety check',
-    custom: 'Time to check in on: ' + escHtml(ticket.title)
+    custom: 'Time to check in on: ' + ticket.title
   };
-  return goalTexts[ticket.category] || ('Check in: ' + escHtml(ticket.title));
+  return goalTexts[ticket.category] || ('Check in: ' + ticket.title);
 }
 
 // ── Pre-Fill and Collection ──
@@ -72969,7 +72982,10 @@ function ctGetTSFEvents() {
         type: 'careticket',
         time: timeStr,
         timeMin: createdTime.getHours() * 60 + createdTime.getMinutes(),
-        label: 'Started tracking: ' + escHtml(ticket.title),
+        // HR-4 (issue #110, V-K-45): pass title RAW — the Today So Far renderer
+        // escapes ev.label via escHtml at the single render boundary
+        // (intelligence-quicklog.js). Escaping here double-escapes (&amp;quot;).
+        label: 'Started tracking: ' + ticket.title,
         detail: '',
         icon: zi(iconName),
         color: color,
@@ -72996,7 +73012,7 @@ function ctGetTSFEvents() {
         type: 'careticket',
         time: ciTimeStr,
         timeMin: ciTime.getHours() * 60 + ciTime.getMinutes(),
-        label: escHtml(ticket.title) + ' check-in',
+        label: ticket.title + ' check-in',
         detail: detailText,
         icon: zi(verdictIcon),
         color: color,
@@ -73018,7 +73034,7 @@ function ctGetTSFEvents() {
           type: 'careticket',
           time: resTimeStr,
           timeMin: resTime.getHours() * 60 + resTime.getMinutes(),
-          label: escHtml(ticket.title) + ' resolved',
+          label: ticket.title + ' resolved',
           detail: '',
           icon: zi('resolve'),
           color: 'sage',

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.28-11",
+  "version": "2026.05.28-13",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.28-13",
+  "version": "2026.05.28-14",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/QA_GATE_SPEC.md
+++ b/split/QA_GATE_SPEC.md
@@ -108,7 +108,7 @@ These checks are **run as bash commands**, not mental checks. The builder must e
 ```
 CHECKS:
 1. zi() icon validation     — every zi('name') cross-referenced against the 52-icon set
-2. Attribute escaping       — every data-arg with JSON uses _alAttrSafe (or equivalent), not bare escHtml
+2. Attribute escaping       — every data-arg with JSON uses escHtml (escapes " since #107; JSON.stringify neutralises \n before escHtml runs). The _alAttrSafe helper was retired in #109/V-K-47.
 3. XSS: escHtml             — all user-originated text in innerHTML passes through escHtml()
 4. No emojis                — Unicode range grep (U+1F300–1F9FF, U+2600–27BF)
 5. No inline onclick        — grep for onclick=, onchange=, oninput=, onfocus=, onblur=
@@ -226,7 +226,7 @@ grep -oP "zi\('\K[^']+" $FILE | sort -u | while read icon; do
 done
 
 echo "── 2. Attribute escaping (JSON in data-arg) ──"
-grep 'data-arg=.*JSON\|data-arg=.*stringify\|data-arg=.*payload' $FILE | grep -v '_alAttrSafe\|_attrSafe' && echo "  ✗ UNESCAPED JSON" || echo "  ✓ PASS"
+grep 'data-arg=.*JSON\|data-arg=.*stringify\|data-arg=.*payload' $FILE | grep -v '_alAttrSafe\|_attrSafe\|escHtml' && echo "  ✗ UNESCAPED JSON" || echo "  ✓ PASS"
 
 echo "── 3. escHtml on user text ──"
 # Manual review: check innerHTML assignments with user data

--- a/split/core.js
+++ b/split/core.js
@@ -939,6 +939,12 @@ function init() {
     else if (action === 'runHomeFoodQuery') runHomeFoodQuery();
     else if (action === 'closeHomeSymptomChecker') closeHomeSymptomChecker();
     else if (action === 'runHomeSymptomCheck') runHomeSymptomCheck();
+    else if (action === 'fillSymptomCheck') {
+      // HR-3 (issue #109): quick-chip fills #homeSymptomInput then runs the check.
+      var _hsi = document.getElementById('homeSymptomInput');
+      if (_hsi) _hsi.value = arg;
+      if (typeof runHomeSymptomCheck === 'function') runHomeSymptomCheck();
+    }
     else if (action === 'promptFeverTrack') promptFeverTrack();
     else if (action === 'promptDiarrhoeaTrack') promptDiarrhoeaTrack();
     else if (action === 'promptVomitingTrack') promptVomitingTrack();
@@ -3974,10 +3980,12 @@ function confirmAction(msg, callback, btnText) {
 // handlers.
 
 // vizArg — encode a detail object into a double-quoted HTML attribute.
-// escHtml is unsuitable here: it rewrites \n to <br> (corrupts JSON) and
-// leaves " unescaped (breaks the attribute). JSON.stringify already
-// escapes \, " and control chars within string values; we only need to
-// HTML-escape the quote and angle/amp glyphs so the attribute parses.
+// escHtml is unsuitable here because it rewrites \n to <br>, which corrupts the
+// JSON payload. (V-K-48, issue #109: escHtml DOES escape " since #107, so
+// quote-safety is no longer the distinguishing reason — the \n→<br> rewrite
+// is.) JSON.stringify already escapes \, " and control chars within string
+// values; we only need to HTML-escape the quote and angle/amp glyphs so the
+// attribute parses.
 function vizArg(detail) {
   return JSON.stringify(detail)
     .replace(/&/g, '&amp;')

--- a/split/intelligence-caretickets.js
+++ b/split/intelligence-caretickets.js
@@ -729,24 +729,27 @@ function ctValidateTickets() {
 }
 
 // ── Notification Text ──
-
+// HR-4 (issue #110, V-K-44): this returns PLAIN TEXT for a Notification.body
+// sink (see _ctSystemNotify), which does NOT decode HTML entities. Pass
+// ticket.title RAW — escaping here renders literal &#39;/&quot; in the system
+// notification. Escape only at HTML render boundaries, never at this producer.
 function ctNotificationText(ticket) {
   var tpl = CT_TEMPLATES[ticket.category];
   if (ticket.status === 'escalated') {
-    return 'Urgent: ' + escHtml(ticket.title) + ' needs attention';
+    return 'Urgent: ' + ticket.title + ' needs attention';
   }
   if (ticket.type === 'incident') {
     var elapsed = ctTimeAgo(ticket.createdAt);
-    return escHtml(ticket.title) + ' \u2014 time for a quick check (' + elapsed + ')';
+    return ticket.title + ' \u2014 time for a quick check (' + elapsed + ')';
   }
   // Goal
   var goalTexts = {
     sleep_improve: 'How was last night? Quick check on sleep progress',
     weight_gain: 'Time for a weight check-in',
     feeding_variety: 'Any new foods today? Quick food variety check',
-    custom: 'Time to check in on: ' + escHtml(ticket.title)
+    custom: 'Time to check in on: ' + ticket.title
   };
-  return goalTexts[ticket.category] || ('Check in: ' + escHtml(ticket.title));
+  return goalTexts[ticket.category] || ('Check in: ' + ticket.title);
 }
 
 // ── Pre-Fill and Collection ──
@@ -2058,7 +2061,10 @@ function ctGetTSFEvents() {
         type: 'careticket',
         time: timeStr,
         timeMin: createdTime.getHours() * 60 + createdTime.getMinutes(),
-        label: 'Started tracking: ' + escHtml(ticket.title),
+        // HR-4 (issue #110, V-K-45): pass title RAW — the Today So Far renderer
+        // escapes ev.label via escHtml at the single render boundary
+        // (intelligence-quicklog.js). Escaping here double-escapes (&amp;quot;).
+        label: 'Started tracking: ' + ticket.title,
         detail: '',
         icon: zi(iconName),
         color: color,
@@ -2085,7 +2091,7 @@ function ctGetTSFEvents() {
         type: 'careticket',
         time: ciTimeStr,
         timeMin: ciTime.getHours() * 60 + ciTime.getMinutes(),
-        label: escHtml(ticket.title) + ' check-in',
+        label: ticket.title + ' check-in',
         detail: detailText,
         icon: zi(verdictIcon),
         color: color,
@@ -2107,7 +2113,7 @@ function ctGetTSFEvents() {
           type: 'careticket',
           time: resTimeStr,
           timeMin: resTime.getHours() * 60 + resTime.getMinutes(),
-          label: escHtml(ticket.title) + ' resolved',
+          label: ticket.title + ' resolved',
           detail: '',
           icon: zi('resolve'),
           color: 'sage',

--- a/split/intelligence-quicklog.js
+++ b/split/intelligence-quicklog.js
@@ -549,6 +549,10 @@ function _alRenderYesterday() {
     var dom = (item.domains && item.domains[0]) ? item.domains[0] : '';
     var meta = AL_DOMAIN_META[dom] || { icon: zi('run'), label: '' };
     var durStr = item.duration ? ' · ' + item.duration + 'm' : '';
+    // V-K-47 (#109): item.text is textarea-sourced and may contain newlines, but
+    // JSON.stringify converts real \n into the two-char escape before escHtml runs,
+    // so escHtml's \n→<br> arm never fires on the stringified payload. Keep this
+    // stringify-before-escHtml order; do not hand-build the data-arg JSON.
     var payload = JSON.stringify({ text: item.text, duration: item.duration || null });
     html += '<button class="al-yesterday-item" data-domain="' + (dom || 'motor') + '" data-action="alTapYesterday" data-arg="' + escHtml(payload) + '">' +
       '<span class="al-yesterday-icon">' + meta.icon + '</span>' +

--- a/split/intelligence-quicklog.js
+++ b/split/intelligence-quicklog.js
@@ -313,10 +313,9 @@ let _alUpgradePrompted = {};
 let _alSuggestInjected = false;
 var _alUpgradeTimerId = null;
 
-// escHtml doesn't escape " — this helper does, for safe JSON in data-arg attributes
-function _alAttrSafe(s) {
-  return escHtml(s).replace(/"/g, '&quot;');
-}
+// V-K-47 (issue #109): the former _alAttrSafe helper was escHtml(s) +
+// a redundant .replace(/"/g,'&quot;') — a no-op since #107 made escHtml escape
+// " itself. Call sites now use escHtml(payload) directly; helper removed.
 
 // ── Step 4: Active milestone → suggestion matching ──
 
@@ -420,7 +419,7 @@ function _alRenderSuggestions() {
     html += '<div class="al-suggest-cards">';
     g.activities.forEach(function(act) {
       var payload = JSON.stringify({ keyword: g.keyword, text: act.text, duration: act.duration, tip: act.tip || '', icon: act.icon || 'run' });
-      html += '<button class="al-suggest-card" data-action="alTapSuggestion" data-arg="' + _alAttrSafe(payload) + '">' +
+      html += '<button class="al-suggest-card" data-action="alTapSuggestion" data-arg="' + escHtml(payload) + '">' +
         '<span class="al-suggest-icon">' + zi(act.icon || 'run') + '</span>' +
         '<span class="al-suggest-text">' + escHtml(act.text) + '</span>' +
         '<span class="al-suggest-dur">' + act.duration + ' min</span>' +
@@ -551,7 +550,7 @@ function _alRenderYesterday() {
     var meta = AL_DOMAIN_META[dom] || { icon: zi('run'), label: '' };
     var durStr = item.duration ? ' · ' + item.duration + 'm' : '';
     var payload = JSON.stringify({ text: item.text, duration: item.duration || null });
-    html += '<button class="al-yesterday-item" data-domain="' + (dom || 'motor') + '" data-action="alTapYesterday" data-arg="' + _alAttrSafe(payload) + '">' +
+    html += '<button class="al-yesterday-item" data-domain="' + (dom || 'motor') + '" data-action="alTapYesterday" data-arg="' + escHtml(payload) + '">' +
       '<span class="al-yesterday-icon">' + meta.icon + '</span>' +
       '<span class="al-yesterday-text">' + escHtml(item.text) + durStr + '</span></button>';
   });
@@ -752,7 +751,7 @@ function _alRenderDomainNudge() {
     nudge.suggestions.forEach(function(s, i) {
       if (i > 0) html += ' · ';
       var payload = JSON.stringify({ keyword: s.keyword, text: s.text, duration: s.duration, tip: s.tip, icon: s.icon });
-      html += '<button class="al-nudge-link" data-action="alTapSuggestion" data-arg="' + _alAttrSafe(payload) + '">' + escHtml(s.text) + '</button>';
+      html += '<button class="al-nudge-link" data-action="alTapSuggestion" data-arg="' + escHtml(payload) + '">' + escHtml(s.text) + '</button>';
     });
     html += '</div>';
   }
@@ -3571,8 +3570,11 @@ function openHomeSymptomChecker() {
   overlay.style.overscrollBehavior = 'contain';
 
   // Build quick chips HTML
+  // HR-3 (issue #109): data-action delegation, not inline onclick. The
+  // dispatcher (core.js: fillSymptomCheck) sets #homeSymptomInput then runs the
+  // check. escHtml at the data-arg + text render boundary (HR-4).
   const chipsHtml = SYMPTOM_QUICK_CHIPS.map(s =>
-    '<span class="sc-quick-chip" onclick="document.getElementById(\'homeSymptomInput\').value=\'' + s + '\';runHomeSymptomCheck()">' + s + '</span>'
+    '<span class="sc-quick-chip" data-action="fillSymptomCheck" data-arg="' + escHtml(s) + '">' + escHtml(s) + '</span>'
   ).join('');
 
   overlay.innerHTML = `

--- a/split/medical.js
+++ b/split/medical.js
@@ -3115,12 +3115,12 @@ function renderVacc() {
       if (isBooked) {
         const apptLabel = getVaccApptLabel(bookedData);
         if (apptLabel) {
-          bsEl.innerHTML = `<div class="vc-booked-pill" data-action="openVaccApptModal" data-arg="${escAttr(upcoming.name)}">
+          bsEl.innerHTML = `<div class="vc-booked-pill" data-action="openVaccApptModal" data-arg="${escHtml(upcoming.name)}">
             <span class="status-good-xs"><span class="zi-check-placeholder"></span> Booked</span>
             <span class="vc-booked-detail">${apptLabel}</span>
           </div>`;
         } else {
-          bsEl.innerHTML = `<div class="vc-booked-pill" data-action="openVaccApptModal" data-arg="${escAttr(upcoming.name)}">
+          bsEl.innerHTML = `<div class="vc-booked-pill" data-action="openVaccApptModal" data-arg="${escHtml(upcoming.name)}">
             <span class="status-good-xs"><span class="zi-check-placeholder"></span> Booked</span>
             <span class="vc-booked-detail-light">Tap to add date & time</span>
           </div>`;
@@ -3128,7 +3128,7 @@ function renderVacc() {
         bsEl.style.display = '';
       } else {
         if (safeD <= 14) {
-          bsEl.innerHTML = `<button class="btn btn-sage vc-book-btn" data-action="markVaccBooked" data-arg="${escAttr(upcoming.name)}">${zi('clock')} Book appointment</button>`;
+          bsEl.innerHTML = `<button class="btn btn-sage vc-book-btn" data-action="markVaccBooked" data-arg="${escHtml(upcoming.name)}">${zi('clock')} Book appointment</button>`;
           bsEl.style.display = '';
         } else {
           bsEl.style.display = 'none';
@@ -3283,7 +3283,7 @@ function _vaccRenderCompletionCard(dueVaccines) {
         <div class="vc-complete-q">Was the vaccination given?</div>
       </div>
       <div class="vc-complete-actions">
-        <button class="btn btn-sage" data-action="vaccMarkDone" data-arg="${escAttr(v.name)}" data-arg2="${escAttr(dueDate)}">Yes, done today</button>
+        <button class="btn btn-sage" data-action="vaccMarkDone" data-arg="${escHtml(v.name)}" data-arg2="${escAttr(dueDate)}">Yes, done today</button>
         <button class="btn btn-ghost" data-action="vaccShowDelay" data-arg="${escAttr(dueDate)}">Not yet</button>
       </div>
     </div>`;
@@ -4313,7 +4313,7 @@ function renderVaccItem(v, status) {
       const apptLabel = getVaccApptLabel(bookedData);
       bookingHtml = apptLabel
         ? `<div style="margin-top:4px;display:inline-flex;align-items:center;gap:var(--sp-4);padding:2px 8px;border-radius:var(--r-full);background:var(--surface-sage);font-size:var(--fs-xs);"><span style="font-weight:600;color:var(--tc-sage);">${zi('check')} Booked</span><span style="font-weight:400;color:var(--mid);">${apptLabel}</span></div>`
-        : `<div style="margin-top:4px;display:inline-flex;align-items:center;gap:var(--sp-4);padding:2px 8px;border-radius:var(--r-full);background:var(--surface-sage);font-size:var(--fs-xs);cursor:pointer;" data-action="openVaccApptModal" data-arg="${escAttr(v.name)}"><span style="font-weight:600;color:var(--tc-sage);">${zi('check')} Booked</span><span style="font-weight:400;color:var(--light);">Add date</span></div>`;
+        : `<div style="margin-top:4px;display:inline-flex;align-items:center;gap:var(--sp-4);padding:2px 8px;border-radius:var(--r-full);background:var(--surface-sage);font-size:var(--fs-xs);cursor:pointer;" data-action="openVaccApptModal" data-arg="${escHtml(v.name)}"><span style="font-weight:600;color:var(--tc-sage);">${zi('check')} Booked</span><span style="font-weight:400;color:var(--light);">Add date</span></div>`;
     }
   }
   return `<div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:8px 10px;border-radius:var(--r-lg);background:${c.bg};border-left:var(--accent-w) solid ${c.border};margin-bottom:4px;">
@@ -4924,11 +4924,11 @@ function renderUpcomingItem(item) {
   if (isDone) {
     actionsHtml = '<span class="upcoming-badge achieved-badge">' + zi('check') + ' Achieved</span>';
   } else if (isIP) {
-    actionsHtml = `<button class="ms-action-btn" data-action="upcomingToMilestoneDone" data-stop="1" data-arg="${escAttr(item.text)}" data-arg2="${item.advanced ? 'true' : 'false'}" data-arg3="${escAttr(catVal)}">${zi('check')} Done</button>`;
+    actionsHtml = `<button class="ms-action-btn" data-action="upcomingToMilestoneDone" data-stop="1" data-arg="${escHtml(item.text)}" data-arg2="${item.advanced ? 'true' : 'false'}" data-arg3="${escAttr(catVal)}">${zi('check')} Done</button>`;
   } else {
     actionsHtml = `
-      <button class="ms-action-btn" data-action="upcomingToMilestoneInProgress" data-stop="1" data-arg="${escAttr(item.text)}" data-arg2="${item.advanced ? 'true' : 'false'}" data-arg3="${escAttr(catVal)}">${zi('target')} Started</button>
-      <button class="ms-action-btn" data-action="upcomingToMilestoneDone" data-stop="1" data-arg="${escAttr(item.text)}" data-arg2="${item.advanced ? 'true' : 'false'}" data-arg3="${escAttr(catVal)}">${zi('check')} Done</button>
+      <button class="ms-action-btn" data-action="upcomingToMilestoneInProgress" data-stop="1" data-arg="${escHtml(item.text)}" data-arg2="${item.advanced ? 'true' : 'false'}" data-arg3="${escAttr(catVal)}">${zi('target')} Started</button>
+      <button class="ms-action-btn" data-action="upcomingToMilestoneDone" data-stop="1" data-arg="${escHtml(item.text)}" data-arg2="${item.advanced ? 'true' : 'false'}" data-arg3="${escAttr(catVal)}">${zi('check')} Done</button>
     `;
   }
 

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -63046,6 +63046,10 @@ function _alRenderYesterday() {
     var dom = (item.domains && item.domains[0]) ? item.domains[0] : '';
     var meta = AL_DOMAIN_META[dom] || { icon: zi('run'), label: '' };
     var durStr = item.duration ? ' · ' + item.duration + 'm' : '';
+    // V-K-47 (#109): item.text is textarea-sourced and may contain newlines, but
+    // JSON.stringify converts real \n into the two-char escape before escHtml runs,
+    // so escHtml's \n→<br> arm never fires on the stringified payload. Keep this
+    // stringify-before-escHtml order; do not hand-build the data-arg JSON.
     var payload = JSON.stringify({ text: item.text, duration: item.duration || null });
     html += '<button class="al-yesterday-item" data-domain="' + (dom || 'motor') + '" data-action="alTapYesterday" data-arg="' + escHtml(payload) + '">' +
       '<span class="al-yesterday-icon">' + meta.icon + '</span>' +

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -19963,6 +19963,12 @@ function init() {
     else if (action === 'runHomeFoodQuery') runHomeFoodQuery();
     else if (action === 'closeHomeSymptomChecker') closeHomeSymptomChecker();
     else if (action === 'runHomeSymptomCheck') runHomeSymptomCheck();
+    else if (action === 'fillSymptomCheck') {
+      // HR-3 (issue #109): quick-chip fills #homeSymptomInput then runs the check.
+      var _hsi = document.getElementById('homeSymptomInput');
+      if (_hsi) _hsi.value = arg;
+      if (typeof runHomeSymptomCheck === 'function') runHomeSymptomCheck();
+    }
     else if (action === 'promptFeverTrack') promptFeverTrack();
     else if (action === 'promptDiarrhoeaTrack') promptDiarrhoeaTrack();
     else if (action === 'promptVomitingTrack') promptVomitingTrack();
@@ -22998,10 +23004,12 @@ function confirmAction(msg, callback, btnText) {
 // handlers.
 
 // vizArg — encode a detail object into a double-quoted HTML attribute.
-// escHtml is unsuitable here: it rewrites \n to <br> (corrupts JSON) and
-// leaves " unescaped (breaks the attribute). JSON.stringify already
-// escapes \, " and control chars within string values; we only need to
-// HTML-escape the quote and angle/amp glyphs so the attribute parses.
+// escHtml is unsuitable here because it rewrites \n to <br>, which corrupts the
+// JSON payload. (V-K-48, issue #109: escHtml DOES escape " since #107, so
+// quote-safety is no longer the distinguishing reason — the \n→<br> rewrite
+// is.) JSON.stringify already escapes \, " and control chars within string
+// values; we only need to HTML-escape the quote and angle/amp glyphs so the
+// attribute parses.
 function vizArg(detail) {
   return JSON.stringify(detail)
     .replace(/&/g, '&amp;')
@@ -44813,12 +44821,12 @@ function renderVacc() {
       if (isBooked) {
         const apptLabel = getVaccApptLabel(bookedData);
         if (apptLabel) {
-          bsEl.innerHTML = `<div class="vc-booked-pill" data-action="openVaccApptModal" data-arg="${escAttr(upcoming.name)}">
+          bsEl.innerHTML = `<div class="vc-booked-pill" data-action="openVaccApptModal" data-arg="${escHtml(upcoming.name)}">
             <span class="status-good-xs"><span class="zi-check-placeholder"></span> Booked</span>
             <span class="vc-booked-detail">${apptLabel}</span>
           </div>`;
         } else {
-          bsEl.innerHTML = `<div class="vc-booked-pill" data-action="openVaccApptModal" data-arg="${escAttr(upcoming.name)}">
+          bsEl.innerHTML = `<div class="vc-booked-pill" data-action="openVaccApptModal" data-arg="${escHtml(upcoming.name)}">
             <span class="status-good-xs"><span class="zi-check-placeholder"></span> Booked</span>
             <span class="vc-booked-detail-light">Tap to add date & time</span>
           </div>`;
@@ -44826,7 +44834,7 @@ function renderVacc() {
         bsEl.style.display = '';
       } else {
         if (safeD <= 14) {
-          bsEl.innerHTML = `<button class="btn btn-sage vc-book-btn" data-action="markVaccBooked" data-arg="${escAttr(upcoming.name)}">${zi('clock')} Book appointment</button>`;
+          bsEl.innerHTML = `<button class="btn btn-sage vc-book-btn" data-action="markVaccBooked" data-arg="${escHtml(upcoming.name)}">${zi('clock')} Book appointment</button>`;
           bsEl.style.display = '';
         } else {
           bsEl.style.display = 'none';
@@ -44981,7 +44989,7 @@ function _vaccRenderCompletionCard(dueVaccines) {
         <div class="vc-complete-q">Was the vaccination given?</div>
       </div>
       <div class="vc-complete-actions">
-        <button class="btn btn-sage" data-action="vaccMarkDone" data-arg="${escAttr(v.name)}" data-arg2="${escAttr(dueDate)}">Yes, done today</button>
+        <button class="btn btn-sage" data-action="vaccMarkDone" data-arg="${escHtml(v.name)}" data-arg2="${escAttr(dueDate)}">Yes, done today</button>
         <button class="btn btn-ghost" data-action="vaccShowDelay" data-arg="${escAttr(dueDate)}">Not yet</button>
       </div>
     </div>`;
@@ -46011,7 +46019,7 @@ function renderVaccItem(v, status) {
       const apptLabel = getVaccApptLabel(bookedData);
       bookingHtml = apptLabel
         ? `<div style="margin-top:4px;display:inline-flex;align-items:center;gap:var(--sp-4);padding:2px 8px;border-radius:var(--r-full);background:var(--surface-sage);font-size:var(--fs-xs);"><span style="font-weight:600;color:var(--tc-sage);">${zi('check')} Booked</span><span style="font-weight:400;color:var(--mid);">${apptLabel}</span></div>`
-        : `<div style="margin-top:4px;display:inline-flex;align-items:center;gap:var(--sp-4);padding:2px 8px;border-radius:var(--r-full);background:var(--surface-sage);font-size:var(--fs-xs);cursor:pointer;" data-action="openVaccApptModal" data-arg="${escAttr(v.name)}"><span style="font-weight:600;color:var(--tc-sage);">${zi('check')} Booked</span><span style="font-weight:400;color:var(--light);">Add date</span></div>`;
+        : `<div style="margin-top:4px;display:inline-flex;align-items:center;gap:var(--sp-4);padding:2px 8px;border-radius:var(--r-full);background:var(--surface-sage);font-size:var(--fs-xs);cursor:pointer;" data-action="openVaccApptModal" data-arg="${escHtml(v.name)}"><span style="font-weight:600;color:var(--tc-sage);">${zi('check')} Booked</span><span style="font-weight:400;color:var(--light);">Add date</span></div>`;
     }
   }
   return `<div style="display:flex;align-items:flex-start;gap:var(--sp-8);padding:8px 10px;border-radius:var(--r-lg);background:${c.bg};border-left:var(--accent-w) solid ${c.border};margin-bottom:4px;">
@@ -46622,11 +46630,11 @@ function renderUpcomingItem(item) {
   if (isDone) {
     actionsHtml = '<span class="upcoming-badge achieved-badge">' + zi('check') + ' Achieved</span>';
   } else if (isIP) {
-    actionsHtml = `<button class="ms-action-btn" data-action="upcomingToMilestoneDone" data-stop="1" data-arg="${escAttr(item.text)}" data-arg2="${item.advanced ? 'true' : 'false'}" data-arg3="${escAttr(catVal)}">${zi('check')} Done</button>`;
+    actionsHtml = `<button class="ms-action-btn" data-action="upcomingToMilestoneDone" data-stop="1" data-arg="${escHtml(item.text)}" data-arg2="${item.advanced ? 'true' : 'false'}" data-arg3="${escAttr(catVal)}">${zi('check')} Done</button>`;
   } else {
     actionsHtml = `
-      <button class="ms-action-btn" data-action="upcomingToMilestoneInProgress" data-stop="1" data-arg="${escAttr(item.text)}" data-arg2="${item.advanced ? 'true' : 'false'}" data-arg3="${escAttr(catVal)}">${zi('target')} Started</button>
-      <button class="ms-action-btn" data-action="upcomingToMilestoneDone" data-stop="1" data-arg="${escAttr(item.text)}" data-arg2="${item.advanced ? 'true' : 'false'}" data-arg3="${escAttr(catVal)}">${zi('check')} Done</button>
+      <button class="ms-action-btn" data-action="upcomingToMilestoneInProgress" data-stop="1" data-arg="${escHtml(item.text)}" data-arg2="${item.advanced ? 'true' : 'false'}" data-arg3="${escAttr(catVal)}">${zi('target')} Started</button>
+      <button class="ms-action-btn" data-action="upcomingToMilestoneDone" data-stop="1" data-arg="${escHtml(item.text)}" data-arg2="${item.advanced ? 'true' : 'false'}" data-arg3="${escAttr(catVal)}">${zi('check')} Done</button>
     `;
   }
 
@@ -62802,10 +62810,9 @@ let _alUpgradePrompted = {};
 let _alSuggestInjected = false;
 var _alUpgradeTimerId = null;
 
-// escHtml doesn't escape " — this helper does, for safe JSON in data-arg attributes
-function _alAttrSafe(s) {
-  return escHtml(s).replace(/"/g, '&quot;');
-}
+// V-K-47 (issue #109): the former _alAttrSafe helper was escHtml(s) +
+// a redundant .replace(/"/g,'&quot;') — a no-op since #107 made escHtml escape
+// " itself. Call sites now use escHtml(payload) directly; helper removed.
 
 // ── Step 4: Active milestone → suggestion matching ──
 
@@ -62909,7 +62916,7 @@ function _alRenderSuggestions() {
     html += '<div class="al-suggest-cards">';
     g.activities.forEach(function(act) {
       var payload = JSON.stringify({ keyword: g.keyword, text: act.text, duration: act.duration, tip: act.tip || '', icon: act.icon || 'run' });
-      html += '<button class="al-suggest-card" data-action="alTapSuggestion" data-arg="' + _alAttrSafe(payload) + '">' +
+      html += '<button class="al-suggest-card" data-action="alTapSuggestion" data-arg="' + escHtml(payload) + '">' +
         '<span class="al-suggest-icon">' + zi(act.icon || 'run') + '</span>' +
         '<span class="al-suggest-text">' + escHtml(act.text) + '</span>' +
         '<span class="al-suggest-dur">' + act.duration + ' min</span>' +
@@ -63040,7 +63047,7 @@ function _alRenderYesterday() {
     var meta = AL_DOMAIN_META[dom] || { icon: zi('run'), label: '' };
     var durStr = item.duration ? ' · ' + item.duration + 'm' : '';
     var payload = JSON.stringify({ text: item.text, duration: item.duration || null });
-    html += '<button class="al-yesterday-item" data-domain="' + (dom || 'motor') + '" data-action="alTapYesterday" data-arg="' + _alAttrSafe(payload) + '">' +
+    html += '<button class="al-yesterday-item" data-domain="' + (dom || 'motor') + '" data-action="alTapYesterday" data-arg="' + escHtml(payload) + '">' +
       '<span class="al-yesterday-icon">' + meta.icon + '</span>' +
       '<span class="al-yesterday-text">' + escHtml(item.text) + durStr + '</span></button>';
   });
@@ -63241,7 +63248,7 @@ function _alRenderDomainNudge() {
     nudge.suggestions.forEach(function(s, i) {
       if (i > 0) html += ' · ';
       var payload = JSON.stringify({ keyword: s.keyword, text: s.text, duration: s.duration, tip: s.tip, icon: s.icon });
-      html += '<button class="al-nudge-link" data-action="alTapSuggestion" data-arg="' + _alAttrSafe(payload) + '">' + escHtml(s.text) + '</button>';
+      html += '<button class="al-nudge-link" data-action="alTapSuggestion" data-arg="' + escHtml(payload) + '">' + escHtml(s.text) + '</button>';
     });
     html += '</div>';
   }
@@ -66060,8 +66067,11 @@ function openHomeSymptomChecker() {
   overlay.style.overscrollBehavior = 'contain';
 
   // Build quick chips HTML
+  // HR-3 (issue #109): data-action delegation, not inline onclick. The
+  // dispatcher (core.js: fillSymptomCheck) sets #homeSymptomInput then runs the
+  // check. escHtml at the data-arg + text render boundary (HR-4).
   const chipsHtml = SYMPTOM_QUICK_CHIPS.map(s =>
-    '<span class="sc-quick-chip" onclick="document.getElementById(\'homeSymptomInput\').value=\'' + s + '\';runHomeSymptomCheck()">' + s + '</span>'
+    '<span class="sc-quick-chip" data-action="fillSymptomCheck" data-arg="' + escHtml(s) + '">' + escHtml(s) + '</span>'
   ).join('');
 
   overlay.innerHTML = `
@@ -71640,24 +71650,27 @@ function ctValidateTickets() {
 }
 
 // ── Notification Text ──
-
+// HR-4 (issue #110, V-K-44): this returns PLAIN TEXT for a Notification.body
+// sink (see _ctSystemNotify), which does NOT decode HTML entities. Pass
+// ticket.title RAW — escaping here renders literal &#39;/&quot; in the system
+// notification. Escape only at HTML render boundaries, never at this producer.
 function ctNotificationText(ticket) {
   var tpl = CT_TEMPLATES[ticket.category];
   if (ticket.status === 'escalated') {
-    return 'Urgent: ' + escHtml(ticket.title) + ' needs attention';
+    return 'Urgent: ' + ticket.title + ' needs attention';
   }
   if (ticket.type === 'incident') {
     var elapsed = ctTimeAgo(ticket.createdAt);
-    return escHtml(ticket.title) + ' \u2014 time for a quick check (' + elapsed + ')';
+    return ticket.title + ' \u2014 time for a quick check (' + elapsed + ')';
   }
   // Goal
   var goalTexts = {
     sleep_improve: 'How was last night? Quick check on sleep progress',
     weight_gain: 'Time for a weight check-in',
     feeding_variety: 'Any new foods today? Quick food variety check',
-    custom: 'Time to check in on: ' + escHtml(ticket.title)
+    custom: 'Time to check in on: ' + ticket.title
   };
-  return goalTexts[ticket.category] || ('Check in: ' + escHtml(ticket.title));
+  return goalTexts[ticket.category] || ('Check in: ' + ticket.title);
 }
 
 // ── Pre-Fill and Collection ──
@@ -72969,7 +72982,10 @@ function ctGetTSFEvents() {
         type: 'careticket',
         time: timeStr,
         timeMin: createdTime.getHours() * 60 + createdTime.getMinutes(),
-        label: 'Started tracking: ' + escHtml(ticket.title),
+        // HR-4 (issue #110, V-K-45): pass title RAW — the Today So Far renderer
+        // escapes ev.label via escHtml at the single render boundary
+        // (intelligence-quicklog.js). Escaping here double-escapes (&amp;quot;).
+        label: 'Started tracking: ' + ticket.title,
         detail: '',
         icon: zi(iconName),
         color: color,
@@ -72996,7 +73012,7 @@ function ctGetTSFEvents() {
         type: 'careticket',
         time: ciTimeStr,
         timeMin: ciTime.getHours() * 60 + ciTime.getMinutes(),
-        label: escHtml(ticket.title) + ' check-in',
+        label: ticket.title + ' check-in',
         detail: detailText,
         icon: zi(verdictIcon),
         color: color,
@@ -73018,7 +73034,7 @@ function ctGetTSFEvents() {
           type: 'careticket',
           time: resTimeStr,
           timeMin: resTime.getHours() * 60 + resTime.getMinutes(),
-          label: escHtml(ticket.title) + ' resolved',
+          label: ticket.title + ' resolved',
           detail: '',
           icon: zi('resolve'),
           color: 'sage',

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -3177,12 +3177,20 @@ test.describe('Polish-10b — HR-3 onclick batch (Care + Home; ~24 sites)', () =
     // data-arg escaping into the combo-card render sites (c.text, h.q,
     // p.partner, queryFoods), so the doctrine guard now reaches both
     // files Maren governs the render boundaries of.
-    const [homeRes, dietRes] = await Promise.all([
+    //
+    // #111 extension: also scan medical.js — Maren's F-35-1 audit named the
+    // vaccine-name (v.name / upcoming.name) and upcoming-milestone (item.text)
+    // data-arg positions in medical.js, which were still using escAttr. The
+    // values are DB-curated (functionally safe today) but the doctrine guard
+    // must reach every render boundary Maren governs.
+    const [homeRes, dietRes, medRes] = await Promise.all([
       request.get('/split/home.js'),
       request.get('/split/diet.js'),
+      request.get('/split/medical.js'),
     ]);
     const home = await homeRes.text();
     const diet = await dietRes.text();
+    const med = await medRes.text();
 
     // Affected fields: m.name (medication), nextMilestone.text (milestone),
     // val (food meal value), f.name (food name), comboStr (combo string),
@@ -3191,14 +3199,66 @@ test.describe('Polish-10b — HR-3 onclick batch (Care + Home; ~24 sites)', () =
     // diet.js user-content fields: c.text (combo quick-chip), h.q (combo
     // history query), p.partner (synergy partner), queryFoods (parsed combo).
     const buggyPatternDiet = /data-arg2?="\$\{escAttr\((c\.text|h\.q|p\.partner|queryFoods)\b/g;
+    // medical.js user-content fields: item.text (upcoming-milestone), v.name /
+    // upcoming.name (vaccine names), m.name (medication name).
+    const buggyPatternMed = /data-arg2?="\$\{escAttr\((item\.text|upcoming\.name|v\.name|m\.name)\b/g;
     const homeViolations = home.match(buggyPatternHome) || [];
     const dietViolations = diet.match(buggyPatternDiet) || [];
+    const medViolations = med.match(buggyPatternMed) || [];
     expect(homeViolations,
       `home.js: zero escAttr in user-content data-arg positions (Maren F-35-1 fix). Found: ${homeViolations.join(' | ')}`)
       .toEqual([]);
     expect(dietViolations,
       `diet.js: zero escAttr in user-content data-arg positions (#107 coverage extension). Found: ${dietViolations.join(' | ')}`)
       .toEqual([]);
+    expect(medViolations,
+      `medical.js: zero escAttr in user-content data-arg positions (#111 coverage extension). Found: ${medViolations.join(' | ')}`)
+      .toEqual([]);
+  });
+
+  test('regression-guard (#110 HR-4) — CareTicket title escaped at render boundary, not producer', async ({ request }) => {
+    // Issue #110 (V-K-44 + V-K-45): escHtml was applied at producer time in
+    // intelligence-caretickets.js — both ctNotificationText (a plain-text
+    // Notification.body sink, where entities do NOT decode → literal &#39;/&quot;)
+    // and the Today So Far event labels (which the TSF renderer re-escapes via
+    // escHtml(ev.label), double-escaping to &amp;quot;). Fix: producers pass
+    // ticket.title RAW; escaping stays at the single render boundary.
+    const [ct, ql] = await Promise.all([
+      (await request.get('/split/intelligence-caretickets.js')).text(),
+      (await request.get('/split/intelligence-quicklog.js')).text(),
+    ]);
+    // Producer side: zero escHtml(ticket.title) in caretickets (raw pass-through).
+    // (Legitimate HTML-render escapes use escHtml(t.title)/escHtml(tpl.title) and
+    // are unaffected by this ticket.title-specific guard.)
+    const producerEscapes = ct.match(/escHtml\(\s*ticket\.title\s*\)/g) || [];
+    expect(producerEscapes,
+      `caretickets.js: ticket.title must be passed RAW from producers (#110) — escape only at the render boundary. Found: ${producerEscapes.join(' | ')}`)
+      .toEqual([]);
+    // Render boundary: Today So Far still escapes ev.label (single canonical escape).
+    expect(ql.includes('escHtml(ev.label)'),
+      'quicklog.js: Today So Far renderer must keep escHtml(ev.label) as the single escape boundary (#110)')
+      .toBeTruthy();
+  });
+
+  test('regression-guard (#109 HR-3 / V-K-47) — symptom quick-chip uses data-action; _alAttrSafe retired', async ({ request }) => {
+    // Issue #109: the sc-quick-chip set-value+run inline onclick (HR-3) is
+    // converted to data-action="fillSymptomCheck" with a core.js dispatcher.
+    // V-K-47: the _alAttrSafe helper (escHtml + redundant "-replace) is removed;
+    // call sites use escHtml(payload) directly (escHtml escapes " since #107).
+    const [ql, core] = await Promise.all([
+      (await request.get('/split/intelligence-quicklog.js')).text(),
+      (await request.get('/split/core.js')).text(),
+    ]);
+    expect(ql.includes("onclick=\"document.getElementById('homeSymptomInput')"),
+      'quicklog.js: sc-quick-chip inline onclick removed (HR-3, #109)').toBeFalsy();
+    expect(/data-action="fillSymptomCheck"/.test(ql),
+      'quicklog.js: sc-quick-chip uses data-action="fillSymptomCheck" (#109)').toBeTruthy();
+    expect(/function\s+_alAttrSafe\b/.test(ql),
+      'quicklog.js: _alAttrSafe helper retired (V-K-47, #109)').toBeFalsy();
+    expect(ql.includes('_alAttrSafe('),
+      'quicklog.js: zero _alAttrSafe call sites remain (V-K-47, #109)').toBeFalsy();
+    expect(core.includes("action === 'fillSymptomCheck'"),
+      'core.js: fillSymptomCheck dispatcher branch present (#109)').toBeTruthy();
   });
 
   test('regression-guard (#107 V-K-14) — escHtml escapes " for double-quoted attribute safety', async ({ request }) => {


### PR DESCRIPTION
Bundled HR-doctrine follow-ups for #109, #110, #111. Each was re-confirmed against current `main` (the filed line numbers were stale).

## #111 — F-35-1: `escAttr`→`escHtml` in user-content `data-arg` (medical.js)
The F-35-1 doctrine (escAttr leaks `\` into `dataset.arg`; double-quoted attributes are parser-safe under `escHtml`, which escapes `"` since #107) was enforced in `home.js`/`diet.js` but not `medical.js`. Converted the named user-content `data-arg` positions:
- `upcoming.name` / `v.name` (vaccine names) — 5 sites
- `item.text` (upcoming-milestone text) — 3 sites

`title="${escAttr(name)}"` (medical.js:4039) was correctly left as `escAttr` per Polish-10a. Extended the **r2 (F-35-1)** regression guard to scan `medical.js` with field list `item.text|upcoming.name|v.name|m.name`.

## #110 — HR-4: CareTicket title double-escape
`escHtml(ticket.title)` was applied at *producer* time, but every consumer is the wrong sink for it:
- **`ctNotificationText`** → `_ctSystemNotify` → `new Notification(..., {body})` — a **plain-text** sink that does not decode entities, so a title with `'`/`"` rendered literal `&#39;`/`&quot;` in the OS notification.
- **Today So Far event labels** (`ct-created`/`ct-checkin`/`ct-resolved`) → re-escaped at the render boundary via `escHtml(ev.label)`, so producer-side escaping **double-escaped** (`&amp;quot;`).

Fix: pass `ticket.title` **raw** from both producers; escaping stays at the single render boundary. The surviving `escHtml(t.title)`/`escHtml(tpl.title)` HTML overlay renders are a different variable and correctly remain escaped. New guard asserts zero `escHtml(ticket.title)` producers + retains `escHtml(ev.label)`.

## #109 — HR-3 / V-K-47 / V-K-48 (scoped: cleanups + sister-site)
⚠️ #109's primary target — the `ql-freq-pill` inline `onclick` — **no longer exists**; the F-2 rework removed it. Per agreed scope this resolves the surviving named sub-items plus the one current site matching #109's "sister" description:
- **HR-3:** the **Home-tab** symptom quick-chip (`sc-quick-chip` in `openHomeSymptomChecker`, intelligence-quicklog.js) → `data-action="fillSymptomCheck"` with a new `core.js` dispatcher.
- **V-K-47:** retired the `_alAttrSafe` helper — its `.replace(/"/g,'&quot;')` arm became a no-op once `escHtml` started escaping `"` (#107). The 3 call sites now use `escHtml(payload)` directly. (Verified safe even for the textarea-sourced payload: `JSON.stringify` neutralises `\n` before `escHtml` runs.)
- **V-K-48:** refreshed the stale `vizArg` doc comment (the `\n→<br>` rewrite — not quote-safety — is now the reason `vizArg ≠ escHtml`).
- **Doc-consistency:** `QA_GATE_SPEC.md` (both copies) no longer mandates `_alAttrSafe`; post-#107 `escHtml` is the sanctioned JSON-in-data-arg escaping.

### Deferred (out of scope, tracked — NOT silently dropped)
- **medical.js:2479 `initSymptomChips`** — the **Medical-tab** sister symptom-chip (`#symptomInput`/`checkSymptoms()`) still carries the same compound inline `onclick`. Distinct surface from the Home-tab chip fixed here; left for a future HR-3 sweep.
- **intelligence-quicklog.js input `onkeydown`** — pre-existing inline handler on the symptom `<input>`; out of #109's named scope.
- The broader compound-`onclick` batch (meal-prog-slot, skip-remaining, ql-bf-pills) remains as tracked **R-10 carry-forward** (distinct fix-shapes).

## Verification
- `pnpm build` clean; all audit gates PASS; 0 CareTicket drift.
- e2e: **304 passed / 1 skipped / 0 failed**, including the 4 affected/added regression guards.

## canon-cc-008 — chain complete ✅
- Build + audit gates + e2e green
- **Maren** (medical.js) `yes` · **Kael** (caretickets.js + core.js) `yes` · **Vela** (quicklog.js) `yes`
- Lyra synthesis folded (clarifying comment + QA_GATE_SPEC doc-consistency)
- **Cipher** Edict V final-pass: **pass** — HR-clean, cross-jurisdiction #110 contract coherent and test-pinned, deferrals correctly out of scope

https://claude.ai/code/session_01QMQk72WmE7ezu3mVB5BHwU