### PR TITLE
spec(isl+diet): re-apply Arc B narrowing onto ratified Wave-2.5 base — supersedes #113

### DIFF
--- a/docs/specs/diet-rework-v1.md
+++ b/docs/specs/diet-rework-v1.md
@@ -1,27 +1,29 @@
-# Spec: Diet Tab Rework v1
+# Spec: Diet Tab Rework v1 — SUPERSEDED
 
-**Version:** v1.0 draft (Mode-1 + Wave 1.5 + Wave 2 main-session synthesis)
+**Version:** v1.0 draft (Mode-1 + Wave 1.5 + Wave 2 main-session synthesis) — **superseded 2026-05-28**
 **Date:** 2026-05-23
 **Authors:**
 - Lyra (Mode-1 subagent) — primary spec body (Wave 1)
 - Lyra (main-session synthesis) — Wave 1.5 amendments folding scribe-scout #1 (food DB) + #2 (ISL capability map) findings
 - Lyra (main-session synthesis) — Wave 2 amendments folding Maren / Kael / Cipher / Aurelius Mode-1 audits
 
-**Authority chain:** `CLAUDE.md` §QA Chain · canon-cc-008 · canon-cc-022 · cc-018 `pending_review`
+**Authority chain:** `CLAUDE.md` §QA Chain · canon-cc-008 · canon-cc-022 · cc-018 `superseded` (ratified 2026-05-23 → superseded 2026-05-28)
 **Against commit:** `b2670f7`
 **Cross-references:** `docs/specs/isl-upgrade-v1.md` (Arc B — Phase 3 of this spec depends on Arc B's keystone trio)
 
-## Status
+## Status — SUPERSEDED (2026-05-28)
 
-`pending_review` (cc-018). Prerequisites for `ratified`:
+**`superseded` (cc-018). Retained for provenance. Do not implement from this body.**
 
-- Architect ratification of IA pattern A, the Wave-1.5 fold-in, the Wave-2 amendments, and the two-spec arc-pair strategy.
-- Maren Mode-1 audit — **complete** (V-M-47 through V-M-54 issued; verdict: yes-with-fixes; fixes folded below).
-- Kael Mode-1 audit — **complete** (V-K-49 through V-K-57 issued; verdict: yes-with-fixes; fixes folded below).
-- Cipher Mode-1 Edict V pre-pass — **complete** (verdict: pass-with-fixes; fixes folded below).
-- Aurelius cross-cluster chronicling — **complete** (verdict: chronicling-ready; amendments folded; Codex Memory.md candidates per Chronicler's discretion post-ratify).
+> Arc A here redesigned the Diet tab into `[Today] [Score] [Insights] [Library]` segments. Between authoring (2026-05-23) and now, **`food-sub-tab-v1` was ratified and shipped** (PRs #166 / #168, spec amendments #167 / #169), restructuring the *same* surface (`#tab-diet`) into a different, now-merged IA — **`[Log] [Library] [Patterns]`** (`switchDietSub` / `.diet-sub-panel` on `main`). Two competing IA visions for one surface; the merged one wins.
 
-**Companion-set deploy delta — paired ratification.** This spec and `isl-upgrade-v1.md` form a single arc-pair artifact under cc-018. Ratifying one without the other constitutes a canon-cc-008 short-circuit unless the Architect explicitly defers one — in which case Arc A Phase 3 must be deferred until Arc B Phase B-1 ratifies separately.
+**Disposition (Architect, 2026-05-28 post-F-2 board triage):**
+
+- **Arc A IA rework — PARKED.** Phases 1, 2, 4, 5, 6 (the whole-tab restructure: segment router `switchDietSegment`, `renderDietSegment` dispatcher, `ziva_diet_segment` sticky-state, meal-card `dqp` compression, expand-by-default Insights, Library overlay) are obsolete — `main` already carries diet sub-tab nav + structured F-1/F-2 entry. Implementing them as-written would rip out merged scaffolding.
+- **Surviving content → migrated to Arc B.** The Phase-3 chemistry/combo surfacing (Fibre Variety / Bioactive Diversity / Variety-nudge tiles, per-food Chemistry detail, `meal_combo_check` chip-stack) was the genuinely valuable half. It is **re-homed into `isl-upgrade-v1.md` (Arc B, §Surfacing re-home)**, re-targeted from Arc A's segments to the merged `[Patterns]` (analytics tiles + combo surfacing) and `[Library]` (per-food chemistry) sub-tabs.
+- **Surviving Care-gap → carried forward.** V-M-50 (the meal-input flow surfaces no proactive age/allergen signal) is a real pre-existing Care gap, independent of IA. Re-evaluate against the F-2 FOB Feed-sheet entry flow; not actioned here.
+
+The Wave-1/1.5/2 audit record below (Maren V-M-47–54, Kael V-K-49–57, Cipher Edict V, Aurelius) is preserved unchanged as the provenance trail.
 
 ## Why
 
@@ -400,4 +402,4 @@ None. All Wave 2 required and recommended fixes folded above.
 
 ---
 
-— Lyra (Mode-1 subagent + Wave 1.5 + Wave 2 main-session synthesis + Wave 2.5 V-M-50 refinement), 2026-05-23, against `616071c`. cc-018 status: `ratified` (Architect signature 2026-05-23 — Wave 2 + Wave 2.5 spec enters implementation phase; per-phase Maren / Kael / Vela Mode-1 audits run at each ship PR per the Phase table above).
+— Lyra (Mode-1 subagent + Wave 1.5 + Wave 2 main-session synthesis + Wave 2.5 V-M-50 refinement), 2026-05-23, against `616071c`. cc-018 status: `ratified` 2026-05-23 → **`superseded` 2026-05-28** (Architect post-F-2 board triage — Arc A's IA rework parked, superseded by the merged `food-sub-tab-v1` IA; see §Status). The V-M-50 "introduce with care" chip below survives as a carried-forward Care gap (re-evaluate against the F-2 Feed-sheet entry flow); the Wave-2.5 V-M-50 lock body is retained as provenance and remains the reference if that chip is later built.

--- a/docs/specs/isl-upgrade-v1.md
+++ b/docs/specs/isl-upgrade-v1.md
@@ -6,21 +6,27 @@
 - Lyra (main-session synthesis) — primary spec body, ingest from scribe-scout #2 capability map (Wave 1.5)
 - Lyra (main-session synthesis) — Wave 2 amendments folding Maren / Kael / Cipher / Aurelius Mode-1 audits
 
-**Authority chain:** `CLAUDE.md` §QA Chain · canon-cc-008 · canon-cc-022 · cc-018 `pending_review`
-**Against commit:** `b2670f7`
-**Cross-references:** `docs/specs/diet-rework-v1.md` (Arc A — Phase 3 depends on Arc B's keystone trio)
+**Authority chain:** `CLAUDE.md` §QA Chain · canon-cc-008 · canon-cc-022 · cc-018 `ratified` (Architect signature 2026-05-23 — Wave 2 + Wave 2.5)
+**Against commit:** `b2670f7` (authored); ratified against `616071c`; reconciliation re-verified against `main` @ `65d5bda`
+**Cross-references:** `docs/specs/diet-rework-v1.md` (Arc A — **SUPERSEDED 2026-05-28**; its IA rework is parked, its chem/combo surfacing re-homed here into the merged `food-sub-tab-v1` sub-tabs — see §Surfacing re-home)
 
 ## Status
 
-`pending_review` (cc-018). Prerequisites for `ratified`:
+**`ratified` (cc-018) — Architect signature 2026-05-23 (Wave 2 + Wave 2.5; see closing signature).** In implementation phase; per-phase Governor audits run at each ship PR per the PR-sequence table.
 
-- Architect ratification of the upgrade roadmap, the Wave-2 amendments, and the Arc-A/Arc-B sequencing.
+**Post-ratification amendments (2026-05-28 → 2026-05-29) — Arc A superseded, Arc B narrowed.** After ratification, the `food-sub-tab-v1` arc (PRs #166 / #168; amendments #167 / #169 / #173) shipped a different, now-merged Diet-tab IA that supersedes Arc A (`diet-rework-v1.md`). Arc B's engine outputs therefore fold their surfacing into the food-sub-tab arc (#173), and Arc B narrows to its engine + hygiene core (PR sequence **B-1 → B-3 → B-4**; the former B-2 dissolved). **The Wave 2 / Wave 2.5 ratified body below — including the V-M-49 cross-Region read locks — is unchanged; only the surfacing home and the former B-2 phase move.** Detail in the two notes below + §Surfacing re-home.
+
+_Ratification prerequisites (all met at 2026-05-23; retained as record):_
+
+- Architect ratification of the upgrade roadmap and the Wave-2 amendments. (Arc-A/Arc-B sequencing now moot — Arc A superseded 2026-05-28; Arc B stands alone.)
 - Kael Mode-1 audit — **complete** (V-K-49 through V-K-57 issued; verdict: yes-with-fixes; fixes folded below).
 - Maren Mode-1 cross-consult — **complete** (V-M-47 through V-M-54 issued; copy + schema + safety-override findings folded below).
 - Cipher Mode-1 Edict V pre-pass — **complete** (verdict: pass-with-fixes; fixes folded below).
 - Aurelius cross-cluster chronicling — **complete** (verdict: chronicling-ready; Codex Memory.md candidates per Chronicler's discretion post-ratify).
 
-**Companion-set deploy delta — paired ratification.** This spec and `diet-rework-v1.md` form a single arc-pair artifact under cc-018. Ratifying one without the other constitutes a canon-cc-008 short-circuit unless the Architect explicitly defers one — in which case Arc A Phase 3 must be deferred until Arc B Phase B-1 ratifies separately.
+**Arc-pair dissolved — Arc B now stands alone (2026-05-28).** Arc A (`diet-rework-v1.md`) is superseded by the ratified-and-merged `food-sub-tab-v1` IA; its surfacing targets are re-homed here (see §Surfacing re-home). Arc B is self-contained on the intelligence layer and **ratifies standalone** — there is no longer a paired Arc A to gate against. The engine work (B-1, B-3, B-4) is surface-agnostic; only the B-2 card surfacing re-points to the merged `[Patterns]` / `[Library]` sub-tabs.
+
+**Reconciliation update (2026-05-29).** The re-homed surfacing is now **folded into the `food-sub-tab-v1` arc itself** (PR #173), not merely re-pointed: B-2's chem-variety / variety-nudge cards land in **food-sub-tab F-4** `[Patterns]`, and the per-food Chemistry detail lands in **food-sub-tab F-3** `[Library]`. Arc B therefore narrows to its **engine + hygiene core — B-1 (the keystone-trio engine), B-3, and B-4**; the diet-tab card mounts belong to the food-sub-tab phases that consume the B-1 engine. Re-verified against `main` @ `65d5bda` (post F-1/F-2): `NUTRITION.chem` + `COMBO_RULES` remain zero-consumer dead data (F-2 wired neither — its `CURATED_COMBOS` is a separate autofill structure). See §Surfacing re-home for the updated mapping.
 
 ## Why
 
@@ -34,9 +40,9 @@ The SproutLab intelligence layer is 7 files, ~18,400 LOC distributed (post-PR-G 
   - The scout swept `qa-handlers.js` only. **Wave 1.5 methodology lesson:** capability-map scouts must grep across the full file-set under audit, not the file where a symbol is "expected" to live.
 - **One CLAUDE.md drift.** CLAUDE.md says "ISL: 22 intents with dedicated handlers." The canonical intent registry `QA_INTENTS` is in `intelligence-qa.js:1–175`, not in ISL, and the count is now **30** (independently verified by Kael). The doc misattributes BOTH location AND count.
 - **Data-layer surfaces waiting for ISL consumers.** `NUTRITION[*].chem` (3 sub-fields) and `COMBO_RULES` (6 rules) are present in `data.js` with zero outside-`data.js` consumers — the data is specced but the intelligence layer doesn't yet pipe it. **`COMBO_RULES` is not uniformly nutrient-keyed (V-K-53):** rule #6 is `{foods:['banana','constipation']}` — food-name + symptom. The handler must tri-resolve, not single-resolve.
-- **Region LOC over the 30K trigger (V-K-56).** Live count: 30,725 LOC for the full Kael jurisdiction (`intelligence-*.js` + `core.js` + `data.js` + `sync.js` + `config.js` + `start.js`). Threshold is 30,000. **The Region is currently over budget, pre-arcs**, and `intelligence-cards.js` is +240 LOC since the Wave-1.5 capability map. Arcs B-1 (+~150 LOC) and B-2 (+~80 LOC) will push further. Surfaced as architectural watch-item — not a B-0 blocker, but Lyra/Cipher should plan for an `intelligence-cards.js` sub-split or similar before Region pressure becomes acute.
+- **Region LOC over the 30K trigger (V-K-56; re-baselined 2026-05-29).** Spec-write count was 30,725; **current `main` @ `65d5bda` is 34,907 LOC** for the full Kael jurisdiction (`intelligence-*.js` + `core.js` + `data.js` + `sync.js` + `config.js` + `start.js`) — F-1/F-2 + milestones work added ~4.2K. Threshold is 30,000. **The Region is ~16% over budget before Arc B adds anything.** B-1 (~150–200 LOC) pushes further. The `intelligence-cards.js` sub-split is no longer a soft watch-item — Lyra/Cipher should treat it as a near-term precondition or pair a split with the first Arc B impl PR.
 
-Arc A Phase 3 is blocked on this layer. Hence this Arc B — surgically targeted upgrades, sized to unblock Arc A Phase 3 and resolve the boundary smells the capability map (corrected) surfaced.
+This dead-data substrate is what the diet surfacing needs. Hence this Arc B — surgically targeted intelligence-layer upgrades that pipe `chem.*` / `COMBO_RULES` to consumers (now the `food-sub-tab-v1` `[Patterns]`/`[Library]` phases, post-reconciliation) and resolve the boundary smells the capability map (corrected) surfaced. (The original "unblock Arc A Phase 3" framing is retired — Arc A is superseded; the consuming surface is the food-sub-tab arc.)
 
 ## Scope
 
@@ -56,6 +62,23 @@ Arc A Phase 3 is blocked on this layer. Hence this Arc B — surgically targeted
 - **Diet-side surfaces (`diet.js`, `home.js`, `core.js` segment routing) — see Arc A (C-REQ-3 boundary).**
 
 **Hard boundary.** Arc B does not modify ISL semantics — it extends ISL surface. Existing intents, handlers, and accessors keep their contracts. New surfaces are additive.
+
+## Surfacing re-home → folded into food-sub-tab arc (2026-05-28; folded 2026-05-29)
+
+Arc B's engine outputs were originally surfaced by Arc A's `[Today]` / `[Score]` / `[Library]` segments. Arc A is superseded by the merged `food-sub-tab-v1` IA, so the surfacing is **folded into the food-sub-tab arc** (PR #173 amends `food-sub-tab-v1.md` F-3/F-4) rather than carried as Arc B phases. Targets on `main` use `switchDietSub` / `.diet-sub-panel`:
+
+| Engine output (Arc B B-1) | Consumer (food-sub-tab arc) |
+|---|---|
+| `renderInfoChemVariety` (Fibre Variety + Bioactive Diversity tiles) | **F-4** `[Patterns]` sub-tab |
+| `renderInfoVarietyNudge` (Variety-nudge tile, V-M-48 copy locked) | **F-4** `[Patterns]` sub-tab |
+| Per-food Chemistry detail (`chem.fibre`/`antiNutrients`/`bioactives`) | **F-3** `[Library]` per-food view |
+| `meal_combo_check` chip-stack (`computeMealCombos`) | **F-4** `[Patterns]` or the F-3 Log review surface (placement confirmed against F-3/F-4 surface contracts at impl time) |
+
+**Arc B retains only the engine.** The B-1 keystone trio (`chemRollup` + `meal_combo_check` intent + `qaAnswerMealCombo` + `computeMealCombos`) ships as Arc B, surface-agnostic. The card renderers above are **food-sub-tab F-3/F-4 deliverables** that consume that engine — listed here to document the contract, not as Arc B phases. (The old B-2 roadmap/PR-sequence rows are correspondingly re-homed; Arc B's own PR sequence is **B-1 → B-3 → B-4**.)
+
+**Design note (feeding read path).** `chemRollup` and `computeMealCombos` must read feeding data via the canonical reader `_fdReadDayMeal(dayObj, mealKey)` (`data.js:3160` on `main`), NOT the raw `entry[meal]` legacy string. The F-2 writer co-writes a legacy comma-string at `entry[meal]` (so a naive read works today), but the structured `items[]` sidecar carries the precise `nutritionRef` resolved at write-time — using it avoids a second-best `_baseFoodName` re-derivation AND stays correct when F-5's `parseFeeding` eventually drops the legacy co-write. (Same note folded into `food-sub-tab-v1.md` §Arc B reconciliation.)
+
+**Wave 2.5 surface references — superseded in place.** The ratified §Wave 2.5 V-M-49 locks below describe the chip-stack rendering "post-meal-save in the `[Today]` segment" (the original Arc A surface). Read those mentions as the **F-4 `[Patterns]` / F-3 Log review** surfaces per this re-home — the surface moved, the **engine locks did not**. Everything V-M-49 ratifies (the state-match dispatch table, the `medical.js` constipation read, the three-Governor cross-Region discipline, render-shape uniformity, caching/staleness, rule-#6 suppression) is surface-agnostic and stands verbatim; only the render call-site is the food-sub-tab arc rather than an Arc A segment.
 
 ## State of the union (scout #2 + Wave 2 corrections)
 
@@ -100,7 +123,7 @@ Arc A Phase 3 is blocked on this layer. Hence this Arc B — surgically targeted
 
 ## Sequencing — the keystone trio (Phase B-1)
 
-**Minimum spec-bearing change to unblock Arc A Phase 3.** Three surgical edits:
+**Minimum spec-bearing change — the engine the food-sub-tab `[Patterns]`/`[Library]` phases consume (post-reconciliation; was framed "unblock Arc A Phase 3").** Three surgical edits:
 
 ### B-1.1 — Extend `_islDietData` with `chemRollup` (`intelligence-isl.js:446–499`)
 
@@ -221,8 +244,8 @@ function qaAnswerMealCombo(intentId) {
 | 1 | Extend `_islDietData` with `chemRollup` (3 fields) | `intelligence-isl.js:446–499` | Keystone — one accessor surfaces `chem.*` to every downstream | M | none | **yes** | **B-1** |
 | 2 | Add `meal_combo_check` intent | `intelligence-qa.js:69, :1643` | Combo intelligence surface | M | #1 | **yes** | **B-1** |
 | 3 | Implement `qaAnswerMealCombo` + `computeMealCombos` data fn | `intelligence-qa-handlers.js` between `:2395`/`:2396`; `intelligence-cards.js` (data fn after `:2020`) | Required for #2; data-fn separation enables Arc A chip-stack reuse | M | #1, #2 | **yes** | **B-1** |
-| 4 | Add `renderInfoChemVariety` + `renderInfoVarietyNudge` cards | `intelligence-cards.js` after `:2020` (V-K — corrects "after `:1885`" to "after the function ends") | Surfaces `chem.fibre`+`chem.bioactives` rollup + the Variety nudge tile (V-M-48 — Maren-drafted copy locked) | M | #1; `fibreDistribution` field ship in B-2 | **yes** | **B-2** |
-| 5 | Promote `chem.antiNutrients` to UIB warnings | `intelligence-qa.js:822` `_iqGetWarnings` | UIB already builds warnings; antiNutrients is a free signal | S | #1 | **yes** | **B-2** |
+| 4 | Add `renderInfoChemVariety` + `renderInfoVarietyNudge` cards | `intelligence-cards.js` after `:2020` (V-K — corrects "after `:1885`" to "after the function ends") | Surfaces `chem.fibre`+`chem.bioactives` rollup + the Variety nudge tile (V-M-48 — Maren-drafted copy locked) | M | #1 (defer-fields `fibreDistribution`/`bioactiveTopFive` ship with the cards) | **yes** | **→ food-sub-tab F-4 (re-homed; was B-2)** |
+| 5 | Promote `chem.antiNutrients` to UIB warnings | `intelligence-qa.js:822` `_iqGetWarnings` | UIB already builds warnings; antiNutrients is a free signal | S | #1 | **yes** | **B-1+ engine (was B-2; UIB extension, not a diet-tab card)** |
 | ~~6~~ | ~~Wire `qaAnswerFavoriteFoods` handler~~ | — | **RETIRED V-K-49 — already wired at `intelligence-quicklog.js:1322`** | — | — | — | — |
 | ~~7~~ | ~~Wire `qaAnswerPredictionAccuracy` handler — or de-register intent~~ | — | **RETIRED V-K-49 — already wired at `intelligence-quicklog.js:1290`** | — | — | — | — |
 | 8 | Extend `resolveTimeQuery` with `last/this Tuesday` + `N weeks ago` | `intelligence-isl.js:242–376` | Closes most-asked temporal gap | M | none | partial | **B-3** |
@@ -291,11 +314,11 @@ function qaAnswerMealCombo(intentId) {
 |-------|------|-------|--------|--------------|-----------|----------|
 | **B-0** | **Spec (this PR)** | This document + Arc A spec + journal. | `claude/sproutlab-diet-rework-p0` (shared with Arc A) | docs-only | small | Wave 2 complete. Architect ratification pending. |
 | B-1 | Keystone trio | `chemRollup` (3 fields) + `meal_combo_check` intent + `qaAnswerMealCombo` handler + `computeMealCombos` data fn | `claude/sproutlab-isl-upgrade-p1` | Kael (4 files); Maren cross-consult on copy/schema (locked above) | medium (~150–200 LOC) | Kael Mode-1 → Lyra synth → Cipher. |
-| B-2 | Chem-variety cards + UIB antiNutrient warnings | `renderInfoChemVariety` + `renderInfoVarietyNudge` cards (after `intelligence-cards.js:~2020`); `_iqGetWarnings` antiNutrients; defer-fields `fibreDistribution` + `bioactiveTopFive` added to `chemRollup` if needed | `claude/sproutlab-isl-upgrade-p2` | Kael; Maren cross-consult on phrasing | small–medium | Kael Mode-1 + Maren cross-consult → synth → Cipher. |
+| ~~B-2~~ | **Dissolved 2026-05-29** | Chem-variety/variety-nudge **cards → food-sub-tab F-4** (PR #173); `_iqGetWarnings` antiNutrient promotion → folds into **B-1** engine track; `chemRollup` defer-fields ship with the F-4 cards if needed. | — | — | — | — |
 | B-3 | Temporal parser ext + silent-catch console.error | `resolveTimeQuery` += `last Tuesday` + `N weeks ago` (HR-12 medium); `console.error` in `intelligence-qa.js:1670–1672` | `claude/sproutlab-isl-upgrade-p3` | Kael | small | Kael Mode-1 → synth → Cipher. **(Scope-collapsed from original B-3 per V-K-49 — pre-alpha intent rows retired.)** |
 | B-4 | Boundary cleanup (hygiene) | Relocate `_qaUpdateSuggestions` + `QA_SUGGEST_POOL` + `_qaDetectDomain` → qa (~172 LOC); `renderInfoAdoption` → cards (~30 LOC). | `claude/sproutlab-isl-upgrade-p4` | Kael | small (~200 LOC moved, concat-order safe) | Kael Mode-1 → synth → Cipher. |
 
-**Dependency on Arc A.** Arc A Phase 3 depends on Arc B Phase B-1. Arc A Phases 1, 2, 4, 5, 6 are independent.
+**Arc A dependency dissolved; Arc B PR sequence is B-1 → B-3 → B-4 (2026-05-29).** Arc A is superseded (parked 2026-05-28); Arc B no longer gates or is gated by it. The former B-2 is dissolved: its chem-variety/variety-nudge **cards fold into food-sub-tab F-4** (PR #173, see §Surfacing re-home), and its `_iqGetWarnings` antiNutrient promotion folds into the **B-1** engine track. B-1/B-3/B-4 are surface-agnostic.
 
 **Regression-guard names (from Cipher Edict V + Wave 2 additions, locked):**
 - B-1: `regression-guard-chemrollup-contract`, `regression-guard-meal-combo-intent-registered`, `regression-guard-combo-tri-resolution` (V-K-53 — confirms tri-resolution catches rule #6).
@@ -303,7 +326,7 @@ function qaAnswerMealCombo(intentId) {
 - B-3: `regression-guard-temporal-tuesday-timezone-safe` (HR-12), `regression-guard-qa-dispatch-console-error` (V-K-52 — confirms catch logs to console).
 - B-4: `regression-guard-concat-order-stable` (all relocated symbols resolve under post-move concat order).
 
-**CLAUDE.md drift fix** — separate tiny docs-only PR. Single-line correction: "ISL: 22 intents with dedicated handlers" → "Smart Q&A: 30 intents (registry in `intelligence-qa.js`); ISL: temporal query parser + 6 domain-data accessors + day/range summary generators."
+**CLAUDE.md drift fix — ALREADY RESOLVED on `main` (retire this item).** The canon-gen-001 CLAUDE.md refresh already reads "Smart Q&A: 30 intents (registry in `intelligence-qa.js`)" plus the corrected ISL line ("temporal query parser + 6 domain-data accessors + day/range summary generators"). The originally-flagged separate-PR correction (was: "ISL: 22 intents with dedicated handlers") is no longer needed.
 
 ## Open questions — Wave 2 resolutions
 
@@ -435,4 +458,4 @@ OR retain the conditional copy as Maren originally approved, accepting the small
 
 ---
 
-— Lyra (main-session Wave 1.5 + Wave 2 synthesis from scribe-scout #2 + Maren/Kael/Cipher/Aurelius Mode-1 audits + Wave 2.5 V-M-49 refinement), 2026-05-23, against `616071c`. cc-018 status: `ratified` (Architect signature 2026-05-23 — Wave 2 + Wave 2.5 spec enters implementation phase; per-phase Kael Mode-1 audits + Maren/Vela cross-consult run at each ship PR per the PR sequence table above).
+— Lyra (main-session Wave 1.5 + Wave 2 synthesis from scribe-scout #2 + Maren/Kael/Cipher/Aurelius Mode-1 audits + Wave 2.5 V-M-49 refinement), 2026-05-23, against `616071c`. cc-018 status: `ratified` (Architect signature 2026-05-23 — Wave 2 + Wave 2.5 spec enters implementation phase; per-phase Kael Mode-1 audits + Maren/Vela cross-consult run at each ship PR per the PR sequence table above). **Post-ratification reconciliation 2026-05-28 → 2026-05-29 (this change):** Arc A superseded by the merged `food-sub-tab-v1` IA; Arc B's surfacing folded into that arc (#173); Arc B narrowed to engine + hygiene (B-1 → B-3 → B-4, former B-2 dissolved). Ratified Wave 2 / Wave 2.5 body — incl. V-M-49 cross-Region locks — unchanged; only the surfacing home moved. See §Status + §Surfacing re-home.


### PR DESCRIPTION
## What this does

Re-applies the **Arc B (ISL Upgrade) narrowing** + **Arc A parking** that were authored on the held **#113**, but onto `main`'s *current* spec — which carries **#114's ratified Wave 2.5 body** (the V-M-49 / V-M-50 locks). This is the "land Arc B properly" follow-up promised when #113 was held: #113's branch had **forked** from `main` and merging it as-is would have deleted ratified content. **Supersedes #113.**

## Why #113 couldn't just be merged

Unshallowing the history showed #113's `isl-upgrade-v1.md` / `diet-rework-v1.md` diverged from `main`'s copies (which came from #114). Merging #113 would have clobbered the entire `## Wave 2.5` lock sections — including the *"constipation lives in medical.js, NOT intelligence-illness.js"* correction and the API-surface / jurisdictional / render-contract / caching / rule-#6 locks. So the narrowing had to be **re-applied on top of `main`**, not merged over it.

## What landed

Cherry-picked the two narrowing commits from #113 (`7680a13` + `9667df3`), then reconciled:

- **`isl-upgrade-v1.md` (Arc B)** — narrowed to **engine + hygiene**. §Surfacing re-home folds B-2's chem-variety / variety-nudge cards into **food-sub-tab F-4 `[Patterns]`** and per-food Chemistry into **F-3 `[Library]`** (PR #173). PR sequence is now **B-1 → B-3 → B-4**; former B-2 dissolved. Region LOC re-baselined 30,725 → 34,907. Added the `_fdReadDayMeal` feeding-read design note. "unblock Arc A Phase 3" framing retired. CLAUDE.md drift item marked already-resolved on `main`.
- **`diet-rework-v1.md` (Arc A)** — marked **superseded** by the merged `food-sub-tab-v1` IA; V-M-50 carried forward as a Care gap. Body retained as provenance.

## Reconciliation over #113 (the part that makes this not a blind re-merge)

- ✅ **#114's Wave 2.5 lock bodies preserved byte-identical to `main`** (V-M-49 cross-Region read locks; V-M-50 chip locks) — verified by section diff.
- ✅ Both specs are `ratified` on `main`, so the narrowing is reframed as a **dated post-ratification amendment**, resolving the top/closing-signature contradictions the stale-base narrowing would otherwise introduce: isl stays `ratified`; diet moves `ratified → superseded`; authority-chain status words aligned.
- ✅ Added a pointer noting the Wave 2.5 V-M-49 `[Today] segment` surface mentions are **superseded-in-place** by the F-4/F-3 re-home — the engine locks stand verbatim, only the render call-site moves.

## Scope / gate

Docs-only (`docs/specs/*.md`) → **canon-cc-008 Governor audit waived** per the docs-only carve-out.

## Follow-up

Once this merges, **#113 can be closed** as superseded (it's held as draft with a fork-warning comment).

https://claude.ai/code/session_01QMQk72WmE7ezu3mVB5BHwU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMQk72WmE7ezu3mVB5BHwU)_