### PR TITLE
fix(sync+a11y+hr3): #53 snapshot-straggler guard + #6 live follow-ups + app-wide live-region a11y

### DIFF
--- a/docs/CARETICKET_STATE_MACHINE.html
+++ b/docs/CARETICKET_STATE_MACHINE.html
@@ -91,7 +91,7 @@ code { font-family: var(--mono); font-size: 12px; color: var(--ink); }
 </head>
 <body>
 <h1>CareTicket State Machine</h1>
-<p class="subtitle">SproutLab — 6-transition lifecycle, spec vs implementation. Generated <code>2026-05-28</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on transition-layout snapshots</strong>; <code>CARETICKETS_SPEC_v5.md</code> wins on transition rationale; CLAUDE.md wins on rules, HRs, build commands, persona.</p>
+<p class="subtitle">SproutLab — 6-transition lifecycle, spec vs implementation. Generated <code>2026-05-29</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on transition-layout snapshots</strong>; <code>CARETICKETS_SPEC_v5.md</code> wins on transition rationale; CLAUDE.md wins on rules, HRs, build commands, persona.</p>
 
 <div class="diagram-wrap">
 <svg viewBox="0 0 520 420" width="520" height="420">

--- a/docs/POOP_COLOR_REFERENCE.html
+++ b/docs/POOP_COLOR_REFERENCE.html
@@ -108,7 +108,7 @@ code { font-family: var(--mono); font-size: 12px; color: var(--ink-soft); }
 </head>
 <body>
 <h1>Poop-Color Reference</h1>
-<p class="subtitle">SproutLab — token + render + contrast + lexicon snapshot. Generated <code>2026-05-28</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on token-value snapshots</strong>; CLAUDE.md wins on usage rules.</p>
+<p class="subtitle">SproutLab — token + render + contrast + lexicon snapshot. Generated <code>2026-05-29</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on token-value snapshots</strong>; CLAUDE.md wins on usage rules.</p>
 
 <div class="meta-bar">
   <span>light <code>--warm</code> <code>#fef6f0</code></span>

--- a/index.html
+++ b/index.html
@@ -10826,7 +10826,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
       <div class="avatar" id="avatarEl" data-action="openAvatarLightbox"><svg class="zi" aria-hidden="true"><use href="#zi-sprout"/></svg></div>
       <div class="avatar-edit" data-action="editAvatar">Edit</div>
     </div>
-    <input type="file" id="avatarInput" accept="image/*" onchange="handleAvatar(event)">
+    <input type="file" id="avatarInput" accept="image/*" data-change-action="handleAvatar">
     <div class="header-info">
       <h1><span id="greetingText">Hello</span>, <span id="babyName">Ziva</span> <span id="greetingEmoji"><svg class="zi" aria-hidden="true"><use href="#zi-sprout"/></svg></span></h1>
       <p id="headerSub">Loading...</p>
@@ -10841,13 +10841,17 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 
   <!-- Offline / halted persistent badge (Phase 1 — sl-1-3). Driven by the
        sync-visibility store from sl-1-2; hidden in connecting/online/syncing
-       states. aria-live=polite so copy changes (including pending-count
-       updates) are announced by AT without interrupting. Reload button is
-       surfaced only in the halted state and routed through the data-action
-       dispatcher wired in sl-1-2 r3 (HR-3/HR-6). -->
-  <div id="offlineBadge" class="offline-badge" role="status" aria-live="polite" aria-atomic="true" hidden>
+       states. Issue #6 item 3 (AT smoke-pass gate): the live region lives on
+       the .offline-badge__copy span, NOT the whole badge — so the Reload button
+       is a sibling of the announced region, not a descendant, and AT does not
+       re-announce the button (or the whole badge atomically) when it toggles
+       from hidden in the halted state. aria-live=polite so copy changes
+       (including pending-count updates) are announced without interrupting.
+       Reload is surfaced only in the halted state and routed through the
+       data-action dispatcher wired in sl-1-2 r3 (HR-3/HR-6). -->
+  <div id="offlineBadge" class="offline-badge" hidden>
     <span class="offline-badge__icon" aria-hidden="true"><svg class="zi"><use href="#zi-alert-circle"/></svg></span>
-    <span class="offline-badge__copy"></span>
+    <span class="offline-badge__copy" role="status" aria-live="polite" aria-atomic="true"></span>
     <button type="button" class="offline-badge__action" data-action="syncReload" hidden>Reload</button>
   </div>
 
@@ -20112,6 +20116,17 @@ function init() {
     if (e.target.classList.contains('vc-check-input')) {
       const label = e.target.closest('.vc-complete-check');
       if (label) label.classList.toggle('checked', e.target.checked);
+    }
+    // HR-3 (issue #6 item 1a): delegated change-action routing for elements that
+    // emit 'change' rather than 'click' (file inputs, selects). Mirrors the
+    // data-action click dispatcher. The change event fires on (and `e.target` is)
+    // the input itself, so handlers receive the same event their inline
+    // `onchange="fn(event)"` did. Extend the map here rather than re-adding
+    // inline handlers (see #172 for the remaining onchange sweep).
+    const ca = e.target.closest('[data-change-action]');
+    if (ca) {
+      const action = ca.dataset.changeAction;
+      if (action === 'handleAvatar') handleAvatar(e);
     }
   });
 
@@ -73162,6 +73177,14 @@ let _syncUser = null;           // current firebase.auth().currentUser snapshot
 let _syncHouseholdId = null;    // active household doc ID
 let _syncHousehold = null;      // cached household doc data
 let _syncListenerUnsubs = [];   // onSnapshot unsubscribe fns
+// Issue #53 — listener generation. Bumped on every _syncDetachListeners().
+// Each onSnapshot callback captures the generation it was attached under and
+// bails if it no longer matches the live one — so a Firestore snapshot
+// callback already queued on the microtask loop at detach time cannot apply
+// stale state (e.g. clobber local via save(lsKey, entries)) after the listener
+// has been torn down. This guards the snapshot-APPLY path; the pre-existing
+// _reconcileDone reset (§6.2(d)) only guarded reconcile RE-FIRE.
+let _syncListenerGen = 0;
 let _remoteWriteDepth = 0;      // counter for remote write detection (used by save())
 let _syncUIRendered = false;    // guard for Settings section injection
 
@@ -73976,7 +73999,15 @@ function _syncDeleteCollection(ref) {
 }
 
 // ─── Detach Listeners ───
+// Issue #53 — inspection getter (top-level `let` is not a window property, so
+// expose the live generation for guards/tests via a hoisted function).
+function _syncListenerGenNow() { return _syncListenerGen; }
+
 function _syncDetachListeners() {
+  // Issue #53 — invalidate any snapshot callbacks already queued from the
+  // generation being torn down. Bump BEFORE unsub() so a straggler that fires
+  // synchronously during teardown is already stale.
+  _syncListenerGen++;
   _syncListenerUnsubs.forEach(function(unsub) { unsub(); });
   _syncListenerUnsubs = [];
   // C0 Fix 5 (Kael): reset listener-ready state so next attach re-earns
@@ -74399,6 +74430,11 @@ function _syncAttachListeners(hId) {
   // tracks the broader straggler limitation; this reset only protects
   // reconcile re-fire, not snapshot-apply.
   _reconcileDone = new Set();
+  // Issue #53 — capture the generation these listeners belong to. _syncDetachListeners()
+  // (called just above, and on any future re-attach) bumps _syncListenerGen; each
+  // callback below bails if its captured _gen no longer matches the live one, so a
+  // straggler snapshot queued before detach cannot apply stale state.
+  var _gen = _syncListenerGen;
   var db = firebase.firestore();
   var hRef = db.collection('households').doc(hId);
 
@@ -74426,6 +74462,7 @@ function _syncAttachListeners(hId) {
   // Data-equality checks inside the handler short-circuit metadata-only fires.
   perEntryCollections.forEach(function(col) {
     var unsub = hRef.collection(col).onSnapshot({ includeMetadataChanges: true }, function(snapshot) {
+      if (_gen !== _syncListenerGen) return;   // #53: straggler from a detached generation — do not apply
       try { if (!_syncDisabled) _syncHandlePerEntrySnapshot(col, snapshot); }
       catch(e) { _syncRecordCrash('per-entry/' + col, e); }
     }, function(err) {
@@ -74440,6 +74477,7 @@ function _syncAttachListeners(hId) {
   // Single-doc collections (in /singles/{docName})
   singleDocNames.forEach(function(docName) {
     var unsub = hRef.collection('singles').doc(docName).onSnapshot({ includeMetadataChanges: true }, function(doc) {
+      if (_gen !== _syncListenerGen) return;   // #53: straggler from a detached generation — do not apply
       try { if (!_syncDisabled) _syncHandleSingleDocSnapshot(docName, doc); }
       catch(e) { _syncRecordCrash('single-doc/' + docName, e); }
     }, function(err) {
@@ -74451,6 +74489,7 @@ function _syncAttachListeners(hId) {
 
   // Household doc listener (member changes, invite code)
   var hUnsub = hRef.onSnapshot(function(doc) {
+    if (_gen !== _syncListenerGen) return;   // #53: straggler from a detached generation — do not apply
     try {
       if (doc.exists) {
         _syncHousehold = doc.data();

--- a/index.html
+++ b/index.html
@@ -4950,6 +4950,21 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
    as a future host for PR-5's "update available" reload affordance.
    Container is always present (so its visibility is mode-independent); the
    #syncStatus child manages its own [hidden] state on cold boot per sl-1-2 r2. */
+/* Visually-hidden but present in the accessibility tree (issue #6 / V-V-2 /
+   V-M-1). Used by the persistent #a11yLive announce region: it must stay in
+   the a11y tree at all times (NOT display:none, which would remove it), so
+   _a11yAnnounce() writes reliably fire a polite announcement. Standard
+   clip-rect technique. */
+.sr-only {
+  position: absolute !important;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .status-strip {
   display:flex; align-items:center; justify-content:flex-end;
   gap:var(--sp-8);
@@ -10768,8 +10783,20 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
        Strip is a sibling of tab-bar, NOT inside #headerFull, so the
        essential-mode rule does not cascade. Future host for PR-5's "update
        available" reload affordance. HR-2: no inline styles, all via tokens. -->
+  <!-- Persistent a11y live region (issue #6 / V-V-2 / V-M-1, all-regions fix).
+       A single polite live region that is ALWAYS in the accessibility tree —
+       never inside a [hidden]/display:none ancestor. The visual status surfaces
+       below (#syncStatus, #syncActivity, #updateToast, the offline/halted badge)
+       are visual-only and announce by writing their copy here via
+       _a11yAnnounce(); they no longer carry their own aria-live, because a live
+       region that toggles via [hidden] (display:none removes it from the a11y
+       tree) does not reliably fire a polite announcement on the same tick it is
+       unhidden-and-populated, on older AT. One shared region also collapses the
+       former #syncStatus + offline-badge double-announce to a single message. -->
+  <div id="a11yLive" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></div>
+
   <div class="status-strip" id="statusStrip">
-    <button id="syncStatus" type="button" class="sync-indicator" hidden aria-live="polite" aria-atomic="true">
+    <button id="syncStatus" type="button" class="sync-indicator" hidden>
       <span class="sync-indicator__dot" aria-hidden="true"></span>
       <span class="sync-indicator__label"></span>
     </button>
@@ -10780,16 +10807,17 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
          #syncStatus visible) vs activity-mode (#syncStatus + #syncActivity
          both visible). Self-dismisses to state mode on timer expiry.
          HR-2: no inline styles; CSS in styles.css gates display via the
-         [hidden] attribute. aria-live="polite" so screen readers announce
-         the activity without interrupting current focus. -->
-    <span id="syncActivity" class="sync-activity" hidden role="status" aria-live="polite" aria-atomic="true"></span>
+         [hidden] attribute. Announcement is via the persistent #a11yLive
+         region (_a11yAnnounce in _syncSetActivity), not a per-element
+         aria-live (see #a11yLive note above). -->
+    <span id="syncActivity" class="sync-activity" hidden></span>
     <!-- Update toast (Phase 2 PR-5). Surfaced when the SW emits 'updatefound'
          AND the new worker reaches 'installed' state with an existing
          controller (= update, not first install). HR-3/HR-6: tap routes
          through data-action="syncReload" — the dispatcher wired in sl-1-2 r3.
          Lives inside #statusStrip so it survives body.essential-mode (the
          #headerFull hide rule does not cascade to the strip's siblings). -->
-    <button id="updateToast" type="button" class="update-toast" hidden role="status" aria-live="polite" aria-atomic="true" data-action="syncReload">
+    <button id="updateToast" type="button" class="update-toast" hidden data-action="syncReload">
       <span class="update-toast__icon" aria-hidden="true"><svg class="zi"><use href="#zi-sparkle"/></svg></span>
       <span class="update-toast__copy">New version available — Tap to reload</span>
     </button>
@@ -10841,17 +10869,16 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 
   <!-- Offline / halted persistent badge (Phase 1 — sl-1-3). Driven by the
        sync-visibility store from sl-1-2; hidden in connecting/online/syncing
-       states. Issue #6 item 3 (AT smoke-pass gate): the live region lives on
-       the .offline-badge__copy span, NOT the whole badge — so the Reload button
-       is a sibling of the announced region, not a descendant, and AT does not
-       re-announce the button (or the whole badge atomically) when it toggles
-       from hidden in the halted state. aria-live=polite so copy changes
-       (including pending-count updates) are announced without interrupting.
-       Reload is surfaced only in the halted state and routed through the
-       data-action dispatcher wired in sl-1-2 r3 (HR-3/HR-6). -->
+       states. Issue #6 item 3 / V-V-2 / V-M-1: this badge is VISUAL-ONLY — it
+       carries no aria-live. Its copy is announced through the persistent
+       #a11yLive region (_a11yAnnounce in _syncUpdateOfflineBadge), so the
+       announcement does not depend on this element being un-hidden in the same
+       tick its text is written (unreliable on older AT), and the Reload button
+       is never inside the announced region. Reload is surfaced only in the
+       halted state and routed through the data-action dispatcher (HR-3/HR-6). -->
   <div id="offlineBadge" class="offline-badge" hidden>
     <span class="offline-badge__icon" aria-hidden="true"><svg class="zi"><use href="#zi-alert-circle"/></svg></span>
-    <span class="offline-badge__copy" role="status" aria-live="polite" aria-atomic="true"></span>
+    <span class="offline-badge__copy"></span>
     <button type="button" class="offline-badge__action" data-action="syncReload" hidden>Reload</button>
   </div>
 
@@ -13583,9 +13610,13 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 
     <!-- App version (Phase 2 PR-3): populated at runtime by displayAppVersion()
          which fetches manifest.json and reads .version. Hidden via :empty when
-         the fetch fails or returns no version field. role=status + polite live
-         region so screen readers announce on populate without interruption. -->
-    <div class="app-version-line" id="appVersion" role="status" aria-live="polite" aria-atomic="true"></div>
+         the fetch fails or returns no version field. V-V-2 / V-M-1 (all-regions
+         fix): this is static reference info inside the settings sidebar (a
+         [hidden] ancestor when closed), NOT a status surface — so it carries no
+         live region (an in-hidden-ancestor aria-live announced unreliably and a
+         build-stamp is not a state change a parent needs spoken). A screen-reader
+         user reads it on demand when the sidebar is open. -->
+    <div class="app-version-line" id="appVersion"></div>
   </div><!-- /sidebar-body -->
 </div><!-- /sidebar -->
 <div class="avatar-lightbox" id="avatarLightbox" data-action="closeAvatarSelf">
@@ -24489,6 +24520,10 @@ if ('serviceWorker' in navigator) {
         if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
           const toast = document.getElementById('updateToast');
           if (toast) toast.removeAttribute('hidden');
+          // V-V-2 / V-M-1: announce via the persistent #a11yLive region (the toast
+          // is visual-only now — it toggles via [hidden], so its own aria-live was
+          // unreliable). Copy mirrors the .update-toast__copy span.
+          if (typeof _a11yAnnounce === 'function') _a11yAnnounce('New version available — Tap to reload');
         }
       });
     });
@@ -24528,6 +24563,26 @@ function isPWA() {
 // Read manifest.json's version field at runtime and surface it in the settings
 // sidebar's #appVersion line. Silent on any failure (network, parse, or
 // missing field) — the :empty CSS rule keeps the row collapsed in that case.
+// Announce a message through the persistent #a11yLive region (issue #6 / V-V-2 /
+// V-M-1). The region is always in the a11y tree (sr-only, never display:none),
+// so unlike the old per-element [hidden] live regions this fires reliably. Clear
+// then set on the next frame so AT registers a text change even when the new
+// message equals the current one (e.g. a repeated offline state); multiple calls
+// in one frame coalesce to the last message (collapses indicator+badge to one).
+function _a11yAnnounce(msg) {
+  if (typeof document === 'undefined') return;
+  var el = document.getElementById('a11yLive');
+  if (!el) return;
+  el.textContent = '';
+  var set = function() { var e = document.getElementById('a11yLive'); if (e) e.textContent = (msg == null ? '' : String(msg)); };
+  // rAF is paused in a backgrounded tab (Cipher Edict V finding #2) — a transition
+  // that happens while hidden would otherwise never run `set` until foreground, by
+  // which point a newer announce may have cleared it. Use a timer when hidden so the
+  // announcement still lands (the polite region will speak it on tab return).
+  if (typeof requestAnimationFrame === 'function' && !(document.hidden)) requestAnimationFrame(set);
+  else setTimeout(set, 0);
+}
+
 async function displayAppVersion() {
   try {
     const res = await fetch('manifest.json', { cache: 'no-store' });
@@ -73702,6 +73757,9 @@ function _syncSetActivity(text, attribution) {
     el.removeAttribute('data-attribution-uid');
   }
   el.removeAttribute('hidden');
+  // V-V-2 / V-M-1: announce via the persistent #a11yLive region (the pill is
+  // visual-only now — it toggles via [hidden], so its own aria-live was unreliable).
+  if (text && typeof _a11yAnnounce === 'function') _a11yAnnounce(text);
   if (_syncActivityHideTimer) clearTimeout(_syncActivityHideTimer);
   _syncActivityHideTimer = setTimeout(function() {
     if (el.parentNode) el.setAttribute('hidden', '');
@@ -74014,6 +74072,10 @@ function _syncDetachListeners() {
   // confirmation. Without this, a re-attach cycle would flush immediately
   // with the previous session's stale shadow.
   _syncReady = {};
+  // #53 (Kael audit): clearing the ready-fallback timers here is what protects
+  // the _syncArmReadyFallback path — its setTimeout callback is NOT generation-
+  // guarded (it touches flush-readiness state, not the snapshot-apply path), so
+  // this clear-on-detach is load-bearing. Do not remove assuming _gen covers it.
   Object.keys(_syncReadyTimers).forEach(function(c) {
     if (_syncReadyTimers[c]) clearTimeout(_syncReadyTimers[c]);
   });
@@ -75425,6 +75487,11 @@ function _syncUpdateStatusIndicator(snap) {
   if (labEl) labEl.textContent = label;
   btn.setAttribute('title', title);
   btn.setAttribute('aria-label', title);
+  // V-V-2 / V-M-1: announce through the persistent #a11yLive region (the button
+  // is visual-only now). Same-frame coalescing means the offline-badge copy —
+  // which subscribes after this and carries the fuller message — wins, so the
+  // parent hears one message, not the indicator + badge double-announce.
+  if (typeof _a11yAnnounce === 'function') _a11yAnnounce(title);
 
   // HR-3 / HR-6 (r3): tap-to-reload is routed through the core.js data-action
   // dispatcher. Only halted is tappable; other states are read-only pills.
@@ -75467,6 +75534,10 @@ function _syncUpdateOfflineBadge(snap) {
 
   var copyEl = badge.querySelector('.offline-badge__copy');
   if (copyEl) copyEl.textContent = copy;
+  // V-V-2 / V-M-1: announce via the persistent #a11yLive region rather than an
+  // aria-live on this (initially [hidden]) badge — reliable on older AT, and the
+  // Reload button stays outside the announced text.
+  if (typeof _a11yAnnounce === 'function') _a11yAnnounce(copy);
 
   // Reload surfaces only in halted (local fault); offline auto-resumes
   // on network restore, no user action needed.
@@ -75499,6 +75570,10 @@ function initSyncVisibility() {
       }
     } catch(e) { /* non-fatal — derived store still works from counters */ }
   }
+  // ORDER-DEPENDENT (Cipher Edict V finding #3): both subscribers fire synchronously
+  // per visibility change and each calls _a11yAnnounce(); same-frame calls coalesce to
+  // the LAST one. The offline badge must stay registered AFTER the indicator so the
+  // parent hears the badge's fuller copy, not the terser indicator title. Do not reorder.
   onSyncVisibilityChange(_syncUpdateStatusIndicator);
   onSyncVisibilityChange(_syncUpdateOfflineBadge);
 }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.28-14",
+  "version": "2026.05.29-1",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.29-1",
+  "version": "2026.05.29-3",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -5461,6 +5461,10 @@ if ('serviceWorker' in navigator) {
         if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
           const toast = document.getElementById('updateToast');
           if (toast) toast.removeAttribute('hidden');
+          // V-V-2 / V-M-1: announce via the persistent #a11yLive region (the toast
+          // is visual-only now — it toggles via [hidden], so its own aria-live was
+          // unreliable). Copy mirrors the .update-toast__copy span.
+          if (typeof _a11yAnnounce === 'function') _a11yAnnounce('New version available — Tap to reload');
         }
       });
     });
@@ -5500,6 +5504,26 @@ function isPWA() {
 // Read manifest.json's version field at runtime and surface it in the settings
 // sidebar's #appVersion line. Silent on any failure (network, parse, or
 // missing field) — the :empty CSS rule keeps the row collapsed in that case.
+// Announce a message through the persistent #a11yLive region (issue #6 / V-V-2 /
+// V-M-1). The region is always in the a11y tree (sr-only, never display:none),
+// so unlike the old per-element [hidden] live regions this fires reliably. Clear
+// then set on the next frame so AT registers a text change even when the new
+// message equals the current one (e.g. a repeated offline state); multiple calls
+// in one frame coalesce to the last message (collapses indicator+badge to one).
+function _a11yAnnounce(msg) {
+  if (typeof document === 'undefined') return;
+  var el = document.getElementById('a11yLive');
+  if (!el) return;
+  el.textContent = '';
+  var set = function() { var e = document.getElementById('a11yLive'); if (e) e.textContent = (msg == null ? '' : String(msg)); };
+  // rAF is paused in a backgrounded tab (Cipher Edict V finding #2) — a transition
+  // that happens while hidden would otherwise never run `set` until foreground, by
+  // which point a newer announce may have cleared it. Use a timer when hidden so the
+  // announcement still lands (the polite region will speak it on tab return).
+  if (typeof requestAnimationFrame === 'function' && !(document.hidden)) requestAnimationFrame(set);
+  else setTimeout(set, 0);
+}
+
 async function displayAppVersion() {
   try {
     const res = await fetch('manifest.json', { cache: 'no-store' });

--- a/split/core.js
+++ b/split/core.js
@@ -1089,6 +1089,17 @@ function init() {
       const label = e.target.closest('.vc-complete-check');
       if (label) label.classList.toggle('checked', e.target.checked);
     }
+    // HR-3 (issue #6 item 1a): delegated change-action routing for elements that
+    // emit 'change' rather than 'click' (file inputs, selects). Mirrors the
+    // data-action click dispatcher. The change event fires on (and `e.target` is)
+    // the input itself, so handlers receive the same event their inline
+    // `onchange="fn(event)"` did. Extend the map here rather than re-adding
+    // inline handlers (see #172 for the remaining onchange sweep).
+    const ca = e.target.closest('[data-change-action]');
+    if (ca) {
+      const action = ca.dataset.changeAction;
+      if (action === 'handleAvatar') handleAvatar(e);
+    }
   });
 
   

--- a/split/styles.css
+++ b/split/styles.css
@@ -4943,6 +4943,21 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
    as a future host for PR-5's "update available" reload affordance.
    Container is always present (so its visibility is mode-independent); the
    #syncStatus child manages its own [hidden] state on cold boot per sl-1-2 r2. */
+/* Visually-hidden but present in the accessibility tree (issue #6 / V-V-2 /
+   V-M-1). Used by the persistent #a11yLive announce region: it must stay in
+   the a11y tree at all times (NOT display:none, which would remove it), so
+   _a11yAnnounce() writes reliably fire a polite announcement. Standard
+   clip-rect technique. */
+.sr-only {
+  position: absolute !important;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .status-strip {
   display:flex; align-items:center; justify-content:flex-end;
   gap:var(--sp-8);

--- a/split/sync.js
+++ b/split/sync.js
@@ -532,6 +532,9 @@ function _syncSetActivity(text, attribution) {
     el.removeAttribute('data-attribution-uid');
   }
   el.removeAttribute('hidden');
+  // V-V-2 / V-M-1: announce via the persistent #a11yLive region (the pill is
+  // visual-only now — it toggles via [hidden], so its own aria-live was unreliable).
+  if (text && typeof _a11yAnnounce === 'function') _a11yAnnounce(text);
   if (_syncActivityHideTimer) clearTimeout(_syncActivityHideTimer);
   _syncActivityHideTimer = setTimeout(function() {
     if (el.parentNode) el.setAttribute('hidden', '');
@@ -844,6 +847,10 @@ function _syncDetachListeners() {
   // confirmation. Without this, a re-attach cycle would flush immediately
   // with the previous session's stale shadow.
   _syncReady = {};
+  // #53 (Kael audit): clearing the ready-fallback timers here is what protects
+  // the _syncArmReadyFallback path — its setTimeout callback is NOT generation-
+  // guarded (it touches flush-readiness state, not the snapshot-apply path), so
+  // this clear-on-detach is load-bearing. Do not remove assuming _gen covers it.
   Object.keys(_syncReadyTimers).forEach(function(c) {
     if (_syncReadyTimers[c]) clearTimeout(_syncReadyTimers[c]);
   });
@@ -2255,6 +2262,11 @@ function _syncUpdateStatusIndicator(snap) {
   if (labEl) labEl.textContent = label;
   btn.setAttribute('title', title);
   btn.setAttribute('aria-label', title);
+  // V-V-2 / V-M-1: announce through the persistent #a11yLive region (the button
+  // is visual-only now). Same-frame coalescing means the offline-badge copy —
+  // which subscribes after this and carries the fuller message — wins, so the
+  // parent hears one message, not the indicator + badge double-announce.
+  if (typeof _a11yAnnounce === 'function') _a11yAnnounce(title);
 
   // HR-3 / HR-6 (r3): tap-to-reload is routed through the core.js data-action
   // dispatcher. Only halted is tappable; other states are read-only pills.
@@ -2297,6 +2309,10 @@ function _syncUpdateOfflineBadge(snap) {
 
   var copyEl = badge.querySelector('.offline-badge__copy');
   if (copyEl) copyEl.textContent = copy;
+  // V-V-2 / V-M-1: announce via the persistent #a11yLive region rather than an
+  // aria-live on this (initially [hidden]) badge — reliable on older AT, and the
+  // Reload button stays outside the announced text.
+  if (typeof _a11yAnnounce === 'function') _a11yAnnounce(copy);
 
   // Reload surfaces only in halted (local fault); offline auto-resumes
   // on network restore, no user action needed.
@@ -2329,6 +2345,10 @@ function initSyncVisibility() {
       }
     } catch(e) { /* non-fatal — derived store still works from counters */ }
   }
+  // ORDER-DEPENDENT (Cipher Edict V finding #3): both subscribers fire synchronously
+  // per visibility change and each calls _a11yAnnounce(); same-frame calls coalesce to
+  // the LAST one. The offline badge must stay registered AFTER the indicator so the
+  // parent hears the badge's fuller copy, not the terser indicator title. Do not reorder.
   onSyncVisibilityChange(_syncUpdateStatusIndicator);
   onSyncVisibilityChange(_syncUpdateOfflineBadge);
 }

--- a/split/sync.js
+++ b/split/sync.js
@@ -7,6 +7,14 @@ let _syncUser = null;           // current firebase.auth().currentUser snapshot
 let _syncHouseholdId = null;    // active household doc ID
 let _syncHousehold = null;      // cached household doc data
 let _syncListenerUnsubs = [];   // onSnapshot unsubscribe fns
+// Issue #53 — listener generation. Bumped on every _syncDetachListeners().
+// Each onSnapshot callback captures the generation it was attached under and
+// bails if it no longer matches the live one — so a Firestore snapshot
+// callback already queued on the microtask loop at detach time cannot apply
+// stale state (e.g. clobber local via save(lsKey, entries)) after the listener
+// has been torn down. This guards the snapshot-APPLY path; the pre-existing
+// _reconcileDone reset (§6.2(d)) only guarded reconcile RE-FIRE.
+let _syncListenerGen = 0;
 let _remoteWriteDepth = 0;      // counter for remote write detection (used by save())
 let _syncUIRendered = false;    // guard for Settings section injection
 
@@ -821,7 +829,15 @@ function _syncDeleteCollection(ref) {
 }
 
 // ─── Detach Listeners ───
+// Issue #53 — inspection getter (top-level `let` is not a window property, so
+// expose the live generation for guards/tests via a hoisted function).
+function _syncListenerGenNow() { return _syncListenerGen; }
+
 function _syncDetachListeners() {
+  // Issue #53 — invalidate any snapshot callbacks already queued from the
+  // generation being torn down. Bump BEFORE unsub() so a straggler that fires
+  // synchronously during teardown is already stale.
+  _syncListenerGen++;
   _syncListenerUnsubs.forEach(function(unsub) { unsub(); });
   _syncListenerUnsubs = [];
   // C0 Fix 5 (Kael): reset listener-ready state so next attach re-earns
@@ -1244,6 +1260,11 @@ function _syncAttachListeners(hId) {
   // tracks the broader straggler limitation; this reset only protects
   // reconcile re-fire, not snapshot-apply.
   _reconcileDone = new Set();
+  // Issue #53 — capture the generation these listeners belong to. _syncDetachListeners()
+  // (called just above, and on any future re-attach) bumps _syncListenerGen; each
+  // callback below bails if its captured _gen no longer matches the live one, so a
+  // straggler snapshot queued before detach cannot apply stale state.
+  var _gen = _syncListenerGen;
   var db = firebase.firestore();
   var hRef = db.collection('households').doc(hId);
 
@@ -1271,6 +1292,7 @@ function _syncAttachListeners(hId) {
   // Data-equality checks inside the handler short-circuit metadata-only fires.
   perEntryCollections.forEach(function(col) {
     var unsub = hRef.collection(col).onSnapshot({ includeMetadataChanges: true }, function(snapshot) {
+      if (_gen !== _syncListenerGen) return;   // #53: straggler from a detached generation — do not apply
       try { if (!_syncDisabled) _syncHandlePerEntrySnapshot(col, snapshot); }
       catch(e) { _syncRecordCrash('per-entry/' + col, e); }
     }, function(err) {
@@ -1285,6 +1307,7 @@ function _syncAttachListeners(hId) {
   // Single-doc collections (in /singles/{docName})
   singleDocNames.forEach(function(docName) {
     var unsub = hRef.collection('singles').doc(docName).onSnapshot({ includeMetadataChanges: true }, function(doc) {
+      if (_gen !== _syncListenerGen) return;   // #53: straggler from a detached generation — do not apply
       try { if (!_syncDisabled) _syncHandleSingleDocSnapshot(docName, doc); }
       catch(e) { _syncRecordCrash('single-doc/' + docName, e); }
     }, function(err) {
@@ -1296,6 +1319,7 @@ function _syncAttachListeners(hId) {
 
   // Household doc listener (member changes, invite code)
   var hUnsub = hRef.onSnapshot(function(doc) {
+    if (_gen !== _syncListenerGen) return;   // #53: straggler from a detached generation — do not apply
     try {
       if (doc.exists) {
         _syncHousehold = doc.data();

--- a/split/template.html
+++ b/split/template.html
@@ -122,8 +122,20 @@
        Strip is a sibling of tab-bar, NOT inside #headerFull, so the
        essential-mode rule does not cascade. Future host for PR-5's "update
        available" reload affordance. HR-2: no inline styles, all via tokens. -->
+  <!-- Persistent a11y live region (issue #6 / V-V-2 / V-M-1, all-regions fix).
+       A single polite live region that is ALWAYS in the accessibility tree —
+       never inside a [hidden]/display:none ancestor. The visual status surfaces
+       below (#syncStatus, #syncActivity, #updateToast, the offline/halted badge)
+       are visual-only and announce by writing their copy here via
+       _a11yAnnounce(); they no longer carry their own aria-live, because a live
+       region that toggles via [hidden] (display:none removes it from the a11y
+       tree) does not reliably fire a polite announcement on the same tick it is
+       unhidden-and-populated, on older AT. One shared region also collapses the
+       former #syncStatus + offline-badge double-announce to a single message. -->
+  <div id="a11yLive" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></div>
+
   <div class="status-strip" id="statusStrip">
-    <button id="syncStatus" type="button" class="sync-indicator" hidden aria-live="polite" aria-atomic="true">
+    <button id="syncStatus" type="button" class="sync-indicator" hidden>
       <span class="sync-indicator__dot" aria-hidden="true"></span>
       <span class="sync-indicator__label"></span>
     </button>
@@ -134,16 +146,17 @@
          #syncStatus visible) vs activity-mode (#syncStatus + #syncActivity
          both visible). Self-dismisses to state mode on timer expiry.
          HR-2: no inline styles; CSS in styles.css gates display via the
-         [hidden] attribute. aria-live="polite" so screen readers announce
-         the activity without interrupting current focus. -->
-    <span id="syncActivity" class="sync-activity" hidden role="status" aria-live="polite" aria-atomic="true"></span>
+         [hidden] attribute. Announcement is via the persistent #a11yLive
+         region (_a11yAnnounce in _syncSetActivity), not a per-element
+         aria-live (see #a11yLive note above). -->
+    <span id="syncActivity" class="sync-activity" hidden></span>
     <!-- Update toast (Phase 2 PR-5). Surfaced when the SW emits 'updatefound'
          AND the new worker reaches 'installed' state with an existing
          controller (= update, not first install). HR-3/HR-6: tap routes
          through data-action="syncReload" — the dispatcher wired in sl-1-2 r3.
          Lives inside #statusStrip so it survives body.essential-mode (the
          #headerFull hide rule does not cascade to the strip's siblings). -->
-    <button id="updateToast" type="button" class="update-toast" hidden role="status" aria-live="polite" aria-atomic="true" data-action="syncReload">
+    <button id="updateToast" type="button" class="update-toast" hidden data-action="syncReload">
       <span class="update-toast__icon" aria-hidden="true"><svg class="zi"><use href="#zi-sparkle"/></svg></span>
       <span class="update-toast__copy">New version available — Tap to reload</span>
     </button>
@@ -195,17 +208,16 @@
 
   <!-- Offline / halted persistent badge (Phase 1 — sl-1-3). Driven by the
        sync-visibility store from sl-1-2; hidden in connecting/online/syncing
-       states. Issue #6 item 3 (AT smoke-pass gate): the live region lives on
-       the .offline-badge__copy span, NOT the whole badge — so the Reload button
-       is a sibling of the announced region, not a descendant, and AT does not
-       re-announce the button (or the whole badge atomically) when it toggles
-       from hidden in the halted state. aria-live=polite so copy changes
-       (including pending-count updates) are announced without interrupting.
-       Reload is surfaced only in the halted state and routed through the
-       data-action dispatcher wired in sl-1-2 r3 (HR-3/HR-6). -->
+       states. Issue #6 item 3 / V-V-2 / V-M-1: this badge is VISUAL-ONLY — it
+       carries no aria-live. Its copy is announced through the persistent
+       #a11yLive region (_a11yAnnounce in _syncUpdateOfflineBadge), so the
+       announcement does not depend on this element being un-hidden in the same
+       tick its text is written (unreliable on older AT), and the Reload button
+       is never inside the announced region. Reload is surfaced only in the
+       halted state and routed through the data-action dispatcher (HR-3/HR-6). -->
   <div id="offlineBadge" class="offline-badge" hidden>
     <span class="offline-badge__icon" aria-hidden="true"><svg class="zi"><use href="#zi-alert-circle"/></svg></span>
-    <span class="offline-badge__copy" role="status" aria-live="polite" aria-atomic="true"></span>
+    <span class="offline-badge__copy"></span>
     <button type="button" class="offline-badge__action" data-action="syncReload" hidden>Reload</button>
   </div>
 
@@ -2937,9 +2949,13 @@
 
     <!-- App version (Phase 2 PR-3): populated at runtime by displayAppVersion()
          which fetches manifest.json and reads .version. Hidden via :empty when
-         the fetch fails or returns no version field. role=status + polite live
-         region so screen readers announce on populate without interruption. -->
-    <div class="app-version-line" id="appVersion" role="status" aria-live="polite" aria-atomic="true"></div>
+         the fetch fails or returns no version field. V-V-2 / V-M-1 (all-regions
+         fix): this is static reference info inside the settings sidebar (a
+         [hidden] ancestor when closed), NOT a status surface — so it carries no
+         live region (an in-hidden-ancestor aria-live announced unreliably and a
+         build-stamp is not a state change a parent needs spoken). A screen-reader
+         user reads it on demand when the sidebar is open. -->
+    <div class="app-version-line" id="appVersion"></div>
   </div><!-- /sidebar-body -->
 </div><!-- /sidebar -->
 <div class="avatar-lightbox" id="avatarLightbox" data-action="closeAvatarSelf">

--- a/split/template.html
+++ b/split/template.html
@@ -180,7 +180,7 @@
       <div class="avatar" id="avatarEl" data-action="openAvatarLightbox"><svg class="zi" aria-hidden="true"><use href="#zi-sprout"/></svg></div>
       <div class="avatar-edit" data-action="editAvatar">Edit</div>
     </div>
-    <input type="file" id="avatarInput" accept="image/*" onchange="handleAvatar(event)">
+    <input type="file" id="avatarInput" accept="image/*" data-change-action="handleAvatar">
     <div class="header-info">
       <h1><span id="greetingText">Hello</span>, <span id="babyName">Ziva</span> <span id="greetingEmoji"><svg class="zi" aria-hidden="true"><use href="#zi-sprout"/></svg></span></h1>
       <p id="headerSub">Loading...</p>
@@ -195,13 +195,17 @@
 
   <!-- Offline / halted persistent badge (Phase 1 — sl-1-3). Driven by the
        sync-visibility store from sl-1-2; hidden in connecting/online/syncing
-       states. aria-live=polite so copy changes (including pending-count
-       updates) are announced by AT without interrupting. Reload button is
-       surfaced only in the halted state and routed through the data-action
-       dispatcher wired in sl-1-2 r3 (HR-3/HR-6). -->
-  <div id="offlineBadge" class="offline-badge" role="status" aria-live="polite" aria-atomic="true" hidden>
+       states. Issue #6 item 3 (AT smoke-pass gate): the live region lives on
+       the .offline-badge__copy span, NOT the whole badge — so the Reload button
+       is a sibling of the announced region, not a descendant, and AT does not
+       re-announce the button (or the whole badge atomically) when it toggles
+       from hidden in the halted state. aria-live=polite so copy changes
+       (including pending-count updates) are announced without interrupting.
+       Reload is surfaced only in the halted state and routed through the
+       data-action dispatcher wired in sl-1-2 r3 (HR-3/HR-6). -->
+  <div id="offlineBadge" class="offline-badge" hidden>
     <span class="offline-badge__icon" aria-hidden="true"><svg class="zi"><use href="#zi-alert-circle"/></svg></span>
-    <span class="offline-badge__copy"></span>
+    <span class="offline-badge__copy" role="status" aria-live="polite" aria-atomic="true"></span>
     <button type="button" class="offline-badge__action" data-action="syncReload" hidden>Reload</button>
   </div>
 

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -10826,7 +10826,7 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
       <div class="avatar" id="avatarEl" data-action="openAvatarLightbox"><svg class="zi" aria-hidden="true"><use href="#zi-sprout"/></svg></div>
       <div class="avatar-edit" data-action="editAvatar">Edit</div>
     </div>
-    <input type="file" id="avatarInput" accept="image/*" onchange="handleAvatar(event)">
+    <input type="file" id="avatarInput" accept="image/*" data-change-action="handleAvatar">
     <div class="header-info">
       <h1><span id="greetingText">Hello</span>, <span id="babyName">Ziva</span> <span id="greetingEmoji"><svg class="zi" aria-hidden="true"><use href="#zi-sprout"/></svg></span></h1>
       <p id="headerSub">Loading...</p>
@@ -10841,13 +10841,17 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 
   <!-- Offline / halted persistent badge (Phase 1 — sl-1-3). Driven by the
        sync-visibility store from sl-1-2; hidden in connecting/online/syncing
-       states. aria-live=polite so copy changes (including pending-count
-       updates) are announced by AT without interrupting. Reload button is
-       surfaced only in the halted state and routed through the data-action
-       dispatcher wired in sl-1-2 r3 (HR-3/HR-6). -->
-  <div id="offlineBadge" class="offline-badge" role="status" aria-live="polite" aria-atomic="true" hidden>
+       states. Issue #6 item 3 (AT smoke-pass gate): the live region lives on
+       the .offline-badge__copy span, NOT the whole badge — so the Reload button
+       is a sibling of the announced region, not a descendant, and AT does not
+       re-announce the button (or the whole badge atomically) when it toggles
+       from hidden in the halted state. aria-live=polite so copy changes
+       (including pending-count updates) are announced without interrupting.
+       Reload is surfaced only in the halted state and routed through the
+       data-action dispatcher wired in sl-1-2 r3 (HR-3/HR-6). -->
+  <div id="offlineBadge" class="offline-badge" hidden>
     <span class="offline-badge__icon" aria-hidden="true"><svg class="zi"><use href="#zi-alert-circle"/></svg></span>
-    <span class="offline-badge__copy"></span>
+    <span class="offline-badge__copy" role="status" aria-live="polite" aria-atomic="true"></span>
     <button type="button" class="offline-badge__action" data-action="syncReload" hidden>Reload</button>
   </div>
 
@@ -20112,6 +20116,17 @@ function init() {
     if (e.target.classList.contains('vc-check-input')) {
       const label = e.target.closest('.vc-complete-check');
       if (label) label.classList.toggle('checked', e.target.checked);
+    }
+    // HR-3 (issue #6 item 1a): delegated change-action routing for elements that
+    // emit 'change' rather than 'click' (file inputs, selects). Mirrors the
+    // data-action click dispatcher. The change event fires on (and `e.target` is)
+    // the input itself, so handlers receive the same event their inline
+    // `onchange="fn(event)"` did. Extend the map here rather than re-adding
+    // inline handlers (see #172 for the remaining onchange sweep).
+    const ca = e.target.closest('[data-change-action]');
+    if (ca) {
+      const action = ca.dataset.changeAction;
+      if (action === 'handleAvatar') handleAvatar(e);
     }
   });
 
@@ -73162,6 +73177,14 @@ let _syncUser = null;           // current firebase.auth().currentUser snapshot
 let _syncHouseholdId = null;    // active household doc ID
 let _syncHousehold = null;      // cached household doc data
 let _syncListenerUnsubs = [];   // onSnapshot unsubscribe fns
+// Issue #53 — listener generation. Bumped on every _syncDetachListeners().
+// Each onSnapshot callback captures the generation it was attached under and
+// bails if it no longer matches the live one — so a Firestore snapshot
+// callback already queued on the microtask loop at detach time cannot apply
+// stale state (e.g. clobber local via save(lsKey, entries)) after the listener
+// has been torn down. This guards the snapshot-APPLY path; the pre-existing
+// _reconcileDone reset (§6.2(d)) only guarded reconcile RE-FIRE.
+let _syncListenerGen = 0;
 let _remoteWriteDepth = 0;      // counter for remote write detection (used by save())
 let _syncUIRendered = false;    // guard for Settings section injection
 
@@ -73976,7 +73999,15 @@ function _syncDeleteCollection(ref) {
 }
 
 // ─── Detach Listeners ───
+// Issue #53 — inspection getter (top-level `let` is not a window property, so
+// expose the live generation for guards/tests via a hoisted function).
+function _syncListenerGenNow() { return _syncListenerGen; }
+
 function _syncDetachListeners() {
+  // Issue #53 — invalidate any snapshot callbacks already queued from the
+  // generation being torn down. Bump BEFORE unsub() so a straggler that fires
+  // synchronously during teardown is already stale.
+  _syncListenerGen++;
   _syncListenerUnsubs.forEach(function(unsub) { unsub(); });
   _syncListenerUnsubs = [];
   // C0 Fix 5 (Kael): reset listener-ready state so next attach re-earns
@@ -74399,6 +74430,11 @@ function _syncAttachListeners(hId) {
   // tracks the broader straggler limitation; this reset only protects
   // reconcile re-fire, not snapshot-apply.
   _reconcileDone = new Set();
+  // Issue #53 — capture the generation these listeners belong to. _syncDetachListeners()
+  // (called just above, and on any future re-attach) bumps _syncListenerGen; each
+  // callback below bails if its captured _gen no longer matches the live one, so a
+  // straggler snapshot queued before detach cannot apply stale state.
+  var _gen = _syncListenerGen;
   var db = firebase.firestore();
   var hRef = db.collection('households').doc(hId);
 
@@ -74426,6 +74462,7 @@ function _syncAttachListeners(hId) {
   // Data-equality checks inside the handler short-circuit metadata-only fires.
   perEntryCollections.forEach(function(col) {
     var unsub = hRef.collection(col).onSnapshot({ includeMetadataChanges: true }, function(snapshot) {
+      if (_gen !== _syncListenerGen) return;   // #53: straggler from a detached generation — do not apply
       try { if (!_syncDisabled) _syncHandlePerEntrySnapshot(col, snapshot); }
       catch(e) { _syncRecordCrash('per-entry/' + col, e); }
     }, function(err) {
@@ -74440,6 +74477,7 @@ function _syncAttachListeners(hId) {
   // Single-doc collections (in /singles/{docName})
   singleDocNames.forEach(function(docName) {
     var unsub = hRef.collection('singles').doc(docName).onSnapshot({ includeMetadataChanges: true }, function(doc) {
+      if (_gen !== _syncListenerGen) return;   // #53: straggler from a detached generation — do not apply
       try { if (!_syncDisabled) _syncHandleSingleDocSnapshot(docName, doc); }
       catch(e) { _syncRecordCrash('single-doc/' + docName, e); }
     }, function(err) {
@@ -74451,6 +74489,7 @@ function _syncAttachListeners(hId) {
 
   // Household doc listener (member changes, invite code)
   var hUnsub = hRef.onSnapshot(function(doc) {
+    if (_gen !== _syncListenerGen) return;   // #53: straggler from a detached generation — do not apply
     try {
       if (doc.exists) {
         _syncHousehold = doc.data();

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -4950,6 +4950,21 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
    as a future host for PR-5's "update available" reload affordance.
    Container is always present (so its visibility is mode-independent); the
    #syncStatus child manages its own [hidden] state on cold boot per sl-1-2 r2. */
+/* Visually-hidden but present in the accessibility tree (issue #6 / V-V-2 /
+   V-M-1). Used by the persistent #a11yLive announce region: it must stay in
+   the a11y tree at all times (NOT display:none, which would remove it), so
+   _a11yAnnounce() writes reliably fire a polite announcement. Standard
+   clip-rect technique. */
+.sr-only {
+  position: absolute !important;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .status-strip {
   display:flex; align-items:center; justify-content:flex-end;
   gap:var(--sp-8);
@@ -10768,8 +10783,20 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
        Strip is a sibling of tab-bar, NOT inside #headerFull, so the
        essential-mode rule does not cascade. Future host for PR-5's "update
        available" reload affordance. HR-2: no inline styles, all via tokens. -->
+  <!-- Persistent a11y live region (issue #6 / V-V-2 / V-M-1, all-regions fix).
+       A single polite live region that is ALWAYS in the accessibility tree —
+       never inside a [hidden]/display:none ancestor. The visual status surfaces
+       below (#syncStatus, #syncActivity, #updateToast, the offline/halted badge)
+       are visual-only and announce by writing their copy here via
+       _a11yAnnounce(); they no longer carry their own aria-live, because a live
+       region that toggles via [hidden] (display:none removes it from the a11y
+       tree) does not reliably fire a polite announcement on the same tick it is
+       unhidden-and-populated, on older AT. One shared region also collapses the
+       former #syncStatus + offline-badge double-announce to a single message. -->
+  <div id="a11yLive" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></div>
+
   <div class="status-strip" id="statusStrip">
-    <button id="syncStatus" type="button" class="sync-indicator" hidden aria-live="polite" aria-atomic="true">
+    <button id="syncStatus" type="button" class="sync-indicator" hidden>
       <span class="sync-indicator__dot" aria-hidden="true"></span>
       <span class="sync-indicator__label"></span>
     </button>
@@ -10780,16 +10807,17 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
          #syncStatus visible) vs activity-mode (#syncStatus + #syncActivity
          both visible). Self-dismisses to state mode on timer expiry.
          HR-2: no inline styles; CSS in styles.css gates display via the
-         [hidden] attribute. aria-live="polite" so screen readers announce
-         the activity without interrupting current focus. -->
-    <span id="syncActivity" class="sync-activity" hidden role="status" aria-live="polite" aria-atomic="true"></span>
+         [hidden] attribute. Announcement is via the persistent #a11yLive
+         region (_a11yAnnounce in _syncSetActivity), not a per-element
+         aria-live (see #a11yLive note above). -->
+    <span id="syncActivity" class="sync-activity" hidden></span>
     <!-- Update toast (Phase 2 PR-5). Surfaced when the SW emits 'updatefound'
          AND the new worker reaches 'installed' state with an existing
          controller (= update, not first install). HR-3/HR-6: tap routes
          through data-action="syncReload" — the dispatcher wired in sl-1-2 r3.
          Lives inside #statusStrip so it survives body.essential-mode (the
          #headerFull hide rule does not cascade to the strip's siblings). -->
-    <button id="updateToast" type="button" class="update-toast" hidden role="status" aria-live="polite" aria-atomic="true" data-action="syncReload">
+    <button id="updateToast" type="button" class="update-toast" hidden data-action="syncReload">
       <span class="update-toast__icon" aria-hidden="true"><svg class="zi"><use href="#zi-sparkle"/></svg></span>
       <span class="update-toast__copy">New version available — Tap to reload</span>
     </button>
@@ -10841,17 +10869,16 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 
   <!-- Offline / halted persistent badge (Phase 1 — sl-1-3). Driven by the
        sync-visibility store from sl-1-2; hidden in connecting/online/syncing
-       states. Issue #6 item 3 (AT smoke-pass gate): the live region lives on
-       the .offline-badge__copy span, NOT the whole badge — so the Reload button
-       is a sibling of the announced region, not a descendant, and AT does not
-       re-announce the button (or the whole badge atomically) when it toggles
-       from hidden in the halted state. aria-live=polite so copy changes
-       (including pending-count updates) are announced without interrupting.
-       Reload is surfaced only in the halted state and routed through the
-       data-action dispatcher wired in sl-1-2 r3 (HR-3/HR-6). -->
+       states. Issue #6 item 3 / V-V-2 / V-M-1: this badge is VISUAL-ONLY — it
+       carries no aria-live. Its copy is announced through the persistent
+       #a11yLive region (_a11yAnnounce in _syncUpdateOfflineBadge), so the
+       announcement does not depend on this element being un-hidden in the same
+       tick its text is written (unreliable on older AT), and the Reload button
+       is never inside the announced region. Reload is surfaced only in the
+       halted state and routed through the data-action dispatcher (HR-3/HR-6). -->
   <div id="offlineBadge" class="offline-badge" hidden>
     <span class="offline-badge__icon" aria-hidden="true"><svg class="zi"><use href="#zi-alert-circle"/></svg></span>
-    <span class="offline-badge__copy" role="status" aria-live="polite" aria-atomic="true"></span>
+    <span class="offline-badge__copy"></span>
     <button type="button" class="offline-badge__action" data-action="syncReload" hidden>Reload</button>
   </div>
 
@@ -13583,9 +13610,13 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 
     <!-- App version (Phase 2 PR-3): populated at runtime by displayAppVersion()
          which fetches manifest.json and reads .version. Hidden via :empty when
-         the fetch fails or returns no version field. role=status + polite live
-         region so screen readers announce on populate without interruption. -->
-    <div class="app-version-line" id="appVersion" role="status" aria-live="polite" aria-atomic="true"></div>
+         the fetch fails or returns no version field. V-V-2 / V-M-1 (all-regions
+         fix): this is static reference info inside the settings sidebar (a
+         [hidden] ancestor when closed), NOT a status surface — so it carries no
+         live region (an in-hidden-ancestor aria-live announced unreliably and a
+         build-stamp is not a state change a parent needs spoken). A screen-reader
+         user reads it on demand when the sidebar is open. -->
+    <div class="app-version-line" id="appVersion"></div>
   </div><!-- /sidebar-body -->
 </div><!-- /sidebar -->
 <div class="avatar-lightbox" id="avatarLightbox" data-action="closeAvatarSelf">
@@ -24489,6 +24520,10 @@ if ('serviceWorker' in navigator) {
         if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
           const toast = document.getElementById('updateToast');
           if (toast) toast.removeAttribute('hidden');
+          // V-V-2 / V-M-1: announce via the persistent #a11yLive region (the toast
+          // is visual-only now — it toggles via [hidden], so its own aria-live was
+          // unreliable). Copy mirrors the .update-toast__copy span.
+          if (typeof _a11yAnnounce === 'function') _a11yAnnounce('New version available — Tap to reload');
         }
       });
     });
@@ -24528,6 +24563,26 @@ function isPWA() {
 // Read manifest.json's version field at runtime and surface it in the settings
 // sidebar's #appVersion line. Silent on any failure (network, parse, or
 // missing field) — the :empty CSS rule keeps the row collapsed in that case.
+// Announce a message through the persistent #a11yLive region (issue #6 / V-V-2 /
+// V-M-1). The region is always in the a11y tree (sr-only, never display:none),
+// so unlike the old per-element [hidden] live regions this fires reliably. Clear
+// then set on the next frame so AT registers a text change even when the new
+// message equals the current one (e.g. a repeated offline state); multiple calls
+// in one frame coalesce to the last message (collapses indicator+badge to one).
+function _a11yAnnounce(msg) {
+  if (typeof document === 'undefined') return;
+  var el = document.getElementById('a11yLive');
+  if (!el) return;
+  el.textContent = '';
+  var set = function() { var e = document.getElementById('a11yLive'); if (e) e.textContent = (msg == null ? '' : String(msg)); };
+  // rAF is paused in a backgrounded tab (Cipher Edict V finding #2) — a transition
+  // that happens while hidden would otherwise never run `set` until foreground, by
+  // which point a newer announce may have cleared it. Use a timer when hidden so the
+  // announcement still lands (the polite region will speak it on tab return).
+  if (typeof requestAnimationFrame === 'function' && !(document.hidden)) requestAnimationFrame(set);
+  else setTimeout(set, 0);
+}
+
 async function displayAppVersion() {
   try {
     const res = await fetch('manifest.json', { cache: 'no-store' });
@@ -73702,6 +73757,9 @@ function _syncSetActivity(text, attribution) {
     el.removeAttribute('data-attribution-uid');
   }
   el.removeAttribute('hidden');
+  // V-V-2 / V-M-1: announce via the persistent #a11yLive region (the pill is
+  // visual-only now — it toggles via [hidden], so its own aria-live was unreliable).
+  if (text && typeof _a11yAnnounce === 'function') _a11yAnnounce(text);
   if (_syncActivityHideTimer) clearTimeout(_syncActivityHideTimer);
   _syncActivityHideTimer = setTimeout(function() {
     if (el.parentNode) el.setAttribute('hidden', '');
@@ -74014,6 +74072,10 @@ function _syncDetachListeners() {
   // confirmation. Without this, a re-attach cycle would flush immediately
   // with the previous session's stale shadow.
   _syncReady = {};
+  // #53 (Kael audit): clearing the ready-fallback timers here is what protects
+  // the _syncArmReadyFallback path — its setTimeout callback is NOT generation-
+  // guarded (it touches flush-readiness state, not the snapshot-apply path), so
+  // this clear-on-detach is load-bearing. Do not remove assuming _gen covers it.
   Object.keys(_syncReadyTimers).forEach(function(c) {
     if (_syncReadyTimers[c]) clearTimeout(_syncReadyTimers[c]);
   });
@@ -75425,6 +75487,11 @@ function _syncUpdateStatusIndicator(snap) {
   if (labEl) labEl.textContent = label;
   btn.setAttribute('title', title);
   btn.setAttribute('aria-label', title);
+  // V-V-2 / V-M-1: announce through the persistent #a11yLive region (the button
+  // is visual-only now). Same-frame coalescing means the offline-badge copy —
+  // which subscribes after this and carries the fuller message — wins, so the
+  // parent hears one message, not the indicator + badge double-announce.
+  if (typeof _a11yAnnounce === 'function') _a11yAnnounce(title);
 
   // HR-3 / HR-6 (r3): tap-to-reload is routed through the core.js data-action
   // dispatcher. Only halted is tappable; other states are read-only pills.
@@ -75467,6 +75534,10 @@ function _syncUpdateOfflineBadge(snap) {
 
   var copyEl = badge.querySelector('.offline-badge__copy');
   if (copyEl) copyEl.textContent = copy;
+  // V-V-2 / V-M-1: announce via the persistent #a11yLive region rather than an
+  // aria-live on this (initially [hidden]) badge — reliable on older AT, and the
+  // Reload button stays outside the announced text.
+  if (typeof _a11yAnnounce === 'function') _a11yAnnounce(copy);
 
   // Reload surfaces only in halted (local fault); offline auto-resumes
   // on network restore, no user action needed.
@@ -75499,6 +75570,10 @@ function initSyncVisibility() {
       }
     } catch(e) { /* non-fatal — derived store still works from counters */ }
   }
+  // ORDER-DEPENDENT (Cipher Edict V finding #3): both subscribers fire synchronously
+  // per visibility change and each calls _a11yAnnounce(); same-frame calls coalesce to
+  // the LAST one. The offline badge must stay registered AFTER the indicator so the
+  // parent hears the badge's fuller copy, not the terser indicator title. Do not reorder.
   onSyncVisibilityChange(_syncUpdateStatusIndicator);
   onSyncVisibilityChange(_syncUpdateOfflineBadge);
 }

--- a/tests/e2e/a11y-live-region.spec.ts
+++ b/tests/e2e/a11y-live-region.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Issue #6 / V-V-2 / V-M-1 — persistent shared a11y live region (all-regions fix).
+//
+// The 5 status surfaces (sync indicator, sync activity pill, update toast,
+// offline/halted badge, app version) previously each carried their own
+// aria-live/role=status on an element toggled via [hidden]. A live region inside
+// a display:none ancestor is removed from the accessibility tree, so a same-tick
+// unhide-then-write does not reliably announce on older AT. The fix routes all
+// announcements through a single persistent #a11yLive region that is ALWAYS in
+// the a11y tree (sr-only, never display:none), via _a11yAnnounce().
+
+async function gotoApp(page: Page): Promise<void> {
+  await page.goto('/?nosync');
+  await page.waitForFunction(() => typeof (window as any)._a11yAnnounce === 'function', null, { timeout: 15_000 });
+}
+
+test('#a11yLive persistent region exists and is in the a11y tree (not display:none)', async ({ page }) => {
+  await gotoApp(page);
+  const live = page.locator('#a11yLive');
+  await expect(live).toHaveCount(1);
+
+  const state = await page.evaluate(() => {
+    const el = document.getElementById('a11yLive')!;
+    const cs = getComputedStyle(el);
+    return {
+      hidden: el.hasAttribute('hidden'),
+      display: cs.display,
+      role: el.getAttribute('role'),
+      ariaLive: el.getAttribute('aria-live'),
+      inHiddenAncestor: !!el.closest('[hidden]'),
+    };
+  });
+  // Must be a polite status region, present and never removed from the a11y tree.
+  expect(state.role).toBe('status');
+  expect(state.ariaLive).toBe('polite');
+  expect(state.hidden).toBe(false);
+  expect(state.display).not.toBe('none');
+  expect(state.inHiddenAncestor).toBe(false);
+});
+
+test('_a11yAnnounce writes into #a11yLive', async ({ page }) => {
+  await gotoApp(page);
+  const text = await page.evaluate(async () => {
+    (window as any)._a11yAnnounce('Test announcement');
+    // _a11yAnnounce clears then sets on the next animation frame.
+    await new Promise<void>((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())));
+    return document.getElementById('a11yLive')!.textContent;
+  });
+  expect(text).toBe('Test announcement');
+});
+
+test('going offline announces through #a11yLive (not the badge\'s own aria-live)', async ({ page, context }) => {
+  await gotoApp(page);
+
+  // Sanity: the visual surfaces are now visual-only — no per-element live region.
+  const attrs = await page.evaluate(() => {
+    const ids = ['syncStatus', 'syncActivity', 'updateToast', 'appVersion'];
+    const out: Record<string, boolean> = {};
+    ids.forEach((id) => {
+      const el = document.getElementById(id);
+      out[id] = !!el && (el.hasAttribute('aria-live') || el.getAttribute('role') === 'status');
+    });
+    const copy = document.querySelector('.offline-badge__copy');
+    out['offlineBadgeCopy'] = !!copy && (copy.hasAttribute('aria-live') || copy.getAttribute('role') === 'status');
+    return out;
+  });
+  // None of the visual surfaces should carry their own live region anymore.
+  expect(Object.values(attrs).some(Boolean)).toBe(false);
+
+  // Flip offline → the visibility store drives _syncUpdateOfflineBadge, which
+  // announces the offline copy through #a11yLive.
+  await context.setOffline(true);
+  await expect(page.locator('#offlineBadge')).toBeVisible({ timeout: 5_000 });
+  await expect
+    .poll(async () => page.evaluate(() => document.getElementById('a11yLive')!.textContent), { timeout: 5_000 })
+    .toContain('Offline');
+
+  await context.setOffline(false);
+});

--- a/tests/e2e/sync-listener-generation-53.spec.ts
+++ b/tests/e2e/sync-listener-generation-53.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Issue #53 — post-detach Firestore snapshot stragglers must not apply stale state.
+//
+// The fix is a listener-generation guard: _syncDetachListeners() bumps a
+// module-scope generation counter, and every onSnapshot callback captures the
+// generation it was attached under and bails (`if (_gen !== _syncListenerGen) return;`)
+// when it no longer matches. A snapshot callback already queued on the microtask
+// loop at detach time therefore cannot reach the snapshot-apply path
+// (save(lsKey, entries)) after its listener has been torn down.
+//
+// Real Firestore callbacks can't fire in the hermetic e2e harness (no backend
+// under ?nosync), so we exercise the mechanism directly through the global
+// helpers it introduces: a detach must invalidate the generation any in-flight
+// callback captured. That invariant is exactly what rejects the straggler.
+
+async function gotoApp(page: Page): Promise<void> {
+  // ?nosync skips Firebase init but keeps the sync module loaded + visibility
+  // wiring running, so the generation helpers are present on window.
+  await page.goto('/?nosync');
+  await page.waitForFunction(
+    () => typeof (window as any)._syncListenerGenNow === 'function'
+       && typeof (window as any)._syncDetachListeners === 'function',
+    null,
+    { timeout: 15_000 },
+  );
+}
+
+test('#53 — _syncDetachListeners() invalidates the generation in-flight callbacks captured', async ({ page }) => {
+  await gotoApp(page);
+
+  const result = await page.evaluate(() => {
+    const w = window as any;
+
+    // A callback attached under the current generation captures it.
+    const capturedAtAttach = w._syncListenerGenNow();
+
+    // Detach (household switch / reconnect / re-attach) tears the listeners down.
+    w._syncDetachListeners();
+    const afterDetach = w._syncListenerGenNow();
+
+    // The straggler's guard is `capturedGen !== _syncListenerGen`.
+    const stragglerIsRejected = capturedAtAttach !== afterDetach;          // must be true
+    const liveCallbackStillApplies = !(afterDetach !== w._syncListenerGenNow()); // must be true
+
+    // Generation is monotonic across repeated detaches (each invalidates the last).
+    w._syncDetachListeners();
+    const afterSecondDetach = w._syncListenerGenNow();
+
+    return {
+      capturedAtAttach,
+      afterDetach,
+      afterSecondDetach,
+      stragglerIsRejected,
+      liveCallbackStillApplies,
+    };
+  });
+
+  // Detach advanced the generation → any callback that captured the prior value is stale.
+  expect(result.afterDetach).toBe(result.capturedAtAttach + 1);
+  expect(result.stragglerIsRejected).toBe(true);
+  // A callback attached under the live generation is NOT spuriously rejected.
+  expect(result.liveCallbackStillApplies).toBe(true);
+  // Each detach invalidates the previous generation (monotonic, no reuse).
+  expect(result.afterSecondDetach).toBe(result.afterDetach + 1);
+});

--- a/tests/e2e/sync-listener-generation-53.spec.ts
+++ b/tests/e2e/sync-listener-generation-53.spec.ts
@@ -13,6 +13,13 @@ import { test, expect, type Page } from '@playwright/test';
 // under ?nosync), so we exercise the mechanism directly through the global
 // helpers it introduces: a detach must invalidate the generation any in-flight
 // callback captured. That invariant is exactly what rejects the straggler.
+//
+// COVERAGE BOUNDARY (Kael audit, #53): this test proves the generation COUNTER
+// invariant, not that the three onSnapshot callbacks actually wire the
+// `_gen !== _syncListenerGen` guard into their bodies — that call-site wiring is
+// covered by code review, not execution (a Firestore emulator would be needed to
+// fire a real queued snapshot). A future regression that dropped the `_gen` line
+// from one callback would NOT be caught here.
 
 async function gotoApp(page: Page): Promise<void> {
   // ?nosync skips Firebase init but keeps the sync module loaded + visibility


### PR DESCRIPTION
Addresses the actionable parts of **#53** and **#6**, plus an app-wide a11y live-region refactor folded in from the canon-cc-008 Governor chain. **Full e2e suite green (307 passed, 2 skipped).** Held draft per Architect.

---

## #53 — post-detach Firestore snapshot stragglers (sync.js · Kael)

In-flight `onSnapshot` callbacks queued at `_syncDetachListeners()` time could still reach `save(lsKey, entries)` and clobber local state. Fix = **generation counter**: `_syncListenerGen` bumped in detach (before unsub); `_syncAttachListeners()` captures `_gen`; each callback (per-entry/single-doc/household) bails `if (_gen !== _syncListenerGen) return;`. Chosen over flipping `_syncDisabled` to keep circuit-breaker/"halted" UI semantics clean. Regression test `sync-listener-generation-53.spec.ts`.

## #6 — Phase 1 follow-ups

- **1a (HR-3):** avatar `onchange` → `data-change-action="handleAvatar"` via the existing delegated `change` dispatcher.
- **3 (AT gate):** see the a11y refactor below — escalated from a badge-only fix to the app-wide pattern.
- **1b / 2:** triaged moot / already-done (proposing to close on merge).

## App-wide live-region a11y refactor (V-V-2 / V-M-1 — folded from the chain)

The Governors' convergent **MAJOR** finding: the app's **5 status live regions** (`#syncStatus`, `#syncActivity`, `#updateToast`, offline-badge copy, `#appVersion`) each carried `aria-live`/`role=status` on a `[hidden]`-toggled element → `display:none` removes it from the a11y tree, so a same-tick unhide+write announces **unreliably** on older AT. Per your "fix all 5 regions" call:

- One **persistent shared `#a11yLive` region** (`sr-only`, always in the a11y tree) + `.sr-only` utility + `_a11yAnnounce()` helper (clear→set next frame; same-frame calls coalesce to the last message).
- All 5 surfaces stripped of their own live region → visual-only; announcements routed through `#a11yLive`. `#appVersion` demoted to static text (reference info, not a status change).
- Net: **one reliable announcement** instead of the former indicator+badge double-announce, and no live region trapped in a hidden ancestor.
- New test `a11y-live-region.spec.ts`.

---

## canon-cc-008 chain (complete)

| Step | Result |
|------|--------|
| Build + audit gates + e2e | ✅ 307 passed, 2 skipped |
| **Kael** (engine: sync.js, core.js) | `yes` — guard sound, dispatcher clean |
| **Maren** (Care: template.html) | `yes-with-fixes` — raised V-M-1 to safety-tier; fixes folded |
| **Vela** (Surfacing: template.html) | `clear-with-notes` — double-announce fix sound; raised V-V-2 |
| **Lyra** synthesis | convergent V-V-2/V-M-1 → app-wide persistent-region fix |
| **Cipher** Edict V | `pass-with-fixes` → both folded (#2 backgrounded-tab `setTimeout` fallback; #3 subscriber-order guard-comment) |

## Remaining gate

⚠️ **#6 item 3 full closure still pends a real NVDA/JAWS/VoiceOver smoke-pass** — I can't run AT in this environment. The structure is now AT-*defensible* (persistent region, never in a hidden ancestor), which is the strongest fix achievable without a device pass. Both Vela and Maren concur the AT pass is still required to *certify* (not just defend) the announcement.

https://claude.ai/code/session_01QMQk72WmE7ezu3mVB5BHwU