### PR TITLE
docs(research): publish Care food-effects research to GitHub Pages

### DIFF
--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,64 @@
+# SproutLab Care — Food-Effects Research Layer
+
+Evidence base for surfacing **food effects** (acute risk, allergy, choking, timing) in the Care layer. Honey is the archetype; this folder is the template + spine for every food that follows.
+
+## What lives here
+
+| Artifact | Role |
+|---|---|
+| `food-effects.manifest.js` | **The data spine.** One summary record per food. Feeds the unified hub *and* is the drop-in for the in-app `FOOD_EFFECTS` table — research and product share one truth. |
+| `_TEMPLATE.food-dashboard.html` | Canonical visual-dashboard template (tabs, swipe, charts). Copy → fill. |
+| `<food>-infant-safety.md` | Full cited prose brief (source of truth). |
+| `<food>-infant-safety.html` | Long-form rendered brief. |
+| `<food>-infant-safety.visual.html` | Skim-layer dashboard (built from the template). |
+| `index.html` *(future)* | The **unified dashboard** — hub over all foods (see plan below). |
+
+Three depth layers per food: **`.visual.html`** (skim) → **`.html`** (full prose) → **`.md`** (source). All three carry the same verified figures.
+
+## Authoring a new food brief — workflow
+
+1. **Research** — `/deep-research` fan-out across the food's axes (mechanism, threshold, symptoms/reaction, forms, context). Audience: Indian family, infants 0–12mo.
+2. **Gap discipline** *(learned on honey — non-negotiable)*: third-party sources are fine for *facts that exist independently* (e.g. NFHS prevalence) but **never** a substitute for *"what body X officially says."* Pull primaries (curl + pypdf for binary PDFs). Two honey "facts" (IAP/FSSAI) were *laundered blog claims* that the primary check overturned. Flag genuinely-absent data honestly; do not manufacture it.
+3. **Write** `<food>-infant-safety.md` (cited) → `.html` (rendered) → copy `_TEMPLATE` to `.visual.html` and fill.
+4. **Append** the food's record to `food-effects.manifest.js`.
+5. Docs-only ⇒ canon-cc-008 chain-exempt. Not wired into the app until the surfacing step is ratified.
+
+## Manifest record schema
+
+```
+food, aliases[], tier, category, effect, minMonth, thresholdBasis,
+allergen, reactionType[], headline, myth{claim,truth}, watchFor[],
+timeCourse, seekCare, breastfeedingSafe, culturalNote, confidence,
+sources[], dashboard, brief, longform, lastReviewed
+```
+
+- **tier** — `critical` (acute illness: honey) · `allergen` (egg, nuts, soy) · `choking` (whole nuts, grapes, popcorn) · `timing` (cow milk, salt, sugar) · `nutritive` (default).
+- **reactionType** — `acute-toxin` · `allergy` · `choking` · `digestive` · `dental` · `renal`. Drives the unified hub's "Reactions" cross-cut.
+- **confidence** — `high` · `moderate` · `weak` (strength of the evidence base).
+
+---
+
+## Unified dashboard — architecture plan (proposed)
+
+**Goal:** one hub over many per-food briefs — browse **one** food, **compare several**, or slice by **reaction**.
+
+**Principle: the manifest is the spine; dashboards are leaves; the hub is a view.** The hub renders entirely from `food-effects.manifest.js`; each card deep-links to that food's `.visual.html`. No data is duplicated — and because the manifest is also the future app `FOOD_EFFECTS` source, the research hub and the product can never drift.
+
+### `index.html` — three modes, one data source
+
+1. **Index** — a filterable grid of all foods, grouped by `tier` / `category`, each card showing `headline` + `minMonth` + a confidence badge, linking to the deep dashboard.
+2. **Compare** — pick 2–4 foods → a side-by-side table (minMonth, tier, allergen, effect, watch-for, seek-care). Answers "egg vs cow's milk vs honey — what's the difference?"
+3. **Reactions** — cross-cut by `reactionType`: group foods by *how* they can harm (allergy / choking / acute-toxin / renal / dental) and map each to its `watchFor` signs. This is the "foods **and** reactions" axis.
+
+### Why now (the conceptual hook)
+
+The data model already supports this. Per food the app holds `AGE_RULES` (gate), `ALLERGENS` (note), `NUTRITION` (facts); the manifest adds the **effect + reaction** layer. The hub is just a *view-join* over the manifest — so once ~5 foods exist, the hub is a few hours of build, not a research effort. **Personalisation tie-in (later):** the in-app version can overlay Ziva's own `foods[]` log (`reaction: ok|watch`) onto the same records — "foods she's tried, and how she reacted" — using the identical spine.
+
+### Phasing
+
+- **Phase 0 — now:** template + manifest + honey. ✅
+- **Phase 1:** 3–4 more critical/allergen foods (whole nuts · egg · cow's milk · salt), each appending to the manifest.
+- **Phase 2:** build `index.html` once the manifest has ~5 foods (Index + Compare + Reactions).
+- **Phase 3:** wire the manifest into the app `data.js FOOD_EFFECTS` for the Finding-A surfacing (separate, ratified change — canon-cc-008 applies there).
+
+> Net: every food we research compounds. The manifest makes the unified dashboard nearly free, and doubles as the product's data source — one spine, three consumers (research hub, skim dashboards, in-app surfacing).

--- a/docs/research/_TEMPLATE.food-dashboard.html
+++ b/docs/research/_TEMPLATE.food-dashboard.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<!-- ═══════════════════════════════════════════════════════════════════════
+  FOOD-DASHBOARD TEMPLATE · SproutLab Care research layer
+  Copy this file to  <food>-infant-safety.visual.html  and fill the {{...}}.
+  Canonical CSS + JS (tab swiping, arrow keys, charts) — DO NOT diverge; if you
+  improve a component, update this template so all dashboards inherit it.
+
+  TABS are generic; relabel per food TYPE:
+    • critical/acute-toxin (honey)  → Summary · The Science · Symptoms & Care · Context · Sources · Data
+    • allergen (egg, nuts, soy)     → Summary · Why/Allergen · Reaction & Introduction · Context · Sources · Data
+    • choking (whole nuts, grapes)  → Summary · The Hazard · Safe Prep · Context · Sources · Data
+    • timing (cow milk, salt, sugar)→ Summary · Why this age · Effects · Context · Sources · Data
+
+  COMPONENT LIBRARY (copy from the commented block at the bottom of <body>):
+    stat tiles · bar chart · donut (SVG) · timeline · thermometer split ·
+    consensus matrix · flag callouts · badges.
+  Every chart value MUST also appear as text (machine-readable for agents).
+  After filling: append a record to food-effects.manifest.js.
+═══════════════════════════════════════════════════════════════════════ -->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{FOOD}} &amp; Infant Safety — Visual Dashboard · SproutLab Care</title>
+<style>
+  :root{
+    --bg:#faf6f0; --card:#fffdf9; --ink:#2e2a26; --mid:#6b6258; --line:#e8ddcf; --track:#efe7da;
+    --sage:#3a7060; --sage-bg:#e8f5ef; --rose:#b04a5e; --rose-bg:#fbe9ec;
+    --amber:#9a7320; --amber-bg:#fbf0d9; --accent:#9a6a3a; --honey:#d99a2b; --honey-bg:#fbeccb;
+    --hi:#2f7d5b; --hi-bg:#e3f3ea; --mod:#9a7320; --mod-bg:#f7eed6; --weak:#9a5a5a; --weak-bg:#f5e6e6;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#1d1a17; --card:#262220; --ink:#ece5db; --mid:#a89c8c; --line:#3a342d; --track:#332d26;
+    --sage:#7ac0a0; --sage-bg:#1e3028; --rose:#e090a0; --rose-bg:#3a2026;
+    --amber:#e0b060; --amber-bg:#352a16; --accent:#c99a6a; --honey:#e8b34a; --honey-bg:#3a2c12;
+    --hi:#7ac0a0; --hi-bg:#1e3028; --mod:#d8b060; --mod-bg:#332a14; --weak:#e09090; --weak-bg:#3a2222; }}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Nunito,sans-serif;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:960px;margin:0 auto;padding:0 18px 90px}
+  header{background:linear-gradient(160deg,var(--honey-bg),var(--bg));border-bottom:1px solid var(--line);padding:26px 0 0}
+  h1{font:700 25px/1.2 Fraunces,Georgia,serif;margin:0 0 4px}
+  .sub{color:var(--mid);font-size:14px;margin:0 0 16px;max-width:680px}
+  nav{display:flex;gap:4px;margin-top:6px;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none}
+  nav::-webkit-scrollbar{display:none}
+  .tab{appearance:none;border:0;background:transparent;color:var(--mid);font:600 13.5px/1 Nunito,sans-serif;white-space:nowrap;flex:0 0 auto;
+    padding:11px 14px;border-radius:10px 10px 0 0;cursor:pointer;border-bottom:3px solid transparent}
+  .tab:hover{color:var(--ink);background:var(--card)}
+  .tab.on{color:var(--accent);background:var(--card);border-bottom-color:var(--accent)}
+  .panel{display:none;animation:f .25s ease}.panel.on{display:block}
+  @keyframes f{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:none}}
+  h2{font:600 18px/1.3 Fraunces,Georgia,serif;margin:26px 0 10px}
+  h3{font:700 13px/1.3 Nunito;text-transform:uppercase;letter-spacing:.4px;color:var(--mid);margin:18px 0 8px}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:16px 18px;margin:12px 0}
+  .grid{display:grid;gap:12px}.g2{grid-template-columns:1fr 1fr}.g3{grid-template-columns:repeat(3,1fr)}.g4{grid-template-columns:repeat(4,1fr)}
+  @media(max-width:680px){.g2,.g3,.g4{grid-template-columns:1fr 1fr}}
+  .stat{text-align:center;padding:16px 10px}
+  .stat .n{font:800 26px/1 Fraunces,Georgia,serif;color:var(--accent)}
+  .stat .l{font-size:12px;color:var(--mid);margin-top:6px;line-height:1.35}
+  .stat.crit .n{color:var(--rose)}.stat.ok .n{color:var(--sage)}
+  .badge{display:inline-block;font:700 10.5px/1 Nunito;text-transform:uppercase;letter-spacing:.3px;padding:4px 8px;border-radius:6px;vertical-align:middle}
+  .b-hi{background:var(--hi-bg);color:var(--hi)}.b-mod{background:var(--mod-bg);color:var(--mod)}.b-weak{background:var(--weak-bg);color:var(--weak)}.b-crit{background:var(--rose-bg);color:var(--rose)}
+  .bar{display:grid;grid-template-columns:130px 1fr 52px;align-items:center;gap:10px;margin:7px 0;font-size:13px}
+  .bar .lab{color:var(--ink);text-align:right;font-weight:600}
+  .bar .trk{display:block;background:var(--track);border:1px solid var(--line);border-radius:7px;height:18px;overflow:hidden}
+  .bar .fil{display:block;height:100%;border-radius:6px;background:var(--sage);min-width:3px}
+  .bar .val{font-weight:700;color:var(--mid);font-size:12.5px}
+  .bar.hl .fil{background:var(--honey)}.bar.hl .lab{color:var(--honey)}.bar.hl .val{color:var(--honey)}
+  .tl{position:relative;margin:14px 0 6px;padding-left:8px}
+  .tl-step{position:relative;padding:0 0 18px 26px;border-left:2px solid var(--line)}
+  .tl-step:last-child{border-left-color:transparent}
+  .tl-dot{position:absolute;left:-8px;top:1px;width:15px;height:15px;border-radius:50%;background:var(--card);border:3px solid var(--accent)}
+  .tl-step.crit .tl-dot{border-color:var(--rose)}.tl-step.first .tl-dot{border-color:var(--honey)}
+  .tl-t{font-weight:700;font-size:13.5px}.tl-d{color:var(--mid);font-size:12.5px}
+  .flag{border-left:3px solid var(--amber);background:var(--amber-bg);border-radius:6px;padding:10px 14px;margin:10px 0;font-size:13px}
+  .flag.good{border-left-color:var(--sage);background:var(--sage-bg)}.flag.bad{border-left-color:var(--rose);background:var(--rose-bg)}
+  table{width:100%;border-collapse:collapse;font-size:13px;margin:8px 0}
+  th,td{padding:8px 9px;border-bottom:1px solid var(--line);text-align:left;vertical-align:top}
+  th{font:700 11px/1.2 Nunito;text-transform:uppercase;letter-spacing:.3px;color:var(--mid)}
+  td.c{text-align:center;font-weight:800}.yes{color:var(--sage)}.no{color:var(--rose)}.dash{color:var(--mid)}
+  td a{color:var(--sage);font-size:12px;word-break:break-all}
+  .pill{display:inline-block;font:600 11px/1 Nunito;padding:5px 10px;border-radius:999px;background:var(--card);border:1px solid var(--line);color:var(--mid);margin:0 4px 4px 0}
+  .pill.warn{background:var(--rose-bg);color:var(--rose);border-color:transparent}
+  .jump{display:inline-block;font-weight:700;color:var(--accent);cursor:pointer;border-bottom:1px dashed var(--accent)}
+  .lead{font-size:16px;line-height:1.5}.lead b{color:var(--accent)}
+  pre{background:#1e1b18;color:#e8e2d6;border-radius:12px;padding:16px;overflow:auto;font:12px/1.5 "SF Mono",Menlo,Consolas,monospace}
+  .therm{display:flex;gap:14px;flex-wrap:wrap}
+  .therm .col{flex:1;min-width:200px;border:1px solid var(--line);border-radius:12px;padding:14px;text-align:center}
+  .therm .big{font:800 19px/1 Fraunces,serif;margin:6px 0}
+  .col.safe{background:var(--sage-bg)}.col.danger{background:var(--rose-bg)}.col.safe .big{color:var(--sage)}.col.danger .big{color:var(--rose)}
+  .foot{color:var(--mid);font-size:12.5px;text-align:center;margin-top:30px}
+</style>
+</head>
+<body>
+<header><div class="wrap">
+  <h1>{{FOOD}} &amp; Infant Safety — Visual Dashboard</h1>
+  <p class="sub">{{ONE-LINE PURPOSE — what this food is and why it has an effect worth surfacing.}}</p>
+  <nav>
+    <button class="tab on" data-p="p-sum">Summary</button>
+    <button class="tab" data-p="p-why">{{Why / Science}}</button>
+    <button class="tab" data-p="p-sym">{{Symptoms / Reaction}}</button>
+    <button class="tab" data-p="p-ctx">Context</button>
+    <button class="tab" data-p="p-src">Sources &amp; Confidence</button>
+    <button class="tab" data-p="p-data">Data Stub</button>
+  </nav>
+  <p style="font-size:11.5px;color:var(--mid);margin:6px 0 10px">Swipe ‹ › between tabs · or use ← → arrow keys</p>
+</div></header>
+
+<div class="wrap">
+
+  <section class="panel on" id="p-sum">
+    <div class="card" style="background:var(--honey-bg);border-color:transparent;margin-top:18px">
+      <p class="lead" style="margin:0">{{THE ONE RULE + the single most important nuance, in one or two sentences.}}</p>
+    </div>
+    <div class="grid g4">
+      <!-- stat tiles: .crit (red) / .ok (sage) / default (accent) -->
+      <div class="card stat crit"><div class="n">{{X}}</div><div class="l">{{label}}</div></div>
+      <div class="card stat crit"><div class="n">{{X}}</div><div class="l">{{label}}</div></div>
+      <div class="card stat"><div class="n">{{X}}</div><div class="l">{{label}}</div></div>
+      <div class="card stat ok"><div class="n">{{X}}</div><div class="l">{{label}}</div></div>
+    </div>
+    <h3>The things to know <span class="badge b-hi">confidence</span></h3>
+    <div class="grid g2">
+      <div class="card"><b>1 · {{point}}.</b> {{detail}} → <span class="jump" data-go="p-why">{{tab}}</span></div>
+      <div class="card"><b>2 · {{point}}.</b> {{detail}} → <span class="jump" data-go="p-why">{{tab}}</span></div>
+      <div class="card"><b>3 · {{point}}.</b> {{detail}} → <span class="jump" data-go="p-sym">{{tab}}</span></div>
+      <div class="card"><b>4 · {{point}}.</b> {{detail}} → <span class="jump" data-go="p-ctx">{{tab}}</span></div>
+    </div>
+    <h3>When to surface this</h3>
+    <div class="card flag good" style="margin-top:0"><b>Recommendation (Maren):</b> {{surfacing trigger + the highest-value lines unique to this food.}}</div>
+    <div style="margin-top:14px">
+      <span class="pill">Reviewer · Maren (Care)</span><span class="pill">{{date}}</span>
+      <span class="pill warn">Research artifact — not yet wired into the app</span>
+    </div>
+  </section>
+
+  <section class="panel" id="p-why"><h2>{{Why it matters / mechanism}}</h2>
+    <div class="card">{{content — use the thermometer / donut / timeline components as needed (see library below).}}</div>
+  </section>
+
+  <section class="panel" id="p-sym"><h2>{{Symptoms / reaction}}</h2>
+    <div class="card">{{symptom timeline + seek-care split (see library).}}</div>
+  </section>
+
+  <section class="panel" id="p-ctx"><h2>Context</h2>
+    <div class="card">{{cultural / regional / prevalence — use bar charts for prevalence (see library).}}</div>
+  </section>
+
+  <section class="panel" id="p-src">
+    <h2>Who says what — consensus matrix</h2>
+    <div class="card" style="overflow-x:auto"><table>
+      <tr><th>Authority</th><th class="c">{{claim A}}</th><th class="c">{{claim B}}</th></tr>
+      <tr><td>{{body}}</td><td class="c yes">✓</td><td class="c no">✗</td></tr>
+    </table></div>
+    <h2>Sources</h2>
+    <div class="card" style="overflow-x:auto"><table>
+      <tr><th>Authority</th><th>Link</th></tr>
+      <tr><td>{{name}}</td><td><a href="{{url}}">{{shorturl}}</a></td></tr>
+    </table></div>
+    <div class="flag"><b>⚑ Open gaps:</b> {{honestly flag anything unverified or genuinely absent.}}</div>
+  </section>
+
+  <section class="panel" id="p-data"><h2>Drop-in record — <code>FOOD_EFFECTS['{{food}}']</code></h2>
+    <p style="font-size:13.5px;color:var(--mid)">Mirror of this food's record in <code>food-effects.manifest.js</code>. Sits alongside <code>AGE_RULES</code>/<code>ALLERGENS</code>. <b>Not yet wired.</b></p>
+<pre>{{paste the manifest record for this food}}</pre>
+  </section>
+
+  <p class="foot">SproutLab · Care visual dashboard · skim layer over <code>{{food}}-infant-safety.md</code> / <code>.html</code><br>
+  Informational, not medical advice. Not yet wired into the app. All chart values are also in text for machine-reading.</p>
+</div>
+
+<!-- ═══════ COMPONENT LIBRARY — copy a block into a panel and fill it ═══════
+<div class="bar"><span class="lab">Label</span><span class="trk"><span class="fil" style="width:73%"></span></span><span class="val">73%</span></div>
+<div class="bar hl"><span class="lab">Highlight</span><span class="trk"><span class="fil" style="width:12%"></span></span><span class="val">8.9%</span></div>
+  (bar widths are % of the track; scale all rows to the max value; ALWAYS put the real number in .val)
+
+<svg viewBox="0 0 120 120" width="118" height="118" role="img" aria-label="DESCRIBE + give the number">
+  <circle cx="60" cy="60" r="52" fill="none" stroke="var(--track)" stroke-width="15"/>
+  <circle cx="60" cy="60" r="52" fill="none" stroke="var(--honey)" stroke-width="15"
+    stroke-dasharray="PCT_LEN REST" stroke-dashoffset="0" transform="rotate(-90 60 60)" stroke-linecap="round"/>
+  <text x="60" y="58" text-anchor="middle" font-size="20" font-weight="800" fill="var(--honey)" font-family="Fraunces,serif">~20%</text>
+</svg>
+  (circumference for r=52 is 326.7; PCT_LEN = pct*3.267, REST = 326.7 - PCT_LEN)
+
+<div class="tl"><div class="tl-step first"><span class="tl-dot"></span><div class="tl-t">First sign</div><div class="tl-d">detail</div></div>
+  <div class="tl-step crit"><span class="tl-dot"></span><div class="tl-t">Emergency</div><div class="tl-d">detail</div></div></div>
+
+<div class="therm"><div class="col safe"><div style="font-size:12px;color:var(--mid)">A</div><div class="big">safe fact</div><div>detail</div></div>
+  <div class="col danger"><div style="font-size:12px;color:var(--mid)">B</div><div class="big">danger fact</div><div>detail</div></div></div>
+
+<div class="flag good|bad"><b>label</b> text</div>   ·   <span class="badge b-hi|b-mod|b-weak">confidence</span>
+═══════════════════════════════════════════════════════════════════════ -->
+
+<script>
+  var tabs = Array.prototype.slice.call(document.querySelectorAll('.tab'));
+  function activate(t){
+    if(!t) return;
+    tabs.forEach(function(x){x.classList.remove('on');});
+    document.querySelectorAll('.panel').forEach(function(x){x.classList.remove('on');});
+    t.classList.add('on');
+    var el = document.getElementById(t.dataset.p); if(el) el.classList.add('on');
+    t.scrollIntoView({inline:'center', block:'nearest'}); window.scrollTo(0,0);
+  }
+  tabs.forEach(function(t){ t.addEventListener('click', function(){ activate(t); }); });
+  document.querySelectorAll('[data-go]').forEach(function(j){
+    j.addEventListener('click', function(){ activate(document.querySelector('.tab[data-p="'+j.dataset.go+'"]')); });
+  });
+  function step(d){ var c=tabs.findIndex(function(t){return t.classList.contains('on');}); var n=c+d; if(n>=0&&n<tabs.length) activate(tabs[n]); }
+  var sx=0, sy=0, tracking=false;
+  document.addEventListener('touchstart', function(e){ if(e.touches.length>1){tracking=false;return;} sx=e.changedTouches[0].clientX; sy=e.changedTouches[0].clientY; tracking=true; }, {passive:true});
+  document.addEventListener('touchend', function(e){
+    if(!tracking) return; tracking=false;
+    var dx=e.changedTouches[0].clientX-sx, dy=e.changedTouches[0].clientY-sy;
+    if(Math.abs(dx) < 55 || Math.abs(dx) < Math.abs(dy)*1.5) return;
+    step(dx < 0 ? 1 : -1);
+  }, {passive:true});
+  document.addEventListener('keydown', function(e){ if(e.key==='ArrowRight') step(1); else if(e.key==='ArrowLeft') step(-1); });
+</script>
+</body>
+</html>

--- a/docs/research/food-effects.manifest.js
+++ b/docs/research/food-effects.manifest.js
@@ -1,0 +1,51 @@
+/* ─────────────────────────────────────────────────────────────────────────
+ * FOOD-EFFECTS MANIFEST — the single data spine for the Care food-effects layer.
+ *
+ * One lightweight summary record per researched food. This file is the source
+ * of truth that feeds BOTH:
+ *   (1) the research hub (docs/research/index.html — the unified dashboard), and
+ *   (2) eventually the in-app surfacing layer (data.js FOOD_EFFECTS), so the
+ *       research docs and the product never diverge.
+ *
+ * Each food also has a deep brief: <food>-infant-safety.{md, html, visual.html}.
+ * Append one record here whenever a new food brief is completed.
+ *
+ * tier:          critical | allergen | choking | timing | nutritive
+ * reactionType:  acute-toxin | allergy | choking | digestive | dental | renal  (array)
+ * confidence:    high | moderate | weak   (strength of the evidence base)
+ * Numbers/text mirror the verified brief; keep this in sync with the brief.
+ * ───────────────────────────────────────────────────────────────────────── */
+window.FOOD_EFFECTS_MANIFEST = [
+  {
+    food:          'honey',
+    aliases:       [],
+    tier:          'critical',
+    category:      'sweetener',
+    effect:        'infant botulism',
+    minMonth:      12,
+    thresholdBasis:'conservative',          // gut defenses develop ~6mo+ (WHO); 12mo = universal floor
+    allergen:      false,
+    reactionType:  ['acute-toxin'],
+    headline:      'Avoid before 12 months — honey can cause infant botulism.',
+    myth:          { claim:'Cooking or baking makes honey safe.',
+                     truth:'No — spores survive baking; honey in biscuits/cooked dishes is still unsafe.' },
+    watchFor:      ['constipation (often first)','weak/altered cry','poor feeding','floppiness','drooping eyelids'],
+    timeCourse:    'within days to a few weeks (commonly 3–30 days)',
+    seekCare:      'Medical emergency. Treatable (BabyBIG); recovery usually full with prompt care.',
+    breastfeedingSafe: true,
+    culturalNote:  'Indian prelacteal practices (janam ghutti, honey on lips/finger) are a real vector.',
+    confidence:    'high',
+    sources:       ['WHO','US CDC','AAP','UK NHS','India MoHFW/NHM','StatPearls','NEJM'],
+    dashboard:     'honey-infant-safety.visual.html',
+    brief:         'honey-infant-safety.md',
+    longform:      'honey-infant-safety.html',
+    lastReviewed:  '2026-05-30',
+  },
+
+  // ── append the next food here (whole nuts / egg / cow's milk / salt …) ──
+];
+
+/* Node/CommonJS convenience (so the hub OR a build step can require it). */
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = window.FOOD_EFFECTS_MANIFEST;
+}

--- a/docs/research/honey-infant-safety.html
+++ b/docs/research/honey-infant-safety.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Honey &amp; Infant Safety — Care Research Brief · SproutLab</title>
+<style>
+  :root{
+    --bg:#faf6f0; --card:#fffdf9; --ink:#2e2a26; --mid:#6b6258; --line:#e8ddcf;
+    --sage:#3a7060; --sage-bg:#e8f5ef; --rose:#b04a5e; --rose-bg:#fbe9ec;
+    --amber:#8a6320; --amber-bg:#fbf0d9; --accent:#9a6a3a;
+    --hi:#2f7d5b; --hi-bg:#e3f3ea; --mod:#9a7320; --mod-bg:#f7eed6; --weak:#9a5a5a; --weak-bg:#f5e6e6;
+  }
+  @media (prefers-color-scheme: dark){
+    :root{ --bg:#1d1a17; --card:#262220; --ink:#ece5db; --mid:#a89c8c; --line:#3a342d;
+      --sage:#7ac0a0; --sage-bg:#1e3028; --rose:#e090a0; --rose-bg:#3a2026;
+      --amber:#e0b060; --amber-bg:#352a16; --accent:#c99a6a;
+      --hi:#7ac0a0; --hi-bg:#1e3028; --mod:#d8b060; --mod-bg:#332a14; --weak:#e09090; --weak-bg:#3a2222; }
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+    font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Nunito,sans-serif;
+    -webkit-font-smoothing:antialiased;padding:0 0 80px}
+  .wrap{max-width:880px;margin:0 auto;padding:0 20px}
+  header{background:linear-gradient(160deg,var(--amber-bg),var(--bg));border-bottom:1px solid var(--line);
+    padding:34px 0 26px;margin-bottom:8px}
+  h1{font:700 27px/1.25 Fraunces,Georgia,serif;margin:0 0 6px}
+  .sub{color:var(--mid);font-size:14.5px;margin:0}
+  .meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
+  .pill{font-size:12px;font-weight:600;padding:4px 10px;border-radius:999px;background:var(--card);
+    border:1px solid var(--line);color:var(--mid)}
+  .pill.warn{background:var(--rose-bg);color:var(--rose);border-color:transparent}
+  h2{font:600 19px/1.3 Fraunces,Georgia,serif;margin:30px 0 12px;padding-top:10px;border-top:1px solid var(--line)}
+  h2 .ax{color:var(--accent);font-weight:700}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:18px 20px;margin:14px 0}
+  .tldr{background:var(--sage-bg);border-color:transparent}
+  .tldr ul{margin:8px 0 0;padding-left:20px}
+  .tldr li{margin:7px 0}
+  ul{margin:6px 0;padding-left:22px}
+  li{margin:6px 0}
+  .badge{display:inline-block;font-size:11px;font-weight:700;letter-spacing:.3px;text-transform:uppercase;
+    padding:3px 9px;border-radius:7px;vertical-align:middle;margin-left:8px}
+  .b-hi{background:var(--hi-bg);color:var(--hi)} .b-mod{background:var(--mod-bg);color:var(--mod)} .b-weak{background:var(--weak-bg);color:var(--weak)}
+  .flag{background:var(--amber-bg);border-left:3px solid var(--amber);border-radius:6px;
+    padding:10px 14px;margin:12px 0;font-size:14px;color:var(--ink)}
+  .flag b{color:var(--amber)}
+  blockquote{margin:12px 0;padding:8px 0 8px 16px;border-left:3px solid var(--sage);color:var(--mid);font-style:italic}
+  code,pre{font-family:"SF Mono",Menlo,Consolas,monospace}
+  pre{background:#1e1b18;color:#e8e2d6;border-radius:12px;padding:18px;overflow:auto;font-size:12.5px;line-height:1.55}
+  pre .c{color:#8a9a7a} pre .k{color:#d8a0b0} pre .s{color:#cbb080}
+  table{width:100%;border-collapse:collapse;font-size:13.5px;margin:10px 0}
+  th,td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{color:var(--mid);font-weight:700;font-size:12px;text-transform:uppercase;letter-spacing:.3px}
+  td a{color:var(--sage);word-break:break-all;font-size:12px}
+  .quote{background:var(--card);border:1px dashed var(--line);border-radius:10px;padding:6px 14px;margin:8px 0;font-size:14px}
+  .quote b{color:var(--accent)}
+  .foot{color:var(--mid);font-size:13px;margin-top:30px;text-align:center}
+  .gap{background:var(--rose-bg);border-color:transparent}
+</style>
+</head>
+<body>
+<header><div class="wrap">
+  <h1>Honey &amp; Infant Safety</h1>
+  <p class="sub">Care research brief — evidence base for surfacing food-effects in SproutLab. Honey is the archetype for the <code>FOOD_EFFECTS</code> layer.</p>
+  <div class="meta">
+    <span class="pill">Reviewer · Maren (Care)</span>
+    <span class="pill">2026-05-30</span>
+    <span class="pill">Honey only · infants 0–12mo · India</span>
+    <span class="pill">+ gap-closing pass (IAP/FSSAI corrected, NFHS-5 verified)</span>
+    <span class="pill warn">Research artifact — NOT yet wired into the app</span>
+  </div>
+</div></header>
+
+<div class="wrap">
+
+  <div class="card tldr">
+    <strong>TL;DR — the parent-facing truth</strong>
+    <ul>
+      <li><b>No honey before 12 months — in <i>any</i> form.</b> WHO, CDC, AAP and NHS all set the same line.</li>
+      <li>The danger is <b>infant botulism</b> — an acute, potentially life-threatening illness — <b>not</b> a nutrition concern.</li>
+      <li><b>Cooking and baking do NOT make it safe.</b> The hazard is heat-resistant <i>spores</i>; baking does not kill them.</li>
+      <li><b>Treatable and usually fully recoverable</b> with prompt care (BabyBIG) — but it is a medical emergency.</li>
+      <li><b>Indian context matters most:</b> traditional prelacteal practices (<i>ghutti / janam ghutti</i>, honey on the lips/finger) are a named, real risk vector.</li>
+    </ul>
+  </div>
+
+  <h2><span class="ax">Axis 1</span> · Mechanism &amp; risk <span class="badge b-hi">High</span></h2>
+  <div class="card">
+    <ul>
+      <li>Infant botulism is caused by ingested <i>C. botulinum</i> <b>spores that germinate and produce toxin <i>inside</i> the infant gut</b> (intestinal toxemia) — not pre-formed toxin in food. The toxin blocks acetylcholine → flaccid paralysis. <span class="badge b-hi">consensus</span></li>
+      <li>Infants &lt;12mo are uniquely susceptible: immature gut, low gastric acidity, no protective competitive flora. Resolves as the gut matures.</li>
+      <li>Peak onset ~3–4 months; most cases &lt;6 months.</li>
+      <li>Honey = ~20% of cases (a minority); most are environmental (soil/dust). Honey is emphasised as the one <b>avoidable</b> source.</li>
+      <li>Botulism is <b>not</b> transmitted through breast milk — a breastfeeding parent may safely eat honey.</li>
+    </ul>
+    <div class="flag"><b>⚑ Flag:</b> the ~20% honey figure is uncertain (most cases have no confirmed source). Don't overstate honey as the main cause — but it is the main <i>preventable</i> one.</div>
+  </div>
+
+  <h2><span class="ax">Axis 2</span> · The 12-month threshold <span class="badge b-hi">High</span></h2>
+  <div class="card">
+    <div class="quote"><b>WHO:</b> "…not to feed honey to the infants before the age of 1 year."</div>
+    <div class="quote"><b>CDC:</b> "Do not give your child honey before 12 months. Do not add honey to your baby's food, water, infant formula, or pacifier."</div>
+    <div class="quote"><b>AAP:</b> "…do not give honey to a baby younger than 12 months." / "safe for children 1 year of age and older."</div>
+    <div class="quote"><b>NHS:</b> "Do not give your child honey until they're over 1 year old."</div>
+    <div class="flag"><b>⚑ Subtlety for surfacing:</b> WHO says intestinal defenses develop "older than about 6 months," yet every body still sets the line at 12 months — a deliberately <b>conservative practical floor</b>, not a precise biological switch. NHS uniquely adds a 2nd rationale: honey = sugar → tooth decay.</div>
+  </div>
+
+  <h2><span class="ax">Axis 3</span> · The baking / cooking misconception <span class="badge b-hi">High</span> <span class="badge b-mod">explicit wording: Moderate</span></h2>
+  <div class="card">
+    <ul>
+      <li><i>C. botulinum</i> <b>spores are heat-resistant and survive boiling and ordinary baking.</b> Reliable destruction needs commercial-canning heat (~121 °C / 250 °F under pressure). <span class="badge b-hi">WHO</span></li>
+      <li>Botulinum <i>toxin</i> is heat-labile — <b>but irrelevant here</b>, because the hazard is the spores, which germinate <i>after</i> ingestion.</li>
+      <li>So honey baked into biscuits/bread/cakes, cooked into dishes, or in cereals/processed foods is <b>still unsafe</b> for under-1s.</li>
+    </ul>
+    <div class="flag"><b>⚑ The single most-misunderstood point.</b> Parents reason "cooking kills germs." For honey spores, it does not. CDC/NHS/AAP state the rule broadly; the explicit "even baked" sentence lives in food-safety/extension sources (UF/IFAS).</div>
+  </div>
+
+  <h2><span class="ax">Axis 4</span> · Forms &amp; hidden sources <span class="badge b-hi">High (named cases)</span> <span class="badge b-mod">Moderate (general list)</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>Pasteurized honey is still unsafe</b> — pasteurization temps too low to kill spores. <span class="badge b-mod">inference</span></li>
+      <li><b>Honey-dipped pacifiers</b> are a documented cause — 2018 Texas cluster of 4 infants. <span class="badge b-hi">Texas DSHS</span></li>
+      <li>Hidden sources: gripe water / <i>ghutti</i>, home cough remedies, honey-flavoured snacks/cereals, honey on a finger/lip/soother.</li>
+    </ul>
+  </div>
+
+  <h2><span class="ax">Axis 5</span> · Symptoms <span class="badge b-hi">High</span></h2>
+  <div class="card">
+    <ol>
+      <li><b>Constipation — often the <i>first</i> sign</b> (~90% of cases).</li>
+      <li>Weak/altered cry; poor feeding / weak suck (milk pooling).</li>
+      <li>Floppiness / hypotonia ("floppy baby").</li>
+      <li>Drooping eyelids (ptosis), flat facial expression, poor head control, diminished gag.</li>
+      <li>Descending, symmetric, flaccid paralysis → can reach respiratory muscles.</li>
+    </ol>
+    <p style="margin:8px 0 0;color:var(--mid);font-size:14px">Infant is usually <b>alert and afebrile</b> — reassuring but misleading. Onset <b>3–30 days</b> after ingestion.</p>
+    <div class="flag"><b>⚑ Source divergence:</b> incubation lower bound 3 days (AAP/CDC) vs 10 days (StatPearls). Use "within days to a few weeks."</div>
+  </div>
+
+  <h2><span class="ax">Axis 6</span> · When to seek care &amp; treatment <span class="badge b-hi">High</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>Medical emergency.</b> Constipation + new weakness/floppiness/feeding change → urgent evaluation (respiratory-failure risk; ~50% need airway support).</li>
+      <li>Treatment: human <b>Botulism Immune Globulin (BabyBIG / BIG-IV)</b>, started without waiting for lab confirmation. NEJM trial: hospital stay <b>5.7 → 2.6 weeks</b>.</li>
+      <li>Antibiotics not first-line; <b>aminoglycosides contraindicated</b> (worsen weakness).</li>
+      <li>Prognosis generally very good with prompt care; recovery weeks–months.</li>
+    </ul>
+    <div class="flag"><b>⚑ Mortality varies by source:</b> "&lt;15%" (broad/historical, StatPearls) vs <b>&lt;1% for promptly-treated US cases</b> (IBTPP/CDC). Use "low with prompt treatment."</div>
+  </div>
+
+  <h2><span class="ax">Axis 7</span> · Indian cultural context <span class="badge b-hi">High (govt guidance)</span> <span class="badge b-weak">Mixed (prevalence)</span></h2>
+  <div class="card">
+    <div class="quote"><b>India MoHFW/NHM (MAA module):</b> babies should not be given any drink/food "like gur, ghutti, honey, sweet water, etc." before breastfeeding starts or up to six months — "No prelacteal feeds should be given."</div>
+    <ul>
+      <li><b>Prelacteal feeds</b> = anything given before breastfeeding begins (sugar/honey/glucose water, <i>ghutti</i> — gur-/bura-/khand-/<b>janam ghutti</b>), usually first 2–3 days. Govt frames harm as infection + breastfeeding failure + colostrum loss (does not itself name botulism).</li>
+      <li>WHO/UNICEF: breastfeed within the first hour, exclusive 6 months, no other food/liquid — which prelacteal honey violates.</li>
+      <li><b>Documented Indian case:</b> 4-day-old fed raw village honey ~2h after birth "as per family tradition" → lethargy, hypotonia, absent Moro; recovered day 15. <span class="badge b-mod">n=1</span></li>
+      <li><b>Prevalence — VERIFIED (NFHS-5, 2019–21):</b> ~15.3–15.5% of children received a prelacteal feed (anything but breast milk in first 3 days), <b>down from ~20.8% in NFHS-4</b>; among those, <b>honey 8.9%</b> (~1.3–1.4% of all newborns). <span class="badge b-mod">peer-reviewed NFHS-5 microdata</span> Regional Lucknow slum study (50.6% prelacteal, 22.6% honey) is a higher-burden local figure.</li>
+      <li>Commercial <i>janam ghutti</i> / gripe-water products remain widely marketed. <span class="badge b-weak">usage rate unquantified</span></li>
+    </ul>
+    <div class="flag" style="border-left-color:var(--sage);background:var(--sage-bg)"><b>✓ Gap-closing pass (2026-05-30) — three of four closed, two by CORRECTING a claim:</b>
+      <ul style="margin:6px 0 0">
+        <li><b>IAP → do NOT attribute the rule to IAP.</b> Both primary IAP feeding PDFs (Breastfeeding + IYCF 2016, 23pp) parsed in full — <b>zero mention of honey or botulism.</b></li>
+        <li><b>FSSAI → drop &amp; reverse.</b> FSSAI's Foods for Infant Nutrition regulation <i>permits</i> honey (manufacturing spore-destruction rule only); <b>no consumer under-1 prohibition.</b> The blog claim was WHO/AAP laundered onto FSSAI. <i>(Permitting spore-destroyed honey in manufactured infant products ≠ "honey is fine for babies at home.")</i></li>
+        <li><b>NFHS-5 % → closed</b> (see verified prevalence above).</li>
+        <li><b>Indian incidence → genuinely absent</b> (no mandatory notification; case reports only). Left honestly flagged.</li>
+      </ul>
+    </div>
+  </div>
+
+  <h2>Proposed data shape · <code>FOOD_EFFECTS['honey']</code></h2>
+  <div class="card">
+    <p style="margin:0 0 10px;font-size:14px;color:var(--mid)">Drop-in record for a future <code>FOOD_EFFECTS</code> table in <code>data.js</code>, sitting alongside <code>AGE_RULES['honey']</code> (which stays the gate; this adds the <i>effect</i>). Surfacing reads <code>headline</code>+<code>why</code>+<code>seekCare</code>. <b>Not yet wired.</b></p>
+<pre><span class="c">// consequence layer atop AGE_RULES/ALLERGENS — critical-tier acute effects</span>
+<span class="k">const</span> FOOD_EFFECTS = {
+  <span class="s">'honey'</span>: {
+    tier:        <span class="s">'critical'</span>,
+    effect:      <span class="s">'infant botulism'</span>,
+    threshold:   { minMonth: <span class="s">12</span>, basis: <span class="s">'conservative'</span> }, <span class="c">// gut defenses ~6mo+ (WHO); 12mo = universal floor</span>
+    mechanism:   <span class="s">'C. botulinum spores germinate in the immature infant gut and produce toxin.'</span>,
+    headline:    <span class="s">'Avoid before 12 months — honey can cause infant botulism.'</span>,
+    why:         <span class="s">'Honey can carry C. botulinum spores. A baby’s immature gut lets them grow…'</span>,
+    myth:        { claim: <span class="s">'Cooking or baking makes honey safe.'</span>,
+                   truth: <span class="s">'No — spores survive baking. Honey in biscuits/cooked dishes is still unsafe.'</span> },
+    hiddenSources: [<span class="s">'baked goods'</span>, <span class="s">'cooked dishes'</span>, <span class="s">'processed snacks'</span>,
+                    <span class="s">'gripe water / ghutti'</span>, <span class="s">'cough remedies'</span>, <span class="s">'honey on pacifier/finger/lip'</span>],
+    watchFor:    [<span class="s">'constipation (often first)'</span>, <span class="s">'weak/altered cry'</span>, <span class="s">'poor feeding'</span>,
+                  <span class="s">'floppiness'</span>, <span class="s">'drooping eyelids'</span>, <span class="s">'reduced facial movement'</span>],
+    timeCourse:  <span class="s">'within days to a few weeks (commonly 3–30 days)'</span>,
+    seekCare:    <span class="s">'Medical emergency. …treatable (BabyBIG); recovery usually full with prompt care.'</span>,
+    breastfeedingSafe: <span class="s">true</span>,
+    culturalNote: <span class="s">'Indian prelacteal practices (janam ghutti, honey on lips/finger) are a real vector…'</span>,
+    confidence:  <span class="s">'high'</span>,
+    lastReviewed: <span class="s">'2026-05-30'</span>,
+  },
+};</pre>
+  </div>
+
+  <h2>Sources</h2>
+  <div class="card">
+  <table>
+    <tr><th>Authority</th><th>URL</th></tr>
+    <tr><td>WHO — Botulism fact sheet</td><td><a href="https://www.who.int/news-room/fact-sheets/detail/botulism">who.int/…/botulism</a></td></tr>
+    <tr><td>CDC — foods to avoid</td><td><a href="https://www.cdc.gov/infant-toddler-nutrition/foods-and-drinks/foods-and-drinks-to-avoid-or-limit.html">cdc.gov/infant-toddler-nutrition</a></td></tr>
+    <tr><td>CDC — infant botulism clinical</td><td><a href="https://www.cdc.gov/botulism/hcp/clinical-overview/infant-botulism.html">cdc.gov/botulism/…</a></td></tr>
+    <tr><td>AAP / HealthyChildren — Botulism</td><td><a href="https://www.healthychildren.org/English/health-issues/conditions/infections/Pages/Botulism.aspx">healthychildren.org/…/Botulism</a></td></tr>
+    <tr><td>NHS — foods to avoid</td><td><a href="https://www.nhs.uk/baby/weaning-and-feeding/foods-to-avoid-giving-babies-and-young-children/">nhs.uk/baby/…</a></td></tr>
+    <tr><td>StatPearls / NCBI — NBK493178</td><td><a href="https://www.ncbi.nlm.nih.gov/books/NBK493178/">ncbi.nlm.nih.gov/books/NBK493178</a></td></tr>
+    <tr><td>NEJM — Arnon (BabyBIG)</td><td><a href="https://www.nejm.org/doi/full/10.1056/NEJMoa051926">nejm.org/…/NEJMoa051926</a></td></tr>
+    <tr><td>Texas DSHS — honey pacifier alert</td><td><a href="https://www.dshs.texas.gov/news-alerts/infant-botulism-health-alert-nov-16-2018">dshs.texas.gov/…</a></td></tr>
+    <tr><td>India MoHFW/NHM — MAA module</td><td><a href="https://nhm.gov.in/New_Updates_2018/NHM_Components/RMNCHA/CH/Schemes/Maa/Training_Module_English_Lowres.pdf">nhm.gov.in/…/MAA module</a></td></tr>
+    <tr><td>IAP — Breastfeeding / IYCF 2016 <i>(checked: no honey/botulism mention)</i></td><td><a href="https://www.indianpediatrics.net/aug2016/703.pdf">indianpediatrics.net/aug2016/703.pdf</a></td></tr>
+    <tr><td>FSSAI — Foods for Infant Nutrition Reg. <i>(checked: permits honey; no under-1 ban)</i></td><td><a href="https://www.fssai.gov.in/upload/uploadfiles/files/Comp_IFR_VERSION-II_04_01_2024.pdf">fssai.gov.in/…/Infant Nutrition 2024</a></td></tr>
+    <tr><td>IIPS / NFHS-5 microdata — prelacteal feeding (PLOS ONE 2023)</td><td><a href="https://pmc.ncbi.nlm.nih.gov/articles/PMC10553319/">pmc.ncbi.nlm.nih.gov/…/PMC10553319</a></td></tr>
+    <tr><td>UNICEF India — Breastfeeding</td><td><a href="https://www.unicef.org/india/breastfeeding-0">unicef.org/india/breastfeeding</a></td></tr>
+    <tr><td>Poison Control — honey &amp; infants</td><td><a href="https://www.poison.org/articles/dont-feed-honey-to-infants">poison.org/…/honey</a></td></tr>
+    <tr><td>PMC — In Search of C. botulinum Spores</td><td><a href="https://pmc.ncbi.nlm.nih.gov/articles/PMC11322261/">pmc.ncbi.nlm.nih.gov/…/PMC11322261</a></td></tr>
+    <tr><td>UF/IFAS — Infant Botulism &amp; Honey</td><td><a href="https://ask.ifas.ufl.edu/publication/AA142">ask.ifas.ufl.edu/…/AA142</a></td></tr>
+    <tr><td>M3 India — Indian honey case report</td><td><a href="https://www.m3india.in/contents/editor_pick/infant-botulism-following-consumption-of-honey">m3india.in/…/infant-botulism</a></td></tr>
+  </table>
+  </div>
+
+  <div class="card">
+    <strong>Verification gaps — status after the 2026-05-30 gap-closing pass</strong>
+    <ol style="margin:8px 0 0">
+      <li>✅ <b>IAP</b> — CLOSED by correction. Primary PDFs parsed; no honey/botulism mention → not attributable to IAP. <i>(Fixed via curl + pypdf; original failure was WebFetch not parsing binary PDFs, not a hidden source.)</i></li>
+      <li>✅ <b>FSSAI</b> — CLOSED &amp; REVERSED. No under-1 directive exists; regulation permits honey. Claim dropped.</li>
+      <li>✅ <b>NFHS-5</b> % — CLOSED. ~15.3–15.5% national; 8.9% of those honey; down from 20.8% (NFHS-4).</li>
+      <li>⚑ <b>Indian botulism surveillance/incidence</b> — GENUINELY ABSENT (no mandatory notification). Cannot be closed; left flagged.</li>
+    </ol>
+    <p style="margin:10px 0 0;font-size:13.5px;color:var(--mid)"><b>Methodology (Maren):</b> third-party sources are legitimate for <i>facts that exist independently</i> (the NFHS-5 figure, via peer-reviewed microdata) but never a substitute for <i>"what body X officially says"</i> (IAP/FSSAI). Two of three fillable gaps closed by <i>correcting</i> a laundered claim — which is why the primary check mattered.</p>
+  </div>
+
+  <div class="card tldr">
+    <strong>Surfacing recommendation (Maren) — feeds Finding A, not yet implemented</strong>
+    <p style="margin:8px 0 0">When a parent marks an age-gated <b>critical-tier</b> food tried for a baby below <code>minMonth</code>, confirm with <code>headline</code> + <code>seekCare</code> rather than a silent log. The <b>myth line</b> ("cooking doesn't make it safe") and the <b>cultural note</b> are the two highest-value nuggets unique to honey.</p>
+  </div>
+
+  <p class="foot">SproutLab · Care research brief · companion to <code>docs/research/honey-infant-safety.md</code> · generated 2026-05-30<br>
+  Research artifact — informational, not medical advice. Not yet wired into the app.</p>
+</div>
+</body>
+</html>

--- a/docs/research/honey-infant-safety.md
+++ b/docs/research/honey-infant-safety.md
@@ -1,0 +1,165 @@
+# Honey & Infant Safety — Care Research Brief
+
+> **Purpose.** Evidence base for SproutLab's Care layer. Built to decide *what consequence-text to surface* when a parent marks **honey** "tried" for an under-12-month-old (food-sub-tab-v1 Finding A), and as the template for future per-food effect briefs.
+> **Scope.** Honey only. Infants 0–12 months. Family context: Indian.
+> **Reviewer.** Maren (Governor of Care), deep-research scout pass.
+> **Date.** 2026-05-30. **Status.** Research complete + gap-closing pass applied — *not yet wired into the app.*
+> **Method.** 5-angle fan-out web search → source fetch → adversarial verification → synthesis, then a targeted gap-closing pass (primary-PDF extraction + NFHS-5 microdata). Authorities: WHO, US CDC, AAP/HealthyChildren, UK NHS, India MoHFW/NHM, IIPS/NFHS-5, NIH/StatPearls, NEJM. **Note:** IAP and FSSAI were checked as primaries and do **not** support a honey-under-1 rule (see gap-closing pass) — the rule rests on WHO/CDC/AAP/NHS + MoHFW/NHM.
+
+---
+
+## TL;DR (the parent-facing truth)
+
+- **No honey before 12 months — in *any* form.** Universal agreement: WHO, CDC, AAP, NHS all set the same line.
+- **The danger is *infant botulism*** — an acute, potentially life-threatening illness — *not* a nutrition concern. This is what makes honey different from "too much salt/sugar."
+- **Cooking and baking do NOT make it safe.** The hazard is heat-resistant *spores* (not the toxin); ordinary baking does not kill them. Honey baked into a biscuit is still unsafe.
+- **It's treatable and usually fully recoverable** with prompt care (BabyBIG) — but it's a medical emergency.
+- **Indian context matters most here.** Traditional prelacteal practices — *ghutti / janam ghutti*, honey on the lips or finger — are a real, named risk vector that Indian government and pediatric guidance explicitly warn against.
+
+---
+
+## Axis 1 — Mechanism & risk  *(confidence: HIGH)*
+
+- **Infant botulism is caused by ingested *Clostridium botulinum* spores that germinate, colonize, and produce botulinum toxin *in vivo* in the infant's large intestine** (intestinal toxemia) — not by pre-formed toxin in the food. The toxin causes flaccid paralysis by blocking acetylcholine release at the neuromuscular junction. *(Consensus — StatPearls/NCBI NBK493178.)*
+- **Infants under 12 months are uniquely susceptible**: immature gut, reduced gastric acidity, and a lack of the competitive bacterial flora that in older children/adults prevents spore germination. The risk resolves as the gut matures. *(Strong/consensus — StatPearls; Poison Control.)*
+- **Peak onset is ~3–4 months; most cases are under 6 months.** *(Consensus — AAP; StatPearls.)*
+- **Honey accounts for ~20% of infant botulism cases** — a *minority*. Most cases come from environmental spores (soil/dust) and have no identified source. Honey is emphasized because it is the **one readily avoidable** dietary source. *(Strong — StatPearls; CDC: "most infant botulism cannot be prevented"; PMC11322261: honey/soil/dust = 94% of *verified* sources, soil most common.)*
+- **Botulism is *not* transmitted through breast milk — a breastfeeding parent may safely eat honey.** *(Consensus — AAP; CDPH.)*
+
+> ⚑ *Flagged nuance:* the "~20%" honey-attributable figure is uncertain because most cases have no confirmed source. Among the small subset of *lab-confirmed-source* cases, honey can dominate. Both framings are reported — don't overstate honey as the main cause, but it is the main *preventable* one.
+
+## Axis 2 — The 12-month threshold  *(confidence: HIGH; consensus unusually tight)*
+
+Verbatim positions:
+- **WHO:** *"Parents and caregivers are therefore warned not to feed honey to the infants before the age of 1 year."*
+- **CDC:** *"Do not give your child honey before 12 months. Do not add honey to your baby's food, water, infant formula, or pacifier."*
+- **AAP:** *"…do not give honey to a baby younger than 12 months."* / *"Honey is safe for children 1 year of age and older."*
+- **NHS:** *"Do not give your child honey until they're over 1 year old."*
+
+> ⚑ *Important subtlety for surfacing:* **WHO says intestinal defenses develop "older than about 6 months," yet every body still sets the avoidance line at 12 months.** So 12 months is a deliberately **conservative practical floor**, not a precise biological switch. Surface it as a firm rule, but know the science behind the margin.
+>
+> *Divergence (minor):* NHS adds a **second** rationale — honey is sugar → tooth decay. Most other bodies cite botulism only.
+
+## Axis 3 — The baking / cooking misconception  *(confidence: HIGH on microbiology; MODERATE that top-tier bodies state it explicitly)*
+
+- ***C. botulinum* spores are heat-resistant and survive boiling and ordinary baking.** Reliable spore destruction needs commercial-canning conditions (~121 °C / 250 °F under pressure). *(WHO: spores "killed by very high temperature treatments such as commercial canning.")*
+- **Botulinum *toxin* is heat-labile** (destroyed by boiling >85 °C for ≥5 min) — **but this is irrelevant to honey**, because the honey hazard is the *spores*, which germinate *after* ingestion. *(WHO.)*
+- **Therefore honey baked into bread/biscuits/cakes, cooked into dishes, or present in cereals/processed foods is still unsafe for under-1s.** *(Strong mechanistic reading; CDC states the rule broadly — "do not add honey to your baby's food"; the explicit "even baked" sentence lives in food-safety/extension sources, e.g. UF/IFAS AA142, not verbatim on CDC/NHS/AAP.)*
+
+> ⚑ *This is the single most-misunderstood point.* Parents reason "cooking kills germs." For honey spores, it does not. Worth surfacing directly.
+
+## Axis 4 — Forms & hidden sources  *(confidence: HIGH for named cases; MODERATE for the general list)*
+
+- **Pasteurized honey is still unsafe** — honey pasteurization temps are too low to reliably kill spores. *(Moderate — inference from spore heat-resistance; not stated verbatim by a top-tier body.)*
+- **Honey-dipped pacifiers are a documented cause** — 2018 Texas cluster of 4 infants linked to honey pacifiers. *(Strong — Texas DSHS alert.)*
+- **Hidden sources to avoid:** gripe water / *ghutti*, traditional/home cough remedies (honey-lemon-ginger, honey cough syrups), honey-flavored snacks/cereals (e.g. honey graham), honey on a finger/lip/soother. *(Moderate — Poison Control; AAP recommends honey for cough only at ≥1 year.)*
+
+## Axis 5 — Symptoms of infant botulism  *(confidence: HIGH)*
+
+In typical order of appearance:
+1. **Constipation — often the *first* sign** (present initially in ~90% of cases).
+2. **Weak or altered cry**; **poor feeding / weak suck** (milk pooling in the mouth).
+3. **Generalized floppiness / hypotonia** ("floppy baby").
+4. **Drooping eyelids (ptosis)**, sluggish pupils, flattened facial expression, poor head control, diminished gag.
+5. **Descending, symmetric, flaccid paralysis** beginning with cranial nerves and progressing to trunk, limbs, and **respiratory muscles**.
+- The infant is usually **alert and afebrile** and may otherwise look well — reassuring but misleading.
+- **Time course: symptoms 3–30 days after spore ingestion**; weakness then progresses over days to ~1–2 weeks. *(AAP/CDC.)*
+
+> ⚑ *Source divergence:* incubation lower bound is **3 days (AAP/CDC)** vs **10 days (StatPearls)**. Use "within days to a few weeks."
+
+## Axis 6 — When to seek care & treatment  *(confidence: HIGH)*
+
+- **It is a medical emergency.** Constipation **plus** new weakness/floppiness or a feeding change in an infant warrants **urgent evaluation** — risk of respiratory failure (~50% need airway support).
+- **Treatment is human-derived Botulism Immune Globulin IV (BIG-IV / "BabyBIG")**, started promptly *without waiting for lab confirmation*. The pivotal NEJM trial showed mean hospital stay cut **5.7 → 2.6 weeks**.
+- **Antibiotics are not first-line; aminoglycosides are contraindicated** (worsen neuromuscular weakness).
+- **Prognosis is generally very good** with prompt care; recovery can take weeks–months.
+
+> ⚑ *Mortality figures vary:* StatPearls "<15%" (broad/historical) vs **<1% for promptly-treated US cases** (IBTPP/CDC). Use "low with prompt treatment."
+> *Operational:* US suspected cases consult the California IBTPP 24/7 (510-231-7600). India has no equivalent single hotline located.
+
+## Axis 7 — Indian cultural context  *(confidence: HIGH for the named government guidance + NFHS-5 prevalence; the IAP/FSSAI attributions were CHECKED and corrected — see gap-closing pass below)*
+
+- **The Indian primary authority for the honey rule is MoHFW/NHM — NOT IAP or FSSAI.** India's MoHFW/NHM **MAA** (Mothers' Absolute Affection) ANM training module instructs that babies should **not** be given any drink/food *"like gur, ghutti, honey, sweet water, etc."* before breastfeeding starts or up to six months, and that *"No prelacteal feeds should be given."* *(STRONG — verbatim primary government document.)*
+- **Definitions:** *Prelacteal feeds* = anything given before breastfeeding begins (sugar/honey/glucose water, *ghutti* — gur-/bura-/khand-/**janam ghutti**), usually in the first 2–3 days. The module frames the harm as **infection + breastfeeding failure + colostrum loss** — it does *not* itself name botulism. *(Strong — same source.)*
+- **WHO/UNICEF standard** — breastfeeding within the first hour, exclusive breastfeeding 6 months with no other food/liquid — which prelacteal honey directly violates. *(Strong.)*
+- **A documented Indian case:** a 4-day-old fed raw village honey ~2 hours after birth "as per family tradition" developed lethargy, limb hypotonia, and absent Moro reflex; recovered by day 15. *(Moderate — single case report, n=1.)*
+- **Prevalence — now VERIFIED (national, NFHS-5 2019–21):** **~15.3–15.5%** of children received a prelacteal feed (anything other than breast milk in the first 3 days), **down from ~20.8% in NFHS-4 (2015–16)** — a clear decline. Among prelacteal-fed infants, **honey was given to 8.9%** (≈1.3–1.4% of all newborns). *(Moderate-HIGH — converging peer-reviewed analyses of NFHS-5 microdata: PLOS ONE 2023 / PMC10553319, PMC12182200. The one-page National Fact Sheet does not tabulate this indicator; the full IIPS report + academic microdata analyses do.)* The earlier regional Lucknow slum study (50.6% prelacteal, 22.6% of those honey) stands as a higher-burden local figure.
+- **Commercial *janam ghutti* / gripe-water products remain widely marketed and used** despite pediatric advice. *(Moderate for availability; weak as a usage rate.)*
+
+> ✓ *Gap-closing pass (2026-05-30) — three of four gaps closed, two by CORRECTING a claim:*
+> - **(a) IAP:** RESOLVED by primary-PDF extraction. The IAP *Breastfeeding* chapter **and** the IAP *IYCF 2016* guidelines were parsed in full (23 pages) — **neither mentions "honey" or "botulism" at all.** ⇒ **Do NOT attribute the honey-under-1 rule to IAP.** IAP's feeding guidance is about breastfeeding/colostrum/complementary-feeding timing, not honey.
+> - **(b) FSSAI:** RESOLVED and **REVERSED.** FSSAI's primary *Foods for Infant Nutrition* regulation (2022 + 2024 versions) **permits** honey as an ingredient and lists honey-sweetened mashed food as a traditional infant food example; its *only* honey provision is a **manufacturing** rule that honey-containing products be processed to destroy *C. botulinum* spores. There is **no FSSAI consumer rule against giving honey under 1.** ⇒ **Drop the FSSAI attribution entirely** — the blog claim was WHO/AAP guidance laundered onto FSSAI's name. *(Caution: FSSAI permitting spore-destroyed honey in **manufactured** infant products is NOT permission to give a baby raw/home honey — different thing; do not let this read as "FSSAI says honey is fine for babies.")*
+> - **(c) NFHS-5 %:** RESOLVED — see the verified prevalence bullet above.
+> - **(d) Indian botulism surveillance/incidence:** **genuinely absent** (India has no mandatory botulism notification). Case reports exist; a national incidence rate does not. Under-reporting remains a *reasoned hypothesis*, not a sourced fact — left flagged.
+
+---
+
+## Proposed data shape — `FOOD_EFFECTS['honey']` (data stub)
+
+Drop-in structured record for a future `FOOD_EFFECTS` table in `data.js`, designed to sit *alongside* the existing `AGE_RULES['honey']` (which stays the gate; this adds the *effect*). Surfacing code (e.g. the confirm-on-mark-tried dialog) reads `headline` + `why` + `seekCare`; richer surfaces can use the rest. **Not yet wired — research artifact only.**
+
+```js
+// FOOD_EFFECTS — consequence layer atop AGE_RULES/ALLERGENS. Critical-tier
+// foods carry an acute (not merely nutritional) effect worth surfacing when a
+// parent logs them against the gate. Sourced in docs/research/<food>-*.md.
+const FOOD_EFFECTS = {
+  'honey': {
+    tier:        'critical',              // acute illness risk, not a nutrition note
+    effect:      'infant botulism',
+    threshold:   { minMonth: 12, basis: 'conservative' }, // gut defenses develop ~6mo+ (WHO); 12mo is the universal practical floor
+    mechanism:   'C. botulinum spores germinate in the immature infant gut and produce toxin in the body (intestinal toxemia).',
+    headline:    'Avoid before 12 months — honey can cause infant botulism.',
+    why:         'Honey can carry C. botulinum spores. A baby’s immature gut lets them grow and make a toxin that causes muscle weakness. Older children and adults are protected; babies under 1 are not.',
+    myth:        { claim: 'Cooking or baking makes honey safe.',
+                   truth: 'No — the spores survive baking. Honey in biscuits, cooked dishes or processed foods is still unsafe under 12 months.' },
+    hiddenSources: ['baked goods', 'cooked dishes', 'processed/honey-flavoured snacks',
+                    'gripe water / ghutti', 'home cough remedies', 'honey on a pacifier, finger or lip'],
+    watchFor:    ['constipation (often the first sign)', 'weak or altered cry',
+                  'poor feeding / weak suck', 'floppiness (low muscle tone)',
+                  'drooping eyelids', 'reduced facial movement'],
+    timeCourse:  'within days to a few weeks of ingestion (commonly 3–30 days)',
+    seekCare:    'Medical emergency. Constipation plus new weakness, floppiness or a feeding change needs urgent care — it is treatable (BabyBIG) and recovery is usually full with prompt treatment.',
+    breastfeedingSafe: true,              // a breastfeeding parent may eat honey
+    culturalNote: 'Traditional Indian prelacteal practices — janam ghutti, honey on the lips or finger, gripe-water remedies — are a real risk vector. India’s MoHFW/NHM advises giving nothing but breast milk and no prelacteal feeds.',
+    confidence:  'high',                  // consensus across WHO/CDC/AAP/NHS
+    sources:     ['WHO botulism fact sheet', 'CDC infant-toddler nutrition', 'AAP HealthyChildren botulism',
+                  'NHS foods to avoid', 'MoHFW/NHM MAA module', 'StatPearls NBK493178', 'NEJM Arnon (BabyBIG)'],
+    lastReviewed: '2026-05-30',
+  },
+};
+```
+
+---
+
+## Source list
+
+| # | Authority | URL |
+|---|-----------|-----|
+| 1 | WHO — Botulism fact sheet | https://www.who.int/news-room/fact-sheets/detail/botulism |
+| 2 | US CDC — Infant & Toddler Nutrition: foods to avoid | https://www.cdc.gov/infant-toddler-nutrition/foods-and-drinks/foods-and-drinks-to-avoid-or-limit.html |
+| 3 | US CDC — Infant botulism clinical overview | https://www.cdc.gov/botulism/hcp/clinical-overview/infant-botulism.html |
+| 4 | AAP / HealthyChildren — Botulism | https://www.healthychildren.org/English/health-issues/conditions/infections/Pages/Botulism.aspx |
+| 5 | UK NHS — Foods to avoid giving babies | https://www.nhs.uk/baby/weaning-and-feeding/foods-to-avoid-giving-babies-and-young-children/ |
+| 6 | StatPearls / NCBI — Infant Botulism (NBK493178) | https://www.ncbi.nlm.nih.gov/books/NBK493178/ |
+| 7 | NEJM — Arnon et al., Human Botulism Immune Globulin (BabyBIG) | https://www.nejm.org/doi/full/10.1056/NEJMoa051926 |
+| 8 | Texas DSHS — Honey pacifier infant botulism alert (2018) | https://www.dshs.texas.gov/news-alerts/infant-botulism-health-alert-nov-16-2018 |
+| 9 | India MoHFW/NHM — MAA ANM Training Module | https://nhm.gov.in/New_Updates_2018/NHM_Components/RMNCHA/CH/Schemes/Maa/Training_Module_English_Lowres.pdf |
+| 10 | IAP — Guidelines on Breastfeeding *(checked: no honey/botulism mention — does NOT support the rule)* | https://iapindia.org/pdf/Ch-039-Breastfeeding.pdf · https://www.indianpediatrics.net/aug2016/703.pdf |
+| 10a | FSSAI — Foods for Infant Nutrition Regulations (2022 / 2024) *(checked: PERMITS honey; no under-1 prohibition)* | https://www.fssai.gov.in/upload/uploadfiles/files/Comp_IFR_VERSION-II_04_01_2024.pdf |
+| 10b | IIPS / NFHS-5 microdata analyses — prelacteal feeding (PLOS ONE 2023) | https://pmc.ncbi.nlm.nih.gov/articles/PMC10553319/ |
+| 11 | UNICEF India — Breastfeeding | https://www.unicef.org/india/breastfeeding-0 |
+| 12 | US Poison Control — Don't feed honey to infants | https://www.poison.org/articles/dont-feed-honey-to-infants |
+| 13 | PMC — Infant Botulism: In Search of C. botulinum Spores | https://pmc.ncbi.nlm.nih.gov/articles/PMC11322261/ |
+| 14 | UF/IFAS Extension — Infant Botulism and Honey (heat-resistance) | https://ask.ifas.ufl.edu/publication/AA142 |
+| 15 | M3 India — Infant botulism following honey (Indian case report) | https://www.m3india.in/contents/editor_pick/infant-botulism-following-consumption-of-honey |
+
+### Verification gaps — status after the 2026-05-30 gap-closing pass
+1. ✅ **IAP** verbatim honey wording — **CLOSED by correction.** Primary IAP Breastfeeding + IYCF 2016 PDFs parsed in full; **no mention of honey or botulism.** The rule is not attributable to IAP. *(Method: `curl` + `pypdf` — the original failure was WebFetch not parsing binary PDFs, not a hidden source.)*
+2. ✅ **FSSAI** honey-under-1 directive — **CLOSED and REVERSED.** No such FSSAI consumer directive exists; FSSAI's infant-nutrition regulation *permits* honey (manufacturing spore-destruction rule only). The secondary claim is dropped.
+3. ✅ **NFHS-5** prelacteal-feeding % — **CLOSED.** ~15.3–15.5% national (NFHS-5), 8.9% of those honey; down from 20.8% (NFHS-4). Peer-reviewed NFHS-5 microdata analyses.
+4. ⚑ **Indian botulism surveillance/incidence** — **GENUINELY ABSENT** (no mandatory notification in India). Case reports only; under-reporting is a hypothesis, not a sourced fact. Cannot be closed — left honestly flagged.
+
+> **Methodology note (Maren).** Third-party sources are legitimate for *facts that exist independently* (the NFHS-5 figure, via peer-reviewed microdata analysis) but are **never** a substitute for *"what body X officially says"* (IAP / FSSAI) — a parent reading "IAP recommends…" deserves IAP's actual words, not a blog's paraphrase. Two of the three "fillable" gaps closed by *correcting* a laundered claim, which is exactly why the primary check mattered.
+
+### Surfacing recommendation (Maren) — feeds the Finding-A decision, not yet implemented
+When a parent marks an age-gated **critical-tier** food tried for a baby below `minMonth`, confirm with `headline` + `seekCare`, not a silent log. Honey is the archetype: acute, treatable, preventable, and culturally live for this family. The *myth* line ("cooking doesn't make it safe") and the *culturalNote* are the two highest-value nuggets unique to this food.

--- a/docs/research/honey-infant-safety.visual.html
+++ b/docs/research/honey-infant-safety.visual.html
@@ -1,0 +1,383 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Honey &amp; Infant Safety — Visual Dashboard · SproutLab Care</title>
+<style>
+  :root{
+    --bg:#faf6f0; --card:#fffdf9; --ink:#2e2a26; --mid:#6b6258; --line:#e8ddcf; --track:#efe7da;
+    --sage:#3a7060; --sage-bg:#e8f5ef; --rose:#b04a5e; --rose-bg:#fbe9ec;
+    --amber:#9a7320; --amber-bg:#fbf0d9; --accent:#9a6a3a; --honey:#d99a2b; --honey-bg:#fbeccb;
+    --hi:#2f7d5b; --hi-bg:#e3f3ea; --mod:#9a7320; --mod-bg:#f7eed6; --weak:#9a5a5a; --weak-bg:#f5e6e6;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#1d1a17; --card:#262220; --ink:#ece5db; --mid:#a89c8c; --line:#3a342d; --track:#332d26;
+    --sage:#7ac0a0; --sage-bg:#1e3028; --rose:#e090a0; --rose-bg:#3a2026;
+    --amber:#e0b060; --amber-bg:#352a16; --accent:#c99a6a; --honey:#e8b34a; --honey-bg:#3a2c12;
+    --hi:#7ac0a0; --hi-bg:#1e3028; --mod:#d8b060; --mod-bg:#332a14; --weak:#e09090; --weak-bg:#3a2222; }}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Nunito,sans-serif;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:960px;margin:0 auto;padding:0 18px 90px}
+  header{background:linear-gradient(160deg,var(--honey-bg),var(--bg));border-bottom:1px solid var(--line);padding:26px 0 0}
+  h1{font:700 25px/1.2 Fraunces,Georgia,serif;margin:0 0 4px}
+  .sub{color:var(--mid);font-size:14px;margin:0 0 16px;max-width:680px}
+  /* tabs */
+  nav{display:flex;gap:4px;margin-top:6px;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none}
+  nav::-webkit-scrollbar{display:none}
+  .tab{appearance:none;border:0;background:transparent;color:var(--mid);font:600 13.5px/1 Nunito,sans-serif;white-space:nowrap;flex:0 0 auto;
+    padding:11px 14px;border-radius:10px 10px 0 0;cursor:pointer;border-bottom:3px solid transparent}
+  .tab:hover{color:var(--ink);background:var(--card)}
+  .tab.on{color:var(--accent);background:var(--card);border-bottom-color:var(--accent)}
+  .panel{display:none;animation:f .25s ease}
+  .panel.on{display:block}
+  @keyframes f{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:none}}
+  h2{font:600 18px/1.3 Fraunces,Georgia,serif;margin:26px 0 10px}
+  h3{font:700 13px/1.3 Nunito;text-transform:uppercase;letter-spacing:.4px;color:var(--mid);margin:18px 0 8px}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:16px 18px;margin:12px 0}
+  .grid{display:grid;gap:12px}
+  .g2{grid-template-columns:1fr 1fr}.g3{grid-template-columns:repeat(3,1fr)}.g4{grid-template-columns:repeat(4,1fr)}
+  @media(max-width:680px){.g2,.g3,.g4{grid-template-columns:1fr 1fr}}
+  /* stat tiles */
+  .stat{text-align:center;padding:16px 10px}
+  .stat .n{font:800 26px/1 Fraunces,Georgia,serif;color:var(--accent)}
+  .stat .l{font-size:12px;color:var(--mid);margin-top:6px;line-height:1.35}
+  .stat.crit .n{color:var(--rose)} .stat.ok .n{color:var(--sage)}
+  /* badges */
+  .badge{display:inline-block;font:700 10.5px/1 Nunito;text-transform:uppercase;letter-spacing:.3px;padding:4px 8px;border-radius:6px;vertical-align:middle}
+  .b-hi{background:var(--hi-bg);color:var(--hi)}.b-mod{background:var(--mod-bg);color:var(--mod)}.b-weak{background:var(--weak-bg);color:var(--weak)}
+  .b-crit{background:var(--rose-bg);color:var(--rose)}
+  /* bar chart */
+  .bar{display:grid;grid-template-columns:130px 1fr 52px;align-items:center;gap:10px;margin:7px 0;font-size:13px}
+  .bar .lab{color:var(--ink);text-align:right;font-weight:600}
+  .bar .trk{display:block;background:var(--track);border:1px solid var(--line);border-radius:7px;height:18px;overflow:hidden}
+  .bar .fil{display:block;height:100%;border-radius:6px;background:var(--sage);min-width:3px}
+  .bar .val{font-weight:700;color:var(--mid);font-size:12.5px}
+  .bar.hl .fil{background:var(--honey)} .bar.hl .lab{color:var(--honey)} .bar.hl .val{color:var(--honey)}
+  /* timeline */
+  .tl{position:relative;margin:14px 0 6px;padding-left:8px}
+  .tl-step{position:relative;padding:0 0 18px 26px;border-left:2px solid var(--line)}
+  .tl-step:last-child{border-left-color:transparent}
+  .tl-dot{position:absolute;left:-8px;top:1px;width:15px;height:15px;border-radius:50%;background:var(--card);border:3px solid var(--accent)}
+  .tl-step.crit .tl-dot{border-color:var(--rose)} .tl-step.first .tl-dot{border-color:var(--honey)}
+  .tl-t{font-weight:700;font-size:13.5px}.tl-d{color:var(--mid);font-size:12.5px}
+  /* flag / callout */
+  .flag{border-left:3px solid var(--amber);background:var(--amber-bg);border-radius:6px;padding:10px 14px;margin:10px 0;font-size:13px}
+  .flag.good{border-left-color:var(--sage);background:var(--sage-bg)}
+  .flag.bad{border-left-color:var(--rose);background:var(--rose-bg)}
+  .flag b{color:inherit}
+  /* matrix */
+  table{width:100%;border-collapse:collapse;font-size:13px;margin:8px 0}
+  th,td{padding:8px 9px;border-bottom:1px solid var(--line);text-align:left;vertical-align:top}
+  th{font:700 11px/1.2 Nunito;text-transform:uppercase;letter-spacing:.3px;color:var(--mid)}
+  td.c{text-align:center;font-weight:800}
+  .yes{color:var(--sage)}.no{color:var(--rose)}.dash{color:var(--mid)}
+  td a{color:var(--sage);font-size:12px;word-break:break-all}
+  /* misc */
+  .pill{display:inline-block;font:600 11px/1 Nunito;padding:5px 10px;border-radius:999px;background:var(--card);border:1px solid var(--line);color:var(--mid);margin:0 4px 4px 0}
+  .pill.warn{background:var(--rose-bg);color:var(--rose);border-color:transparent}
+  .jump{display:inline-block;font-weight:700;color:var(--accent);cursor:pointer;border-bottom:1px dashed var(--accent)}
+  .lead{font-size:16px;line-height:1.5}
+  .lead b{color:var(--accent)}
+  ul.tight{margin:6px 0;padding-left:20px}.tight li{margin:5px 0}
+  pre{background:#1e1b18;color:#e8e2d6;border-radius:12px;padding:16px;overflow:auto;font:12px/1.5 "SF Mono",Menlo,Consolas,monospace}
+  pre .c{color:#8a9a7a}.k{color:#d8a0b0}.s{color:#cbb080}
+  .donut-wrap{display:flex;align-items:center;gap:18px;flex-wrap:wrap}
+  .legend{font-size:12.5px;color:var(--mid)}.legend b{color:var(--ink)}
+  .foot{color:var(--mid);font-size:12.5px;text-align:center;margin-top:30px}
+  .therm{display:flex;gap:14px;flex-wrap:wrap}
+  .therm .col{flex:1;min-width:200px;border:1px solid var(--line);border-radius:12px;padding:14px;text-align:center}
+  .therm .big{font:800 19px/1 Fraunces,serif;margin:6px 0}
+  .col.safe{background:var(--sage-bg)}.col.danger{background:var(--rose-bg)}
+  .col.safe .big{color:var(--sage)}.col.danger .big{color:var(--rose)}
+</style>
+</head>
+<body>
+<header><div class="wrap">
+  <h1>Honey &amp; Infant Safety — Visual Dashboard</h1>
+  <p class="sub">Visual Care dashboard — the honey evidence base at a glance, for any agent or human deciding how to surface food-effects in SproutLab. Skim the Summary; drill into a tab only if you need the detail.</p>
+  <nav>
+    <button class="tab on" data-p="p-sum">Summary</button>
+    <button class="tab" data-p="p-sci">The Science</button>
+    <button class="tab" data-p="p-sym">Symptoms &amp; Care</button>
+    <button class="tab" data-p="p-ind">India Context</button>
+    <button class="tab" data-p="p-src">Sources &amp; Confidence</button>
+    <button class="tab" data-p="p-data">Data Stub</button>
+  </nav>
+  <p style="font-size:11.5px;color:var(--mid);margin:6px 0 10px">Swipe ‹ › between tabs · or use ← → arrow keys</p>
+</div></header>
+
+<div class="wrap">
+
+<!-- ───────── SUMMARY ───────── -->
+<section class="panel on" id="p-sum">
+  <div class="card" style="background:var(--honey-bg);border-color:transparent;margin-top:18px">
+    <p class="lead" style="margin:0">The one rule: <b>no honey before 12 months — in any form.</b> The danger is <b>infant botulism</b>, an acute illness — not a nutrition concern. <b>Cooking/baking does NOT make it safe.</b> It's treatable but a medical emergency. For this Indian family, the <b>ghutti / prelacteal-feed tradition</b> is the live risk vector.</p>
+  </div>
+
+  <div class="grid g4">
+    <div class="card stat crit"><div class="n">&lt;12<span style="font-size:14px">mo</span></div><div class="l">No honey under 12 months — WHO·CDC·AAP·NHS, unanimous</div></div>
+    <div class="card stat crit"><div class="n">acute</div><div class="l">Risk tier: infant botulism, not nutrition</div></div>
+    <div class="card stat"><div class="n">≈20%</div><div class="l">of botulism cases linked to honey — the one <i>avoidable</i> source</div></div>
+    <div class="card stat ok"><div class="n">5.7→2.6<span style="font-size:14px">wk</span></div><div class="l">hospital stay cut by BabyBIG — treatable, usually full recovery</div></div>
+  </div>
+
+  <h3>The four things to know <span class="badge b-hi">all high-confidence</span></h3>
+  <div class="grid g2">
+    <div class="card"><b>1 · Why it's different.</b> Spores germinate inside the immature infant gut and make toxin <i>in the body</i>. Older kids/adults are protected by mature gut flora; under-1s aren't. → <span class="jump" data-go="p-sci">The Science</span></div>
+    <div class="card"><b>2 · The myth that bites.</b> "Cooking kills germs" is false here — the spores survive baking (need pressure-canning heat). Honey in a biscuit is still unsafe. → <span class="jump" data-go="p-sci">The Science</span></div>
+    <div class="card"><b>3 · What to watch for.</b> Constipation first (~90%), then weak cry/suck, floppiness, drooping eyelids, descending weakness. Onset 3–30 days. → <span class="jump" data-go="p-sym">Symptoms &amp; Care</span></div>
+    <div class="card"><b>4 · The India vector.</b> Honey/ghutti as a prelacteal feed — named by MoHFW/NHM as a thing to avoid; ~15% of Indian newborns still get a prelacteal feed. → <span class="jump" data-go="p-ind">India Context</span></div>
+  </div>
+
+  <h3>When to surface this (the design hook)</h3>
+  <div class="card flag good" style="margin-top:0">
+    <b>Recommendation (Maren):</b> when a parent marks an age-gated <b>critical-tier</b> food tried for a baby below its <code>minMonth</code>, <b>confirm</b> with the headline + seek-care line rather than logging silently. Honey is the archetype. The two highest-value, honey-unique nuggets to show: the <b>baking myth</b> and the <b>cultural note</b>. Ready-to-wire shape → <span class="jump" data-go="p-data">Data Stub</span>.
+  </div>
+
+  <div style="margin-top:14px">
+    <span class="pill">Reviewer · Maren (Care)</span>
+    <span class="pill">2026-05-30 · + gap-closing pass</span>
+    <span class="pill warn">Research artifact — not yet wired into the app</span>
+  </div>
+  <p style="font-size:12.5px;color:var(--mid);margin-top:10px">Full prose: <code>honey-infant-safety.md</code> · long-form HTML: <code>honey-infant-safety.html</code>. This dashboard is the skim layer over both.</p>
+</section>
+
+<!-- ───────── SCIENCE ───────── -->
+<section class="panel" id="p-sci">
+  <h2>Why infants — the mechanism</h2>
+  <div class="card">
+    <p style="margin:0 0 6px"><i>Clostridium botulinum</i> <b>spores</b> in honey are swallowed → in the <b>immature infant gut</b> (no protective flora, low acidity) they <b>germinate and produce toxin in the body</b> (intestinal toxemia) → toxin blocks acetylcholine → flaccid paralysis. Older children/adults are protected by mature gut flora. <span class="badge b-hi">consensus</span></p>
+  </div>
+
+  <h3>The 12-month line is a <i>conservative floor</i>, not a biological switch</h3>
+  <div class="card">
+    <!-- gut-defense timeline -->
+    <svg viewBox="0 0 600 96" width="100%" height="96" role="img" aria-label="Gut-defense timeline: danger zone 0 to 12 months; WHO notes defenses develop after about 6 months; avoidance floor set at 12 months">
+      <rect x="20" y="34" width="560" height="20" rx="10" fill="var(--track)"/>
+      <rect x="20" y="34" width="280" height="20" rx="10" fill="var(--rose-bg)"/>
+      <rect x="20" y="34" width="560" height="20" rx="10" fill="none" stroke="var(--line)"/>
+      <line x1="300" y1="24" x2="300" y2="64" stroke="var(--amber)" stroke-width="2" stroke-dasharray="4 3"/>
+      <line x1="580" y1="24" x2="580" y2="64" stroke="var(--rose)" stroke-width="3"/>
+      <circle cx="20" cy="44" r="4" fill="var(--rose)"/>
+      <text x="20" y="80" font-size="12" fill="var(--mid)">birth</text>
+      <text x="270" y="20" font-size="12" fill="var(--amber)">~6 mo · WHO: gut defenses develop</text>
+      <text x="470" y="80" font-size="12" fill="var(--rose)">12 mo · avoidance floor (all bodies)</text>
+      <text x="120" y="48" font-size="11.5" fill="var(--rose)" font-weight="700">HIGHEST RISK</text>
+    </svg>
+    <p style="font-size:12.5px;color:var(--mid);margin:4px 0 0">WHO notes natural intestinal defenses develop after ~6 months, yet every authority still sets avoidance at <b>12 months</b> — a deliberate safety margin. <span class="badge b-hi">consensus</span></p>
+  </div>
+
+  <h3>The baking myth — spores vs toxin</h3>
+  <div class="therm">
+    <div class="col safe">
+      <div style="font-size:12px;color:var(--mid)">Botulinum TOXIN</div>
+      <div class="big">destroyed ≥85°C</div>
+      <div style="font-size:12.5px">heat-labile — but <b>irrelevant to honey</b>, because honey carries spores, not pre-formed toxin</div>
+    </div>
+    <div class="col danger">
+      <div style="font-size:12px;color:var(--mid)">Botulinum SPORES (the honey hazard)</div>
+      <div class="big">survive baking</div>
+      <div style="font-size:12.5px">need ~121°C / 250°F <b>pressure-canning</b> heat. Ordinary baking/boiling does <b>not</b> kill them.</div>
+    </div>
+  </div>
+  <div class="flag"><b>⚑ Most-misunderstood point.</b> Honey baked into bread/biscuits/cakes, cooked into dishes, or in processed foods is <b>still unsafe</b> under 12 months. Pasteurization doesn't reliably kill spores either. <span class="badge b-hi">microbiology: high</span> <span class="badge b-mod">explicit-wording: moderate</span></div>
+
+  <h3>Honey is the avoidable source — not the main one</h3>
+  <div class="card donut-wrap">
+    <svg viewBox="0 0 120 120" width="118" height="118" role="img" aria-label="Honey accounts for about 20 percent of infant botulism cases; about 80 percent are environmental spores from soil and dust">
+      <circle cx="60" cy="60" r="52" fill="none" stroke="var(--track)" stroke-width="15"/>
+      <circle cx="60" cy="60" r="52" fill="none" stroke="var(--honey)" stroke-width="15"
+        stroke-dasharray="65.3 261.4" stroke-dashoffset="0" transform="rotate(-90 60 60)" stroke-linecap="round"/>
+      <text x="60" y="56" text-anchor="middle" font-size="20" font-weight="800" fill="var(--honey)" font-family="Fraunces,serif">~20%</text>
+      <text x="60" y="72" text-anchor="middle" font-size="9" fill="var(--mid)">from honey</text>
+    </svg>
+    <div class="legend">
+      <p style="margin:0 0 6px"><b style="color:var(--honey)">■ ~20%</b> linked to <b>honey</b> — the one source a parent can control.</p>
+      <p style="margin:0"><b>■ ~80%</b> from <b>environmental spores</b> (soil/dust); most cases have no identified source and are not preventable.</p>
+      <p style="font-size:11.5px;margin:8px 0 0">⚑ The 20% is an attribution estimate (most cases unconfirmed) — don't overstate honey as the main cause, but it <i>is</i> the main preventable one. <span class="badge b-mod">moderate</span></p>
+    </div>
+  </div>
+</section>
+
+<!-- ───────── SYMPTOMS & CARE ───────── -->
+<section class="panel" id="p-sym">
+  <h2>Symptom progression</h2>
+  <div class="card">
+    <p style="margin:0 0 6px;font-size:13px;color:var(--mid)">Descending, symmetric, flaccid — starts at the head, moves down. Onset <b>3–30 days</b> after ingestion. Baby is usually <b>alert and afebrile</b> (reassuring but misleading).</p>
+    <div class="tl">
+      <div class="tl-step first"><span class="tl-dot"></span><div class="tl-t">Constipation — often the FIRST sign <span class="badge b-hi">~90%</span></div><div class="tl-d">May precede the neuromuscular signs.</div></div>
+      <div class="tl-step"><span class="tl-dot"></span><div class="tl-t">Weak / altered cry · poor feeding · weak suck</div><div class="tl-d">Milk pooling in the mouth.</div></div>
+      <div class="tl-step"><span class="tl-dot"></span><div class="tl-t">Floppiness (hypotonia) · drooping eyelids (ptosis)</div><div class="tl-d">Poor head control, reduced facial movement, diminished gag.</div></div>
+      <div class="tl-step crit"><span class="tl-dot"></span><div class="tl-t">Descending symmetric weakness → respiratory muscles</div><div class="tl-d">~50% need airway/ventilation support — the emergency.</div></div>
+    </div>
+    <p style="font-size:11.5px;color:var(--mid);margin:2px 0 0">⚑ Incubation lower bound differs by source: 3 days (AAP/CDC) vs 10 days (StatPearls). Use "within days to a few weeks."</p>
+  </div>
+
+  <h2>When to seek care &amp; treatment</h2>
+  <div class="grid g2">
+    <div class="card flag bad" style="margin:0">
+      <b>Medical emergency.</b> Constipation <b>+</b> new weakness / floppiness / feeding change → urgent evaluation. Risk of respiratory failure. <span class="badge b-hi">high</span>
+    </div>
+    <div class="card flag good" style="margin:0">
+      <b>Treatable.</b> Human Botulism Immune Globulin (<b>BabyBIG / BIG-IV</b>), started without waiting for lab confirmation. Hospital stay <b>5.7 → 2.6 weeks</b> (NEJM trial). Prognosis generally very good.
+    </div>
+  </div>
+  <div class="flag"><b>⚑ Don't:</b> antibiotics are not first-line; <b>aminoglycosides are contraindicated</b> (worsen weakness). Mortality is low with prompt treatment (&lt;1% in promptly-treated US cases; "&lt;15%" figures are broad/historical).</div>
+</section>
+
+<!-- ───────── INDIA CONTEXT ───────── -->
+<section class="panel" id="p-ind">
+  <h2>The cultural vector</h2>
+  <div class="card">
+    <p style="margin:0"><b>Prelacteal feeds</b> — anything given before breastfeeding begins (honey, <i>gur</i>, sugar water, <b>janam ghutti</b>), usually in the first 2–3 days. India's <b>MoHFW/NHM (MAA module)</b> names them directly: babies should not be given <i>"gur, ghutti, honey, sweet water, etc."</i> and <i>"no prelacteal feeds should be given."</i> <span class="badge b-hi">primary govt source</span></p>
+  </div>
+
+  <h3>Prelacteal feeding in India is declining but persists <span class="badge b-mod">NFHS-5 microdata</span></h3>
+  <div class="card">
+    <div class="bar"><span class="lab">NFHS-4 (2015–16)</span><span class="trk"><span class="fil" style="width:69%;background:var(--mid)"></span></span><span class="val">20.8%</span></div>
+    <div class="bar hl"><span class="lab">NFHS-5 (2019–21)</span><span class="trk"><span class="fil" style="width:51%"></span></span><span class="val">15.3%</span></div>
+    <p style="font-size:12px;color:var(--mid);margin:6px 0 0">% of children given anything other than breast milk in the first 3 days. A clear decline — but ~1 in 7 newborns still receives a prelacteal feed.</p>
+  </div>
+
+  <h3>What prelacteal-fed infants are given <span class="badge b-mod">% among prelacteal-fed</span></h3>
+  <div class="card">
+    <div class="bar"><span class="lab">Other (non-breast) milk</span><span class="trk"><span class="fil" style="width:100%;background:var(--mid)"></span></span><span class="val">71.9%</span></div>
+    <div class="bar"><span class="lab">Plain water</span><span class="trk"><span class="fil" style="width:15.6%;background:var(--mid)"></span></span><span class="val">11.2%</span></div>
+    <div class="bar hl"><span class="lab">Honey</span><span class="trk"><span class="fil" style="width:12.4%"></span></span><span class="val">8.9%</span></div>
+    <div class="bar"><span class="lab">Sugar / glucose water</span><span class="trk"><span class="fil" style="width:11.1%;background:var(--mid)"></span></span><span class="val">8.0%</span></div>
+    <div class="bar"><span class="lab">Janam ghutti</span><span class="trk"><span class="fil" style="width:7.6%;background:var(--mid)"></span></span><span class="val">5.5%</span></div>
+    <div class="bar"><span class="lab">Tea / infusions</span><span class="trk"><span class="fil" style="width:7.5%;background:var(--mid)"></span></span><span class="val">5.4%</span></div>
+    <div class="bar"><span class="lab">Infant formula</span><span class="trk"><span class="fil" style="width:6.4%;background:var(--mid)"></span></span><span class="val">4.6%</span></div>
+    <p style="font-size:12px;color:var(--mid);margin:6px 0 0">Honey ≈ <b>8.9%</b> of prelacteal-fed infants → roughly <b>1.3–1.4% of all newborns</b>. A documented Indian case: a 4-day-old fed raw village honey "as per family tradition" developed hypotonia; recovered by day 15. <span class="badge b-mod">n=1</span></p>
+  </div>
+
+  <h3>Gap-closing pass — two claims CORRECTED</h3>
+  <div class="card flag bad" style="margin-top:0">
+    <b>✗ IAP — do NOT attribute the rule to IAP.</b> Both primary IAP feeding PDFs (Breastfeeding + IYCF 2016, 23pp) were parsed in full → <b>zero mention of honey or botulism.</b> The "IAP says no honey" claim is unsupported.
+  </div>
+  <div class="card flag bad" style="margin-top:0">
+    <b>✗ FSSAI — reversed.</b> FSSAI's Foods for Infant Nutrition regulation <i>permits</i> honey (only a manufacturing spore-destruction rule); <b>no consumer under-1 ban.</b> The blog claim was WHO/AAP laundered onto FSSAI's name. <i>(Permitting spore-destroyed honey in manufactured products ≠ raw honey is OK at home.)</i>
+  </div>
+  <div class="card flag good" style="margin-top:0">
+    <b>✓ The India-specific authority is MoHFW/NHM</b> — not IAP/FSSAI. Plus WHO/CDC/AAP/NHS for the universal rule.
+  </div>
+</section>
+
+<!-- ───────── SOURCES & CONFIDENCE ───────── -->
+<section class="panel" id="p-src">
+  <h2>Who says what — consensus matrix</h2>
+  <div class="card" style="overflow-x:auto">
+  <table>
+    <tr><th>Authority</th><th class="c">No honey &lt;12mo</th><th class="c">Names honey</th><th class="c">India-specific</th></tr>
+    <tr><td>WHO</td><td class="c yes">✓</td><td class="c yes">✓</td><td class="c dash">—</td></tr>
+    <tr><td>US CDC</td><td class="c yes">✓</td><td class="c yes">✓</td><td class="c dash">—</td></tr>
+    <tr><td>AAP / HealthyChildren</td><td class="c yes">✓</td><td class="c yes">✓</td><td class="c dash">—</td></tr>
+    <tr><td>UK NHS</td><td class="c yes">✓</td><td class="c yes">✓</td><td class="c dash">—</td></tr>
+    <tr><td>India MoHFW/NHM (MAA)</td><td class="c yes">✓</td><td class="c yes">✓</td><td class="c yes">✓</td></tr>
+    <tr><td>IAP <i>(checked)</i></td><td class="c dash">—</td><td class="c no">✗</td><td class="c yes">✓</td></tr>
+    <tr><td>FSSAI <i>(checked)</i></td><td class="c no">✗ permits</td><td class="c yes">✓ as allowed</td><td class="c yes">✓</td></tr>
+  </table>
+  <p style="font-size:12px;color:var(--mid);margin:6px 0 0">✓ supports · ✗ does not / opposite · — not applicable. IAP/FSSAI columns reflect the gap-closing pass: neither supports a consumer honey-under-1 rule.</p>
+  </div>
+
+  <h2>Sources</h2>
+  <div class="card" style="overflow-x:auto">
+  <table>
+    <tr><th>Authority</th><th>Link</th></tr>
+    <tr><td>WHO — Botulism fact sheet</td><td><a href="https://www.who.int/news-room/fact-sheets/detail/botulism">who.int/…/botulism</a></td></tr>
+    <tr><td>CDC — foods to avoid</td><td><a href="https://www.cdc.gov/infant-toddler-nutrition/foods-and-drinks/foods-and-drinks-to-avoid-or-limit.html">cdc.gov/infant-toddler-nutrition</a></td></tr>
+    <tr><td>CDC — infant botulism clinical</td><td><a href="https://www.cdc.gov/botulism/hcp/clinical-overview/infant-botulism.html">cdc.gov/botulism</a></td></tr>
+    <tr><td>AAP / HealthyChildren — Botulism</td><td><a href="https://www.healthychildren.org/English/health-issues/conditions/infections/Pages/Botulism.aspx">healthychildren.org/…/Botulism</a></td></tr>
+    <tr><td>UK NHS — foods to avoid</td><td><a href="https://www.nhs.uk/baby/weaning-and-feeding/foods-to-avoid-giving-babies-and-young-children/">nhs.uk/baby</a></td></tr>
+    <tr><td>StatPearls / NCBI — NBK493178</td><td><a href="https://www.ncbi.nlm.nih.gov/books/NBK493178/">ncbi.nlm.nih.gov/books/NBK493178</a></td></tr>
+    <tr><td>NEJM — Arnon (BabyBIG trial)</td><td><a href="https://www.nejm.org/doi/full/10.1056/NEJMoa051926">nejm.org/…/NEJMoa051926</a></td></tr>
+    <tr><td>Texas DSHS — honey pacifier alert</td><td><a href="https://www.dshs.texas.gov/news-alerts/infant-botulism-health-alert-nov-16-2018">dshs.texas.gov</a></td></tr>
+    <tr><td>India MoHFW/NHM — MAA module</td><td><a href="https://nhm.gov.in/New_Updates_2018/NHM_Components/RMNCHA/CH/Schemes/Maa/Training_Module_English_Lowres.pdf">nhm.gov.in/…/MAA</a></td></tr>
+    <tr><td>IAP — Breastfeeding / IYCF 2016 <i>(no honey mention)</i></td><td><a href="https://www.indianpediatrics.net/aug2016/703.pdf">indianpediatrics.net/aug2016/703.pdf</a></td></tr>
+    <tr><td>FSSAI — Foods for Infant Nutrition Reg. <i>(permits honey)</i></td><td><a href="https://www.fssai.gov.in/upload/uploadfiles/files/Comp_IFR_VERSION-II_04_01_2024.pdf">fssai.gov.in/…/Infant Nutrition 2024</a></td></tr>
+    <tr><td>IIPS / NFHS-5 microdata (PLOS ONE 2023)</td><td><a href="https://pmc.ncbi.nlm.nih.gov/articles/PMC10553319/">pmc.ncbi.nlm.nih.gov/…/PMC10553319</a></td></tr>
+    <tr><td>UF/IFAS — Infant Botulism &amp; Honey (heat)</td><td><a href="https://ask.ifas.ufl.edu/publication/AA142">ask.ifas.ufl.edu/…/AA142</a></td></tr>
+  </table>
+  </div>
+
+  <div class="flag"><b>⚑ Open gap (genuinely absent):</b> India has no mandatory botulism surveillance — case reports exist, but a national incidence rate was never collected. Under-reporting is a reasoned hypothesis, not a sourced fact.</div>
+</section>
+
+<!-- ───────── DATA STUB ───────── -->
+<section class="panel" id="p-data">
+  <h2>Drop-in data shape — <code>FOOD_EFFECTS['honey']</code></h2>
+  <p style="font-size:13.5px;color:var(--mid)">Sits alongside <code>AGE_RULES['honey']</code> (which stays the gate; this adds the <i>effect</i>). The surfacing dialog reads <code>headline</code> + <code>seekCare</code>; richer surfaces use the rest. <b>Not yet wired.</b></p>
+<pre><span class="c">// consequence layer atop AGE_RULES/ALLERGENS — critical-tier acute effects</span>
+<span class="k">const</span> FOOD_EFFECTS = {
+  <span class="s">'honey'</span>: {
+    tier:        <span class="s">'critical'</span>,            <span class="c">// acute illness, not a nutrition note</span>
+    effect:      <span class="s">'infant botulism'</span>,
+    threshold:   { minMonth: <span class="s">12</span>, basis: <span class="s">'conservative'</span> },
+    headline:    <span class="s">'Avoid before 12 months — honey can cause infant botulism.'</span>,
+    why:         <span class="s">'Honey can carry C. botulinum spores; a baby’s immature gut lets them grow…'</span>,
+    myth:        { claim: <span class="s">'Cooking or baking makes honey safe.'</span>,
+                   truth: <span class="s">'No — spores survive baking; honey in biscuits/cooked dishes is still unsafe.'</span> },
+    hiddenSources: [<span class="s">'baked goods'</span>, <span class="s">'cooked dishes'</span>, <span class="s">'gripe water / ghutti'</span>,
+                    <span class="s">'cough remedies'</span>, <span class="s">'honey on pacifier/finger/lip'</span>],
+    watchFor:    [<span class="s">'constipation (often first)'</span>, <span class="s">'weak/altered cry'</span>, <span class="s">'poor feeding'</span>,
+                  <span class="s">'floppiness'</span>, <span class="s">'drooping eyelids'</span>],
+    timeCourse:  <span class="s">'within days to a few weeks (commonly 3–30 days)'</span>,
+    seekCare:    <span class="s">'Medical emergency. Treatable (BabyBIG); recovery usually full with prompt care.'</span>,
+    breastfeedingSafe: <span class="s">true</span>,
+    culturalNote: <span class="s">'Indian prelacteal practices (janam ghutti, honey on lips/finger) are a real vector.'</span>,
+    confidence:  <span class="s">'high'</span>,
+    lastReviewed: <span class="s">'2026-05-30'</span>,
+  },
+};</pre>
+  <div class="flag good"><b>Surfacing hook:</b> trigger on <code>mark-tried</code> when <code>AGE_RULES[food].minMonth &gt; getAgeInMonths()</code> AND <code>FOOD_EFFECTS[food].tier === 'critical'</code> → confirm dialog with <code>headline</code> + <code>seekCare</code>. The <code>myth</code> + <code>culturalNote</code> are honey's unique high-value lines.</div>
+</section>
+
+<p class="foot">SproutLab · Care visual dashboard · skim layer over <code>honey-infant-safety.md</code> / <code>.html</code> · 2026-05-30<br>
+Informational, not medical advice. Not yet wired into the app. All chart values are also in text for machine-reading.</p>
+</div>
+
+<script>
+  var tabs = Array.prototype.slice.call(document.querySelectorAll('.tab'));
+  function activate(t){
+    if(!t) return;
+    tabs.forEach(function(x){x.classList.remove('on');});
+    document.querySelectorAll('.panel').forEach(function(x){x.classList.remove('on');});
+    t.classList.add('on');
+    var el = document.getElementById(t.dataset.p);
+    if(el) el.classList.add('on');
+    t.scrollIntoView({inline:'center', block:'nearest'});
+    window.scrollTo(0,0);
+  }
+  tabs.forEach(function(t){ t.addEventListener('click', function(){ activate(t); }); });
+  // in-page "jump to tab" links on the summary
+  document.querySelectorAll('[data-go]').forEach(function(j){
+    j.addEventListener('click', function(){
+      activate(document.querySelector('.tab[data-p="'+j.dataset.go+'"]'));
+    });
+  });
+  function step(dir){
+    var cur = tabs.findIndex(function(t){return t.classList.contains('on');});
+    var next = cur + dir;
+    if(next >= 0 && next < tabs.length) activate(tabs[next]);
+  }
+  // ── Tab swiping (touch) — horizontal swipe switches tabs; vertical scroll untouched ──
+  var sx=0, sy=0, tracking=false;
+  document.addEventListener('touchstart', function(e){
+    if(e.touches.length>1){ tracking=false; return; }
+    sx=e.changedTouches[0].clientX; sy=e.changedTouches[0].clientY; tracking=true;
+  }, {passive:true});
+  document.addEventListener('touchend', function(e){
+    if(!tracking) return; tracking=false;
+    var dx=e.changedTouches[0].clientX - sx, dy=e.changedTouches[0].clientY - sy;
+    // require a clear, mostly-horizontal swipe so vertical scrolling isn't hijacked
+    if(Math.abs(dx) < 55 || Math.abs(dx) < Math.abs(dy)*1.5) return;
+    step(dx < 0 ? 1 : -1);   // swipe left → next tab, swipe right → previous
+  }, {passive:true});
+  // keyboard arrows too (desktop convenience)
+  document.addEventListener('keydown', function(e){
+    if(e.key==='ArrowRight') step(1); else if(e.key==='ArrowLeft') step(-1);
+  });
+</script>
+</body>
+</html>

--- a/docs/research/index.html
+++ b/docs/research/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Care Research — Food Effects · SproutLab</title>
+<style>
+  :root{--bg:#faf6f0;--card:#fffdf9;--ink:#2e2a26;--mid:#6b6258;--line:#e8ddcf;
+    --accent:#9a6a3a;--honey:#d99a2b;--honey-bg:#fbeccb;--rose:#b04a5e;--rose-bg:#fbe9ec;
+    --sage:#3a7060;--sage-bg:#e8f5ef;}
+  @media(prefers-color-scheme:dark){:root{--bg:#1d1a17;--card:#262220;--ink:#ece5db;--mid:#a89c8c;--line:#3a342d;
+    --accent:#c99a6a;--honey:#e8b34a;--honey-bg:#3a2c12;--rose:#e090a0;--rose-bg:#3a2026;--sage:#7ac0a0;--sage-bg:#1e3028;}}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Nunito,sans-serif;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:760px;margin:0 auto;padding:34px 20px 80px}
+  h1{font:700 26px/1.2 Fraunces,Georgia,serif;margin:0 0 6px}
+  .sub{color:var(--mid);font-size:14.5px;margin:0 0 24px;max-width:600px}
+  h2{font:700 12px/1.3 Nunito;text-transform:uppercase;letter-spacing:.5px;color:var(--mid);margin:28px 0 10px}
+  .food{background:var(--card);border:1px solid var(--line);border-radius:16px;padding:18px 20px;margin:12px 0}
+  .food .top{display:flex;align-items:center;justify-content:space-between;gap:10px;flex-wrap:wrap}
+  .food .name{font:700 19px/1.2 Fraunces,serif}
+  .tier{font:700 10.5px/1 Nunito;text-transform:uppercase;letter-spacing:.4px;padding:5px 9px;border-radius:7px;background:var(--rose-bg);color:var(--rose)}
+  .one{color:var(--mid);font-size:13.5px;margin:8px 0 14px}
+  .links{display:flex;gap:8px;flex-wrap:wrap}
+  .links a{flex:1 1 auto;text-align:center;text-decoration:none;font:600 13px/1 Nunito;padding:11px 12px;border-radius:10px;border:1px solid var(--line);color:var(--ink);background:var(--bg)}
+  .links a:hover{border-color:var(--accent);color:var(--accent)}
+  .links a.primary{background:var(--honey);color:#3a2c12;border-color:transparent}
+  .note{background:var(--sage-bg);border-radius:12px;padding:14px 16px;font-size:13.5px;color:var(--ink);margin:10px 0}
+  .meta{font-size:12.5px;color:var(--mid);margin-top:8px}
+  code{font:12.5px "SF Mono",Menlo,Consolas,monospace;background:var(--honey-bg);padding:1px 5px;border-radius:5px}
+  a.plain{color:var(--sage)}
+  footer{color:var(--mid);font-size:12.5px;margin-top:34px;border-top:1px solid var(--line);padding-top:14px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Care Research · Food Effects</h1>
+  <p class="sub">Evidence base for surfacing food effects in SproutLab's Care layer. Each food has a skim dashboard, a long-form brief, and a cited source doc. Honey is the archetype; more foods follow.</p>
+
+  <h2>Foods</h2>
+  <div class="food">
+    <div class="top">
+      <span class="name">Honey</span>
+      <span class="tier">Critical · infant botulism</span>
+    </div>
+    <p class="one">No honey before 12 months, in any form — the danger is infant botulism, not nutrition. Cooking/baking does <b>not</b> make it safe. Treatable but a medical emergency. For an Indian family, the <i>ghutti</i> / prelacteal-feed tradition is the live vector.</p>
+    <div class="links">
+      <a class="primary" href="honey-infant-safety.visual.html">Visual dashboard ›</a>
+      <a href="honey-infant-safety.html">Long-form brief</a>
+      <a href="honey-infant-safety.md">Source (.md)</a>
+    </div>
+    <p class="meta">Reviewed 2026-05-30 · confidence: high · WHO · CDC · AAP · NHS · India MoHFW/NHM</p>
+  </div>
+
+  <h2>How this is built</h2>
+  <div class="note">
+    One <b>data spine</b> — <code>food-effects.manifest.js</code> — holds a summary record per food, feeding both this research layer and (eventually) the in-app surfacing. New foods are authored from <code>_TEMPLATE.food-dashboard.html</code>. Once enough foods exist, a unified hub will let you browse one food, compare several, or slice by reaction. See <a class="plain" href="README.md">README.md</a> for the full plan.
+  </div>
+  <p class="meta">Three depth layers per food: <b>visual dashboard</b> (skim) → <b>long-form</b> (full prose) → <b>.md</b> (source of truth). All carry the same verified figures.</p>
+
+  <footer>SproutLab · Care research layer · informational, not medical advice. Not yet wired into the app.</footer>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## What

Publishes the `docs/research/` Care food-effects layer to `main` so it's permanently live on GitHub Pages at:

**https://rishabh1804.github.io/sproutlab/docs/research/**

Pages serves the `docs/` tree from `main` root (same as the existing `docs/MODULE_MAP.html` etc.), so these files go live on merge.

## Contents (docs-only)

- `index.html` — landing/entry point for the research layer (seeds the future unified hub)
- `honey-infant-safety.visual.html` — tabbed visual dashboard (skim layer; swipe/arrow tab nav, CSS/SVG charts)
- `honey-infant-safety.html` — long-form rendered brief
- `honey-infant-safety.md` — cited source-of-truth brief
- `_TEMPLATE.food-dashboard.html` — reusable dashboard template for future foods
- `food-effects.manifest.js` — the data spine (one summary record per food)
- `README.md` — authoring guide + unified-dashboard architecture plan

## Scope / safety

- **Docs-only** — no `split/` or app changes; `index.html`/`sproutlab.html` at repo root are untouched, so the live app is unaffected.
- **canon-cc-008 chain-exempt** (docs-only → Governor audit waived).
- Branched off `main` and contains **only** `docs/research/` — none of the in-flight F-3 feature work.
- Research artifacts: informational, not medical advice; not wired into the app.

https://claude.ai/code/session_0136Gf7ZEtcmmDntMTARNY15

---
_Generated by [Claude Code](https://claude.ai/code/session_0136Gf7ZEtcmmDntMTARNY15)_