### PR TITLE
P0.2: route diet.js safety-table matches through the word-boundary resolver

### DIFF
--- a/index.html
+++ b/index.html
@@ -37992,12 +37992,14 @@ function _fdIsFoodTried(name) {
   return foods.some(f => _fdSameFood(base, f.name));
 }
 
-// Resolve an allergen note for a food name (mirrors the diet.js combo-check
-// lookup at line ~508 — exact, suffix-stripped, then substring).
+// Resolve an allergen note for a food name. Routes through the shared
+// word-boundary resolver (core.js _lookupByFoodName) so allergen matching uses
+// the SAME semantics as the age gate (_fdAgeRule) and the consequence card
+// (getFoodEffect) — one food-name matching rule across the project, not two.
+// Word-boundary (not substring) retires the honeydew-class door: a name only
+// matches an ALLERGENS key on a whole word (V-K-30 word-boundary doctrine).
 function _fdAllergenNote(name) {
-  const n = String(name).toLowerCase().trim();
-  return ALLERGENS[n] || ALLERGENS[n.replace(/s$/, '')] ||
-    (Object.entries(ALLERGENS).find(([k]) => n.includes(k)) || [])[1] || null;
+  return _lookupByFoodName(ALLERGENS, name);
 }
 
 // Resolve an age-gate rule {minMonth, reason} for a food name.
@@ -38695,8 +38697,10 @@ function checkFoodCombo() {
 
   // ── 1. Check age safety ──
   rawFoods.forEach(food => {
-    // Direct match
-    const rule = AGE_RULES[food] || AGE_RULES[food.replace(/s$/, '')] || Object.entries(AGE_RULES).find(([k]) => food.includes(k))?.[1];
+    // Word-boundary resolve via the shared core.js resolver — same semantics as
+    // _fdAgeRule + the consequence card; substring matching retired (V-K-30 /
+    // honeydew-class door closed across the project, not just the safety surfaces).
+    const rule = _lookupByFoodName(AGE_RULES, food);
     if (rule && mo < rule.minMonth) {
       verdict = 'avoid';
       verdictEmoji = zi('warn');
@@ -38706,7 +38710,7 @@ function checkFoodCombo() {
 
   // ── 2. Check allergens ──
   rawFoods.forEach(food => {
-    const alert = ALLERGENS[food] || ALLERGENS[food.replace(/s$/, '')] || Object.entries(ALLERGENS).find(([k]) => food.includes(k))?.[1];
+    const alert = _lookupByFoodName(ALLERGENS, food);
     if (alert) {
       allergenNotes.push(`${zi('warn')} ${food}: ${alert}`);
       if (verdict === 'safe') { verdict = 'caution'; verdictEmoji = zi('warn'); }

--- a/index.html
+++ b/index.html
@@ -16533,6 +16533,7 @@ const ALLERGENS = {
   'sesame':    'Seed allergen. Start small — ½ tsp ground. Watch for reactions.',
   'til':       'Seed allergen. Start small — ½ tsp ground. Watch for reactions.',
   'soy':       'Common allergen. Start with small amounts.',
+  'soya':      'Common allergen. Start with small amounts.',
   'soybean':   'Common allergen. Start with small amounts.',
   'wheat':     'Contains gluten. Watch for signs of intolerance — bloating, rash, loose stools.',
   'oats':      'May contain traces of gluten. Use certified gluten-free if family has coeliac history.',

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.30-17",
+  "version": "2026.05.30-18",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.30-18",
+  "version": "2026.05.30-19",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/data.js
+++ b/split/data.js
@@ -2463,6 +2463,7 @@ const ALLERGENS = {
   'sesame':    'Seed allergen. Start small — ½ tsp ground. Watch for reactions.',
   'til':       'Seed allergen. Start small — ½ tsp ground. Watch for reactions.',
   'soy':       'Common allergen. Start with small amounts.',
+  'soya':      'Common allergen. Start with small amounts.',
   'soybean':   'Common allergen. Start with small amounts.',
   'wheat':     'Contains gluten. Watch for signs of intolerance — bloating, rash, loose stools.',
   'oats':      'May contain traces of gluten. Use certified gluten-free if family has coeliac history.',

--- a/split/diet.js
+++ b/split/diet.js
@@ -472,12 +472,14 @@ function _fdIsFoodTried(name) {
   return foods.some(f => _fdSameFood(base, f.name));
 }
 
-// Resolve an allergen note for a food name (mirrors the diet.js combo-check
-// lookup at line ~508 — exact, suffix-stripped, then substring).
+// Resolve an allergen note for a food name. Routes through the shared
+// word-boundary resolver (core.js _lookupByFoodName) so allergen matching uses
+// the SAME semantics as the age gate (_fdAgeRule) and the consequence card
+// (getFoodEffect) — one food-name matching rule across the project, not two.
+// Word-boundary (not substring) retires the honeydew-class door: a name only
+// matches an ALLERGENS key on a whole word (V-K-30 word-boundary doctrine).
 function _fdAllergenNote(name) {
-  const n = String(name).toLowerCase().trim();
-  return ALLERGENS[n] || ALLERGENS[n.replace(/s$/, '')] ||
-    (Object.entries(ALLERGENS).find(([k]) => n.includes(k)) || [])[1] || null;
+  return _lookupByFoodName(ALLERGENS, name);
 }
 
 // Resolve an age-gate rule {minMonth, reason} for a food name.
@@ -1175,8 +1177,10 @@ function checkFoodCombo() {
 
   // ── 1. Check age safety ──
   rawFoods.forEach(food => {
-    // Direct match
-    const rule = AGE_RULES[food] || AGE_RULES[food.replace(/s$/, '')] || Object.entries(AGE_RULES).find(([k]) => food.includes(k))?.[1];
+    // Word-boundary resolve via the shared core.js resolver — same semantics as
+    // _fdAgeRule + the consequence card; substring matching retired (V-K-30 /
+    // honeydew-class door closed across the project, not just the safety surfaces).
+    const rule = _lookupByFoodName(AGE_RULES, food);
     if (rule && mo < rule.minMonth) {
       verdict = 'avoid';
       verdictEmoji = zi('warn');
@@ -1186,7 +1190,7 @@ function checkFoodCombo() {
 
   // ── 2. Check allergens ──
   rawFoods.forEach(food => {
-    const alert = ALLERGENS[food] || ALLERGENS[food.replace(/s$/, '')] || Object.entries(ALLERGENS).find(([k]) => food.includes(k))?.[1];
+    const alert = _lookupByFoodName(ALLERGENS, food);
     if (alert) {
       allergenNotes.push(`${zi('warn')} ${food}: ${alert}`);
       if (verdict === 'safe') { verdict = 'caution'; verdictEmoji = zi('warn'); }

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -37992,12 +37992,14 @@ function _fdIsFoodTried(name) {
   return foods.some(f => _fdSameFood(base, f.name));
 }
 
-// Resolve an allergen note for a food name (mirrors the diet.js combo-check
-// lookup at line ~508 — exact, suffix-stripped, then substring).
+// Resolve an allergen note for a food name. Routes through the shared
+// word-boundary resolver (core.js _lookupByFoodName) so allergen matching uses
+// the SAME semantics as the age gate (_fdAgeRule) and the consequence card
+// (getFoodEffect) — one food-name matching rule across the project, not two.
+// Word-boundary (not substring) retires the honeydew-class door: a name only
+// matches an ALLERGENS key on a whole word (V-K-30 word-boundary doctrine).
 function _fdAllergenNote(name) {
-  const n = String(name).toLowerCase().trim();
-  return ALLERGENS[n] || ALLERGENS[n.replace(/s$/, '')] ||
-    (Object.entries(ALLERGENS).find(([k]) => n.includes(k)) || [])[1] || null;
+  return _lookupByFoodName(ALLERGENS, name);
 }
 
 // Resolve an age-gate rule {minMonth, reason} for a food name.
@@ -38695,8 +38697,10 @@ function checkFoodCombo() {
 
   // ── 1. Check age safety ──
   rawFoods.forEach(food => {
-    // Direct match
-    const rule = AGE_RULES[food] || AGE_RULES[food.replace(/s$/, '')] || Object.entries(AGE_RULES).find(([k]) => food.includes(k))?.[1];
+    // Word-boundary resolve via the shared core.js resolver — same semantics as
+    // _fdAgeRule + the consequence card; substring matching retired (V-K-30 /
+    // honeydew-class door closed across the project, not just the safety surfaces).
+    const rule = _lookupByFoodName(AGE_RULES, food);
     if (rule && mo < rule.minMonth) {
       verdict = 'avoid';
       verdictEmoji = zi('warn');
@@ -38706,7 +38710,7 @@ function checkFoodCombo() {
 
   // ── 2. Check allergens ──
   rawFoods.forEach(food => {
-    const alert = ALLERGENS[food] || ALLERGENS[food.replace(/s$/, '')] || Object.entries(ALLERGENS).find(([k]) => food.includes(k))?.[1];
+    const alert = _lookupByFoodName(ALLERGENS, food);
     if (alert) {
       allergenNotes.push(`${zi('warn')} ${food}: ${alert}`);
       if (verdict === 'safe') { verdict = 'caution'; verdictEmoji = zi('warn'); }

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -16533,6 +16533,7 @@ const ALLERGENS = {
   'sesame':    'Seed allergen. Start small — ½ tsp ground. Watch for reactions.',
   'til':       'Seed allergen. Start small — ½ tsp ground. Watch for reactions.',
   'soy':       'Common allergen. Start with small amounts.',
+  'soya':      'Common allergen. Start with small amounts.',
   'soybean':   'Common allergen. Start with small amounts.',
   'wheat':     'Contains gluten. Watch for signs of intolerance — bloating, rash, loose stools.',
   'oats':      'May contain traces of gluten. Use certified gluten-free if family has coeliac history.',


### PR DESCRIPTION
## What

Unifies food-name matching onto **one** semantics. Three `diet.js` sites resolved food names against the `AGE_RULES` / `ALLERGENS` **safety tables** with the pre-`honeydew` loose `.includes()` substring match — a second matching rule alongside the shared word-boundary resolver `_lookupByFoodName` the age gate + consequence card already use. Routed all three through `_lookupByFoodName` (exact → de-plural → `\bkey\b`, never bare substring):

| Site | Surface |
|------|---------|
| `diet.js:482` `_fdAllergenNote` | allergen-note lookup |
| `diet.js:1183` | combo-checker age rule |
| `diet.js:1193` | combo-checker allergen flag |

Plus one `data.js` fold (`ALLERGENS['soya']`) — see chain below.

## Deliberately out of scope
`_mealFoodMatches` (`intelligence-cards.js:2378`) + synergy match (`diet.js:1650`) are fuzzy 2-string synergy matchers (normalized, bidirectional), **not** safety-table lookups — "route through `_lookupByFoodName`" is a category mismatch and changing them is a render-surface (Vela) behavior change. Deferred for a deliberate decision.

## QA gate (canon-cc-008) — CHAIN COMPLETE ✅

| Step | Owner | Verdict |
|------|-------|---------|
| Gate 2 (builder self-check) | Lyra | ✅ build clean, **319/319 e2e** |
| Care audit (`diet.js`) | **Maren** | ⚠️→✅ **`amended`** — found `\bsoy\b` silently dropped the **"soya"** allergen flag (dominant Indian spelling, common-case under-warn). Prescribed fix folded: `ALLERGENS['soya']` added (`data.js`). |
| Intelligence audit (`data.js`) | **Kael** | ✅ **`LGTM`** — fold resolver-verified (exact-match arm, no shadowing), all 3 ALLERGENS consumers safe |
| Synthesis | Lyra | folded Maren's fix (`f6f9268`), re-verified, e2e green |
| Edict V final-pass | **Cipher** | ✅ **`LGTM`** — substring→word-boundary is the only delta; resolver normalization a verified no-op; `null`/`undefined` contract inert. *"Clean fold. Ship it."* |

## Ledger (recorded, not blocking — feeds the food-effects-v2 work)
- **`ALLERGENS` sits outside the P0.1 sync gate** (Kael) — the dropped `soya` flag was caught by a human Care audit, not the build. Candidate for a gate extension (`ALLERGENS ↔ manifest`) so the next dropped allergen fails a build.
- **No-separator glued-token gap** (Maren/Cipher) — `tilkut`→`til`, `cornflour`→`corn` no longer resolve via `\b`. Strictly narrower than the substring era's over-match (honeydew-class); accepted as the correct trade.
- **Pre-existing:** unescaped `${food}` interpolation at `diet.js:1195` (untouched by this PR; render-jurisdiction HR-4 follow-up).

Chain complete → out of draft. Merge is the Architect's call.

https://claude.ai/code/session_01Lyt9cV76X1DB8htAShmX5G