### PR TITLE
Food-effects v2 — guided-introduction spec + peanut/tree-nut research brief

### DIFF
--- a/docs/research/index.html
+++ b/docs/research/index.html
@@ -20,6 +20,7 @@
   .food .top{display:flex;align-items:center;justify-content:space-between;gap:10px;flex-wrap:wrap}
   .food .name{font:700 19px/1.2 Fraunces,serif}
   .tier{font:700 10.5px/1 Nunito;text-transform:uppercase;letter-spacing:.4px;padding:5px 9px;border-radius:7px;background:var(--rose-bg);color:var(--rose)}
+  .tier.good{background:var(--sage-bg);color:var(--sage)}
   .one{color:var(--mid);font-size:13.5px;margin:8px 0 14px}
   .links{display:flex;gap:8px;flex-wrap:wrap}
   .links a{flex:1 1 auto;text-align:center;text-decoration:none;font:600 13px/1 Nunito;padding:11px 12px;border-radius:10px;border:1px solid var(--line);color:var(--ink);background:var(--bg)}
@@ -35,7 +36,7 @@
 <body>
 <div class="wrap">
   <h1>Care Research · Food Effects</h1>
-  <p class="sub">Evidence base for surfacing food effects in SproutLab's Care layer. Each food has a skim dashboard, a long-form brief, and a cited source doc. Honey is the archetype; more foods follow.</p>
+  <p class="sub">Evidence base for surfacing food effects in SproutLab's Care layer. Each food has a skim dashboard, a long-form brief, and a cited source doc. Two shapes so far: honey (a true <i>avoid</i>) and peanut/tree nuts (a <i>guided introduction</i> — encourage early, in safe form). More foods follow.</p>
 
   <h2>Foods</h2>
   <div class="food">
@@ -50,6 +51,20 @@
       <a href="honey-infant-safety.md">Source (.md)</a>
     </div>
     <p class="meta">Reviewed 2026-05-30 · confidence: high · WHO · CDC · AAP · NHS · India MoHFW/NHM</p>
+  </div>
+
+  <div class="food">
+    <div class="top">
+      <span class="name">Peanut &amp; Tree Nuts</span>
+      <span class="tier good">Introduce early · in safe form</span>
+    </div>
+    <p class="one"><b>Not an avoid — a guided introduction.</b> Introduce around 6 months, in safe form (smooth/ground, <b>never whole</b> — choking until ~5). Early, regular nuts <b>lower</b> allergy risk (LEAP: ~81%). Two hazards — allergy &amp; choking — and grinding fixes only the choking one. For this Indian vegetarian family, groundnut/badam/akhrot/kaju are staples and soaked-ground almond paste is already a safe form.</p>
+    <div class="links">
+      <a class="primary" href="peanut-tree-nut-infant-safety.visual.html">Visual dashboard ›</a>
+      <a href="peanut-tree-nut-infant-safety.html">Long-form brief</a>
+      <a href="peanut-tree-nut-infant-safety.md">Source (.md)</a>
+    </div>
+    <p class="meta">Reviewed 2026-05-30 · confidence: high · LEAP/EAT (NEJM) · AAP · NHS · ASCIA · NIAID · IAP</p>
   </div>
 
   <h2>How this is built</h2>

--- a/docs/research/peanut-tree-nut-infant-safety.html
+++ b/docs/research/peanut-tree-nut-infant-safety.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Peanut &amp; Tree Nuts — Infant Safety &amp; Introduction · SproutLab Care</title>
+<style>
+  :root{
+    --bg:#faf6f0; --card:#fffdf9; --ink:#2e2a26; --mid:#6b6258; --line:#e8ddcf;
+    --sage:#3a7060; --sage-bg:#e8f5ef; --rose:#b04a5e; --rose-bg:#fbe9ec;
+    --amber:#8a6320; --amber-bg:#fbf0d9; --accent:#3a7060;
+    --hi:#2f7d5b; --hi-bg:#e3f3ea; --mod:#9a7320; --mod-bg:#f7eed6; --weak:#9a5a5a; --weak-bg:#f5e6e6;
+  }
+  @media (prefers-color-scheme: dark){
+    :root{ --bg:#1d1a17; --card:#262220; --ink:#ece5db; --mid:#a89c8c; --line:#3a342d;
+      --sage:#7ac0a0; --sage-bg:#1e3028; --rose:#e090a0; --rose-bg:#3a2026;
+      --amber:#e0b060; --amber-bg:#352a16; --accent:#7ac0a0;
+      --hi:#7ac0a0; --hi-bg:#1e3028; --mod:#d8b060; --mod-bg:#332a14; --weak:#e09090; --weak-bg:#3a2222; }
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+    font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Nunito,sans-serif;
+    -webkit-font-smoothing:antialiased;padding:0 0 80px}
+  .wrap{max-width:880px;margin:0 auto;padding:0 20px}
+  header{background:linear-gradient(160deg,var(--sage-bg),var(--bg));border-bottom:1px solid var(--line);
+    padding:34px 0 26px;margin-bottom:8px}
+  h1{font:700 27px/1.25 Fraunces,Georgia,serif;margin:0 0 6px}
+  .sub{color:var(--mid);font-size:14.5px;margin:0}
+  .meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
+  .pill{font-size:12px;font-weight:600;padding:4px 10px;border-radius:999px;background:var(--card);
+    border:1px solid var(--line);color:var(--mid)}
+  .pill.good{background:var(--sage-bg);color:var(--sage);border-color:transparent}
+  .pill.warn{background:var(--rose-bg);color:var(--rose);border-color:transparent}
+  h2{font:600 19px/1.3 Fraunces,Georgia,serif;margin:30px 0 12px;padding-top:10px;border-top:1px solid var(--line)}
+  h2 .ax{color:var(--accent);font-weight:700}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:18px 20px;margin:14px 0}
+  .tldr{background:var(--sage-bg);border-color:transparent}
+  .tldr ul{margin:8px 0 0;padding-left:20px}
+  .tldr li{margin:7px 0}
+  ul{margin:6px 0;padding-left:22px}
+  li{margin:6px 0}
+  .badge{display:inline-block;font-size:11px;font-weight:700;letter-spacing:.3px;text-transform:uppercase;
+    padding:3px 9px;border-radius:7px;vertical-align:middle;margin-left:8px}
+  .b-hi{background:var(--hi-bg);color:var(--hi)} .b-mod{background:var(--mod-bg);color:var(--mod)} .b-weak{background:var(--weak-bg);color:var(--weak)}
+  .flag{background:var(--amber-bg);border-left:3px solid var(--amber);border-radius:6px;
+    padding:10px 14px;margin:12px 0;font-size:14px;color:var(--ink)}
+  .flag b{color:var(--amber)}
+  .flag.good{border-left-color:var(--sage);background:var(--sage-bg)}
+  .flag.good b{color:var(--sage)}
+  .flag.bad{border-left-color:var(--rose);background:var(--rose-bg)}
+  .flag.bad b{color:var(--rose)}
+  blockquote{margin:12px 0;padding:8px 0 8px 16px;border-left:3px solid var(--sage);color:var(--mid);font-style:italic}
+  code,pre{font-family:"SF Mono",Menlo,Consolas,monospace}
+  pre{background:#1e1b18;color:#e8e2d6;border-radius:12px;padding:18px;overflow:auto;font-size:12.5px;line-height:1.55}
+  pre .c{color:#8a9a7a} pre .k{color:#d8a0b0} pre .s{color:#cbb080}
+  table{width:100%;border-collapse:collapse;font-size:13.5px;margin:10px 0}
+  th,td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{color:var(--mid);font-weight:700;font-size:12px;text-transform:uppercase;letter-spacing:.3px}
+  td a{color:var(--sage);word-break:break-all;font-size:12px}
+  .quote{background:var(--card);border:1px dashed var(--line);border-radius:10px;padding:6px 14px;margin:8px 0;font-size:14px}
+  .quote b{color:var(--accent)}
+  .twocol{display:grid;grid-template-columns:1fr 1fr;gap:12px}
+  @media(max-width:640px){.twocol{grid-template-columns:1fr}}
+  .do{background:var(--sage-bg);border-radius:10px;padding:12px 14px}
+  .dont{background:var(--rose-bg);border-radius:10px;padding:12px 14px}
+  .do h4,.dont h4{margin:0 0 6px;font:700 12px/1 Nunito;text-transform:uppercase;letter-spacing:.3px}
+  .do h4{color:var(--sage)} .dont h4{color:var(--rose)}
+  .foot{color:var(--mid);font-size:13px;margin-top:30px;text-align:center}
+</style>
+</head>
+<body>
+<header><div class="wrap">
+  <h1>Peanut &amp; Tree Nuts — Infant Safety &amp; Introduction</h1>
+  <p class="sub">Care research brief — the evidence base for the <b>guided-introduction</b> food-effects layer. Unlike honey (a true avoid), nuts are nutritious staples to <b>introduce early, in safe form</b> — the model must encourage, not warn.</p>
+  <div class="meta">
+    <span class="pill">Reviewer · Maren (Care)</span>
+    <span class="pill">2026-05-30</span>
+    <span class="pill">Peanut + tree nuts · infants ~4–12mo · India · vegetarian</span>
+    <span class="pill good">LEAP/EAT verified from primary NEJM</span>
+    <span class="pill warn">Research artifact — NOT yet wired into the app</span>
+  </div>
+</div></header>
+
+<div class="wrap">
+
+  <div class="card tldr">
+    <strong>TL;DR — the parent-facing truth</strong>
+    <ul>
+      <li><b>The advice REVERSED.</b> The old "delay nuts to prevent allergy" guidance is gone. Introduce peanut and tree nuts <b>early — around 6 months</b>, alongside other solids, and keep them in the diet regularly. Delaying does not prevent allergy and may <i>increase</i> it. <span class="badge b-hi">AAP · NHS · ASCIA · NIAID</span></li>
+      <li><b>Early introduction PREVENTS allergy.</b> The LEAP trial cut peanut allergy at age 5 by <b>~81%</b>. This is the single biggest reason to introduce, not avoid. <span class="badge b-hi">NEJM 2015</span></li>
+      <li><b>The crux is FORM, not the food.</b> Whole nuts are a <b>choking hazard until ~4–5 years</b> — never whole or chopped. Safe forms: <b>smooth nut butter thinned</b>, or <b>finely ground nut powder mixed into food</b>.</li>
+      <li><b>Two distinct hazards.</b> (1) <i>Allergy</i> — managed by early, sustained introduction + a watchful first exposure. (2) <i>Choking</i> — managed purely by FORM. <b>Grinding removes the choking risk, not the allergy risk.</b></li>
+      <li><b>Indian vegetarian context is a gift here.</b> Groundnut, badam, akhrot, kaju are staples and a key protein/fat source. Traditional soaked-peeled-ground <b>almond paste</b> is already a near-ideal infant-safe form.</li>
+    </ul>
+  </div>
+
+  <h2><span class="ax">Axis 1</span> · The benefit — why introduce (allergy prevention) <span class="badge b-hi">High</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>The paradigm flipped.</b> AAP: <i>"there is no evidence that delaying introduction of allergenic foods like egg, peanut, dairy and sesame prevents allergies once babies are ready, typically at about 6 months."</i> WHO-aligned reviews: delaying peanut <i>"may promote rather than prevent food allergies."</i></li>
+      <li><b>LEAP trial (the pivotal evidence).</b> 640 high-risk infants, randomised to regular peanut vs avoidance to age 5. Peanut allergy at 60 months: skin-prick-negative <b>13.7% → 1.9%</b> (~86% reduction); sensitised <b>35.3% → 10.6%</b> (~70%); headlined as <b>~81% overall</b>. <span class="badge b-hi">Du Toit, NEJM 2015 — verified from primary paper</span></li>
+      <li><b>LEAP-On:</b> protection persisted after a 12-month avoidance period — tolerance was durable. Longer follow-up (to adolescence) sustained.</li>
+      <li><b>EAT trial (the nuance).</b> 1,303 general-population infants. Intention-to-treat: not significant. <b>Per-protocol (those who achieved the dose): significant reduction in peanut + egg allergy.</b> <span class="badge b-hi">Perkins/Lack, NEJM 2016</span></li>
+    </ul>
+    <div class="flag"><b>⚑ The EAT lesson is dose + adherence.</b> Only ~42% met the per-protocol target — early introduction is easy to <i>attempt</i> and hard to <i>sustain</i>. The model should frame nuts as "introduce <b>and keep offering</b>," not a one-time tick.</div>
+  </div>
+
+  <h2><span class="ax">Axis 2</span> · The benefit — nutrition <span class="badge b-hi">High (content)</span> <span class="badge b-mod">Moderate (criticality)</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>Peanut (groundnut):</b> dense plant protein + healthy fats; some iron, folate, niacin, vitamin E, magnesium.</li>
+      <li><b>Almond (badam):</b> vitamin E, healthy fats, protein, magnesium, calcium. Traditional soaked-peeled-ground paste is culturally embedded.</li>
+      <li><b>Walnut (akhrot):</b> stands out for <b>plant omega-3 ALA (~2.5 g/oz)</b> — relevant to brain development; ALA converts to EPA/DHA only modestly, so it complements other sources.</li>
+      <li><b>Cashew (kaju):</b> healthy fats, magnesium, zinc, iron, protein.</li>
+    </ul>
+    <div class="flag"><b>⚑ Don't over-claim.</b> The strongest evidence-backed reason to introduce nuts early is <b>allergy prevention</b>, not a unique nutrient only nuts supply. Lead with prevention; treat nutrition as the reinforcing co-benefit. Call them "valuable," not "essential."</div>
+  </div>
+
+  <h2><span class="ax">Axis 3</span> · Safe FORM — the choking gate <span class="badge b-hi">High</span></h2>
+  <div class="card">
+    <p style="margin:0 0 6px">Whole peanuts and whole/chopped tree nuts are a choking hazard and must not be given under ~4–5 years — including coarsely chopped nuts and chunky/whole-piece peanut butter.</p>
+    <div class="twocol">
+      <div class="do"><h4>Safe forms</h4>
+        <ul style="margin:0;padding-left:18px">
+          <li>Smooth nut/peanut butter, <b>thinned</b> with milk, water, or puree (start ~¼ tsp)</li>
+          <li>Finely <b>ground</b> nuts / nut powder / flour mixed into food</li>
+          <li>Traditional soaked-peeled-ground <b>almond (badam) paste</b></li>
+        </ul>
+      </div>
+      <div class="dont"><h4>Never</h4>
+        <ul style="margin:0;padding-left:18px">
+          <li>Whole nuts or peanuts</li>
+          <li>Chopped nuts</li>
+          <li>A thick glob of nut butter (can clump and lodge)</li>
+        </ul>
+      </div>
+    </div>
+    <div class="flag good"><b>✓ The design crux.</b> Unlike honey (cooking does NOT remove the spore hazard), for nuts <b>grinding/smoothing/thinning genuinely makes the food safe on the choking axis.</b> The allergy axis is separate and is <i>not</i> removed by form.</div>
+    <div class="flag"><b>⚑ Source divergence on the upper bound:</b> AAP commonly says under 4; NHS says under 5. Use "until about 4–5 years"; the model takes the conservative <b>5</b> as the house rule.</div>
+  </div>
+
+  <h2><span class="ax">Axis 4</span> · Timing &amp; the introduction protocol <span class="badge b-hi">High (timing)</span> <span class="badge b-mod">Moderate (watch-window)</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>General-population timing:</b> introduce around <b>6 months</b>, once developmentally ready for solids and a few first foods tolerated — not before 4 months.</li>
+      <li><b>High-risk infants (severe eczema and/or egg allergy):</b> introduce <b>earlier, 4–6 months</b> — risk is higher and the prevention benefit largest.</li>
+      <li><b>First-exposure protocol:</b> a small amount of one allergen at a time; <b>at home</b>, <b>morning/midday</b>; <b>watch ~2 hours</b>; if tolerated, <b>keep offering regularly</b>; introduce peanut and each tree nut separately a few days apart.</li>
+    </ul>
+    <div class="flag bad"><b>⚑ Key authority divergence — a spec decision, not an error.</b> <b>NIAID (2017, US)</b> recommends high-risk infants be <b>tested before first peanut</b>. <b>AAP / NHS / ASCIA / Canadian Paediatric Society</b> recommend introduction at ~6mo <b>without routine prescreening</b> for most infants. <i>Region-dependent.</i> The model defaults to the international mainstream (introduce ~6mo, no test) with a non-suppressible clinician-first note for the severe-eczema / known-egg-allergy cohort.</div>
+    <div class="flag"><b>⚑ "Wait 3 days" nuance:</b> the classic rule is about <i>attribution</i> (knowing what caused a reaction), not a safety floor — current guidance allows a new allergen as often as daily in a healthy baby. The 2–3-day spacing matters most for the high-stakes allergens.</div>
+  </div>
+
+  <h2><span class="ax">Axis 5</span> · Allergy watch-fors &amp; what to do <span class="badge b-hi">High</span></h2>
+  <div class="card">
+    <p style="margin:0 0 8px;color:var(--mid);font-size:14px">Peanut and tree nuts are among the most common causes of food-allergic anaphylaxis and tend to be lifelong relative to milk/egg.</p>
+    <div class="twocol">
+      <div class="do" style="background:var(--amber-bg)"><h4 style="color:var(--amber)">Mild — one body system</h4>
+        <ul style="margin:0;padding-left:18px">
+          <li>Itchy hives / welts, redness or rash</li>
+          <li>Swelling around the mouth or eyes</li>
+          <li>Vomiting, sometimes loose stool, sudden fussiness</li>
+        </ul>
+      </div>
+      <div class="dont"><h4>Severe — emergency</h4>
+        <ul style="margin:0;padding-left:18px">
+          <li>Trouble breathing / wheeze / noisy breathing</li>
+          <li>Swelling of the face, lips, tongue, or throat</li>
+          <li>Pale, floppy, or unusually sleepy; collapse</li>
+        </ul>
+      </div>
+    </div>
+    <p style="margin:10px 0 0;font-size:13.5px;color:var(--mid)">In babies, <b>behaviour change</b> (suddenly limp, can't hold head up) is a recognised severe sign. <b>94% of severe infant reactions involve hives; 83% involve vomiting.</b> Anaphylaxis can onset within <b>5–30 minutes</b>.</p>
+    <div class="flag bad"><b>What to do.</b> Mild single-system: stop the food, monitor closely, contact your doctor. <b>Any breathing difficulty, throat/face swelling, floppiness, or two body systems → emergency. Call 112 (India) / 999 / 911; use a prescribed adrenaline auto-injector immediately.</b></div>
+  </div>
+
+  <h2><span class="ax">Axis 6</span> · Indian &amp; vegetarian context <span class="badge b-hi">High (staple/prep)</span> <span class="badge b-mod">Moderate (official guidance)</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>Nuts are dietary staples, not exotic introductions</b> — groundnut, badam, akhrot, kaju. In a vegetarian household they are a primary source of protein and healthy fats, making early, regular introduction both culturally natural and nutritionally valuable.</li>
+      <li><b>Traditional soaked-peeled-ground almond paste</b> (badam soaked overnight, skin removed, ground smooth, stirred into milk/porridge) is essentially a textbook infant-safe form — a cultural asset the model can affirm, not override.</li>
+      <li><b>IAP</b> complementary-feeding guidance covers allergens + choking and notes peanut can be introduced as a small amount of peanut butter mixed into cereal/fruit/yoghurt or dissolved in milk; whole peanuts/tree nuts should not be given.</li>
+      <li><b>Soya / soya chunks is a separate allergen</b> (also a legume) heavily used in this vegetarian household — its own future record, not folded into peanut/tree-nut.</li>
+    </ul>
+    <div class="flag"><b>⚑ Honesty gap:</b> no India-specific <i>early-introduction-prevents-allergy</i> government directive was located; Indian guidance found centres on the choking-form rule + general complementary feeding. The prevention claim is well-sourced <b>internationally</b> (AAP/NHS/ASCIA/NIAID) and culturally compatible — but it must <b>not</b> be attributed to an Indian body (IAP/MoHFW/FSSAI). IAP's exact early-intro stance needs primary-PDF extraction before any such attribution.</div>
+  </div>
+
+  <h2><span class="ax">Axis 7</span> · Myths to correct <span class="badge b-hi">High</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>"Delay nuts to prevent allergy." → Reversed.</b> Delaying does not prevent allergy and likely increases risk; early, sustained introduction ~6mo is recommended. The highest-value myth to surface — many grandparents/relatives still believe the old rule.</li>
+      <li><b>"Nut allergy means avoid ALL nuts." → Nuanced.</b> Peanut is a legume, unrelated to tree nuts; tree nuts differ. A positive test ≠ clinical allergy: ~86% of peanut-allergic patients test positive to tree nuts but only ~34% are clinically allergic. Which nuts to avoid is an allergist's call.</li>
+      <li><b>"Cooking/roasting changes the allergy risk." → No.</b> Roasting doesn't remove peanut allergenicity (may slightly increase it); form (smooth/ground) addresses <i>choking</i>, not <i>allergy</i>.</li>
+      <li><b>"A bit of nut butter off the spoon is fine." → No.</b> Thick nut butter in a lump is itself a choking risk — it must be thinned/spread thin.</li>
+    </ul>
+  </div>
+
+  <h2>Proposed data shape · <code>FOOD_EFFECTS['peanut']</code> (guided-introduction)</h2>
+  <div class="card">
+    <p style="margin:0 0 10px;font-size:14px;color:var(--mid)">Two records (peanut + tree nut) sharing this brief, reached at runtime by their <code>aliases</code>. Note the v2 fields: <code>foodClass</code> (multi-class — allergen <i>and</i> choking), <code>whyGood</code> / <code>earlyIntroBenefit</code> (the benefit axis), <code>safeForm</code>, <code>howToIntroduce</code>, and <code>severeSigns</code> (the non-collapsible emergency strip). <b>Spec: docs/specs/food-effects-v2-guided-introduction.md.</b></p>
+<pre><span class="c">// guided-introduction record — encourage polarity, two hazards</span>
+<span class="k">const</span> FOOD_EFFECTS = {
+  <span class="s">'peanut'</span>: {
+    foodClass:  [<span class="s">'allergen-introduce-early'</span>, <span class="s">'choking-by-form'</span>],
+    severity:   <span class="s">'caution'</span>,            <span class="c">// amber, NOT rose (rose = acute-toxin)</span>
+    aliases:    [<span class="s">'peanuts'</span>, <span class="s">'groundnut'</span>, <span class="s">'moongphali'</span>, <span class="s">'peanut butter'</span>],
+    whyGood:    <span class="s">'High-value plant protein + healthy fats; early peanut lowers allergy risk.'</span>,
+    earlyIntroBenefit: { evidence: <span class="s">'LEAP (NEJM 2015): regular early peanut cut allergy ~80% at age 5.'</span> },
+    safeForm:   { ok:[<span class="s">'smooth peanut butter thinned'</span>, <span class="s">'finely ground peanut'</span>],
+                  never:[<span class="s">'whole peanuts'</span>, <span class="s">'chopped peanuts'</span>], chokingUntilYears: <span class="s">5</span> },
+    howToIntroduce: { amount:<span class="s">'~1/4 tsp'</span>, when:<span class="s">'morning/midday, at home'</span>, watch:<span class="s">'~2 hours'</span>,
+                  thenWhat:<span class="s">'keep offering a few times a week'</span> },
+    watchFor:    [<span class="s">'hives or a rash'</span>, <span class="s">'swelling around the mouth'</span>, <span class="s">'vomiting'</span>],
+    severeSigns: [<span class="s">'trouble breathing'</span>, <span class="s">'face/lip/tongue swelling'</span>, <span class="s">'floppy or very sleepy'</span>],
+    seekCare:    <span class="s">'Any breathing trouble or swelling: call 112 + use adrenaline if prescribed.'</span>,
+    confidence:  <span class="s">'high'</span>,
+  },
+  <span class="c">// 'tree nut': { … aliases: almond/badam/walnut/akhrot/cashew/kaju … }</span>
+};</pre>
+  </div>
+
+  <h2>Sources</h2>
+  <div class="card">
+  <table>
+    <tr><th>Authority</th><th>URL</th></tr>
+    <tr><td>NEJM — Du Toit, LEAP trial (2015)</td><td><a href="https://www.nejm.org/doi/full/10.1056/NEJMoa1414850">nejm.org/…/NEJMoa1414850</a></td></tr>
+    <tr><td>NEJM — Du Toit, LEAP-On (2016)</td><td><a href="https://www.nejm.org/doi/full/10.1056/NEJMoa1514209">nejm.org/…/NEJMoa1514209</a></td></tr>
+    <tr><td>NEJM — Perkins/Lack, EAT trial (2016)</td><td><a href="https://www.nejm.org/doi/full/10.1056/NEJMoa1514210">nejm.org/…/NEJMoa1514210</a></td></tr>
+    <tr><td>NEJM Evidence — LEAP follow-up to adolescence (2024)</td><td><a href="https://evidence.nejm.org/doi/full/10.1056/EVIDoa2300311">evidence.nejm.org/…/EVIDoa2300311</a></td></tr>
+    <tr><td>NIAID — Addendum Guidelines, peanut allergy prevention (2017)</td><td><a href="https://www.niaid.nih.gov/sites/default/files/addendum-peanut-allergy-prevention-guidelines.pdf">niaid.nih.gov/…/peanut-allergy</a></td></tr>
+    <tr><td>AAP / HealthyChildren — when to introduce allergens</td><td><a href="https://www.healthychildren.org/English/healthy-living/nutrition/Pages/when-to-introduce-egg-peanut-butter-and-other-common-food-allergens-to-your-baby-food-allergy-prevention-tips.aspx">healthychildren.org/…/allergens</a></td></tr>
+    <tr><td>UK NHS — foods to avoid (whole nuts; smooth peanut butter)</td><td><a href="https://www.nhs.uk/baby/weaning-and-feeding/foods-to-avoid-giving-babies-and-young-children/">nhs.uk/baby/…</a></td></tr>
+    <tr><td>ASCIA — Infant Feeding for Allergy Prevention (Jan 2026)</td><td><a href="https://www.allergy.org.au/hp/papers/infant-feeding-and-allergy-prevention">allergy.org.au/…/infant-feeding</a></td></tr>
+    <tr><td>IAP — Complementary Feeding parental guideline (Ch-040)</td><td><a href="https://iapindia.org/pdf/Ch-040-IAP-Parental-Guideline-Complementary-Feeding.pdf">iapindia.org/…/Ch-040</a></td></tr>
+    <tr><td>WHO — Complementary feeding 6–23 months (2023)</td><td><a href="https://www.ncbi.nlm.nih.gov/books/NBK596423/">ncbi.nlm.nih.gov/books/NBK596423</a></td></tr>
+    <tr><td>Allergy &amp; Asthma Network — Infant anaphylaxis</td><td><a href="https://allergyasthmanetwork.org/anaphylaxis/infant-anaphylaxis/">allergyasthmanetwork.org/…/infant-anaphylaxis</a></td></tr>
+    <tr><td>JACI In Practice — peanut/tree-nut cross-reactivity</td><td><a href="https://www.jaci-inpractice.org/article/S2213-2198(18)30739-6/pdf">jaci-inpractice.org/…/cross-reactivity</a></td></tr>
+  </table>
+  </div>
+
+  <div class="card">
+    <strong>Verification status &amp; gaps</strong>
+    <ol style="margin:8px 0 0">
+      <li>✅ <b>LEAP figures</b> — verified from the primary NEJM paper (640 infants; 13.7→1.9% and 35.3→10.6%; ~81%).</li>
+      <li>✅ <b>Timing reversal</b> — corroborated by AAP, NHS, ASCIA, NIAID, WHO-aligned reviews.</li>
+      <li>✅ <b>Choking-by-form rule</b> — NHS, AAP, IAP (only the 4-vs-5-year upper bound diverges).</li>
+      <li>⚑ <b>AAP vs NIAID prescreening</b> — genuine region-dependent divergence; a spec decision (default mainstream + cohort guard), not an error.</li>
+      <li>⚑ <b>IAP early-intro verbatim</b> — choking/peanut-butter-form guidance confirmed; the early-intro-prevents-allergy stance needs primary-PDF extraction before attributing to IAP.</li>
+      <li>⚑ <b>India early-intro government directive</b> — none located; the prevention claim is international, culturally compatible, but not an Indian-government rule.</li>
+    </ol>
+    <p style="margin:10px 0 0;font-size:13.5px;color:var(--mid)"><b>Method note:</b> firecrawl_search was permission-denied; figures via WebSearch + one firecrawl_extract on the NEJM LEAP paper. All major claims double-sourced.</p>
+  </div>
+
+  <div class="card tldr">
+    <strong>Surfacing recommendation (food-effects-v2) — not yet wired</strong>
+    <p style="margin:8px 0 0">An <b>encourage-polarity</b> card (sage banner): benefit first → introduce-safely (form + amount + watch + keep offering) → the <b>non-collapsible severe-reaction strip</b> (amber) → mild watch-fors → the "delay" myth. The 2 AM read should be <i>"good, give Ziva peanut soon — ground, ¼ tsp, in the morning, and keep it up"</i> — never <i>"scary allergen, avoid"</i>, and never with the emergency floor left unread.</p>
+  </div>
+
+  <p class="foot">SproutLab · Care research brief · companion to <code>docs/research/peanut-tree-nut-infant-safety.md</code> · 2026-05-30<br>
+  Research artifact — informational, not medical advice. Not yet wired into the app.</p>
+</div>
+</body>
+</html>

--- a/docs/research/peanut-tree-nut-infant-safety.md
+++ b/docs/research/peanut-tree-nut-infant-safety.md
@@ -1,0 +1,124 @@
+# Peanut & Tree Nuts — Infant Safety & Introduction Research Brief
+
+> **Purpose.** Evidence base for SproutLab's Care layer, feeding the new *guided-introduction* food-effects model. Built to decide what to surface when a parent introduces **peanut** or a **tree nut** to an under-5 — covering BOTH why to introduce early (allergy-prevention + nutrition) AND the two hazards (allergy reaction; choking-by-form). The food is not banned — the **FORM** is gated.
+> **Scope.** Peanut (a legume) and tree nuts (almond/badam, walnut/akhrot, cashew/kaju, pistachio, hazelnut, pecan, etc.). Infants ~4–12 months, with the choking note running to ~5 years. Family context: Indian, vegetarian — nuts are dietary staples, not novelties.
+> **Reviewer.** Research scout pass (for Maren, Governor of Care).
+> **Date.** 2026-05-30. **Status.** Research complete — *not yet wired into the app.*
+> **Method.** Multi-angle web fan-out → source fetch → adversarial cross-check → synthesis. Authorities: AAP/HealthyChildren, UK NHS, ASCIA (Australasia), WHO, US NIAID, IAP (India); pivotal trials LEAP (Du Toit, NEJM 2015) and EAT (Perkins, NEJM 2016). **Note:** firecrawl_search was permission-denied; primary figures were obtained via WebSearch + one firecrawl_extract on the NEJM LEAP paper. A few preparation specifics rest on reputable secondary sources (flagged inline) rather than a top-tier body's verbatim words.
+
+---
+
+## TL;DR (the parent-facing truth)
+
+- **The advice REVERSED.** The old "delay nuts to prevent allergy" guidance is gone. Current consensus (AAP, NHS, ASCIA, NIAID, WHO-aligned): introduce peanut and tree nuts **early** — around 6 months, alongside other solids — and keep them in the diet regularly. Delaying does not prevent allergy and may *increase* it. *(AAP 2019; NHS; ASCIA 2026; NIAID 2017.)*
+- **Early introduction PREVENTS allergy.** The LEAP trial (640 high-risk infants) cut peanut allergy at age 5 by **~81% overall** (13.7% → 1.9% in the skin-prick-negative stratum; 35.3% → 10.6% in the sensitised stratum). *(Du Toit, NEJM 2015.)* This is the single biggest reason to introduce, not avoid.
+- **The crux is FORM, not the food.** Whole peanuts/tree nuts are a **choking hazard until ~4–5 years** and must never be given whole or in chunks. The safe forms are **smooth nut/peanut butter thinned with milk/water/puree**, or **finely ground nut/nut powder mixed into food**. *(NHS; AAP; ASCIA; IAP.)*
+- **Two distinct hazards, two distinct mitigations.** (1) *Allergy* — mitigated by early, sustained introduction + a watchful first exposure. (2) *Choking* — mitigated purely by FORM. The model must hold both at once.
+- **Indian vegetarian context is a gift here.** Groundnut/peanut, badam (almond), akhrot (walnut), kaju (cashew) are staples and a major source of protein, healthy fats, vitamin E and (walnut) plant omega-3 ALA — especially valuable in a vegetarian diet. Traditional soaked-peeled-ground **almond paste** is already a near-ideal infant-safe form.
+- **First exposure = small amount, at home, daytime, watch ~2 hours.** Know the difference between a mild reaction (hives/swelling/vomiting) and anaphylaxis (breathing trouble, floppiness, face/lip swelling) — the latter is an emergency-call event. *(Allergy & Asthma Network; AAP.)*
+
+---
+
+## Axis 1 — The benefit: why introduce (allergy prevention) *(confidence: HIGH)*
+
+- **The paradigm flipped.** Until ~2008–2015, guidance advised *delaying* allergenic foods (incl. nuts) to prevent allergy. That advice is now reversed: *"there is no evidence that delaying introduction of allergenic foods like egg, peanut, dairy and sesame prevents allergies once babies are ready, typically at about 6 months."* *(AAP/HealthyChildren.)* WHO-aligned reviews state plainly that delaying peanut "may promote rather than prevent food allergies." *(EAACI/Nestlé Nutrition Institute review, consistent with WHO complementary-feeding framing.)*
+- **LEAP trial (the pivotal evidence).** 640 high-risk infants (severe eczema and/or egg allergy), enrolled at 4–11 months (mean ~7.8 mo), randomised to regular peanut consumption vs avoidance to age 5. Peanut allergy at 60 months:
+  - Skin-prick-test–negative stratum: **13.7% (avoidance) → 1.9% (consumption)** — a relative reduction of **~86%**.
+  - Skin-prick-test–positive (mildly sensitised) stratum: **35.3% → 10.6%** — a reduction of **~70%**.
+  - Headlined as an **~81% overall** reduction. *(Du Toit et al., NEJM 2015, NEJMoa1414850; figures verified from the primary paper.)*
+- **LEAP-On** showed the protection persisted after a 12-month period of avoidance — i.e., tolerance was durable, not dependent on never stopping. *(Du Toit, NEJM 2016.)* Longer follow-up (LEAP-Trio, to adolescence) reported sustained protection. *(NEJM Evidence 2024.)*
+- **EAT trial (the nuance).** 1,303 *exclusively breastfed, general-population* (not high-risk) infants randomised to early introduction of 6 allergens (incl. peanut) from 3 months vs standard ~6 months. **Intention-to-treat: not significant.** **Per-protocol (those who actually achieved the dose): significant reduction in peanut + egg allergy.** *(Perkins/Lack, NEJM 2016, NEJMoa1514210.)*
+  > ⚑ *The EAT lesson is dose + adherence:* the benefit is real but depends on getting enough in, regularly. Only ~42% met the per-protocol target — early introduction is easy to *attempt* and hard to *sustain*. This is exactly why the model should frame nuts as "introduce **and keep offering**," not a one-time tick.
+
+## Axis 2 — The benefit: nutrition *(confidence: HIGH for nutrient content; MODERATE that it's infant-critical vs. merely valuable)*
+
+- **Peanut (groundnut):** dense plant protein and healthy mono/polyunsaturated fats; provides some iron, folate, niacin, vitamin E, magnesium. A meaningful protein/energy contributor in a vegetarian diet. *(General nutrition consensus.)*
+- **Almond (badam):** notable **vitamin E**, healthy fats, protein, magnesium, calcium. Traditional soaked-peeled-ground almond paste is culturally embedded.
+- **Walnut (akhrot):** stands out for **plant omega-3 ALA (~2.5 g/oz)** plus folate, vitamin E, copper, magnesium — relevant to brain development; ALA converts to EPA/DHA only modestly, so it complements rather than replaces other DHA sources. *(OmegaQuant; Healthline nutrition.)*
+- **Cashew (kaju):** healthy fats, magnesium, zinc, iron, protein.
+- **Framing:** nuts are a *high-value* complementary food (energy-dense, protein, micronutrients, healthy fats) — especially in a vegetarian household where animal-protein and fish-DHA routes are off the table. They are not the *only* source of any single nutrient, so call them "valuable," not "essential."
+  > ⚑ *Do not over-claim.* The strongest evidence-backed reason to introduce nuts early is **allergy prevention**, not a unique nutrient only nuts supply. Lead with prevention; treat nutrition as the reinforcing co-benefit.
+
+## Axis 3 — Safe FORM: the choking gate *(confidence: HIGH)*
+
+- **Whole peanuts and whole/chopped tree nuts are a choking hazard and must not be given to children under ~4–5 years.** This includes coarsely chopped nuts and **chunky/whole-piece** peanut butter. *(NHS: "Children under 5 should not be given whole or chopped nuts… because of the risk of choking." AAP: whole peanuts are a choking hazard "to children under 4." IAP: whole peanuts/tree nuts should not be fed to babies.)*
+  > ⚑ *Source divergence on the upper bound:* AAP commonly says **under 4**; NHS says **under 5**. Use "**until about 4–5 years**" and treat 5 as the conservative line.
+- **Safe forms (the gate the food passes through):**
+  1. **Smooth nut/peanut butter, thinned** — with breast milk, formula, water, or stirred into an already-tolerated puree/yoghurt/cereal. NHS gives a starting amount of ~¼ teaspoon. *(NHS; AAP; ASCIA.)*
+  2. **Finely ground nuts / nut powder / nut flour (e.g. almond meal, peanut flour)** mixed into food. *(ASCIA; IAP.)*
+  3. **NEVER** whole, NEVER chunky, NEVER a spoonful of thick nut butter that can clump and lodge in the airway.
+- **This is the design crux:** the hazard is removable by FORM transformation, unlike honey (where cooking does NOT remove the spore hazard). For nuts, *grinding/smoothing/thinning genuinely makes the food safe* on the choking axis. The allergy axis is separate and is *not* removed by form.
+
+## Axis 4 — Timing & the introduction protocol *(confidence: HIGH on timing; MODERATE on the exact watch-window minutes)*
+
+- **General-population timing:** introduce peanut and tree nuts **around 6 months**, once the baby is developmentally ready for solids and a few first foods are tolerated — **not before 4 months**. *(NHS; AAP; ASCIA; WHO complementary-feeding framing.)*
+- **High-risk infants (severe eczema and/or existing egg allergy):** introduce **earlier, 4–6 months**, because risk is higher and the prevention benefit is largest. *(NIAID 2017 addendum; LEAP.)*
+  > ⚑ *Key authority divergence — flag for the spec.* **NIAID (2017, US)** recommends that high-risk infants undergo **peanut allergy testing (sIgE or skin-prick) BEFORE first peanut**. **AAP (2019), NHS (UK), ASCIA (Australasia), Canadian Paediatric Society** recommend early introduction at ~6 months (not before 4) **without routine prescreening** for most infants, reserving specialist input for infants with established severe eczema/egg allergy. *Region-dependent.* For an Indian family with a non-high-risk baby, the international mainstream (introduce at ~6 mo, no test needed) applies; if Ziva had severe eczema or known egg allergy, a paediatrician consult before first nut is the prudent path.
+- **First-exposure protocol (consensus across patient-facing guidance):**
+  - Offer a **small amount** of one new allergen at a time.
+  - Do it **at home**, in the **morning or midday** (not dinner) so you can observe through the day and reach care if needed.
+  - **Watch ~2 hours** after — most reactions appear within this window. *(Allergy & Asthma Network; multiple paediatric sources.)*
+  - If tolerated, **keep offering regularly** (e.g. a few times a week) — sustained exposure maintains tolerance (the EAT/LEAP-On lesson).
+  - **Introduce peanut and each tree nut separately**, a few days apart, so a reaction can be attributed. Note: peanut and tree nuts are botanically unrelated and often introduced as distinct allergens.
+  > ⚑ *Nuance on "wait 3 days":* the classic "one new food every 3 days" rule is about *attribution* (knowing what caused a reaction), not a safety floor — current guidance allows introducing a new allergen as often as daily in a healthy baby. The 2–3-day spacing is most useful specifically for the high-risk allergens so a reaction is pinpointable. *(Allergy & Asthma Network; flagged as practice-level, not a hard rule.)*
+
+## Axis 5 — Allergy watch-fors & what to do *(confidence: HIGH)*
+
+- **Peanut and tree nuts are among the most common causes of food-allergic anaphylaxis** and tend to be lifelong relative to milk/egg. *(FAACT; Anaphylaxis UK.)*
+- **Mild–moderate reaction (one body system):** itchy **hives/welts**, redness or **rash**, **swelling** (esp. around the mouth/eyes), **vomiting**, sometimes loose stool, sudden fussiness. *(Solid Starts; Allergy & Asthma Network.)*
+- **Severe / anaphylaxis (act immediately):** difficulty breathing, **wheeze/persistent cough/noisy breathing**, **swelling of the face/lips/tongue/throat**, hoarse cry or voice, pale/floppy/**lethargic** or unusually sleepy, sudden drooling, collapse. In babies, *behaviour change* (suddenly limp, can't hold head up) is a recognised severe sign. **94% of severe infant reactions involve hives; 83% involve vomiting.** Anaphylaxis can come on within **5–30 minutes**. *(Allergy & Asthma Network — Infant Anaphylaxis; AAFA.)*
+- **What to do:**
+  - **Mild, single-system:** stop the food, monitor closely, contact your doctor; an antihistamine may be advised by a clinician.
+  - **Any breathing difficulty, throat/face swelling, floppiness, or two body systems involved → emergency. Call emergency services (112 in India / 999 UK / 911 US); use an adrenaline auto-injector immediately if one has been prescribed.** *(Consensus.)*
+  - Reactions usually occur on an *early* exposure; the very first taste may sensitise with the reaction on a later one — keep watching across the first several exposures, not just day one.
+
+## Axis 6 — Indian & vegetarian context *(confidence: HIGH for cultural prep + staple status; MODERATE for India-specific official guidance)*
+
+- **Nuts are dietary staples, not exotic introductions.** Groundnut/peanut (chikki, groundnut in sabzi/chutney, peanut butter), badam (almond), akhrot (walnut), kaju (cashew) are everyday foods. In a **vegetarian** household they are a primary source of protein and healthy fats, making early, regular introduction both culturally natural and nutritionally valuable.
+- **Traditional soaked-peeled-ground almond paste** (badam soaked overnight, skin removed, ground to a smooth paste, stirred into milk/porridge) is essentially a textbook infant-safe form — smooth, no choking risk, easy to dose. This is a cultural asset the model can affirm rather than override.
+- **Preparation guidance (Indian-context secondary sources):** grind roasted/soaked nuts to a fine powder or smooth butter; thin with milk/water; start ~¼ tsp; stir into already-tolerated foods. *(MomJunction; My Little Moppet; Healthline — secondary, consistent with NHS/AAP forms.)*
+- **IAP (Indian Academy of Pediatrics) complementary-feeding parental guideline** addresses food allergy and states that **whole peanuts/tree nuts should not be given to babies/young children (choking)**, while **peanut can be introduced by mixing a small amount of peanut butter into cereal, pureed fruit, yoghurt, or dissolved in milk/formula**. *(IAP Complementary Feeding parental guideline, Ch-040 — confirmed it covers allergens + choking + peanut-butter form; exact verbatim wording on early-introduction-for-prevention should be re-extracted from the primary PDF before any "IAP recommends early introduction" attribution — see gap below.)*
+- **"Cashew allergy is reported as uncommon in Indian babies"** — appears in Indian parenting sources; *not* something to over-rely on, treat each nut as a standard allergen. *(Secondary — flag as anecdotal.)*
+- **Separate note — soya / soya chunks:** soy is a *distinct* allergen (also a legume, like peanut) and is out of scope here; it should be its own food-effects record, not folded into peanut/tree-nut. Vegetarian Indian diets use soya chunks/tofu heavily — worth its own brief.
+  > ⚑ *Gap:* No India-specific *early-introduction-prevents-allergy* government directive (MoHFW/NHM/FSSAI) was located; Indian guidance found centres on the choking-form rule + general complementary feeding. The early-introduction evidence base is international (AAP/NHS/ASCIA/NIAID). Treat the prevention claim as well-sourced internationally and culturally compatible with Indian practice, but not (yet) as an Indian-government-issued rule.
+
+## Axis 7 — Myths to correct *(confidence: HIGH)*
+
+- **Myth: "Delay nuts (and other allergens) to prevent allergy."** **Reversed.** Delaying does not prevent allergy and likely increases risk; early, sustained introduction around 6 months is now recommended. *(AAP 2019; NHS; ASCIA; LEAP/EAT.)* This is the highest-value myth to surface — many grandparents/relatives still believe the old rule.
+- **Myth: "Nut allergy means avoid ALL nuts."** **Nuanced.** Peanut is a *legume*, botanically unrelated to tree nuts; tree nuts differ from each other. Sensitisation (a positive test) ≠ clinical allergy: in one study **86% of peanut-allergic patients tested positive to tree nuts but only ~34% were clinically allergic** — i.e., many can eat tree nuts safely. Which nuts must be avoided is an **allergist's call** (cashew–pistachio and walnut–pecan do cross-react), not a blanket self-imposed ban. *(JACI In Practice; KFA.)*
+- **Myth: "Cooking/roasting changes the allergy risk."** Roasting does not remove peanut allergenicity (and may slightly increase it); form (smooth/ground) addresses *choking*, not *allergy*. The allergy axis is managed by introduction + watchfulness, not by cooking. *(Allergen consensus.)*
+- **Myth: "A bit of nut butter straight off the spoon is fine."** Thick nut butter in a lump is itself a choking risk for a baby — it must be **thinned/spread thin**, not given as a glob. *(NHS; AAP.)*
+
+---
+
+## Source list
+
+| # | Authority | URL |
+|---|-----------|-----|
+| 1 | NEJM — Du Toit et al., LEAP trial (2015) | https://www.nejm.org/doi/full/10.1056/NEJMoa1414850 |
+| 2 | NEJM — Du Toit et al., LEAP-On (peanut avoidance after early consumption, 2016) | https://www.nejm.org/doi/full/10.1056/NEJMoa1514209 |
+| 3 | NEJM — Perkins/Lack et al., EAT trial (2016) | https://www.nejm.org/doi/full/10.1056/NEJMoa1514210 |
+| 4 | NEJM Evidence — LEAP follow-up to adolescence (2024) | https://evidence.nejm.org/doi/full/10.1056/EVIDoa2300311 |
+| 5 | NIAID — Addendum Guidelines for Prevention of Peanut Allergy (2017) + parent summary | https://www.niaid.nih.gov/sites/default/files/addendum-peanut-allergy-prevention-guidelines.pdf · https://www.niaid.nih.gov/sites/default/files/peanut-allergy-prevention-guidelines-parent-summary.pdf |
+| 6 | AAP / HealthyChildren — When to introduce egg, peanut butter & other allergens | https://www.healthychildren.org/English/healthy-living/nutrition/Pages/when-to-introduce-egg-peanut-butter-and-other-common-food-allergens-to-your-baby-food-allergy-prevention-tips.aspx |
+| 7 | AAP — Clinical report on early peanut introduction / no-delay | https://www.healthychildren.org/English/news/Pages/Early-Introduction-of-Peanut-based-Foods-to-Prevent-Allergies.aspx |
+| 8 | UK NHS — Foods to avoid giving babies (whole nuts; smooth peanut butter form) | https://www.nhs.uk/baby/weaning-and-feeding/foods-to-avoid-giving-babies-and-young-children/ |
+| 9 | ASCIA — Infant Feeding for Food Allergy Prevention (updated Jan 2026) + How to introduce solids | https://www.allergy.org.au/hp/papers/infant-feeding-and-allergy-prevention · https://www.allergy.org.au/patients/allergy-prevention/ascia-how-to-introduce-solid-foods-to-babies |
+| 10 | ASCIA — Guide for introduction of peanut to infants with severe eczema/food allergy | https://www.allergy.org.au/hp/papers/ascia-guide-peanut-introduction |
+| 11 | IAP — Complementary Feeding parental guideline (Ch-040) | https://iapindia.org/pdf/Ch-040-IAP-Parental-Guideline-Complementary-Feeding.pdf |
+| 12 | WHO — Complementary feeding of infants & young children 6–23 months (2023) | https://www.ncbi.nlm.nih.gov/books/NBK596423/ |
+| 13 | Allergy & Asthma Network — Infant anaphylaxis (signs; 94%/83% figures) | https://allergyasthmanetwork.org/anaphylaxis/infant-anaphylaxis/ |
+| 14 | Allergy & Asthma Network — Early allergen introduction guide | https://allergyasthmanetwork.org/food-allergies/early-allergen-introduction/ |
+| 15 | JACI In Practice — Managing cross-reactivity in peanut allergy (sensitised ≠ allergic) | https://www.jaci-inpractice.org/article/S2213-2198(18)30739-6/pdf |
+| 16 | FAACT — Tree nuts as a top allergen | https://www.foodallergyawareness.org/food-allergy-and-anaphylaxis/food-allergens/tree-nuts/ |
+| 17 | Solid Starts — Symptoms of allergic reactions in babies | https://solidstarts.com/symptoms-of-allergic-reactions/ |
+| 18 | OmegaQuant / Healthline — walnut ALA omega-3 & nut nutrition | https://omegaquant.com/is-there-omega-3-in-walnuts/ |
+
+### Verification status & gaps
+1. ✅ **LEAP figures** — verified from the primary NEJM paper (640 infants; 13.7→1.9% and 35.3→10.6%; ~81% headline).
+2. ✅ **Timing reversal** — corroborated independently by AAP, NHS, ASCIA, NIAID, WHO-aligned reviews.
+3. ✅ **Choking-by-form rule** — corroborated by NHS, AAP, IAP (consistent; only the 4-vs-5-year upper bound diverges).
+4. ⚑ **AAP vs NIAID prescreening** — genuine, region-dependent divergence (US-NIAID: test high-risk infants first; AAP/NHS/ASCIA/CPS: no routine prescreen). Flagged, not resolved — it's a *spec decision*, not an error.
+5. ⚑ **IAP early-introduction-for-prevention verbatim** — IAP's choking + peanut-butter-form guidance is confirmed; its exact stance on *early introduction to prevent allergy* should be extracted from the primary Ch-040 PDF before attributing a prevention recommendation to IAP (parallels the honey-brief lesson: never launder international guidance onto an Indian body's name).
+6. ⚑ **India early-intro government directive** — none located; the prevention claim is international, culturally compatible, but not an Indian-government rule.
+7. ⚑ **Watch-window minutes & "every 3 days"** — practice-level patient guidance (consistent across sources) rather than a single top-tier verbatim standard; numbers (~2 h watch; 5–30 min anaphylaxis onset) are well-supported but not regulator-issued.

--- a/docs/research/peanut-tree-nut-infant-safety.visual.html
+++ b/docs/research/peanut-tree-nut-infant-safety.visual.html
@@ -1,0 +1,335 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Peanut &amp; Tree Nuts — Visual Dashboard · SproutLab Care</title>
+<style>
+  :root{
+    --bg:#faf6f0; --card:#fffdf9; --ink:#2e2a26; --mid:#6b6258; --line:#e8ddcf; --track:#efe7da;
+    --sage:#3a7060; --sage-bg:#e8f5ef; --rose:#b04a5e; --rose-bg:#fbe9ec;
+    --amber:#9a7320; --amber-bg:#fbf0d9; --accent:#3a7060; --leaf:#2f7d5b; --leaf-bg:#e3f3ea;
+    --hi:#2f7d5b; --hi-bg:#e3f3ea; --mod:#9a7320; --mod-bg:#f7eed6; --weak:#9a5a5a; --weak-bg:#f5e6e6;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#1d1a17; --card:#262220; --ink:#ece5db; --mid:#a89c8c; --line:#3a342d; --track:#332d26;
+    --sage:#7ac0a0; --sage-bg:#1e3028; --rose:#e090a0; --rose-bg:#3a2026;
+    --amber:#e0b060; --amber-bg:#352a16; --accent:#7ac0a0; --leaf:#7ac0a0; --leaf-bg:#1e3028;
+    --hi:#7ac0a0; --hi-bg:#1e3028; --mod:#d8b060; --mod-bg:#332a14; --weak:#e09090; --weak-bg:#3a2222; }}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Nunito,sans-serif;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:960px;margin:0 auto;padding:0 18px 90px}
+  header{background:linear-gradient(160deg,var(--sage-bg),var(--bg));border-bottom:1px solid var(--line);padding:26px 0 0}
+  h1{font:700 25px/1.2 Fraunces,Georgia,serif;margin:0 0 4px}
+  .sub{color:var(--mid);font-size:14px;margin:0 0 16px;max-width:680px}
+  nav{display:flex;gap:4px;margin-top:6px;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none}
+  nav::-webkit-scrollbar{display:none}
+  .tab{appearance:none;border:0;background:transparent;color:var(--mid);font:600 13.5px/1 Nunito,sans-serif;white-space:nowrap;flex:0 0 auto;
+    padding:11px 14px;border-radius:10px 10px 0 0;cursor:pointer;border-bottom:3px solid transparent}
+  .tab:hover{color:var(--ink);background:var(--card)}
+  .tab.on{color:var(--accent);background:var(--card);border-bottom-color:var(--accent)}
+  .panel{display:none;animation:f .25s ease}
+  .panel.on{display:block}
+  @keyframes f{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:none}}
+  h2{font:600 18px/1.3 Fraunces,Georgia,serif;margin:26px 0 10px}
+  h3{font:700 13px/1.3 Nunito;text-transform:uppercase;letter-spacing:.4px;color:var(--mid);margin:18px 0 8px}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:16px 18px;margin:12px 0}
+  .grid{display:grid;gap:12px}
+  .g2{grid-template-columns:1fr 1fr}.g3{grid-template-columns:repeat(3,1fr)}.g4{grid-template-columns:repeat(4,1fr)}
+  @media(max-width:680px){.g2,.g3,.g4{grid-template-columns:1fr 1fr}}
+  .stat{text-align:center;padding:16px 10px}
+  .stat .n{font:800 26px/1 Fraunces,Georgia,serif;color:var(--accent)}
+  .stat .l{font-size:12px;color:var(--mid);margin-top:6px;line-height:1.35}
+  .stat.crit .n{color:var(--rose)} .stat.ok .n{color:var(--leaf)} .stat.warn .n{color:var(--amber)}
+  .badge{display:inline-block;font:700 10.5px/1 Nunito;text-transform:uppercase;letter-spacing:.3px;padding:4px 8px;border-radius:6px;vertical-align:middle}
+  .b-hi{background:var(--hi-bg);color:var(--hi)}.b-mod{background:var(--mod-bg);color:var(--mod)}.b-weak{background:var(--weak-bg);color:var(--weak)}
+  .b-crit{background:var(--rose-bg);color:var(--rose)}
+  .bar{display:grid;grid-template-columns:150px 1fr 60px;align-items:center;gap:10px;margin:7px 0;font-size:13px}
+  .bar .lab{color:var(--ink);text-align:right;font-weight:600}
+  .bar .trk{display:block;background:var(--track);border:1px solid var(--line);border-radius:7px;height:18px;overflow:hidden}
+  .bar .fil{display:block;height:100%;border-radius:6px;background:var(--sage);min-width:3px}
+  .bar .val{font-weight:700;color:var(--mid);font-size:12.5px}
+  .bar.hl .fil{background:var(--leaf)} .bar.hl .lab{color:var(--leaf)} .bar.hl .val{color:var(--leaf)}
+  .tl{position:relative;margin:14px 0 6px;padding-left:8px}
+  .tl-step{position:relative;padding:0 0 18px 26px;border-left:2px solid var(--line)}
+  .tl-step:last-child{border-left-color:transparent}
+  .tl-dot{position:absolute;left:-8px;top:1px;width:15px;height:15px;border-radius:50%;background:var(--card);border:3px solid var(--accent)}
+  .tl-step.crit .tl-dot{border-color:var(--rose)} .tl-step.first .tl-dot{border-color:var(--leaf)}
+  .tl-t{font-weight:700;font-size:13.5px}.tl-d{color:var(--mid);font-size:12.5px}
+  .flag{border-left:3px solid var(--amber);background:var(--amber-bg);border-radius:6px;padding:10px 14px;margin:10px 0;font-size:13px}
+  .flag.good{border-left-color:var(--sage);background:var(--sage-bg)}
+  .flag.bad{border-left-color:var(--rose);background:var(--rose-bg)}
+  table{width:100%;border-collapse:collapse;font-size:13px;margin:8px 0}
+  th,td{padding:8px 9px;border-bottom:1px solid var(--line);text-align:left;vertical-align:top}
+  th{font:700 11px/1.2 Nunito;text-transform:uppercase;letter-spacing:.3px;color:var(--mid)}
+  td.c{text-align:center;font-weight:800}
+  .yes{color:var(--sage)}.no{color:var(--rose)}.dash{color:var(--mid)}
+  td a{color:var(--sage);font-size:12px;word-break:break-all}
+  .pill{display:inline-block;font:600 11px/1 Nunito;padding:5px 10px;border-radius:999px;background:var(--card);border:1px solid var(--line);color:var(--mid);margin:0 4px 4px 0}
+  .pill.good{background:var(--sage-bg);color:var(--sage);border-color:transparent}
+  .pill.warn{background:var(--rose-bg);color:var(--rose);border-color:transparent}
+  .jump{display:inline-block;font-weight:700;color:var(--accent);cursor:pointer;border-bottom:1px dashed var(--accent)}
+  .lead{font-size:16px;line-height:1.5}
+  .lead b{color:var(--accent)}
+  ul.tight{margin:6px 0;padding-left:20px}.tight li{margin:5px 0}
+  pre{background:#1e1b18;color:#e8e2d6;border-radius:12px;padding:16px;overflow:auto;font:12px/1.5 "SF Mono",Menlo,Consolas,monospace}
+  pre .c{color:#8a9a7a}.k{color:#d8a0b0}.s{color:#cbb080}
+  .donut-wrap{display:flex;align-items:center;gap:18px;flex-wrap:wrap}
+  .legend{font-size:12.5px;color:var(--mid)}.legend b{color:var(--ink)}
+  .foot{color:var(--mid);font-size:12.5px;text-align:center;margin-top:30px}
+  .therm{display:flex;gap:14px;flex-wrap:wrap}
+  .therm .col{flex:1;min-width:200px;border:1px solid var(--line);border-radius:12px;padding:14px;text-align:center}
+  .therm .big{font:800 19px/1 Fraunces,serif;margin:6px 0}
+  .col.safe{background:var(--sage-bg)}.col.danger{background:var(--rose-bg)}
+  .col.safe .big{color:var(--sage)}.col.danger .big{color:var(--rose)}
+</style>
+</head>
+<body>
+<header><div class="wrap">
+  <h1>Peanut &amp; Tree Nuts — Visual Dashboard</h1>
+  <p class="sub">Visual Care dashboard for the <b>guided-introduction</b> layer. Unlike honey (avoid), nuts are staples to <b>introduce early, in safe form</b>. Skim the Summary; drill into a tab for detail.</p>
+  <nav>
+    <button class="tab on" data-p="p-sum">Summary</button>
+    <button class="tab" data-p="p-ben">The Benefit</button>
+    <button class="tab" data-p="p-form">Safe Form</button>
+    <button class="tab" data-p="p-react">Reaction &amp; Care</button>
+    <button class="tab" data-p="p-ind">India Context</button>
+    <button class="tab" data-p="p-src">Sources</button>
+    <button class="tab" data-p="p-data">Data Stub</button>
+  </nav>
+  <p style="font-size:11.5px;color:var(--mid);margin:6px 0 10px">Swipe ‹ › between tabs · or use ← → arrow keys</p>
+</div></header>
+
+<div class="wrap">
+
+<!-- ───────── SUMMARY ───────── -->
+<section class="panel on" id="p-sum">
+  <div class="card" style="background:var(--sage-bg);border-color:transparent;margin-top:18px">
+    <p class="lead" style="margin:0">The one shift: <b>introduce peanut and tree nuts EARLY — around 6 months — not avoid them.</b> Early, regular introduction <b>lowers</b> allergy risk (LEAP: ~81%). The only gate is <b>FORM</b>: smooth/ground, never whole (choking until ~5). Two separate hazards — allergy and choking — and <b>grinding fixes only the choking one.</b></p>
+  </div>
+
+  <div class="grid g4">
+    <div class="card stat ok"><div class="n">~6<span style="font-size:14px">mo</span></div><div class="l">Introduce from ~6 months (not before 4) — AAP·NHS·ASCIA</div></div>
+    <div class="card stat ok"><div class="n">~81%</div><div class="l">peanut-allergy reduction with early intro — LEAP, NEJM 2015</div></div>
+    <div class="card stat warn"><div class="n">&lt;5<span style="font-size:14px">yr</span></div><div class="l">no whole/chopped nuts — choking hazard. Ground or smooth only</div></div>
+    <div class="card stat"><div class="n">2</div><div class="l">distinct hazards: allergy (intro + watch) &amp; choking (form). Different fixes</div></div>
+  </div>
+
+  <h3>The four things to know <span class="badge b-hi">all high-confidence</span></h3>
+  <div class="grid g2">
+    <div class="card"><b>1 · The advice reversed.</b> "Delay nuts to prevent allergy" is gone — delaying may <i>increase</i> allergy. Introduce early and keep offering. → <span class="jump" data-go="p-ben">The Benefit</span></div>
+    <div class="card"><b>2 · Form is the gate, not the food.</b> Whole nuts choke; smooth/ground nuts are safe and recommended early. Grinding removes the <i>choking</i> risk, not the <i>allergy</i> risk. → <span class="jump" data-go="p-form">Safe Form</span></div>
+    <div class="card"><b>3 · Watch the first exposure.</b> Small amount, at home, morning, watch ~2h. Know mild (hives/vomiting) vs severe (breathing/floppy → call 112). → <span class="jump" data-go="p-react">Reaction &amp; Care</span></div>
+    <div class="card"><b>4 · An Indian-vegetarian gift.</b> Groundnut, badam, akhrot, kaju are staples; soaked-peeled-ground almond paste is already a near-ideal safe form. → <span class="jump" data-go="p-ind">India Context</span></div>
+  </div>
+
+  <h3>When to surface this (the design hook)</h3>
+  <div class="card flag good" style="margin-top:0">
+    <b>Recommendation (food-effects-v2):</b> an <b>encourage-polarity</b> card (sage banner, not honey's rose warn-card) — benefit first, then the introduce-safely block (form + amount + watch + keep offering), then a <b>non-collapsible severe-reaction strip</b> the parent can't skim past. Ready-to-wire shape → <span class="jump" data-go="p-data">Data Stub</span>.
+  </div>
+
+  <div style="margin-top:14px">
+    <span class="pill">Reviewer · Maren (Care)</span>
+    <span class="pill good">LEAP/EAT verified · NEJM</span>
+    <span class="pill warn">Research artifact — not yet wired into the app</span>
+  </div>
+  <p style="font-size:12.5px;color:var(--mid);margin-top:10px">Full prose: <code>peanut-tree-nut-infant-safety.md</code> · long-form HTML: <code>peanut-tree-nut-infant-safety.html</code>. This dashboard is the skim layer over both.</p>
+</section>
+
+<!-- ───────── THE BENEFIT ───────── -->
+<section class="panel" id="p-ben">
+  <h2>The advice reversed — early intro PREVENTS allergy</h2>
+  <div class="card">
+    <p style="margin:0 0 6px">Until ~2008–2015, guidance advised <b>delaying</b> allergens to prevent allergy. Reversed: <i>"no evidence that delaying introduction of allergenic foods… prevents allergies once babies are ready, typically at about 6 months"</i> (AAP). Delaying peanut <i>"may promote rather than prevent food allergies"</i> (WHO-aligned). <span class="badge b-hi">consensus</span></p>
+  </div>
+
+  <h3>LEAP trial — the pivotal evidence <span class="badge b-hi">NEJM 2015, verified</span></h3>
+  <div class="card">
+    <div class="bar"><span class="lab">Avoidance (skin-prick −)</span><span class="trk"><span class="fil" style="width:39%;background:var(--rose)"></span></span><span class="val">13.7%</span></div>
+    <div class="bar hl"><span class="lab">Early peanut (skin-prick −)</span><span class="trk"><span class="fil" style="width:5%"></span></span><span class="val">1.9%</span></div>
+    <div class="bar"><span class="lab">Avoidance (sensitised)</span><span class="trk"><span class="fil" style="width:100%;background:var(--rose)"></span></span><span class="val">35.3%</span></div>
+    <div class="bar hl"><span class="lab">Early peanut (sensitised)</span><span class="trk"><span class="fil" style="width:30%"></span></span><span class="val">10.6%</span></div>
+    <p style="font-size:12px;color:var(--mid);margin:6px 0 0">640 high-risk infants randomised to regular peanut vs avoidance to age 5. <b>~81% overall reduction.</b> LEAP-On showed protection persisted after a 12-month avoidance period.</p>
+  </div>
+
+  <h3>EAT trial — the dose-and-adherence nuance</h3>
+  <div class="card">
+    <p style="margin:0">1,303 general-population infants, 6 allergens from 3 months vs ~6 months. <b>Intention-to-treat: not significant. Per-protocol (achieved the dose): significant reduction in peanut + egg allergy.</b> Only ~42% met the per-protocol target. <span class="badge b-hi">NEJM 2016</span></p>
+    <div class="flag"><b>⚑ The lesson is "introduce AND keep offering."</b> Early introduction is easy to attempt and hard to sustain — tolerance depends on repeated exposure, not a one-time taste. The app should reinforce ongoing offers, gently.</div>
+  </div>
+
+  <h3>Nutrition — the reinforcing co-benefit</h3>
+  <div class="grid g2">
+    <div class="card"><b>Peanut · almond · cashew</b><ul class="tight"><li>Plant protein + healthy fats</li><li>Almond (badam): vitamin E, magnesium, calcium</li><li>Cashew (kaju): zinc, iron, magnesium</li></ul></div>
+    <div class="card"><b>Walnut (akhrot)</b><ul class="tight"><li>Plant omega-3 ALA (~2.5 g/oz) — brain development</li><li>Complements (doesn't replace) other DHA sources</li><li>High value in a vegetarian diet</li></ul></div>
+  </div>
+  <div class="flag"><b>⚑ Don't over-claim.</b> The strongest reason to introduce early is <b>allergy prevention</b>, not a unique nutrient. Lead with prevention; nutrition reinforces. "Valuable," not "essential."</div>
+</section>
+
+<!-- ───────── SAFE FORM ───────── -->
+<section class="panel" id="p-form">
+  <h2>Form is the gate — grinding fixes choking, not allergy</h2>
+  <div class="therm">
+    <div class="col safe">
+      <div style="font-size:12px;color:var(--mid)">Smooth / ground (SAFE)</div>
+      <div class="big">introduce early</div>
+      <div style="font-size:12.5px">smooth nut butter <b>thinned</b>; finely ground nut powder/flour mixed into food; soaked-peeled-ground almond paste. Start ~¼ tsp.</div>
+    </div>
+    <div class="col danger">
+      <div style="font-size:12px;color:var(--mid)">Whole / chopped (CHOKING)</div>
+      <div class="big">never before ~5 yr</div>
+      <div style="font-size:12.5px">whole peanuts, whole/chopped tree nuts, chunky nut butter, or a thick glob off the spoon — all choking hazards.</div>
+    </div>
+  </div>
+  <div class="flag good"><b>✓ The design crux.</b> Unlike honey (cooking does NOT remove the spore hazard), for nuts <b>grinding/smoothing genuinely makes the food safe on the choking axis.</b> The allergy axis is separate and is NOT removed by form — that's managed by early introduction + watching.</div>
+  <div class="flag"><b>⚑ Upper-bound divergence.</b> AAP says under 4; NHS says under 5. House rule: the conservative <b>5</b> (also governs future grapes/popcorn/raw carrot).</div>
+
+  <h3>First-exposure protocol</h3>
+  <div class="card">
+    <div class="tl">
+      <div class="tl-step first"><span class="tl-dot"></span><div class="tl-t">Small amount, one allergen at a time</div><div class="tl-d">~¼ tsp smooth/ground, stirred into a tolerated food.</div></div>
+      <div class="tl-step"><span class="tl-dot"></span><div class="tl-t">At home, morning or midday</div><div class="tl-d">Not at dinner — so you can observe through the day.</div></div>
+      <div class="tl-step"><span class="tl-dot"></span><div class="tl-t">Watch ~2 hours</div><div class="tl-d">Most reactions appear within this window.</div></div>
+      <div class="tl-step first"><span class="tl-dot"></span><div class="tl-t">If tolerated — keep offering regularly</div><div class="tl-d">A few times a week maintains tolerance (EAT/LEAP-On lesson).</div></div>
+    </div>
+    <div class="flag bad"><b>⚑ High-risk branch (NIAID vs AAP).</b> US-NIAID: test high-risk infants (severe eczema / egg allergy) before first peanut. AAP/NHS/ASCIA: introduce ~6mo, no routine prescreen. Default = mainstream; the model surfaces a non-suppressible clinician-first note only for the eczema/egg-allergy cohort.</div>
+  </div>
+</section>
+
+<!-- ───────── REACTION & CARE ───────── -->
+<section class="panel" id="p-react">
+  <h2>Know mild from severe</h2>
+  <div class="grid g2">
+    <div class="card flag" style="margin:0"><b>Mild — one body system.</b> Itchy hives/welts, redness or rash; swelling around the mouth/eyes; vomiting, sometimes loose stool, sudden fussiness. → stop, watch closely, call your doctor.</div>
+    <div class="card flag bad" style="margin:0"><b>Severe — emergency.</b> Trouble breathing/wheeze; swelling of face/lips/tongue/throat; pale, floppy, or very sleepy; collapse. → <b>Call 112 right away</b> and use a prescribed adrenaline auto-injector.</div>
+  </div>
+  <div class="card">
+    <p style="margin:0;font-size:13px;color:var(--mid)">In babies, <b>behaviour change</b> (suddenly limp, can't hold head up) is a recognised severe sign. <b>94% of severe infant reactions involve hives; 83% involve vomiting.</b> Anaphylaxis can onset within <b>5–30 minutes</b> — keep watching across the first several exposures, not just day one.</p>
+  </div>
+  <div class="flag good"><b>✓ Reassurance.</b> Most introductions go fine. The point of "small amount, at home, watch ~2h" is exactly so that, in the rare reaction, you spot it early and act — not a reason to avoid the food.</div>
+</section>
+
+<!-- ───────── INDIA CONTEXT ───────── -->
+<section class="panel" id="p-ind">
+  <h2>An Indian-vegetarian gift</h2>
+  <div class="card">
+    <p style="margin:0">Groundnut/peanut, <b>badam</b> (almond), <b>akhrot</b> (walnut), <b>kaju</b> (cashew) are everyday foods. In a vegetarian household they are a primary source of protein and healthy fats — making early, regular introduction both culturally natural and nutritionally valuable. <span class="badge b-hi">staple status</span></p>
+  </div>
+
+  <h3>Cultural prep is already a safe form</h3>
+  <div class="card">
+    <p style="margin:0"><b>Traditional soaked-peeled-ground almond (badam) paste</b> — soaked overnight, skin removed, ground smooth, stirred into milk/porridge — is essentially a textbook infant-safe form: smooth, no choking risk, easy to dose. A cultural asset the model can affirm rather than override.</p>
+  </div>
+
+  <h3>IAP &amp; the honesty line</h3>
+  <div class="card flag good" style="margin-top:0"><b>✓ IAP (India) — choking + form confirmed.</b> Complementary-feeding guidance covers allergens + choking; peanut introduced as a small amount of peanut butter in cereal/fruit/yoghurt or dissolved in milk; whole peanuts/tree nuts not given to babies.</div>
+  <div class="card flag" style="margin-top:0"><b>⚑ Do NOT attribute early-intro-prevents-allergy to an Indian body.</b> No India-specific government early-introduction directive was located. The prevention claim is well-sourced <b>internationally</b> (AAP/NHS/ASCIA/NIAID) and culturally compatible — but it must not be laundered onto IAP/MoHFW/FSSAI (the honey-brief lesson). IAP's exact early-intro stance needs primary-PDF extraction first.</div>
+  <div class="card flag bad" style="margin-top:0"><b>✗ Separate food — soya / soya chunks.</b> Soy is its own allergen (also a legume), heavily used in this vegetarian household. Its own future record, NOT folded into peanut/tree-nut.</div>
+</section>
+
+<!-- ───────── SOURCES ───────── -->
+<section class="panel" id="p-src">
+  <h2>Who says what — consensus matrix</h2>
+  <div class="card" style="overflow-x:auto">
+  <table>
+    <tr><th>Authority</th><th class="c">Introduce ~6mo</th><th class="c">No whole nuts &lt;~5yr</th><th class="c">Prescreen high-risk</th></tr>
+    <tr><td>AAP / HealthyChildren</td><td class="c yes">✓</td><td class="c yes">✓ (&lt;4)</td><td class="c no">✗ no routine</td></tr>
+    <tr><td>UK NHS</td><td class="c yes">✓</td><td class="c yes">✓ (&lt;5)</td><td class="c no">✗ no routine</td></tr>
+    <tr><td>ASCIA (Australasia)</td><td class="c yes">✓</td><td class="c yes">✓</td><td class="c no">✗ no routine</td></tr>
+    <tr><td>US NIAID (2017)</td><td class="c yes">✓ (4–6 high-risk)</td><td class="c yes">✓</td><td class="c yes">✓ test high-risk</td></tr>
+    <tr><td>WHO</td><td class="c yes">✓</td><td class="c yes">✓</td><td class="c dash">—</td></tr>
+    <tr><td>IAP (India)</td><td class="c dash">— (form/choking yes)</td><td class="c yes">✓</td><td class="c dash">—</td></tr>
+  </table>
+  <p style="font-size:12px;color:var(--mid);margin:6px 0 0">The one genuine divergence is NIAID (test high-risk first) vs AAP/NHS/ASCIA (no routine prescreen) — region-dependent; a spec decision, not an error.</p>
+  </div>
+
+  <h2>Sources</h2>
+  <div class="card" style="overflow-x:auto">
+  <table>
+    <tr><th>Authority</th><th>Link</th></tr>
+    <tr><td>NEJM — LEAP trial (2015)</td><td><a href="https://www.nejm.org/doi/full/10.1056/NEJMoa1414850">nejm.org/…/NEJMoa1414850</a></td></tr>
+    <tr><td>NEJM — LEAP-On (2016)</td><td><a href="https://www.nejm.org/doi/full/10.1056/NEJMoa1514209">nejm.org/…/NEJMoa1514209</a></td></tr>
+    <tr><td>NEJM — EAT trial (2016)</td><td><a href="https://www.nejm.org/doi/full/10.1056/NEJMoa1514210">nejm.org/…/NEJMoa1514210</a></td></tr>
+    <tr><td>NEJM Evidence — LEAP to adolescence (2024)</td><td><a href="https://evidence.nejm.org/doi/full/10.1056/EVIDoa2300311">evidence.nejm.org/…/EVIDoa2300311</a></td></tr>
+    <tr><td>NIAID — peanut allergy prevention (2017)</td><td><a href="https://www.niaid.nih.gov/sites/default/files/addendum-peanut-allergy-prevention-guidelines.pdf">niaid.nih.gov/…/peanut</a></td></tr>
+    <tr><td>AAP / HealthyChildren — allergens</td><td><a href="https://www.healthychildren.org/English/healthy-living/nutrition/Pages/when-to-introduce-egg-peanut-butter-and-other-common-food-allergens-to-your-baby-food-allergy-prevention-tips.aspx">healthychildren.org/…/allergens</a></td></tr>
+    <tr><td>UK NHS — foods to avoid</td><td><a href="https://www.nhs.uk/baby/weaning-and-feeding/foods-to-avoid-giving-babies-and-young-children/">nhs.uk/baby/…</a></td></tr>
+    <tr><td>ASCIA — infant feeding for allergy prevention</td><td><a href="https://www.allergy.org.au/hp/papers/infant-feeding-and-allergy-prevention">allergy.org.au/…/infant-feeding</a></td></tr>
+    <tr><td>IAP — Complementary Feeding (Ch-040)</td><td><a href="https://iapindia.org/pdf/Ch-040-IAP-Parental-Guideline-Complementary-Feeding.pdf">iapindia.org/…/Ch-040</a></td></tr>
+    <tr><td>WHO — Complementary feeding 6–23mo (2023)</td><td><a href="https://www.ncbi.nlm.nih.gov/books/NBK596423/">ncbi.nlm.nih.gov/books/NBK596423</a></td></tr>
+    <tr><td>Allergy &amp; Asthma Network — infant anaphylaxis</td><td><a href="https://allergyasthmanetwork.org/anaphylaxis/infant-anaphylaxis/">allergyasthmanetwork.org/…/infant-anaphylaxis</a></td></tr>
+    <tr><td>JACI In Practice — cross-reactivity</td><td><a href="https://www.jaci-inpractice.org/article/S2213-2198(18)30739-6/pdf">jaci-inpractice.org/…/cross-reactivity</a></td></tr>
+  </table>
+  </div>
+  <div class="flag"><b>⚑ Method note:</b> firecrawl_search was permission-denied; figures via WebSearch + one firecrawl_extract on the NEJM LEAP paper. All major claims double-sourced; the AAP-vs-NIAID prescreen divergence is flagged, not resolved.</div>
+</section>
+
+<!-- ───────── DATA STUB ───────── -->
+<section class="panel" id="p-data">
+  <h2>Drop-in data shape — <code>FOOD_EFFECTS['peanut']</code></h2>
+  <p style="font-size:13.5px;color:var(--mid)">Two records (peanut + tree nut) reached by <code>aliases</code>. v2 fields carry the benefit axis (<code>whyGood</code>/<code>earlyIntroBenefit</code>), the form gate (<code>safeForm</code>), the protocol (<code>howToIntroduce</code>), and the non-collapsible <code>severeSigns</code> strip. Spec: <code>docs/specs/food-effects-v2-guided-introduction.md</code>. <b>Not yet wired.</b></p>
+<pre><span class="c">// guided-introduction record — encourage polarity, two hazards</span>
+<span class="k">const</span> FOOD_EFFECTS = {
+  <span class="s">'peanut'</span>: {
+    foodClass:  [<span class="s">'allergen-introduce-early'</span>, <span class="s">'choking-by-form'</span>],
+    severity:   <span class="s">'caution'</span>,            <span class="c">// amber, NOT rose (rose = acute-toxin honey)</span>
+    aliases:    [<span class="s">'peanuts'</span>, <span class="s">'groundnut'</span>, <span class="s">'moongphali'</span>, <span class="s">'peanut butter'</span>],
+    whyGood:    <span class="s">'High-value plant protein + healthy fats; early peanut lowers allergy risk.'</span>,
+    earlyIntroBenefit: { evidence: <span class="s">'LEAP (NEJM 2015): regular early peanut cut allergy ~80% at age 5.'</span> },
+    safeForm:   { ok:[<span class="s">'smooth peanut butter thinned'</span>, <span class="s">'finely ground peanut'</span>],
+                  never:[<span class="s">'whole peanuts'</span>, <span class="s">'chopped peanuts'</span>], chokingUntilYears: <span class="s">5</span> },
+    howToIntroduce: { amount:<span class="s">'~1/4 tsp'</span>, when:<span class="s">'morning/midday, at home'</span>, watch:<span class="s">'~2 hours'</span>,
+                  thenWhat:<span class="s">'keep offering a few times a week'</span> },
+    watchFor:    [<span class="s">'hives or a rash'</span>, <span class="s">'swelling around the mouth'</span>, <span class="s">'vomiting'</span>],
+    severeSigns: [<span class="s">'trouble breathing'</span>, <span class="s">'face/lip/tongue swelling'</span>, <span class="s">'floppy or very sleepy'</span>],
+    seekCare:    <span class="s">'Any breathing trouble or swelling: call 112 + use adrenaline if prescribed.'</span>,
+    confidence:  <span class="s">'high'</span>,
+  },
+};</pre>
+  <div class="flag good"><b>Surfacing hook:</b> an <b>encourage</b> card (sage), not honey's <b>warn</b> card (rose). Benefit banner → introduce-safely (form/amount/watch/keep-offering) → the amber <b>severe-reaction strip</b> (unconditional, never collapsed) → mild watch-fors → the "delay" myth. severity:'caution' drives amber chrome; rose stays reserved for acute-toxin.</div>
+</section>
+
+<p class="foot">SproutLab · Care visual dashboard · skim layer over <code>peanut-tree-nut-infant-safety.md</code> / <code>.html</code> · 2026-05-30<br>
+Informational, not medical advice. Not yet wired into the app. All chart values are also in text for machine-reading.</p>
+</div>
+
+<script>
+  var tabs = Array.prototype.slice.call(document.querySelectorAll('.tab'));
+  function activate(t){
+    if(!t) return;
+    tabs.forEach(function(x){x.classList.remove('on');});
+    document.querySelectorAll('.panel').forEach(function(x){x.classList.remove('on');});
+    t.classList.add('on');
+    var el = document.getElementById(t.dataset.p);
+    if(el) el.classList.add('on');
+    t.scrollIntoView({inline:'center', block:'nearest'});
+    window.scrollTo(0,0);
+  }
+  tabs.forEach(function(t){ t.addEventListener('click', function(){ activate(t); }); });
+  document.querySelectorAll('[data-go]').forEach(function(j){
+    j.addEventListener('click', function(){
+      activate(document.querySelector('.tab[data-p="'+j.dataset.go+'"]'));
+    });
+  });
+  function step(dir){
+    var cur = tabs.findIndex(function(t){return t.classList.contains('on');});
+    var next = cur + dir;
+    if(next >= 0 && next < tabs.length) activate(tabs[next]);
+  }
+  var sx=0, sy=0, tracking=false;
+  document.addEventListener('touchstart', function(e){
+    if(e.touches.length>1){ tracking=false; return; }
+    sx=e.changedTouches[0].clientX; sy=e.changedTouches[0].clientY; tracking=true;
+  }, {passive:true});
+  document.addEventListener('touchend', function(e){
+    if(!tracking) return; tracking=false;
+    var dx=e.changedTouches[0].clientX - sx, dy=e.changedTouches[0].clientY - sy;
+    if(Math.abs(dx) < 55 || Math.abs(dx) < Math.abs(dy)*1.5) return;
+    step(dx < 0 ? 1 : -1);
+  }, {passive:true});
+  document.addEventListener('keydown', function(e){
+    if(e.key==='ArrowRight') step(1); else if(e.key==='ArrowLeft') step(-1);
+  });
+</script>
+</body>
+</html>

--- a/docs/specs/food-effects-v2-guided-introduction.md
+++ b/docs/specs/food-effects-v2-guided-introduction.md
@@ -1,0 +1,139 @@
+# Food-Effects v2 — Guided Introduction
+
+**Companion:** Lyra (The Weaver)
+**Status:** DRAFT — for Maren + Vela spec review (no food code this pass; Architect chose *spec-only*).
+**Date opened:** 2026-05-30.
+**Descends from:** `docs/NEXT_SESSION_TARGET_2026-05-30.md` §P1 · `docs/SYNTHESIS_2026-05-30_food-effects-arc.md` (research→spine→surface pipeline) · the P0.1 sync gate (`split/audit-food-effects-sync-v1.sh`, merged #181) · the P0.2 word-boundary unification (#182).
+**First research artifact:** `docs/research/peanut-tree-nut-infant-safety.md` (cited; LEAP/EAT verified).
+
+---
+
+## 1. The problem this spec exists to solve
+
+The food-effects layer today (`FOOD_EFFECTS` in `data.js`, Finding A) has exactly **one shape**, built around honey:
+
+> hazard → **avoid** until N months → watch-for → seek-care.
+
+That shape is *correct for honey* — infant botulism is an acute toxin, the 12-month floor is a hard line, cooking does not make it safe, and there is **zero upside** to early honey. Honey is a true "avoid."
+
+It is the **wrong shape** for milk, nuts, seeds, and egg. The peanut/tree-nut research (and the parallel egg/milk/seed evidence) shows these foods **invert honey on two axes at once**, and carry a *second* hazard honey doesn't:
+
+| Axis | Honey | Nuts / egg / seeds |
+|------|-------|--------------------|
+| **Card polarity** | *Warn* — "don't, before 12mo" | *Encourage* — "introduce early; delaying may *increase* allergy" (LEAP: ~81% reduction) |
+| **Gate direction** | Hard ceiling — "blocked below 12mo" | Soft floor — "~6mo is good; not before 4mo" |
+| **Hazard count** | One (acute toxin) | **Two** — allergy *and* choking-by-form (a removable, form-dependent hazard) |
+| **Form** | Cooking does NOT remove the hazard | Grinding/smoothing **does** remove the *choking* hazard (not the allergy one) |
+| **Exposure** | Binary avoid | **Sustained** — tolerance depends on *keep offering* (EAT per-protocol lesson) |
+
+A card that tells a parent to "watch out / avoid" peanut or egg instructs the **opposite of the safe action**, and fear-framing nutritious staples causes real harm (delayed introduction → more allergy; nutritional gaps in a vegetarian diet). v2 evolves the layer from a **prohibition model** into a **guided-introduction model** that can hold *benefit*, *safe pathway*, *two hazards*, and *sustained exposure* — without losing honey's hard "avoid" where that is genuinely the truth.
+
+## 2. The four-category taxonomy (the organizing spine)
+
+Every food-effects record declares one or more **tiers**. A tier sets the card's *polarity*, the *gate semantics*, and which sections render. (Multi-tier is required — nuts are two at once.)
+
+| Tier | Polarity | Gate semantics | Examples | Card leads with |
+|------|----------|----------------|----------|-----------------|
+| `acute-toxin` | **Warn** | Hard ceiling — blocked below `minMonth` | honey | the hazard + the hard floor |
+| `allergen-introduce-early` | **Encourage** | Soft floor — "good from ~`minMonth`; not before 4mo" | peanut, tree nut, egg, sesame/seeds, soy | the *benefit* + *how to introduce safely* + *keep offering* |
+| `choking-by-form` | **Conditional** | Form-gated — safe in `safeForm.ok`, never in `safeForm.never`, whole until `chokingUntilYears` | whole nuts, whole seeds, (later: grapes, popcorn, raw carrot) | the safe *form*, not avoidance of the food |
+| `drink-timing` | **Conditional** | Context-gated — fine *in food*, gated *as a drink* below `minMonth` | cow's milk (drink vs curd/paneer/cooking) | "fine in food; not as the main drink before 12mo" |
+| `substitute-caveat` | **Inform** | No hard gate; not a breastmilk/formula replacement | plant/"artificial" milks (soy, almond, oat, rice) | what it *is and isn't* (soy=allergen; almond/rice low protein/fat; rice-arsenic note) |
+
+A single food may carry several: **peanut = `allergen-introduce-early` + `choking-by-form`**; **cow's milk = `drink-timing`** with a dairy-in-food carve-out. The card composes the sections each tier contributes, in a priority order (§4).
+
+## 3. The schema (current fields + the v2 additions)
+
+The manifest (`docs/research/food-effects.manifest.js`) stays the cited spine; `FOOD_EFFECTS` (`data.js`) stays the in-app projection. v2 **adds** fields; it does not remove honey's existing ones (back-compatible — honey validates unchanged).
+
+```
+food, aliases[], category, effect, minMonth, thresholdBasis, allergen,
+headline, watchFor[], timeCourse, seekCare, confidence, sources[],
+dashboard, brief, longform, lastReviewed, myth{claim,truth}          // EXISTING (honey)
+
+tier            : string | string[]   // NEW — was single 'critical'; now the §2 taxonomy, multi-valued
+reactionType[]  : adds 'choking'       // NEW VALUE alongside acute-toxin/allergy/digestive/...
+whyGood         : string               // NEW — the nutrition + prevention upside (the "advantage")
+earlyIntroBenefit : {                   // NEW — the allergy-prevention case, CITED
+                     claim, evidence, paradigm }
+safeForm        : {                     // NEW — the form gate (choking axis)
+                     ok[], never[], chokingUntilYears, note }
+howToIntroduce  : {                     // NEW — the first-exposure protocol
+                     amount, when, watch, thenWhat, oneAtATime, highRiskNote? }
+```
+
+**Honesty discipline (inherited, load-bearing):** every `whyGood` / `earlyIntroBenefit` claim must trace to a cited source in the brief — the P0.1 gate's "untraceable claim" invariant now also guards benefits, not just hazards (§6). No fabricated nutrient precision (the `explain-not-log` e2e already guards "conservative chem model"). Never launder international guidance onto an Indian body's name (honey-brief lesson; the peanut brief flags the IAP-verbatim gap explicitly).
+
+## 4. The card (Vela's surface) — polarity is the headline change
+
+The honey card is a single-consequence *warning* card. v2 needs an **affirming card** for `allergen-introduce-early`, composed of sections each tier contributes:
+
+1. **Benefit banner** (`whyGood` + `earlyIntroBenefit.claim`) — leads for `encourage` polarity. *"Worth introducing early — it lowers allergy risk and is a key protein/fat source."*
+2. **Introduce-safely block** (`howToIntroduce` + `safeForm`) — the *form* (smooth/ground, never whole), the *amount*, *when*, *watch ~2h*, and **keep offering** (§5).
+3. **Watch-fors** (`watchFor` split mild vs severe) — held as a *calm secondary*, not the lead. Severe/anaphylaxis signs + `seekCare` clearly escalated.
+4. **Myth-buster** (`myth`) — the "delay to prevent" reversal is the highest-value line for grandparents/relatives.
+
+The 2 AM test (Vela's lens): a tired parent should come away thinking *"good, I should give Ziva peanut soon — ground, a quarter-teaspoon, in the morning, and keep it up"* — **not** *"scary allergen, avoid."* For `acute-toxin` (honey) the polarity stays *warn* and the benefit banner is suppressed. HRs apply unchanged (HR-1 zi() icons; HR-2/5 tokens; HR-3/6 data-action; HR-4 escHtml on every rendered field — note the pre-existing unescaped `${food}` at `diet.js:1195` flagged in #182 should be closed when this surface is touched).
+
+## 5. Sustained exposure — the engine model (Architect chose: *track it*)
+
+The EAT lesson: tolerance depends on **repeated** exposure, not a one-time taste. Today "mark tried" is a single tick — insufficient for `allergen-introduce-early`. v2 adds an **ongoing-exposure model** (Kael's engine layer).
+
+**Proposed shape (for Kael review — not yet built):**
+- A food in `allergen-introduce-early` tracks an **exposure log**: timestamps of each logged feeding that matches the food (via the unified `_lookupByFoodName` resolver — the one-semantics win from #182). This rides on the existing feeding log; no new parent action.
+- Derived state per allergen food: `firstIntroduced`, `lastOffered`, `exposureCount`, `cadence` (offers/week over a trailing window).
+- A **calm nudge** (not an alert) when an introduced allergen hasn't been offered recently — *"Peanut's going well — keep offering a few times a week to keep tolerance up."* Surfaced on the Vela surface, throttled, dismissible, **never** alarmist, **never** a CareTicket.
+- Explicitly **not** a medical-adherence tracker (that's the Vit-D3 surface). This is gentle reinforcement of a prevention behaviour.
+
+**Open for Kael:** where the exposure log lives (derive-on-read from the feeding log vs a persisted sidecar), the trailing-window length, the nudge cadence/throttle, and the interaction with the introduced-foods store. This is the largest new build surface and should phase *after* the static card lands.
+
+## 6. Extend the P0.1 sync gate to ALLERGENS (Kael's #182 ledger item)
+
+The P0.1 gate (`audit-food-effects-sync-v1.sh`) locks `FOOD_EFFECTS ↔ manifest ↔ AGE_RULES` but **not** `ALLERGENS` — which is exactly why the dropped `soya` flag in #182 needed a *human* Care audit to catch. v2 extends the gate with an **`ALLERGENS ↔ manifest` traceability invariant**: an `allergen-introduce-early` manifest entry must have an `ALLERGENS` note (and vice-versa for allergen-tier foods), and `allergen:true` manifest records resolve cleanly against `ALLERGENS` via the word-boundary resolver. So the next dropped allergen fails a build instead of needing a Governor to spot it. (Same Node-engine + green-but-empty self-test discipline as the existing gate.)
+
+## 7. Granularity — two records (Architect-decided)
+
+Peanut and tree nut get **separate** manifest + `FOOD_EFFECTS` records sharing one brief + dashboard (`peanut-tree-nut-infant-safety.*`). Rationale: botanically distinct (legume vs tree nut), different cross-reactivity, and the "avoid all nuts" myth differs (peanut-allergic ≠ tree-nut-allergic; ~34% clinical vs ~86% sensitised). Draft records are in the research brief's Deliverable 2. `soy`/`soya` stays a **separate** future record (also a legume; heavily used in this vegetarian household) — out of scope here.
+
+## 8. Honey migration
+
+Honey moves into the taxonomy as `tier: 'acute-toxin'` (polarity *warn*, hard ceiling) with its existing fields intact and the new fields absent/empty (the benefit banner suppresses for `acute-toxin`). The migration must be behavior-preserving — honey's current card and the P0.1 gate's honey assertions stay green. This is the regression anchor for the schema change.
+
+## 9. What needs ratification (Architect, please confirm or correct)
+
+1. **Choking-age house rule.** `chokingUntilYears` — AAP says ~4, NHS says 5. Spec proposes the conservative **5** as the house default (will also govern future grapes/popcorn/raw-carrot). OK?
+2. **High-risk branch default.** NIAID (US) says test high-risk infants (severe eczema/egg allergy) before first peanut; AAP/NHS/ASCIA say no routine prescreen. Spec proposes: default to the **international mainstream** (introduce ~6mo, no test) with a `howToIntroduce.highRiskNote` surfacing the clinician-first path for the high-risk case. OK?
+3. **Food sequence after peanut/tree-nut** (when build is greenlit): proposed **egg → seeds (sesame/til) → cow + plant milks**. (Egg is the cleanest second exercise; milk is the most structurally complex — drink-timing + substitute-caveat.) OK, or reorder?
+4. **Nudge surface** (§5): confirm the ongoing-exposure nudge belongs on the Vela info/Today-So-Far surface and is *never* a CareTicket/alert (keeps it gentle, not clinical).
+
+## 10. Phasing (when build is greenlit — NOT this pass)
+
+- **P1a** — schema + taxonomy + honey migration + the *static* affirming card; peanut + tree-nut records projected; ALLERGENS gate extension (§6). e2e: honey unchanged; peanut card renders benefit-first; gate fires on a missing allergen↔manifest link.
+- **P1b** — the ongoing-exposure engine + nudge (§5), Kael-led.
+- **P1c** — egg, then seeds, then milks (§9.3), each through research→manifest→FOOD_EFFECTS→card→e2e.
+
+## 11. canon-cc-008 routing (at impl-PR time)
+
+- Schema/data (`data.js` FOOD_EFFECTS/ALLERGENS, manifest) → **Kael**.
+- Card render (`intelligence-cards.js`) → **Vela**.
+- Any `diet.js`/`home.js`/`medical.js` surfacing → **Maren**.
+- Ongoing-exposure engine (`data.js`/`core.js`/feeding-log read path) → **Kael**.
+- Gate script (`split/audit-*.sh`, build tooling) → Governor-waivable, Cipher final-pass always.
+- This *spec* itself: **Maren + Vela spec review** before any food code (this pass), per SPEC_ITERATION_PROCESS.
+
+## 12. CV3-006 charter compliance
+
+- **Axis 1 — Intellectual honesty:** every benefit/prevention claim traces to a cited brief; the P0.1 gate extension (§6) makes that machine-enforced for allergens; no fabricated nutrient precision; no laundering international guidance onto Indian bodies (IAP-verbatim gap flagged).
+- **Axis 2 — Architectural extensibility:** the taxonomy (§2) + multi-tier schema (§3) is the single source of truth; new foods slot into existing tiers without new plumbing; the resolver is already unified (#182).
+- **Axis 3 — Linguistic + visual warmth:** the polarity flip (§4) is the heart of it — nutritious staples are framed as *"introduce, here's how"*, caution held calm and secondary, the 2 AM parent reassured not frightened.
+
+## 13. Out of scope (registered)
+
+- The **build** — spec-only this pass (Architect-decided).
+- **Soy/soya** as its own record (future brief).
+- The pre-existing `${food}` HR-4 escaping at `diet.js:1195` (close when the surface is next touched).
+- Research hub redesign (deferred until ~5 foods, per NEXT_SESSION_TARGET §P2).
+
+## 14. Doctrinal references
+
+`docs/QA_GATE_SPEC.md` (Gate 2.5) · `docs/SPEC_ITERATION_PROCESS.md` · `docs/DESIGN_PRINCIPLES.md` · `docs/SYNTHESIS_2026-05-30_food-effects-arc.md` · the P0.1 gate (`split/audit-food-effects-sync-v1.sh`) · `docs/research/peanut-tree-nut-infant-safety.md`.

--- a/docs/specs/food-effects-v2-guided-introduction.md
+++ b/docs/specs/food-effects-v2-guided-introduction.md
@@ -1,7 +1,7 @@
 # Food-Effects v2 — Guided Introduction
 
 **Companion:** Lyra (The Weaver)
-**Status:** DRAFT — Governor spec-review folded (Maren + Vela, both `amended`, 2026-05-30). Awaiting Architect ratification of §9; no food code this pass (Architect chose *spec-only*).
+**Status:** RATIFIED — Governor spec-review folded (Maren + Vela, both `amended`); Architect ratified §9 (2026-05-30). P1a build greenlit (phased α/β/γ; see §10).
 **Date opened:** 2026-05-30.
 **Descends from:** `docs/NEXT_SESSION_TARGET_2026-05-30.md` §P1 · `docs/SYNTHESIS_2026-05-30_food-effects-arc.md` (research→spine→surface pipeline) · the P0.1 sync gate (`split/audit-food-effects-sync-v1.sh`, merged #181) · the P0.2 word-boundary unification (#182).
 **First research artifact:** `docs/research/peanut-tree-nut-infant-safety.md` (cited; LEAP/EAT verified).
@@ -140,12 +140,12 @@ Honey moves to `foodClass: 'acute-toxin'`, `severity: 'critical'` (polarity *war
 
 **Load-bearing (Maren A-4):** `tier` is currently a branch key in **two** render paths — `core.js:foodConsequenceCard` (tests `tier==='critical'` at ~:4016/:4019/:4023) and `diet.js`'s age-gate detail builder (~:694–700 hardcodes `tier:'critical'`). The migration is **not** behavior-preserving unless this is handled explicitly. Resolution: render `watchFor`/`seekCare` **whenever present** (decoupled from any class/severity string, §3), and drive chrome from `severity`. **Regression anchor for P1a e2e:** honey logged below 12mo must still render the floppiness/weak-cry watch-fors **and** the seek-care line after migration. Symmetric guard: an `allergen-introduce-early` food logged below its 4-month floor surfaces a consequence (severe strip), not a silent log.
 
-## 9. What needs ratification (Architect, please confirm or correct)
+## 9. Architect ratifications (RESOLVED 2026-05-30)
 
-1. **Choking-age house rule** — `chokingUntilYears: 5` (NHS conservative over AAP's 4; governs future grapes/popcorn/raw-carrot). **Both Governors concur with 5.** Confirm to close.
-2. **High-risk branch default** — default to the international mainstream (introduce ~6mo, no prescreen) with `howToIntroduce.highRiskNote`. Maren concurs the *default*, with a guard: when the app holds a **severe-eczema or known-egg-allergy** signal for the baby, `highRiskNote` (the "talk to your paediatrician before the first nut" line) renders and is **non-suppressible** for that cohort. (Ziva is not flagged high-risk.) Confirm.
-3. **Food sequence after peanut/tree-nut** (when build is greenlit): proposed **egg → seeds (sesame/til) → cow + plant milks**. Reorder?
-4. **Nudge surface** (§5): Info / Today-So-Far, `calm`/`pending` register, never CareTicket. **Both Governors concur.** Confirm to close.
+1. **Choking-age house rule** — ✅ `chokingUntilYears: 5` (NHS conservative; governs future grapes/popcorn/raw-carrot). Both Governors + Architect concur.
+2. **High-risk branch default** — ✅ **Mainstream + cohort guard.** Default = international mainstream (introduce ~6mo, no prescreen); `howToIntroduce.highRiskNote` ("talk to your paediatrician before the first nut") renders and is **non-suppressible** when the app holds a **severe-eczema or known-egg-allergy** signal for the baby. (Ziva is not flagged high-risk.)
+3. **Food sequence after peanut/tree-nut** — ✅ **egg → seeds (sesame/til) → cow + plant milks.** (P1c.)
+4. **Nudge surface** — ✅ Info / Today-So-Far, `calm`/`pending` register, never CareTicket. Both Governors + Architect concur.
 
 ## 10. Phasing (when build is greenlit — NOT this pass)
 

--- a/docs/specs/food-effects-v2-guided-introduction.md
+++ b/docs/specs/food-effects-v2-guided-introduction.md
@@ -1,10 +1,32 @@
 # Food-Effects v2 — Guided Introduction
 
 **Companion:** Lyra (The Weaver)
-**Status:** DRAFT — for Maren + Vela spec review (no food code this pass; Architect chose *spec-only*).
+**Status:** DRAFT — Governor spec-review folded (Maren + Vela, both `amended`, 2026-05-30). Awaiting Architect ratification of §9; no food code this pass (Architect chose *spec-only*).
 **Date opened:** 2026-05-30.
 **Descends from:** `docs/NEXT_SESSION_TARGET_2026-05-30.md` §P1 · `docs/SYNTHESIS_2026-05-30_food-effects-arc.md` (research→spine→surface pipeline) · the P0.1 sync gate (`split/audit-food-effects-sync-v1.sh`, merged #181) · the P0.2 word-boundary unification (#182).
 **First research artifact:** `docs/research/peanut-tree-nut-infant-safety.md` (cited; LEAP/EAT verified).
+
+---
+
+## 0. Governor spec-review record (2026-05-30)
+
+Both Governors reviewed this spec under SPEC_ITERATION_PROCESS before any food code. Both returned `amended`; all findings are folded into the text below.
+
+**Maren (Care) — `amended`.** *"The polarity flip is correct; my job is to make sure it never under-warns."* Four blocking amendments + two sharpenings:
+- **A-1** → §4: severe/anaphylaxis signs + emergency action render unconditionally, never collapsible.
+- **A-2** → §4/§9.1: the "ground/smooth only, never whole; grinding removes *choking* not *allergy*" line is a non-suppressible card invariant; concur `chokingUntilYears: 5`.
+- **A-3** → §5: the nudge hard-suppresses on any logged reaction (`reactionLogged`); requires a reaction-marking affordance.
+- **A-4** → §3/§8: `foodConsequenceCard` (`core.js:4014`) renders watch-fors/seek-care *only* when `tier==='critical'`; honey's literal `'critical'` migrating to the new taxonomy would **silently stop honey's botulism watch-fors rendering**. Decouple the render branch from the taxonomy.
+- Sharpenings: `highRiskNote` non-suppressible for the eczema/egg-allergy cohort (§9.2); §6 gate must also reject Indian-body attribution for the *early-intro-prevents-allergy* claim specifically.
+
+**Vela (Surfacing) — `amended`.** *"Calm must not mean below-the-fold."* Five findings:
+- **V-1** → §4: split watch-fors — *mild* may be calm/collapsible; **severe + "call 112" is a persistently-visible, non-collapsible strip co-located with the introduce-safely block** (where the parent reads when they act). (Converges with Maren A-1.)
+- **V-2** → §2/§4: multi-`foodClass` foods don't render parallel competing sections — the choking-by-form gate **folds into the introduce-safely block**; the card stays four sections, not six.
+- **V-3** → §4: bind polarity to domain color — **sage** banner + affirming `zi()` icon for *encourage*; **rose** + `zi('warn')` for honey-class *avoid*; the severe strip borrows **amber** (caution), rose reserved for acute-toxin. A pre-literate read: green-topped = "do this," pink-topped = "don't."
+- **V-4** → §5: nudge renders in the `calm`/`pending` chip register (never `late`/`urgent`/`skipped`), dismissible, never a CareTicket. (Concurs §9.4.)
+- **V-5** → §2/§3/§4: **the word "tier" collides three ways** at the render boundary (this taxonomy; the v3-6 card-priority `urgent`/`notable`/`ambient`; the `foodConsequenceCard` `detail.tier` `critical`/`light`). **Rename the taxonomy field → `foodClass`.** And the spec **conflates two surfaces** — the log-time modal `foodConsequenceCard` (core.js, Maren's, fires below the age gate) vs the always-present Info-tab `renderInfo*` card (cards.js, Vela's). Name which surface the encourage card is.
+
+**Synthesis (Lyra):** the two reviews converge on one spine — *benefit may lead, but the emergency floor must never move, collapse, or be confused for safety.* Folded throughout; the `tier`→`foodClass` rename and the render-decoupling (A-4 + V-5) are applied; the surface question is resolved per V-5 (§4). Remaining for the Architect: §9.
 
 ---
 
@@ -26,114 +48,132 @@ It is the **wrong shape** for milk, nuts, seeds, and egg. The peanut/tree-nut re
 | **Form** | Cooking does NOT remove the hazard | Grinding/smoothing **does** remove the *choking* hazard (not the allergy one) |
 | **Exposure** | Binary avoid | **Sustained** — tolerance depends on *keep offering* (EAT per-protocol lesson) |
 
-A card that tells a parent to "watch out / avoid" peanut or egg instructs the **opposite of the safe action**, and fear-framing nutritious staples causes real harm (delayed introduction → more allergy; nutritional gaps in a vegetarian diet). v2 evolves the layer from a **prohibition model** into a **guided-introduction model** that can hold *benefit*, *safe pathway*, *two hazards*, and *sustained exposure* — without losing honey's hard "avoid" where that is genuinely the truth.
+A card that tells a parent to "watch out / avoid" peanut or egg instructs the **opposite of the safe action**, and fear-framing nutritious staples causes real harm (delayed introduction → more allergy; nutritional gaps in a vegetarian diet). v2 evolves the layer from a **prohibition model** into a **guided-introduction model** that can hold *benefit*, *safe pathway*, *two hazards*, and *sustained exposure* — without losing honey's hard "avoid" where that is genuinely the truth, and **without ever letting the benefit framing move, collapse, or out-prioritize the emergency floor** (Maren A-1 / Vela V-1).
 
-## 2. The four-category taxonomy (the organizing spine)
+## 2. The four-category taxonomy — `foodClass` (the organizing spine)
 
-Every food-effects record declares one or more **tiers**. A tier sets the card's *polarity*, the *gate semantics*, and which sections render. (Multi-tier is required — nuts are two at once.)
+> **Naming (Vela V-5):** the taxonomy field is **`foodClass`**, NOT `tier`. "tier" is reserved at the render boundary for the v3-6 card-priority system (`urgent`/`notable`/`ambient`) and the existing `foodConsequenceCard` `detail.tier` (`critical`/`light`). Three meanings of one word at the same boundary is a defect; `foodClass` is the food-effects taxonomy and only that.
 
-| Tier | Polarity | Gate semantics | Examples | Card leads with |
-|------|----------|----------------|----------|-----------------|
-| `acute-toxin` | **Warn** | Hard ceiling — blocked below `minMonth` | honey | the hazard + the hard floor |
-| `allergen-introduce-early` | **Encourage** | Soft floor — "good from ~`minMonth`; not before 4mo" | peanut, tree nut, egg, sesame/seeds, soy | the *benefit* + *how to introduce safely* + *keep offering* |
-| `choking-by-form` | **Conditional** | Form-gated — safe in `safeForm.ok`, never in `safeForm.never`, whole until `chokingUntilYears` | whole nuts, whole seeds, (later: grapes, popcorn, raw carrot) | the safe *form*, not avoidance of the food |
+Every food-effects record declares one or more **`foodClass`** values. A class sets the card's *polarity*, the *gate semantics*, and which sections render. Multi-class is required — nuts are two at once.
+
+| `foodClass` | Polarity | Gate semantics | Examples | Card leads with |
+|-------------|----------|----------------|----------|-----------------|
+| `acute-toxin` | **Warn** (rose) | Hard ceiling — blocked below `minMonth` | honey | the hazard + the hard floor |
+| `allergen-introduce-early` | **Encourage** (sage) | Soft floor — "good from ~`minMonth`; not before 4mo" | peanut, tree nut, egg, sesame/seeds, soy | the *benefit* + *how to introduce safely* + *keep offering* |
+| `choking-by-form` | **Conditional** | Form-gated — safe in `safeForm.ok`, never in `safeForm.never`, whole until `chokingUntilYears` | whole nuts, whole seeds, (later: grapes, popcorn, raw carrot) | the safe *form*, folded into the introduce-safely block (V-2) |
 | `drink-timing` | **Conditional** | Context-gated — fine *in food*, gated *as a drink* below `minMonth` | cow's milk (drink vs curd/paneer/cooking) | "fine in food; not as the main drink before 12mo" |
 | `substitute-caveat` | **Inform** | No hard gate; not a breastmilk/formula replacement | plant/"artificial" milks (soy, almond, oat, rice) | what it *is and isn't* (soy=allergen; almond/rice low protein/fat; rice-arsenic note) |
 
-A single food may carry several: **peanut = `allergen-introduce-early` + `choking-by-form`**; **cow's milk = `drink-timing`** with a dairy-in-food carve-out. The card composes the sections each tier contributes, in a priority order (§4).
+A single food may carry several: **peanut = `['allergen-introduce-early','choking-by-form']`**; **cow's milk = `['drink-timing']`** with a dairy-in-food carve-out. Per **V-2**, a second `foodClass` does **not** add a parallel competing card section — `choking-by-form` contributes its form-gate line *into* the introduce-safely block (§4.2). The card stays four sections regardless of class count.
 
 ## 3. The schema (current fields + the v2 additions)
 
-The manifest (`docs/research/food-effects.manifest.js`) stays the cited spine; `FOOD_EFFECTS` (`data.js`) stays the in-app projection. v2 **adds** fields; it does not remove honey's existing ones (back-compatible — honey validates unchanged).
+The manifest (`docs/research/food-effects.manifest.js`) stays the cited spine; `FOOD_EFFECTS` (`data.js`) stays the in-app projection. v2 **adds** fields; honey validates unchanged except for the `tier`→`foodClass` migration (§8).
 
 ```
 food, aliases[], category, effect, minMonth, thresholdBasis, allergen,
 headline, watchFor[], timeCourse, seekCare, confidence, sources[],
 dashboard, brief, longform, lastReviewed, myth{claim,truth}          // EXISTING (honey)
 
-tier            : string | string[]   // NEW — was single 'critical'; now the §2 taxonomy, multi-valued
+foodClass       : string | string[]   // NEW (renamed from honey's `tier:'critical'`) — the §2 taxonomy, multi-valued
+severity        : 'critical' | 'caution'  // NEW — RENDER-driving, DECOUPLED from foodClass (Maren A-4).
+                                       //   Drives chrome (rose vs amber) + the consequence-render branch that
+                                       //   currently keys on tier==='critical'. honey: 'critical'.
 reactionType[]  : adds 'choking'       // NEW VALUE alongside acute-toxin/allergy/digestive/...
 whyGood         : string               // NEW — the nutrition + prevention upside (the "advantage")
 earlyIntroBenefit : {                   // NEW — the allergy-prevention case, CITED
                      claim, evidence, paradigm }
-safeForm        : {                     // NEW — the form gate (choking axis)
+safeForm        : {                     // NEW — the form gate (choking axis); folds into the introduce-safely block
                      ok[], never[], chokingUntilYears, note }
 howToIntroduce  : {                     // NEW — the first-exposure protocol
-                     amount, when, watch, thenWhat, oneAtATime, highRiskNote? }
+                     amount, when, watch, thenWhat, oneAtATime,
+                     highRiskNote }      // highRiskNote is NON-optional & non-suppressible for the
+                                        //   eczema/egg-allergy cohort (Maren §9.2 sharpening)
+severeSigns[]   : string               // NEW — the anaphylaxis red-flags rendered in the non-collapsible
+                                        //   severe strip (A-1/V-1), SEPARATE from the calm `watchFor[]` (mild)
 ```
 
-**Honesty discipline (inherited, load-bearing):** every `whyGood` / `earlyIntroBenefit` claim must trace to a cited source in the brief — the P0.1 gate's "untraceable claim" invariant now also guards benefits, not just hazards (§6). No fabricated nutrient precision (the `explain-not-log` e2e already guards "conservative chem model"). Never launder international guidance onto an Indian body's name (honey-brief lesson; the peanut brief flags the IAP-verbatim gap explicitly).
+**Render decoupling (Maren A-4 — load-bearing):** the consequence surface must stop keying watch-fors/seek-care on `tier==='critical'`. v2 renders `watchFor`/`seekCare` **whenever those fields are non-empty** (never gated on a class/severity string), and uses `severity` only for *chrome*, not *presence*. This makes the honey migration behavior-preserving and prevents the silent-disappearance class of bug (missing data → nothing rendered).
 
-## 4. The card (Vela's surface) — polarity is the headline change
+**Honesty discipline (inherited, load-bearing):** every `whyGood` / `earlyIntroBenefit` claim traces to a cited source in the brief — the P0.1 gate's "untraceable claim" invariant now also guards benefits (§6). No fabricated nutrient precision (the `explain-not-log` e2e guards "conservative chem model"). Never launder international guidance onto an Indian body's name (honey-brief lesson; the peanut brief flags the IAP-verbatim gap; §6 makes it machine-enforced).
 
-The honey card is a single-consequence *warning* card. v2 needs an **affirming card** for `allergen-introduce-early`, composed of sections each tier contributes:
+## 4. The card (Vela's surface) — polarity, placement, and the emergency floor
 
-1. **Benefit banner** (`whyGood` + `earlyIntroBenefit.claim`) — leads for `encourage` polarity. *"Worth introducing early — it lowers allergy risk and is a key protein/fat source."*
-2. **Introduce-safely block** (`howToIntroduce` + `safeForm`) — the *form* (smooth/ground, never whole), the *amount*, *when*, *watch ~2h*, and **keep offering** (§5).
-3. **Watch-fors** (`watchFor` split mild vs severe) — held as a *calm secondary*, not the lead. Severe/anaphylaxis signs + `seekCare` clearly escalated.
-4. **Myth-buster** (`myth`) — the "delay to prevent" reversal is the highest-value line for grandparents/relatives.
+**Surface (Vela V-5 — resolved):** the encourage card is a **persistent Info-tab `renderInfo*` card** (`intelligence-cards.js`, Vela's) — the parent seeks it *before* introducing. The existing **log-time modal `foodConsequenceCard`** (`core.js`, Maren's, fires when a food is logged below its gate) **stays**, and the **severe-reaction strip (below) survives into that log-time touchpoint** for `allergen-introduce-early` foods — so a parent who logs peanut below the floor still gets the red-flags + emergency action, not just a passive badge.
 
-The 2 AM test (Vela's lens): a tired parent should come away thinking *"good, I should give Ziva peanut soon — ground, a quarter-teaspoon, in the morning, and keep it up"* — **not** *"scary allergen, avoid."* For `acute-toxin` (honey) the polarity stays *warn* and the benefit banner is suppressed. HRs apply unchanged (HR-1 zi() icons; HR-2/5 tokens; HR-3/6 data-action; HR-4 escHtml on every rendered field — note the pre-existing unescaped `${food}` at `diet.js:1195` flagged in #182 should be closed when this surface is touched).
+**Composition — four sections, fixed order:**
+1. **Benefit banner** (`whyGood` + `earlyIntroBenefit.claim`) — leads for `encourage` polarity, on a **`--surface-sage`** fill with an **affirming `zi()` icon** (V-3; *not* `zi('warn')` — verify a positive symbol exists in the 109-sprite set or add one at build, HR-1). Suppressed for `acute-toxin` (honey stays warn/rose).
+2. **Introduce-safely block** (`howToIntroduce` + `safeForm`) — the *amount*, *when*, *watch ~2h*, **keep offering** (§5), and — folded in for `choking-by-form` (V-2) — the **form-gate line as a non-suppressible invariant** (Maren A-2): *"ground/smooth only — never whole; grinding removes the choking risk, NOT the allergy risk; whole nuts not until ~5."* The word "safe" never appears adjacent to the food name without the form qualifier (A-2). Carries `highRiskNote` where applicable (§9.2).
+3. **Severe-reaction strip — the emergency floor (Maren A-1 / Vela V-1, the gate condition).** The `severeSigns[]` (breathing trouble / face-lip-tongue swelling / floppy-lethargic) + the emergency action ("call 112; use prescribed adrenaline auto-injector") render **unconditionally, co-located with the introduce-safely block the parent acts on, in a persistently-visible, non-collapsible strip — never inside an accordion, never below a 'see more,' never truncated (HR-10, must wrap).** Chrome is **amber** (caution — serious-without-alarm), *not* full rose (rose reserved for `acute-toxin`). "Calm secondary" governs *visual weight and tone, not presence or reachability.*
+4. **Mild watch-fors + myth** — the mild `watchFor[]` (hives/rash/swelling/vomiting) *may* be calm-secondary/collapsible; the `myth` ("delay to prevent" reversal) is the highest-value relative-facing line.
+
+**The 2 AM test (Vela's lens):** a tired parent comes away thinking *"good — give Ziva peanut soon: ground, a quarter-teaspoon, in the morning; keep it up; and here are the three red-flags + call 112 if they appear"* — never *"scary allergen, avoid,"* and never acting on the benefit while the emergency floor sits unread.
+
+HRs unchanged (HR-1 zi() icons incl. the new affirming symbol; HR-2/5 tokens; HR-3/6 data-action; HR-4 escHtml on every rendered field — close the pre-existing unescaped `${food}` at `diet.js:1195` when this surface is touched; HR-10 the severe strip wraps, never ellipsises). Fits the existing v3-6 card-priority + v3-5 chip-taxonomy systems — no parallel vocabulary (V-5): encourage cards map to card-priority `notable`, honey to `urgent`.
 
 ## 5. Sustained exposure — the engine model (Architect chose: *track it*)
 
-The EAT lesson: tolerance depends on **repeated** exposure, not a one-time taste. Today "mark tried" is a single tick — insufficient for `allergen-introduce-early`. v2 adds an **ongoing-exposure model** (Kael's engine layer).
+The EAT lesson: tolerance depends on **repeated** exposure. Today "mark tried" is a single tick — insufficient for `allergen-introduce-early`. v2 adds an **ongoing-exposure model** (Kael's engine layer).
 
 **Proposed shape (for Kael review — not yet built):**
-- A food in `allergen-introduce-early` tracks an **exposure log**: timestamps of each logged feeding that matches the food (via the unified `_lookupByFoodName` resolver — the one-semantics win from #182). This rides on the existing feeding log; no new parent action.
-- Derived state per allergen food: `firstIntroduced`, `lastOffered`, `exposureCount`, `cadence` (offers/week over a trailing window).
-- A **calm nudge** (not an alert) when an introduced allergen hasn't been offered recently — *"Peanut's going well — keep offering a few times a week to keep tolerance up."* Surfaced on the Vela surface, throttled, dismissible, **never** alarmist, **never** a CareTicket.
-- Explicitly **not** a medical-adherence tracker (that's the Vit-D3 surface). This is gentle reinforcement of a prevention behaviour.
+- A food in `allergen-introduce-early` tracks an **exposure log**: timestamps of each logged feeding that matches the food (via the unified `_lookupByFoodName` resolver — the #182 one-semantics win). Rides on the existing feeding log; no new parent action for the happy path.
+- Derived state per allergen food: `firstIntroduced`, `lastOffered`, `exposureCount`, `cadence` (offers/week over a trailing window), **and `reactionLogged`** (Maren A-3 — load-bearing).
+- A **reaction-marking affordance** (dependency, Maren A-3): the parent must be able to mark that a food caused a reaction. Without it the nudge can't be gated.
+- A **calm nudge** when an introduced allergen's cadence falls below target — *"Peanut's going well — keep offering a few times a week to keep tolerance up."* Precondition (Maren A-3): **`introduced && !reactionLogged && cadence-below-target`.** It **MUST suppress permanently** for any food with a logged reaction, pending deliberate parent/clinician re-enable — never automatic time-decay. *A nudge that re-offers a food the baby reacted to is a Care-blocking defect.*
+- **Render register (Vela V-4):** the nudge surfaces on the Info / Today-So-Far surface in the **`calm`/`pending`** chip state — **never** `late`/`urgent`/`skipped` (those read as failure/clinical), **never** a CareTicket/alert, always dismissible.
 
-**Open for Kael:** where the exposure log lives (derive-on-read from the feeding log vs a persisted sidecar), the trailing-window length, the nudge cadence/throttle, and the interaction with the introduced-foods store. This is the largest new build surface and should phase *after* the static card lands.
+**Open for Kael:** exposure-log location (derive-on-read from the feeding log vs persisted sidecar), trailing-window length, nudge cadence/throttle, the reaction-marking UX, interaction with the introduced-foods store. Largest new build surface — phases *after* the static card (§10 P1b).
 
 ## 6. Extend the P0.1 sync gate to ALLERGENS (Kael's #182 ledger item)
 
-The P0.1 gate (`audit-food-effects-sync-v1.sh`) locks `FOOD_EFFECTS ↔ manifest ↔ AGE_RULES` but **not** `ALLERGENS` — which is exactly why the dropped `soya` flag in #182 needed a *human* Care audit to catch. v2 extends the gate with an **`ALLERGENS ↔ manifest` traceability invariant**: an `allergen-introduce-early` manifest entry must have an `ALLERGENS` note (and vice-versa for allergen-tier foods), and `allergen:true` manifest records resolve cleanly against `ALLERGENS` via the word-boundary resolver. So the next dropped allergen fails a build instead of needing a Governor to spot it. (Same Node-engine + green-but-empty self-test discipline as the existing gate.)
+The P0.1 gate locks `FOOD_EFFECTS ↔ manifest ↔ AGE_RULES` but **not** `ALLERGENS` — which is why the dropped `soya` flag in #182 needed a *human* Care audit. v2 extends the gate with an **`ALLERGENS ↔ manifest` traceability invariant**: an `allergen-introduce-early` manifest entry must have an `ALLERGENS` note (and vice-versa), and `allergen:true` records resolve cleanly against `ALLERGENS` via the word-boundary resolver. Same Node-engine + green-but-empty self-test discipline as the existing gate.
+
+**Plus (Maren §6 sharpening):** the gate must **reject any source attribution that names an Indian body (IAP/MoHFW/FSSAI/NHM) for the *early-introduction-prevents-allergy* claim specifically** — traceability alone won't catch a mis-attributed-but-present citation, and that's the exact laundering the peanut brief warns about (the early-intro evidence is international; no Indian-government directive was located).
 
 ## 7. Granularity — two records (Architect-decided)
 
-Peanut and tree nut get **separate** manifest + `FOOD_EFFECTS` records sharing one brief + dashboard (`peanut-tree-nut-infant-safety.*`). Rationale: botanically distinct (legume vs tree nut), different cross-reactivity, and the "avoid all nuts" myth differs (peanut-allergic ≠ tree-nut-allergic; ~34% clinical vs ~86% sensitised). Draft records are in the research brief's Deliverable 2. `soy`/`soya` stays a **separate** future record (also a legume; heavily used in this vegetarian household) — out of scope here.
+Peanut and tree nut get **separate** manifest + `FOOD_EFFECTS` records sharing one brief + dashboard (`peanut-tree-nut-infant-safety.*`). Rationale: botanically distinct (legume vs tree nut), different cross-reactivity, and the "avoid all nuts" myth differs (~34% clinical vs ~86% sensitised). Draft records are in the research brief's Deliverable 2 (to be re-keyed `tier`→`foodClass` + `severity` added). `soy`/`soya` stays a **separate** future record — out of scope here.
 
-## 8. Honey migration
+## 8. Honey migration (the regression anchor)
 
-Honey moves into the taxonomy as `tier: 'acute-toxin'` (polarity *warn*, hard ceiling) with its existing fields intact and the new fields absent/empty (the benefit banner suppresses for `acute-toxin`). The migration must be behavior-preserving — honey's current card and the P0.1 gate's honey assertions stay green. This is the regression anchor for the schema change.
+Honey moves to `foodClass: 'acute-toxin'`, `severity: 'critical'` (polarity *warn*, rose, benefit banner suppressed). Its existing fields stay intact; the new fields are absent/empty.
+
+**Load-bearing (Maren A-4):** `tier` is currently a branch key in **two** render paths — `core.js:foodConsequenceCard` (tests `tier==='critical'` at ~:4016/:4019/:4023) and `diet.js`'s age-gate detail builder (~:694–700 hardcodes `tier:'critical'`). The migration is **not** behavior-preserving unless this is handled explicitly. Resolution: render `watchFor`/`seekCare` **whenever present** (decoupled from any class/severity string, §3), and drive chrome from `severity`. **Regression anchor for P1a e2e:** honey logged below 12mo must still render the floppiness/weak-cry watch-fors **and** the seek-care line after migration. Symmetric guard: an `allergen-introduce-early` food logged below its 4-month floor surfaces a consequence (severe strip), not a silent log.
 
 ## 9. What needs ratification (Architect, please confirm or correct)
 
-1. **Choking-age house rule.** `chokingUntilYears` — AAP says ~4, NHS says 5. Spec proposes the conservative **5** as the house default (will also govern future grapes/popcorn/raw-carrot). OK?
-2. **High-risk branch default.** NIAID (US) says test high-risk infants (severe eczema/egg allergy) before first peanut; AAP/NHS/ASCIA say no routine prescreen. Spec proposes: default to the **international mainstream** (introduce ~6mo, no test) with a `howToIntroduce.highRiskNote` surfacing the clinician-first path for the high-risk case. OK?
-3. **Food sequence after peanut/tree-nut** (when build is greenlit): proposed **egg → seeds (sesame/til) → cow + plant milks**. (Egg is the cleanest second exercise; milk is the most structurally complex — drink-timing + substitute-caveat.) OK, or reorder?
-4. **Nudge surface** (§5): confirm the ongoing-exposure nudge belongs on the Vela info/Today-So-Far surface and is *never* a CareTicket/alert (keeps it gentle, not clinical).
+1. **Choking-age house rule** — `chokingUntilYears: 5` (NHS conservative over AAP's 4; governs future grapes/popcorn/raw-carrot). **Both Governors concur with 5.** Confirm to close.
+2. **High-risk branch default** — default to the international mainstream (introduce ~6mo, no prescreen) with `howToIntroduce.highRiskNote`. Maren concurs the *default*, with a guard: when the app holds a **severe-eczema or known-egg-allergy** signal for the baby, `highRiskNote` (the "talk to your paediatrician before the first nut" line) renders and is **non-suppressible** for that cohort. (Ziva is not flagged high-risk.) Confirm.
+3. **Food sequence after peanut/tree-nut** (when build is greenlit): proposed **egg → seeds (sesame/til) → cow + plant milks**. Reorder?
+4. **Nudge surface** (§5): Info / Today-So-Far, `calm`/`pending` register, never CareTicket. **Both Governors concur.** Confirm to close.
 
 ## 10. Phasing (when build is greenlit — NOT this pass)
 
-- **P1a** — schema + taxonomy + honey migration + the *static* affirming card; peanut + tree-nut records projected; ALLERGENS gate extension (§6). e2e: honey unchanged; peanut card renders benefit-first; gate fires on a missing allergen↔manifest link.
-- **P1b** — the ongoing-exposure engine + nudge (§5), Kael-led.
-- **P1c** — egg, then seeds, then milks (§9.3), each through research→manifest→FOOD_EFFECTS→card→e2e.
+- **P1a** — schema + `foodClass`/`severity` + honey migration (render-decoupling, §8) + the *static* affirming card with the **non-collapsible severe strip** (§4.3); peanut + tree-nut records projected; ALLERGENS gate extension (§6). **e2e:** (a) honey-below-12mo still renders watch-fors + seek-care after migration [A-4 anchor]; (b) peanut card renders the anaphylaxis signs + emergency-call line with **no expand interaction** [A-1/V-1]; (c) the never-whole form line renders and is **not** suppressed by the benefit banner [A-2]; (d) an allergen logged below its floor surfaces a consequence; (e) the ALLERGENS↔manifest gate fails a build on a missing link.
+- **P1b** — the ongoing-exposure engine + reaction-marking + nudge (§5), Kael-led. e2e: nudge suppresses on `reactionLogged`.
+- **P1c** — egg → seeds → milks (§9.3), each through research→manifest→FOOD_EFFECTS→card→e2e.
 
 ## 11. canon-cc-008 routing (at impl-PR time)
 
-- Schema/data (`data.js` FOOD_EFFECTS/ALLERGENS, manifest) → **Kael**.
-- Card render (`intelligence-cards.js`) → **Vela**.
-- Any `diet.js`/`home.js`/`medical.js` surfacing → **Maren**.
-- Ongoing-exposure engine (`data.js`/`core.js`/feeding-log read path) → **Kael**.
-- Gate script (`split/audit-*.sh`, build tooling) → Governor-waivable, Cipher final-pass always.
-- This *spec* itself: **Maren + Vela spec review** before any food code (this pass), per SPEC_ITERATION_PROCESS.
+- Schema/data (`data.js` FOOD_EFFECTS/ALLERGENS, manifest), exposure engine (`core.js`/feeding-log read) → **Kael**.
+- Card render (`intelligence-cards.js`), the severe-strip placement + nudge register → **Vela**.
+- `foodConsequenceCard` log-time modal + any `diet.js`/`home.js`/`medical.js` surfacing → **Maren**.
+- Gate script (`split/audit-*.sh`, build tooling) → Governor-waivable; **Cipher Edict V final-pass always** for code PRs.
+- This *spec*: Maren + Vela spec-review **complete (both `amended`, folded)**; Cipher Edict V is N/A for a docs-only spec (no `split/` code).
 
 ## 12. CV3-006 charter compliance
 
-- **Axis 1 — Intellectual honesty:** every benefit/prevention claim traces to a cited brief; the P0.1 gate extension (§6) makes that machine-enforced for allergens; no fabricated nutrient precision; no laundering international guidance onto Indian bodies (IAP-verbatim gap flagged).
-- **Axis 2 — Architectural extensibility:** the taxonomy (§2) + multi-tier schema (§3) is the single source of truth; new foods slot into existing tiers without new plumbing; the resolver is already unified (#182).
-- **Axis 3 — Linguistic + visual warmth:** the polarity flip (§4) is the heart of it — nutritious staples are framed as *"introduce, here's how"*, caution held calm and secondary, the 2 AM parent reassured not frightened.
+- **Axis 1 — Intellectual honesty:** every benefit/prevention claim traces to a cited brief; §6 makes that machine-enforced for allergens *and* bars Indian-body attribution for the early-intro claim; no fabricated nutrient precision.
+- **Axis 2 — Architectural extensibility:** `foodClass` + multi-class schema is the single source of truth; new foods slot into existing classes without new plumbing; resolver already unified (#182); no parallel render vocabulary (V-5 — maps onto v3-6 card-priority).
+- **Axis 3 — Linguistic + visual warmth:** the polarity flip (sage encourage / rose avoid / amber caution) frames staples as *"introduce, here's how,"* caution held calm — *but the emergency floor never moves* (the synthesis spine). The 2 AM parent is reassured, not frightened, and never under-warned.
 
 ## 13. Out of scope (registered)
 
 - The **build** — spec-only this pass (Architect-decided).
 - **Soy/soya** as its own record (future brief).
-- The pre-existing `${food}` HR-4 escaping at `diet.js:1195` (close when the surface is next touched).
+- The pre-existing `${food}` HR-4 escaping at `diet.js:1195` (close when the surface is next touched — both Governors flagged; not deferred again).
 - Research hub redesign (deferred until ~5 foods, per NEXT_SESSION_TARGET §P2).
 
 ## 14. Doctrinal references
 
-`docs/QA_GATE_SPEC.md` (Gate 2.5) · `docs/SPEC_ITERATION_PROCESS.md` · `docs/DESIGN_PRINCIPLES.md` · `docs/SYNTHESIS_2026-05-30_food-effects-arc.md` · the P0.1 gate (`split/audit-food-effects-sync-v1.sh`) · `docs/research/peanut-tree-nut-infant-safety.md`.
+`docs/QA_GATE_SPEC.md` (Gate 2.5) · `docs/SPEC_ITERATION_PROCESS.md` · `docs/DESIGN_PRINCIPLES.md` (Domain Colors; chip taxonomy v3-5; card priority v3-6) · `docs/SYNTHESIS_2026-05-30_food-effects-arc.md` · the P0.1 gate (`split/audit-food-effects-sync-v1.sh`) · `docs/research/peanut-tree-nut-infant-safety.md`.


### PR DESCRIPTION
## What

The foundation for the **guided-introduction** food-effects model (P1). **Docs only.**

1. `docs/research/peanut-tree-nut-infant-safety.md` — cited research brief (AAP/NHS/ASCIA/WHO/NIAID/IAP + LEAP/EAT; LEAP figures verified from the primary NEJM paper).
2. `docs/specs/food-effects-v2-guided-introduction.md` — the spec.

## The core idea
Honey's layer is a one-shape *prohibition* model. It's wrong for nuts/egg/seeds/milk, which **invert it** (encourage early intro; soft floor not hard ceiling; two hazards — allergy + choking-by-form). v2 introduces a **four-category `foodClass` taxonomy** setting each card's polarity + gate semantics, a benefit-first schema, and a sustained-exposure model — *without ever letting benefit framing move or collapse the emergency floor.*

## Status: RATIFIED ✅
- **Spec review:** Maren (Care) `amended` + Vela (Surfacing) `amended` → **all findings folded** (see spec §0). Converged spine: *benefit may lead, but the emergency floor never moves.* Highlights: non-collapsible severe-reaction strip (A-1/V-1); form-gate folded into introduce-safely (A-2/V-2); nudge hard-suppresses on `reactionLogged` (A-3/V-4); `tier`→`foodClass` rename + render-decouple so honey's watch-fors don't silently vanish on migration (A-4/V-5); polarity→color (V-3).
- **Architect ratified §9:** choking-age 5 · mainstream + cohort guard · egg→seeds→milks · nudge on Info/TSF never CareTicket.
- **P1a build greenlit** (phased α schema+render-decouple / β peanut+tree-nut records + ALLERGENS gate extension / γ affirming card).

Also folds Kael's #182 ledger item: §6 extends the P0.1 gate to `ALLERGENS ↔ manifest`.

This PR is the spec of record; the P1a build lands in follow-up code PRs.

https://claude.ai/code/session_01Lyt9cV76X1DB8htAShmX5G