### PR TITLE
food-effects v2 Phase γ: persistent encourage Info-tab card (peanut + tree nut)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,10 +9,10 @@
 
 You are **Lyra**, The Weaver. You see connections across domains — how a sleep regression correlates with a dietary change, how a vaccination timeline intersects with a milestone window. You weave the threads of a baby's development into a coherent tapestry that tired parents can actually read.
 
-**QA chain (30K Rule — 76,308 LOC; per-jurisdiction trigger; canon-gen-001 generational expansion ratified 2026-05-23; LOC refreshed 2026-05-31 post-#184 food-effects-v2 P1a):**
+**QA chain (30K Rule — 76,500 LOC; per-jurisdiction trigger; canon-gen-001 generational expansion ratified 2026-05-23; LOC refreshed 2026-05-31 post-#187 food-effects-v2 Phase γ):**
 1. **Maren** (Governor of Care) audits home.js + diet.js + medical.js (26,892 lines). Protective, thorough, worst-case but warm. Asks "what if this data is wrong and a parent acts on it?"
 2. **Kael** (Governor of Intelligence — engine layer) audits intelligence-isl.js + intelligence-qa.js + intelligence-qa-handlers.js + intelligence-illness.js + intelligence-correlate.js + intelligence-caretickets.js + core.js + data.js + sync.js + config.js + start.js (27,024 lines). Pattern-seeking, systematic. Audits ISL, Smart Q&A, illness state machines, the cross-domain correlation primitive, CareTicket lifecycle data, Firebase sync boundaries. **The engine layer — what the data does before it renders.**
-3. **Vela** (Governor of Surfacing — render layer) audits intelligence-cards.js + intelligence-quicklog.js (8,428 lines). Second-generation Companion seated under canon-gen-001 — parent personas Lyra (Builder ancestor) + Kael (Governor predecessor; Intelligence Region split between Kael and Vela at the data→render boundary). Surface-watching, comprehension-first. Audits Info-tab cards, Activity Log + Smart Quick Log + Today So Far, sleep-info renders, cross-domain heatmap legends. **The render layer — where Kael's correct data and Maren's safe data become parent-legible.** Lens: the half-awake test — would a parent read this correctly at 2 AM holding a baby?
+3. **Vela** (Governor of Surfacing — render layer) audits intelligence-cards.js + intelligence-quicklog.js (8,570 lines). Second-generation Companion seated under canon-gen-001 — parent personas Lyra (Builder ancestor) + Kael (Governor predecessor; Intelligence Region split between Kael and Vela at the data→render boundary). Surface-watching, comprehension-first. Audits Info-tab cards, Activity Log + Smart Quick Log + Today So Far, sleep-info renders, cross-domain heatmap legends. **The render layer — where Kael's correct data and Maren's safe data become parent-legible.** Lens: the half-awake test — would a parent read this correctly at 2 AM holding a baby?
 4. **Shared modules** (styles.css + template.html = 13,964 lines) get sequential triple-jurisdiction review from all three Governors (rotation: Maren → Kael → Vela, with first-Governor by heaviest-touched Region).
 5. Lyra synthesizes all three Governor reports and implements fixes.
 6. **Cipher** (The Codewright) does final cross-cutting QA — HR compliance, integration across all three Governor jurisdictions.
@@ -80,7 +80,7 @@ Baby development tracker for **Ziva Jain** (born 4 Sep 2025). Architecture: spli
 
 ## Architecture
 
-Split-file PWA. 16 JS modules + 2 shared files (styles.css + template.html), **76,308 lines total** (refreshed 2026-05-31 post-#184 food-effects-v2 P1a; was 76,167 post-#178, 67,442 at the canon-gen-001 ratification 2026-05-23).
+Split-file PWA. 16 JS modules + 2 shared files (styles.css + template.html), **76,500 lines total** (refreshed 2026-05-31 post-#187 food-effects-v2 Phase γ; was 76,308 post-#184, 76,167 post-#178, 67,442 at the canon-gen-001 ratification 2026-05-23).
 
 **Module map:** [docs/MODULE_MAP.html](docs/MODULE_MAP.html) — visual index of the split-file architecture, jurisdictional regions (Maren / Kael / shared), and the write hot path. Built from a specific commit; drift-check with `wc -l split/*`. Open in a browser, not as text.
 
@@ -93,8 +93,8 @@ Split-file PWA. 16 JS modules + 2 shared files (styles.css + template.html), **7
 ```
 split/
 ├── build.sh           ← stdout to sproutlab.html (NOT self-copying like Codex)
-├── template.html      ← HTML shell + zi() symbol sprite (3,228 lines)        [shared — triple-Gov review]
-├── styles.css         ← All CSS (10,736 lines)                               [shared — triple-Gov review]
+├── template.html      ← HTML shell + zi() symbol sprite (3,245 lines)        [shared — triple-Gov review]
+├── styles.css         ← All CSS (10,769 lines)                               [shared — triple-Gov review]
 ├── config.js          ← Firebase config (94 lines)                           [Kael]
 ├── data.js            ← Constants, food DB, milestone DB, FOOD_EFFECTS (5,195) [Kael]
 ├── core.js            ← Utilities, escHtml, overlays, toasts, scoring, food resolver (7,016) [Kael]
@@ -107,17 +107,17 @@ split/
 ├── intelligence-illness.js      ← fever / diarrhoea / vomiting / cold episodes (2,667) [Kael — engine]
 ├── intelligence-correlate.js    ← v3-3 cross-domain correlation primitive (274)     [Kael — engine]
 ├── intelligence-caretickets.js  ← CareTickets data + lifecycle (2,230)               [Kael — engine]
-├── intelligence-cards.js        ← Cross-domain + info-tab renderInfo* (2,896)        [Vela — render]
+├── intelligence-cards.js        ← Cross-domain + info-tab renderInfo* (3,038)        [Vela — render]
 ├── intelligence-quicklog.js     ← Activity Log + Smart Quick Log + Today So Far (5,532) [Vela — render]
 ├── sync.js            ← Firebase auth + Firestore sync (2,393 lines)         [Kael]
 └── start.js           ← Init + event delegation bootstrap (19 lines)          [Kael]
 ```
 
-**Jurisdiction summary (post-canon-gen-001; LOC refreshed 2026-05-30 post-#178):**
+**Jurisdiction summary (post-canon-gen-001; LOC refreshed 2026-05-31 post-#187):**
 - **Maren (Care):** home + diet + medical = 26,892 LOC (≈3,108 headroom to 30K)
 - **Kael (Intelligence engine):** isl + qa + qa-handlers + illness + correlate + caretickets + core + data + sync + config + start = 27,024 LOC (≈2,976 headroom to 30K — nearest-term split candidate; core.js + data.js carry the steepest recent growth)
-- **Vela (Surfacing render):** cards + quicklog = 8,428 LOC (≈21,572 headroom to 30K)
-- **Shared (triple-Gov):** styles.css + template.html = 13,964 LOC
+- **Vela (Surfacing render):** cards + quicklog = 8,570 LOC (≈21,430 headroom to 30K)
+- **Shared (triple-Gov):** styles.css + template.html = 14,014 LOC
 
 **Concat order:** config → data → core → home → diet → medical → intelligence-isl → intelligence-qa → intelligence-qa-handlers → intelligence-illness → intelligence-correlate → intelligence-quicklog → intelligence-cards → intelligence-caretickets → sync → start
 

--- a/docs/NEXT_SESSION_TARGET_2026-05-31.md
+++ b/docs/NEXT_SESSION_TARGET_2026-05-31.md
@@ -10,26 +10,21 @@
 
 ## The recommended next move
 
-**Phase γ — build the persistent *encourage* Info-tab card.**
+**P1b — the sustained-exposure engine + nudge, with the negation-leak guard first. Architect-decided start mode: SPEC THE ENGINE FIRST.**
 
-P1a (#184) put peanut + tree nut into the data layer with the full guided-introduction schema (benefit, safe-form, watch-fors, severe-signs) — but the only surface that renders it is the **log-time consequence card**, which fires *only when a food is logged below its age floor*. Ziva is ~9 months; the peanut/tree-nut floor is 6 months — so **for the exact baby who is the right age to be introduced, none of the guidance shows.** The benefit and the safe-form rule and the anaphylaxis watch-fors all sit in `FOOD_EFFECTS`, invisible.
+> **Phase γ is SHIPPED (PR #187, ready/merged-pending).** The persistent *encourage* Info-tab card now surfaces the peanut/tree-nut benefit + safe-form + watch-for guidance to an age-appropriate parent — the gap below is closed. canon-cc-008 clean (Vela + Maren + Kael all `clear-with-notes`; M-γ-1 per-food keep-offering + V-V-γ-1 advisory-fill folded; **Cipher Edict V "Ship it."**). See `docs/SESSION_HANDOFF_2026-05-31_PM.md`.
 
-Phase γ is the surface that closes that gap: a **persistent, benefit-first Info-tab card** (Vela's `intelligence-cards.js`) that a parent seeks out *before* introducing a food. It is the move that makes the entire v2 model actually reach a parent.
+The next gap: P1a put benefit/safe-form/watch-fors into the data and γ made them *visible*, but the **sustained-exposure** lesson (EAT: tolerance depends on *keep offering*, not a one-time tick) is still un-modelled. P1b builds the engine that tracks it and the calm nudge that surfaces it — and **before any auto-counting**, the `\b(no|free|without|-free)\b` negation-leak guard (today "peanut-free" whole-word-matches `peanut`). Per the 2026-05-31 PM close, **start P1b by writing the engine spec** (the §5 open questions — exposure-log location, trailing window, nudge throttle, reaction-marking UX) for Kael spec-review *before* code.
 
 ---
 
 ## Priority ladder
 
-### P-γ (do this first) — the persistent encourage card
-Per spec `docs/specs/food-effects-v2-guided-introduction.md` §4. A `renderInfo*` card in `intelligence-cards.js` composing, in fixed order:
-1. **Benefit banner** — `whyGood` + `earlyIntroBenefit.claim`, `--surface-sage` fill + affirming icon (not `zi('warn')`). Suppressed for `acute-toxin` (honey stays warn/rose).
-2. **Introduce-safely block** — `howToIntroduce` (amount/when/watch/keep-offering) + the `safeForm` form-gate line ("ground/smooth only, never whole; grinding removes choking not allergy"), non-suppressible; carries `highRiskNote` for the eczema/egg cohort.
-3. **Severe-reaction strip** — `severeSigns[]` + emergency action, **unconditional, non-collapsible, amber** (the A-1/V-1/V-3 invariant — reuse the `.cons-severe` pattern already shipped).
-4. **Mild watch-fors + the "delay" myth.**
-Polarity→color: sage encourage, rose reserved for acute-toxin, amber the caution strip. Chain: **Vela-primary** (render); **Maren** on any safety-copy surfaced; **Cipher** Edict V terminal. e2e: the card renders benefit-first for peanut; the severe strip is non-collapsible; honey (acute-toxin) suppresses the benefit banner and stays rose.
+### P-γ — the persistent encourage card — ✅ SHIPPED (PR #187)
+Per spec `docs/specs/food-effects-v2-guided-introduction.md` §4. A `renderInfoNutIntro()` card in `intelligence-cards.js` (single combined peanut+tree-nut card, all copy record-sourced) composing, in fixed order: benefit banner (sage, `zi('sprout')`) → introduce-safely (per-food keep-offering + the non-suppressible form-gate note + the neutral high-risk note) → the **non-collapsible amber severe strip** (in the always-visible summary, never the accordion) → the "delay" myth; mild watch-fors in the collapse body. e2e `food-effects-v2-encourage-card.spec.ts` (6 guards). **Render realisation of the emergency-floor invariant: the non-collapsible content lives in the card's summary slot, not inside the collapse-body — so the uniform collapsible shell (the v3-6 "first info card has a body" contract) and the §4.3 floor both hold.**
 
-### P1b — sustained-exposure engine + nudge + the negation guard (Kael)
-Per spec §5. The exposure log (derive-on-read vs sidecar — Kael's call), `firstIntroduced`/`lastOffered`/`cadence`/**`reactionLogged`**, and the calm "keep offering" nudge (Info / Today-So-Far, `calm`/`pending` chip register, never a CareTicket, hard-suppress on `reactionLogged`). **Land the negation-leak guard FIRST** (a leading `\b(no|free|without|-free)\b` check in/around the resolver) — "peanut-free" currently whole-word-matches `peanut`, and once the engine auto-counts resolver matches it would accrue false "peanut introduced" exposures. (Kael flagged; pre-existing, becomes load-bearing here.)
+### P1b (do this first) — sustained-exposure engine + nudge + the negation guard (Kael)
+Per spec §5. **Start by SPEC-ing the engine** (Architect decision, 2026-05-31 PM): the §5 open questions — exposure-log location (derive-on-read from the feeding log vs a persisted sidecar), trailing-window length, nudge cadence/throttle, the reaction-marking UX, interaction with the introduced-foods store — go into a P1b spec for **Kael spec-review** before code. Then build: the exposure log, `firstIntroduced`/`lastOffered`/`cadence`/**`reactionLogged`**, and the calm "keep offering" nudge (Info / Today-So-Far, `calm`/`pending` chip register, never a CareTicket, hard-suppress on `reactionLogged`). **Land the negation-leak guard FIRST** (a leading `\b(no|free|without|-free)\b` check in/around the resolver) — "peanut-free" currently whole-word-matches `peanut`, and once the engine auto-counts resolver matches it would accrue false "peanut introduced" exposures. (Kael flagged; pre-existing, becomes load-bearing here.)
 
 ### P1c — the remaining foods, through the pipeline
 Architect-ratified order: **egg → seeds (sesame/til) → cow + plant milks.** Each: research (`docs/research/<food>-infant-safety.{md,html,visual.html}`) → manifest record → `FOOD_EFFECTS` + `AGE_RULES` → it surfaces automatically via the γ card → e2e + canon-cc-008. Milk is the most complex (drink-timing + the plant/"artificial"-milk `substitute-caveat` sub-typing); egg is the cleanest second exercise.

--- a/docs/SESSION_HANDOFF_2026-05-31_PM.md
+++ b/docs/SESSION_HANDOFF_2026-05-31_PM.md
@@ -1,0 +1,145 @@
+# Session handoff — 2026-05-31 PM (food-effects v2 Phase γ — the persistent *encourage* Info-tab card)
+
+**Companion:** Lyra (The Weaver)
+**Session theme:** Build Phase γ — the persistent, benefit-first *encourage* Info-tab card that surfaces the peanut/tree-nut guided-introduction guidance to an age-appropriate parent. γ-only scope (confirmed at open); P1b held for a fresh session.
+**Branch:** `claude/food-effects-encourage-card-oiGQY` (off `main` @ `4bdb94f`).
+**Predecessor handoff:** `docs/SESSION_HANDOFF_2026-05-31.md` (the AM session — #181–#184, the guided-introduction model).
+
+---
+
+## What shipped (the record)
+
+**PR #187 — `food-effects v2 Phase γ: persistent encourage Info-tab card` — READY (Architect merge pending).** Two commits:
+- `e275e7a` — the card: `renderInfoNutIntro()` in `intelligence-cards.js`, the `infoNutIntroCard` shell in `template.html` (Food Intelligence section), the `.enc-*` class family in `styles.css`, and `tests/e2e/food-effects-v2-encourage-card.spec.ts`.
+- `8c9f759` — the two canon-cc-008 folds (M-γ-1, V-V-γ-1).
+
+**The gap it closes.** P1a (#184) put peanut + tree nut into `FOOD_EFFECTS` with the full schema (benefit, safe-form, watch-fors, severe-signs), but the only surface rendering it was the **log-time consequence card**, which fires *only below the age floor*. Ziva is ~9mo; the floor is 6mo — so for the exact baby who should be introduced, none of it showed. γ is the persistent surface that reaches her parent.
+
+**What it is.** A single combined peanut+tree-nut card (per the Architect's "single combined nut card" call), **all copy record-sourced** (no hardcoded safety claim), composed in spec §4 fixed order:
+1. **Benefit banner** — sage `--surface-sage`, `zi('sprout')` (affirming, never `zi('warn')`), `earlyIntroBenefit.claim`/`.evidence` (LEAP ~80%) + each food's `whyGood`.
+2. **Introduce-safely** — shared amount/when/watch; **per-food** keep-offering lines (M-γ-1); the non-suppressible `safeForm` form-gate note ("grinding removes choking, NOT allergy; never whole") with the `never` list in rose; the neutral high-risk note.
+3. **Severe-reaction strip** — `severeSigns[]` + the call-112 emergency action, **unconditional, non-collapsible, amber** (reuses the shipped `.cons-severe`), in the always-visible summary slot.
+4. **The "delay" myth** (visible) + mild watch-fors (in the collapse body).
+
+**Verification:** `pnpm build` clean, **12 audit gates pass**; full e2e green (333 discovered, **0 failures**); γ spec **6/6**; v3-6 card-priority **22/22**.
+
+---
+
+## QA chain that ran (canon-cc-008)
+
+| Governor | Region | Verdict | Headline |
+|----------|--------|---------|----------|
+| **Vela** | render | `clear-with-notes` | floor reachability-proven; **V-V-γ-1** — `.enc-highrisk` shared amber with the severe strip, diluting its salience → folded to `--surface-neutral` + calm accent (amber reserved for caution-and-up). |
+| **Maren** | Care | `clear-with-notes` | the floor holds, never under-warns; **M-γ-1** — the combined card sourced the protocol from peanut only, dropping tree nut's "introduce each nut on its own, a few days apart" attribution line → folded to **per-food keep-offering**. |
+| **Kael** | engine/shared | `clear-with-notes` | no `FOOD_EFFECTS` source mutation (the `.slice()` discipline is load-bearing — `diet.js:712` hands the same arrays to the log-time card by reference); direct keyed read is the correct contract (not a `_lookupByFoodName` case); no token/sprite drift. |
+| **Cipher** | Edict V | **"Ship it."** | both folds integrate without weakening the floor; honest / extensible / warm attested. |
+
+**M-γ-2 resolved no-change:** Vela (the render Governor whose call it was) ruled mild watch-fors default-collapsed is correct calm-secondary weighting (§4.4); the always-visible `seekCare` line already references a mild rash. Both folds are e2e-guarded.
+
+**The session's signature catch — M-γ-1.** The "single combined nut card" decision (§7) was *meant* to fold two distinct allergens into one surface; Maren caught that the naïve implementation silently dropped tree nut's one-at-a-time attribution guidance — the exact "one tolerance test covers all nuts" hazard the combined card risked. A green build shipped it; only the Care lens caught it. **canon-cc-008 earns its gate again.**
+
+---
+
+## Pre-close state
+
+- **PR #187:** READY, awaiting Architect merge (a feature PR — not self-merged). The session-close docs (this handoff + the next-target update + the CLAUDE.md LOC refresh) ride the **same designated branch** per the hard branch rule, in the same PR; **docs portion is Governor-code-audit-waived** (docs-only), Cipher Edict V N/A for the docs.
+- **PR subscription:** #187 activity subscription **kept** (the Architect asked to watch it; it is unmerged, so not unsubscribed per close hygiene). CI is green (Vercel preview check); no review comments.
+- **Build + gates:** green. **LOC:** 76,500 (Maren 26,892 · Kael 27,024 · **Vela 8,570** · shared 14,014). 12 audit gates (unchanged — no new gate this session).
+
+---
+
+## Carry-forward register (open)
+
+### Successors — the food-effects-v2 build (detailed in `docs/NEXT_SESSION_TARGET_2026-05-31.md`)
+- **P1b — sustained-exposure engine + nudge + the negation guard (Kael). The recommended next move.** Architect decision (this close): **spec the engine first** — the §5 open questions (exposure-log location: derive-on-read vs sidecar; trailing window; nudge throttle; reaction-marking UX) go to Kael spec-review before code. **Land the `\b(no|free|without|-free)\b` negation-leak guard FIRST** (today "peanut-free" whole-word-matches `peanut`; once the engine auto-counts it accrues false "introduced" exposures).
+- **P1c — egg → seeds (sesame/til) → cow + plant milks** (Architect-ratified order). Each surfaces automatically via the γ card once its record lands.
+
+### Quality / debt
+- **Amber register** — γ folded V-V-γ-1 (the high-risk note off amber). The original Vela V-V-N (severe strip + mild-watch block both `--surface-amber`) is *softened* (they're now in different slots — summary vs collapse body) but the shared token remains; tighten the severe fill to read categorically heavier if the card is next touched.
+- The pre-existing unescaped `${food}` at `diet.js:1195` (HR-4) — not touched this session (γ didn't go near it); close when that surface is next touched.
+- Inherited: #6 item 3 AT smoke-pass (human-only); F-4/F-5 (`parseFeeding` normalizer); milestones-tab-v1 e2e (~28 guards); `CURATED_COMBOS maxAgeMonths`; `_qlPredictFood` SKIPPED_MEAL filter; `NUTRITION_QTY_DEFAULTS` coverage; comma-dish-name parse.
+
+### Housekeeping
+- Delete merged remote branches via the GitHub UI (env blocks delete-push; MCP has no delete-branch): the ~30 stale `claude/*` + this branch once #187 merges.
+
+### Codex canon-reconciliation (action-required, inherited)
+- The SproutLab `.claude/agents/*` mirrors (Lyra/Maren/Kael/Vela) were edited the prior session under Architect waiver while Codex was unreachable. **Port into Codex canon + re-establish byte parity next Codex-reachable session** (canon-cc-026), or the session-start overlay reverts them. (Codex was not touched this session.)
+
+### Candidate Codex canon (surfaced, not ratified)
+- **The emergency floor in a collapsible render.** When a surface must be uniform-collapsible (a render contract) *and* hold content that must never fold (a safety invariant), put the unfoldable content in the always-visible **summary slot**, never inside the collapse-body — the chevron toggles only the secondary block. (γ's resolution of the v3-6 "first info card has a body" contract vs the §4.3 floor.)
+- **A combined multi-entity card must not drop a per-entity safety line.** Folding two records into one card (the §7 "single combined" decision) is only honest if each entity's *distinct* guidance still renders — source the differing field per-entity, never just the lead's (M-γ-1).
+- Prior, still candidate: the guided-introduction model; the research→spine→surface pipeline; "substring food-name matching is a safety defect."
+
+---
+
+## Session opening prompt for next session
+
+```
+SESSION OPENING — next — food-effects-v2 P1b: the sustained-exposure engine (SPEC FIRST) + the negation-leak guard
+
+Hi Lyra. The 2026-05-31 AM session built the GUIDED-INTRODUCTION model (#181–#184);
+the PM session shipped Phase γ (#187) — the persistent ENCOURAGE Info-tab card that
+finally surfaces the peanut/tree-nut benefit + safe-form + watch-for guidance to an
+age-appropriate parent. canon-cc-008 clean; Cipher "Ship it." The card is data-driven
+and record-sourced — P1c foods (egg/seeds/milks) will surface through it automatically.
+
+THE GAP TO CLOSE NOW: the EAT lesson (tolerance depends on KEEP OFFERING, not a one-time
+tick) is still un-modelled. P1b builds the sustained-exposure engine + the calm "keep
+offering" nudge — and the negation-leak guard that must land before any auto-counting.
+
+Session goal — P1b, in this order:
+ 1. SPEC THE ENGINE FIRST (Architect decision): write the P1b engine spec resolving the
+    spec §5 open questions — exposure-log location (derive-on-read from the feeding log
+    vs a persisted sidecar), trailing-window length, nudge cadence/throttle, the
+    reaction-marking UX, interaction with the introduced-foods store. Kael spec-review
+    (SPEC_ITERATION_PROCESS) before any engine code.
+ 2. The negation-leak guard FIRST in code: a leading \b(no|free|without|-free)\b check
+    in/around _lookupByFoodName — "peanut-free" currently whole-word-matches `peanut`;
+    once the engine auto-counts resolver matches it accrues false "introduced" exposures.
+    Its own small PR (Kael), e2e: "peanut-free" / "nut-free" resolve to nothing.
+ 3. Then the engine: exposure log + firstIntroduced/lastOffered/cadence/reactionLogged +
+    the calm nudge (Info / Today-So-Far, calm/pending chip, never a CareTicket,
+    hard-suppress on reactionLogged). Kael-primary; Vela on the nudge render.
+
+Required context — read BEFORE acting:
+ 1. /home/user/sproutlab/CLAUDE.md — IN FULL (12 audit gates; canon-cc-008 routing;
+    jurisdiction LOC 76,500; HR-1..12)
+ 2. /home/user/sproutlab/docs/SESSION_HANDOFF_2026-05-31_PM.md — THIS handoff
+ 3. /home/user/sproutlab/docs/specs/food-effects-v2-guided-introduction.md — §5 (the
+    engine model + the open questions), §10 (phasing P1b)
+ 4. /home/user/sproutlab/docs/NEXT_SESSION_TARGET_2026-05-31.md — the ladder
+ 5. /home/user/sproutlab/docs/research/peanut-tree-nut-infant-safety.md — Axis-1 (EAT
+    per-protocol: dose + adherence — the reason for "keep offering")
+
+Required at session start:
+ 1. cwd /home/user/sproutlab; git fetch; confirm main at 4bdb94f or later; confirm #187
+    merged (or note it parked); no surprise open PRs.
+ 2. Verify subagent registration (expected still missing → persona-briefed
+    general-purpose workaround; load .claude/agents/<name>.md as step 1 of each
+    Governor/Cipher invocation).
+ 3. Read required context.
+ 4. P1b spec on a fresh branch off main; Kael spec-review; then code through full
+    canon-cc-008 (Kael-primary engine; Vela on nudge render; Maren on any safety-copy;
+    Cipher Edict V terminal).
+
+Architect directives in force:
+ - canon-cc-008 is a non-negotiable release gate; Cipher Edict V last; shared-module
+   touch → triple-Gov; docs-only may waive Governors (state it).
+ - The emergency floor never moves: severe-reaction signs + the action render
+   unconditionally, non-collapsibly, whenever an encourage surface shows.
+ - A nudge that re-offers a food the baby reacted to is a Care-blocking defect — the
+   nudge MUST hard-suppress permanently on reactionLogged (never auto time-decay).
+ - One food-name semantics — everything routes through _lookupByFoodName (now
+   alias-aware; negation-guard it before the engine auto-counts). Substring matching is
+   a safety defect.
+ - The food-effects pipeline is the canonical path for a new food: research → manifest →
+   FOOD_EFFECTS. No hardcoded safety claim without a manifest entry.
+ - When Codex is reachable, reconcile the .claude/agents/* mirror edits into Codex canon
+   (canon-cc-026 parity).
+
+Goal issued. Ask first.
+```
+
+---
+
+— *Lyra, 2026-05-31 (PM). The AM session taught the layer to hold "yes, soon, here's how" in data. This session taught the app to say it out loud — to Ziva's parent, at nine months, at 2 AM. The hard part wasn't the benefit banner; it was keeping the one line that matters in the thirty minutes after the first taste both unmissable AND inside a card that collapses like every other. The answer: the floor lives in the part that never folds. And Maren — again — caught the thing a green build would have shipped: a combined card that quietly forgot to tell a parent to introduce each nut on its own. Same lens, same save. Next we model the part the EAT trial proved hardest: not the first taste, but the fiftieth.*

--- a/index.html
+++ b/index.html
@@ -3987,6 +3987,36 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
 [data-theme="dark"] .consequence-card { background:var(--surface); }
 [data-theme="dark"] .cons-severe { background:var(--surface-amber); }
 
+/* ── food-effects v2 Phase γ — persistent encourage (nut-introduction) card ──
+   Polarity→color (V-3): SAGE leads (encourage); the severe strip borrows the
+   shared .cons-severe AMBER (serious-without-alarm); rose stays reserved for
+   acute-toxin. The benefit banner is the only top-of-card affirmer — green-topped
+   reads pre-literately as "do this," never "avoid." */
+.enc-benefit { background:var(--surface-sage); border-left:3px solid var(--sage-deepest); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); margin-bottom:var(--sp-16); }
+.enc-benefit-h { display:flex; align-items:center; gap:var(--sp-8); font-size:var(--fs-sm); font-weight:700; color:var(--sage-deepest); text-transform:uppercase; letter-spacing:0.3px; margin-bottom:var(--sp-8); }
+.enc-benefit-h .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--sage-deepest); }
+.enc-claim { font-size:var(--fs-base); font-weight:700; color:var(--text); line-height:var(--lh-relaxed); margin:0 0 var(--sp-4); }
+.enc-evidence { font-size:var(--fs-sm); color:var(--light); line-height:var(--lh-relaxed); margin:0 0 var(--sp-8); }
+.enc-why-list { margin:0; padding-left:var(--sp-20); }
+.enc-why-list li { font-size:var(--fs-base); color:var(--text); margin:var(--sp-4) 0; line-height:var(--lh-relaxed); }
+.enc-block { margin-bottom:var(--sp-16); }
+.enc-block-h { display:flex; align-items:center; gap:var(--sp-8); font-size:var(--fs-sm); font-weight:700; color:var(--text); text-transform:uppercase; letter-spacing:0.3px; margin-bottom:var(--sp-8); }
+.enc-block-h .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--tc-sage); }
+.enc-proto { margin:0 0 var(--sp-12); display:flex; flex-direction:column; gap:var(--sp-4); }
+.enc-proto-row { font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); }
+.enc-proto-row b { color:var(--sage-deepest); }
+.enc-form { background:var(--surface-sage); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); }
+.enc-form-sub { font-size:var(--fs-sm); font-weight:700; color:var(--text); text-transform:uppercase; letter-spacing:0.3px; margin:0 0 var(--sp-8); }
+.enc-form-list { margin:0 0 var(--sp-8); padding-left:var(--sp-20); }
+.enc-form-list li { font-size:var(--fs-base); color:var(--text); margin:var(--sp-4) 0; line-height:var(--lh-relaxed); }
+.enc-form-list.enc-never li { color:var(--rose-deep); }
+.enc-form-note { font-size:var(--fs-base); font-weight:700; color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-8) 0 0; }
+.enc-highrisk { font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-12) 0 0; padding:var(--sp-8) var(--sp-12); background:var(--surface-amber); border-radius:var(--r-sm); }
+.enc-emergency { display:flex; align-items:flex-start; gap:var(--sp-8); font-size:var(--fs-sm); color:var(--amber-deepest); margin:var(--sp-8) 0 0; line-height:var(--lh-relaxed); }
+.enc-emergency .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--amber-deep); margin-top:3px; }
+.enc-myth { display:flex; align-items:flex-start; gap:var(--sp-8); font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-16) 0 0; padding:var(--sp-12) var(--sp-16); background:var(--surface-lav); border-radius:var(--r-md); }
+.enc-myth .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--tc-lav); margin-top:3px; }
+
 /* ── Viz detail popup (PR-I — viz interactivity layer) ── */
 /* Tap affordance: every wired data element (SVG dot/cell/bar/segment or
    HTML cell) gets a pointer cursor without a per-element class. */
@@ -12483,6 +12513,23 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 
       <!-- ─── FOOD INTELLIGENCE ─── -->
       <div class="home-section-label sec-t3 col-full">Food Intelligence</div>
+
+      <!-- Introducing nuts early (food-effects v2 Phase γ — persistent encourage card).
+           Emergency-floor invariant (§4.3, A-1/V-1): the severe-reaction strip must
+           never sit inside an accordion. So the always-visible summary slot
+           (#infoNutIntro) carries benefit → introduce-safely → SEVERE STRIP → myth,
+           and only the calm MILD watch-fors (§4.4) live in the collapse body. The
+           chevron toggles the mild block alone; the severe strip is never folded. -->
+      <div class="card card-daily col-full" id="infoNutIntroCard">
+        <div class="card-header" data-collapse-target="infoNutIntroBody" data-collapse-chevron="infoNutIntroChevron">
+          <div class="card-title"><div class="icon icon-sage"><svg class="zi"><use href="#zi-sprout"/></svg></div> Introducing nuts early</div>
+          <span class="collapse-chevron" id="infoNutIntroChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
+        </div>
+        <div id="infoNutIntro" class="mt-4"></div>
+        <div id="infoNutIntroBody" class="collapse-body fx-col g8" style="display:none;">
+          <div id="infoNutIntroMore" class="mt-4"></div>
+        </div>
+      </div>
 
       <!-- Food Introduction Rate -->
       <div class="card card-daily col-full" id="infoFoodIntroCard">
@@ -70027,6 +70074,7 @@ function renderInfoMilestoneSleepCorrelation() {
 }
 
 function renderInfo() {
+  renderInfoNutIntro();
   renderInfoFoodIntro();
   renderInfoNutrientHeatmap();
   renderInfoComboFreq();
@@ -70079,6 +70127,135 @@ function renderInfo() {
   // boundary) per spec §Sort implementation F4+F6 IMPL-note: visible-reflow
   // avoidance + .card:nth-child(N) animation-delay alignment.
   _sortInfoTabByPriority();
+}
+
+// ════════════════════════════════════════
+// Persistent encourage card — guided introduction (food-effects v2 Phase γ)
+// ════════════════════════════════════════
+// Surfaces the peanut + tree-nut FOOD_EFFECTS records as ONE benefit-first
+// Info-tab card, so an age-appropriate parent (Ziva is past the 6-month floor)
+// reaches the benefit / safe-form / watch-for guidance that the log-time
+// consequence card only fires BELOW the gate — the γ gap. Spec §4.
+//
+// Invariants enforced here:
+//   • All copy is sourced from FOOD_EFFECTS — no hardcoded safety claim
+//     (the research→manifest→FOOD_EFFECTS pipeline is the canonical path).
+//   • Emergency floor (A-1/V-1): the severeSigns strip + the emergency action
+//     render UNCONDITIONALLY and NON-COLLAPSIBLY (the card has no accordion;
+//     see the template note). Benefit may lead, but it never moves the floor.
+//   • Form gate (A-2): the "grinding removes choking, NOT allergy / never whole"
+//     note renders whenever a record carries it — never suppressed by benefit.
+//   • Polarity→color (V-3): sage benefit banner; amber severe strip (shared
+//     .cons-severe); rose stays reserved for acute-toxin.
+function renderInfoNutIntro() {
+  var host = document.getElementById('infoNutIntro');       // always-visible summary
+  var moreHost = document.getElementById('infoNutIntroMore'); // collapse body (mild)
+  if (!host) return;
+  var FE = (typeof FOOD_EFFECTS !== 'undefined') ? FOOD_EFFECTS : null;
+  var peanut  = FE ? FE['peanut']   : null;
+  var treeNut = FE ? FE['tree nut'] : null;
+  // Need at least one record to say anything truthful; otherwise leave the card
+  // empty and drop it to ambient so the priority sort de-emphasises it.
+  if (!peanut && !treeNut) {
+    host.innerHTML = '';
+    if (moreHost) moreHost.innerHTML = '';
+    _setCardPriority('infoNutIntroCard', 'ambient');
+    return;
+  }
+  var lead = peanut || treeNut;          // peanut carries the strongest (LEAP) evidence
+  var foods = [peanut, treeNut].filter(Boolean);
+  var html = '';
+
+  // ── Section 1: Benefit banner (sage, encourage polarity — V-3) ──
+  var benefit = (lead.earlyIntroBenefit && lead.earlyIntroBenefit.claim) ? lead.earlyIntroBenefit : null;
+  html += '<div class="enc-benefit">';
+  html += '<div class="enc-benefit-h">' + zi('sprout') + '<span>Why introduce early</span></div>';
+  if (benefit) {
+    html += '<p class="enc-claim">' + escHtml(benefit.claim) + '</p>';
+    if (benefit.evidence) html += '<p class="enc-evidence">' + escHtml(benefit.evidence) + '</p>';
+  }
+  // Each food's own cited nutrition line (no fabricated merge across records).
+  var whyItems = foods.filter(function(f){ return f.whyGood; })
+    .map(function(f){ return '<li>' + escHtml(f.whyGood) + '</li>'; }).join('');
+  if (whyItems) html += '<ul class="enc-why-list">' + whyItems + '</ul>';
+  html += '</div>';
+
+  // ── Section 2: Introduce-safely block (protocol + non-suppressible form gate, A-2) ──
+  html += '<div class="enc-block">';
+  html += '<div class="enc-block-h">' + zi('spoon') + '<span>How to introduce safely</span></div>';
+  var hti = lead.howToIntroduce || {};
+  html += '<div class="enc-proto">';
+  if (hti.amount)   html += '<div class="enc-proto-row"><b>Amount:</b> ' + escHtml(hti.amount) + '</div>';
+  if (hti.when)     html += '<div class="enc-proto-row"><b>When:</b> ' + escHtml(hti.when) + '</div>';
+  if (hti.watch)    html += '<div class="enc-proto-row"><b>Watch:</b> ' + escHtml(hti.watch) + '</div>';
+  if (hti.thenWhat) html += '<div class="enc-proto-row"><b>Keep offering:</b> ' + escHtml(hti.thenWhat) + '</div>';
+  html += '</div>';
+  // Safe-form gate — union the cited ok/never lists across both records (dedup),
+  // then the non-suppressible note (Maren A-2: grinding removes choking, NOT allergy).
+  var okSet = [], neverSet = [], note = '';
+  foods.forEach(function(f){
+    var sf = f.safeForm || {};
+    (sf.ok || []).forEach(function(x){ if (okSet.indexOf(x) === -1) okSet.push(x); });
+    (sf.never || []).forEach(function(x){ if (neverSet.indexOf(x) === -1) neverSet.push(x); });
+    if (!note && sf.note) note = sf.note;
+  });
+  if (okSet.length || neverSet.length || note) {
+    html += '<div class="enc-form">';
+    if (okSet.length) {
+      html += '<div class="enc-form-sub">Safe forms</div><ul class="enc-form-list">' +
+        okSet.map(function(x){ return '<li>' + escHtml(x) + '</li>'; }).join('') + '</ul>';
+    }
+    if (neverSet.length) {
+      html += '<div class="enc-form-sub">Never</div><ul class="enc-form-list enc-never">' +
+        neverSet.map(function(x){ return '<li>' + escHtml(x) + '</li>'; }).join('') + '</ul>';
+    }
+    if (note) html += '<p class="enc-form-note">' + escHtml(note) + '</p>';
+    html += '</div>';
+  }
+  // High-risk cohort note (Maren §9.2 — non-suppressible when applicable).
+  if (hti.highRiskNote) html += '<p class="enc-highrisk">' + escHtml(hti.highRiskNote) + '</p>';
+  html += '</div>';
+
+  // ── Section 3: Severe-reaction strip — the emergency floor (A-1/V-1) ──
+  // Unconditional, non-collapsible, amber. Reuses the shipped .cons-severe
+  // pattern verbatim so this card and the log-time card read identically.
+  // slice() first — never mutate the FOOD_EFFECTS source array.
+  var severe = (lead.severeSigns && lead.severeSigns.length) ? lead.severeSigns.slice() : [];
+  foods.forEach(function(f){
+    (f.severeSigns || []).forEach(function(s){ if (severe.indexOf(s) === -1) severe.push(s); });
+  });
+  if (severe.length) {
+    html += '<div class="cons-severe"><div class="cons-severe-h">' + zi('siren') +
+      '<span>If this happens, it’s an emergency</span></div><ul class="cons-severe-list">' +
+      severe.map(function(s){ return '<li>' + escHtml(s) + '</li>'; }).join('') + '</ul>';
+    if (lead.seekCare) {
+      html += '<p class="enc-emergency">' + zi('siren') + '<span>' + escHtml(lead.seekCare) + '</span></p>';
+    }
+    html += '</div>';
+  }
+
+  // ── Section 4a: the "delay" myth — stays in the always-visible summary.
+  // It is the highest-value relative-facing line (spec §4.4), so it is never
+  // folded into the collapse body.
+  var myth = (benefit && benefit.paradigm) ? benefit.paradigm : '';
+  if (myth) {
+    html += '<div class="enc-myth">' + zi('bulb') + '<span>' + escHtml(myth) + '</span></div>';
+  }
+
+  host.innerHTML = html;
+
+  // ── Section 4b: mild watch-fors — calm-secondary (spec §4.4), so they live in
+  // the collapse body the chevron toggles. The SEVERE strip above is never here.
+  var mild = (lead.watchFor && lead.watchFor.length) ? lead.watchFor.slice() : [];
+  if (moreHost) {
+    moreHost.innerHTML = mild.length
+      ? '<div class="cons-watch"><div class="cons-watch-h">Milder signs to watch for</div><ul class="cons-watch-list">' +
+          mild.map(function(w){ return '<li>' + escHtml(w) + '</li>'; }).join('') + '</ul></div>'
+      : '';
+  }
+
+  // Encourage cards map to card-priority 'notable' (spec §4); honey → 'urgent'.
+  _setCardPriority('infoNutIntroCard', 'notable');
 }
 
 function renderInfoFoodIntro() {

--- a/index.html
+++ b/index.html
@@ -4011,7 +4011,10 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
 .enc-form-list li { font-size:var(--fs-base); color:var(--text); margin:var(--sp-4) 0; line-height:var(--lh-relaxed); }
 .enc-form-list.enc-never li { color:var(--rose-deep); }
 .enc-form-note { font-size:var(--fs-base); font-weight:700; color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-8) 0 0; }
-.enc-highrisk { font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-12) 0 0; padding:var(--sp-8) var(--sp-12); background:var(--surface-amber); border-radius:var(--r-sm); }
+/* V-V-γ-1 (Vela): advisory, NOT emergency — a neutral fill + calm left accent
+   keeps the amber register reserved for the severe strip (caution-and-up), so
+   the two no longer blur at the §2/§3 seam. */
+.enc-highrisk { font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-12) 0 0; padding:var(--sp-8) var(--sp-12); background:var(--surface-neutral); border-left:3px solid var(--border-subtle); border-radius:var(--r-sm); }
 .enc-emergency { display:flex; align-items:flex-start; gap:var(--sp-8); font-size:var(--fs-sm); color:var(--amber-deepest); margin:var(--sp-8) 0 0; line-height:var(--lh-relaxed); }
 .enc-emergency .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--amber-deep); margin-top:3px; }
 .enc-myth { display:flex; align-items:flex-start; gap:var(--sp-8); font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-16) 0 0; padding:var(--sp-12) var(--sp-16); background:var(--surface-lav); border-radius:var(--r-md); }
@@ -70185,10 +70188,22 @@ function renderInfoNutIntro() {
   html += '<div class="enc-block-h">' + zi('spoon') + '<span>How to introduce safely</span></div>';
   var hti = lead.howToIntroduce || {};
   html += '<div class="enc-proto">';
+  // Amount / when / watch are materially identical across the records — source
+  // the shared first-exposure rhythm from lead.
   if (hti.amount)   html += '<div class="enc-proto-row"><b>Amount:</b> ' + escHtml(hti.amount) + '</div>';
   if (hti.when)     html += '<div class="enc-proto-row"><b>When:</b> ' + escHtml(hti.when) + '</div>';
   if (hti.watch)    html += '<div class="enc-proto-row"><b>Watch:</b> ' + escHtml(hti.watch) + '</div>';
-  if (hti.thenWhat) html += '<div class="enc-proto-row"><b>Keep offering:</b> ' + escHtml(hti.thenWhat) + '</div>';
+  // Keep-offering guidance is PER-FOOD (Maren M-γ-1): tree nut carries the
+  // load-bearing "introduce each nut on its own, a few days apart" attribution
+  // line that peanut's does not. A combined card must never drop one food's
+  // distinct guidance — render each present food's own thenWhat, labelled, so
+  // the parent doesn't apply peanut's rhythm to a mixed-nut paste.
+  var keepOffering = [{ rec: peanut, label: 'Peanut' }, { rec: treeNut, label: 'Tree nuts' }]
+    .filter(function(x){ return x.rec && x.rec.howToIntroduce && x.rec.howToIntroduce.thenWhat; });
+  keepOffering.forEach(function(x){
+    html += '<div class="enc-proto-row"><b>Keep offering — ' + escHtml(x.label) + ':</b> ' +
+      escHtml(x.rec.howToIntroduce.thenWhat) + '</div>';
+  });
   html += '</div>';
   // Safe-form gate — union the cited ok/never lists across both records (dedup),
   // then the non-suppressible note (Maren A-2: grinding removes choking, NOT allergy).

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.31-8",
+  "version": "2026.05.31-10",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.31-6",
+  "version": "2026.05.31-8",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.31-10",
+  "version": "2026.05.31-11",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/intelligence-cards.js
+++ b/split/intelligence-cards.js
@@ -1235,6 +1235,7 @@ function renderInfoMilestoneSleepCorrelation() {
 }
 
 function renderInfo() {
+  renderInfoNutIntro();
   renderInfoFoodIntro();
   renderInfoNutrientHeatmap();
   renderInfoComboFreq();
@@ -1287,6 +1288,135 @@ function renderInfo() {
   // boundary) per spec §Sort implementation F4+F6 IMPL-note: visible-reflow
   // avoidance + .card:nth-child(N) animation-delay alignment.
   _sortInfoTabByPriority();
+}
+
+// ════════════════════════════════════════
+// Persistent encourage card — guided introduction (food-effects v2 Phase γ)
+// ════════════════════════════════════════
+// Surfaces the peanut + tree-nut FOOD_EFFECTS records as ONE benefit-first
+// Info-tab card, so an age-appropriate parent (Ziva is past the 6-month floor)
+// reaches the benefit / safe-form / watch-for guidance that the log-time
+// consequence card only fires BELOW the gate — the γ gap. Spec §4.
+//
+// Invariants enforced here:
+//   • All copy is sourced from FOOD_EFFECTS — no hardcoded safety claim
+//     (the research→manifest→FOOD_EFFECTS pipeline is the canonical path).
+//   • Emergency floor (A-1/V-1): the severeSigns strip + the emergency action
+//     render UNCONDITIONALLY and NON-COLLAPSIBLY (the card has no accordion;
+//     see the template note). Benefit may lead, but it never moves the floor.
+//   • Form gate (A-2): the "grinding removes choking, NOT allergy / never whole"
+//     note renders whenever a record carries it — never suppressed by benefit.
+//   • Polarity→color (V-3): sage benefit banner; amber severe strip (shared
+//     .cons-severe); rose stays reserved for acute-toxin.
+function renderInfoNutIntro() {
+  var host = document.getElementById('infoNutIntro');       // always-visible summary
+  var moreHost = document.getElementById('infoNutIntroMore'); // collapse body (mild)
+  if (!host) return;
+  var FE = (typeof FOOD_EFFECTS !== 'undefined') ? FOOD_EFFECTS : null;
+  var peanut  = FE ? FE['peanut']   : null;
+  var treeNut = FE ? FE['tree nut'] : null;
+  // Need at least one record to say anything truthful; otherwise leave the card
+  // empty and drop it to ambient so the priority sort de-emphasises it.
+  if (!peanut && !treeNut) {
+    host.innerHTML = '';
+    if (moreHost) moreHost.innerHTML = '';
+    _setCardPriority('infoNutIntroCard', 'ambient');
+    return;
+  }
+  var lead = peanut || treeNut;          // peanut carries the strongest (LEAP) evidence
+  var foods = [peanut, treeNut].filter(Boolean);
+  var html = '';
+
+  // ── Section 1: Benefit banner (sage, encourage polarity — V-3) ──
+  var benefit = (lead.earlyIntroBenefit && lead.earlyIntroBenefit.claim) ? lead.earlyIntroBenefit : null;
+  html += '<div class="enc-benefit">';
+  html += '<div class="enc-benefit-h">' + zi('sprout') + '<span>Why introduce early</span></div>';
+  if (benefit) {
+    html += '<p class="enc-claim">' + escHtml(benefit.claim) + '</p>';
+    if (benefit.evidence) html += '<p class="enc-evidence">' + escHtml(benefit.evidence) + '</p>';
+  }
+  // Each food's own cited nutrition line (no fabricated merge across records).
+  var whyItems = foods.filter(function(f){ return f.whyGood; })
+    .map(function(f){ return '<li>' + escHtml(f.whyGood) + '</li>'; }).join('');
+  if (whyItems) html += '<ul class="enc-why-list">' + whyItems + '</ul>';
+  html += '</div>';
+
+  // ── Section 2: Introduce-safely block (protocol + non-suppressible form gate, A-2) ──
+  html += '<div class="enc-block">';
+  html += '<div class="enc-block-h">' + zi('spoon') + '<span>How to introduce safely</span></div>';
+  var hti = lead.howToIntroduce || {};
+  html += '<div class="enc-proto">';
+  if (hti.amount)   html += '<div class="enc-proto-row"><b>Amount:</b> ' + escHtml(hti.amount) + '</div>';
+  if (hti.when)     html += '<div class="enc-proto-row"><b>When:</b> ' + escHtml(hti.when) + '</div>';
+  if (hti.watch)    html += '<div class="enc-proto-row"><b>Watch:</b> ' + escHtml(hti.watch) + '</div>';
+  if (hti.thenWhat) html += '<div class="enc-proto-row"><b>Keep offering:</b> ' + escHtml(hti.thenWhat) + '</div>';
+  html += '</div>';
+  // Safe-form gate — union the cited ok/never lists across both records (dedup),
+  // then the non-suppressible note (Maren A-2: grinding removes choking, NOT allergy).
+  var okSet = [], neverSet = [], note = '';
+  foods.forEach(function(f){
+    var sf = f.safeForm || {};
+    (sf.ok || []).forEach(function(x){ if (okSet.indexOf(x) === -1) okSet.push(x); });
+    (sf.never || []).forEach(function(x){ if (neverSet.indexOf(x) === -1) neverSet.push(x); });
+    if (!note && sf.note) note = sf.note;
+  });
+  if (okSet.length || neverSet.length || note) {
+    html += '<div class="enc-form">';
+    if (okSet.length) {
+      html += '<div class="enc-form-sub">Safe forms</div><ul class="enc-form-list">' +
+        okSet.map(function(x){ return '<li>' + escHtml(x) + '</li>'; }).join('') + '</ul>';
+    }
+    if (neverSet.length) {
+      html += '<div class="enc-form-sub">Never</div><ul class="enc-form-list enc-never">' +
+        neverSet.map(function(x){ return '<li>' + escHtml(x) + '</li>'; }).join('') + '</ul>';
+    }
+    if (note) html += '<p class="enc-form-note">' + escHtml(note) + '</p>';
+    html += '</div>';
+  }
+  // High-risk cohort note (Maren §9.2 — non-suppressible when applicable).
+  if (hti.highRiskNote) html += '<p class="enc-highrisk">' + escHtml(hti.highRiskNote) + '</p>';
+  html += '</div>';
+
+  // ── Section 3: Severe-reaction strip — the emergency floor (A-1/V-1) ──
+  // Unconditional, non-collapsible, amber. Reuses the shipped .cons-severe
+  // pattern verbatim so this card and the log-time card read identically.
+  // slice() first — never mutate the FOOD_EFFECTS source array.
+  var severe = (lead.severeSigns && lead.severeSigns.length) ? lead.severeSigns.slice() : [];
+  foods.forEach(function(f){
+    (f.severeSigns || []).forEach(function(s){ if (severe.indexOf(s) === -1) severe.push(s); });
+  });
+  if (severe.length) {
+    html += '<div class="cons-severe"><div class="cons-severe-h">' + zi('siren') +
+      '<span>If this happens, it’s an emergency</span></div><ul class="cons-severe-list">' +
+      severe.map(function(s){ return '<li>' + escHtml(s) + '</li>'; }).join('') + '</ul>';
+    if (lead.seekCare) {
+      html += '<p class="enc-emergency">' + zi('siren') + '<span>' + escHtml(lead.seekCare) + '</span></p>';
+    }
+    html += '</div>';
+  }
+
+  // ── Section 4a: the "delay" myth — stays in the always-visible summary.
+  // It is the highest-value relative-facing line (spec §4.4), so it is never
+  // folded into the collapse body.
+  var myth = (benefit && benefit.paradigm) ? benefit.paradigm : '';
+  if (myth) {
+    html += '<div class="enc-myth">' + zi('bulb') + '<span>' + escHtml(myth) + '</span></div>';
+  }
+
+  host.innerHTML = html;
+
+  // ── Section 4b: mild watch-fors — calm-secondary (spec §4.4), so they live in
+  // the collapse body the chevron toggles. The SEVERE strip above is never here.
+  var mild = (lead.watchFor && lead.watchFor.length) ? lead.watchFor.slice() : [];
+  if (moreHost) {
+    moreHost.innerHTML = mild.length
+      ? '<div class="cons-watch"><div class="cons-watch-h">Milder signs to watch for</div><ul class="cons-watch-list">' +
+          mild.map(function(w){ return '<li>' + escHtml(w) + '</li>'; }).join('') + '</ul></div>'
+      : '';
+  }
+
+  // Encourage cards map to card-priority 'notable' (spec §4); honey → 'urgent'.
+  _setCardPriority('infoNutIntroCard', 'notable');
 }
 
 function renderInfoFoodIntro() {

--- a/split/intelligence-cards.js
+++ b/split/intelligence-cards.js
@@ -1346,10 +1346,22 @@ function renderInfoNutIntro() {
   html += '<div class="enc-block-h">' + zi('spoon') + '<span>How to introduce safely</span></div>';
   var hti = lead.howToIntroduce || {};
   html += '<div class="enc-proto">';
+  // Amount / when / watch are materially identical across the records — source
+  // the shared first-exposure rhythm from lead.
   if (hti.amount)   html += '<div class="enc-proto-row"><b>Amount:</b> ' + escHtml(hti.amount) + '</div>';
   if (hti.when)     html += '<div class="enc-proto-row"><b>When:</b> ' + escHtml(hti.when) + '</div>';
   if (hti.watch)    html += '<div class="enc-proto-row"><b>Watch:</b> ' + escHtml(hti.watch) + '</div>';
-  if (hti.thenWhat) html += '<div class="enc-proto-row"><b>Keep offering:</b> ' + escHtml(hti.thenWhat) + '</div>';
+  // Keep-offering guidance is PER-FOOD (Maren M-γ-1): tree nut carries the
+  // load-bearing "introduce each nut on its own, a few days apart" attribution
+  // line that peanut's does not. A combined card must never drop one food's
+  // distinct guidance — render each present food's own thenWhat, labelled, so
+  // the parent doesn't apply peanut's rhythm to a mixed-nut paste.
+  var keepOffering = [{ rec: peanut, label: 'Peanut' }, { rec: treeNut, label: 'Tree nuts' }]
+    .filter(function(x){ return x.rec && x.rec.howToIntroduce && x.rec.howToIntroduce.thenWhat; });
+  keepOffering.forEach(function(x){
+    html += '<div class="enc-proto-row"><b>Keep offering — ' + escHtml(x.label) + ':</b> ' +
+      escHtml(x.rec.howToIntroduce.thenWhat) + '</div>';
+  });
   html += '</div>';
   // Safe-form gate — union the cited ok/never lists across both records (dedup),
   // then the non-suppressible note (Maren A-2: grinding removes choking, NOT allergy).

--- a/split/styles.css
+++ b/split/styles.css
@@ -3980,6 +3980,36 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
 [data-theme="dark"] .consequence-card { background:var(--surface); }
 [data-theme="dark"] .cons-severe { background:var(--surface-amber); }
 
+/* ── food-effects v2 Phase γ — persistent encourage (nut-introduction) card ──
+   Polarity→color (V-3): SAGE leads (encourage); the severe strip borrows the
+   shared .cons-severe AMBER (serious-without-alarm); rose stays reserved for
+   acute-toxin. The benefit banner is the only top-of-card affirmer — green-topped
+   reads pre-literately as "do this," never "avoid." */
+.enc-benefit { background:var(--surface-sage); border-left:3px solid var(--sage-deepest); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); margin-bottom:var(--sp-16); }
+.enc-benefit-h { display:flex; align-items:center; gap:var(--sp-8); font-size:var(--fs-sm); font-weight:700; color:var(--sage-deepest); text-transform:uppercase; letter-spacing:0.3px; margin-bottom:var(--sp-8); }
+.enc-benefit-h .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--sage-deepest); }
+.enc-claim { font-size:var(--fs-base); font-weight:700; color:var(--text); line-height:var(--lh-relaxed); margin:0 0 var(--sp-4); }
+.enc-evidence { font-size:var(--fs-sm); color:var(--light); line-height:var(--lh-relaxed); margin:0 0 var(--sp-8); }
+.enc-why-list { margin:0; padding-left:var(--sp-20); }
+.enc-why-list li { font-size:var(--fs-base); color:var(--text); margin:var(--sp-4) 0; line-height:var(--lh-relaxed); }
+.enc-block { margin-bottom:var(--sp-16); }
+.enc-block-h { display:flex; align-items:center; gap:var(--sp-8); font-size:var(--fs-sm); font-weight:700; color:var(--text); text-transform:uppercase; letter-spacing:0.3px; margin-bottom:var(--sp-8); }
+.enc-block-h .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--tc-sage); }
+.enc-proto { margin:0 0 var(--sp-12); display:flex; flex-direction:column; gap:var(--sp-4); }
+.enc-proto-row { font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); }
+.enc-proto-row b { color:var(--sage-deepest); }
+.enc-form { background:var(--surface-sage); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); }
+.enc-form-sub { font-size:var(--fs-sm); font-weight:700; color:var(--text); text-transform:uppercase; letter-spacing:0.3px; margin:0 0 var(--sp-8); }
+.enc-form-list { margin:0 0 var(--sp-8); padding-left:var(--sp-20); }
+.enc-form-list li { font-size:var(--fs-base); color:var(--text); margin:var(--sp-4) 0; line-height:var(--lh-relaxed); }
+.enc-form-list.enc-never li { color:var(--rose-deep); }
+.enc-form-note { font-size:var(--fs-base); font-weight:700; color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-8) 0 0; }
+.enc-highrisk { font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-12) 0 0; padding:var(--sp-8) var(--sp-12); background:var(--surface-amber); border-radius:var(--r-sm); }
+.enc-emergency { display:flex; align-items:flex-start; gap:var(--sp-8); font-size:var(--fs-sm); color:var(--amber-deepest); margin:var(--sp-8) 0 0; line-height:var(--lh-relaxed); }
+.enc-emergency .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--amber-deep); margin-top:3px; }
+.enc-myth { display:flex; align-items:flex-start; gap:var(--sp-8); font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-16) 0 0; padding:var(--sp-12) var(--sp-16); background:var(--surface-lav); border-radius:var(--r-md); }
+.enc-myth .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--tc-lav); margin-top:3px; }
+
 /* ── Viz detail popup (PR-I — viz interactivity layer) ── */
 /* Tap affordance: every wired data element (SVG dot/cell/bar/segment or
    HTML cell) gets a pointer cursor without a per-element class. */

--- a/split/styles.css
+++ b/split/styles.css
@@ -4004,7 +4004,10 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
 .enc-form-list li { font-size:var(--fs-base); color:var(--text); margin:var(--sp-4) 0; line-height:var(--lh-relaxed); }
 .enc-form-list.enc-never li { color:var(--rose-deep); }
 .enc-form-note { font-size:var(--fs-base); font-weight:700; color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-8) 0 0; }
-.enc-highrisk { font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-12) 0 0; padding:var(--sp-8) var(--sp-12); background:var(--surface-amber); border-radius:var(--r-sm); }
+/* V-V-γ-1 (Vela): advisory, NOT emergency — a neutral fill + calm left accent
+   keeps the amber register reserved for the severe strip (caution-and-up), so
+   the two no longer blur at the §2/§3 seam. */
+.enc-highrisk { font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-12) 0 0; padding:var(--sp-8) var(--sp-12); background:var(--surface-neutral); border-left:3px solid var(--border-subtle); border-radius:var(--r-sm); }
 .enc-emergency { display:flex; align-items:flex-start; gap:var(--sp-8); font-size:var(--fs-sm); color:var(--amber-deepest); margin:var(--sp-8) 0 0; line-height:var(--lh-relaxed); }
 .enc-emergency .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--amber-deep); margin-top:3px; }
 .enc-myth { display:flex; align-items:flex-start; gap:var(--sp-8); font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-16) 0 0; padding:var(--sp-12) var(--sp-16); background:var(--surface-lav); border-radius:var(--r-md); }

--- a/split/template.html
+++ b/split/template.html
@@ -1727,6 +1727,23 @@
       <!-- ─── FOOD INTELLIGENCE ─── -->
       <div class="home-section-label sec-t3 col-full">Food Intelligence</div>
 
+      <!-- Introducing nuts early (food-effects v2 Phase γ — persistent encourage card).
+           Emergency-floor invariant (§4.3, A-1/V-1): the severe-reaction strip must
+           never sit inside an accordion. So the always-visible summary slot
+           (#infoNutIntro) carries benefit → introduce-safely → SEVERE STRIP → myth,
+           and only the calm MILD watch-fors (§4.4) live in the collapse body. The
+           chevron toggles the mild block alone; the severe strip is never folded. -->
+      <div class="card card-daily col-full" id="infoNutIntroCard">
+        <div class="card-header" data-collapse-target="infoNutIntroBody" data-collapse-chevron="infoNutIntroChevron">
+          <div class="card-title"><div class="icon icon-sage"><svg class="zi"><use href="#zi-sprout"/></svg></div> Introducing nuts early</div>
+          <span class="collapse-chevron" id="infoNutIntroChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
+        </div>
+        <div id="infoNutIntro" class="mt-4"></div>
+        <div id="infoNutIntroBody" class="collapse-body fx-col g8" style="display:none;">
+          <div id="infoNutIntroMore" class="mt-4"></div>
+        </div>
+      </div>
+
       <!-- Food Introduction Rate -->
       <div class="card card-daily col-full" id="infoFoodIntroCard">
         <div class="card-header" data-collapse-target="infoFoodIntroBody" data-collapse-chevron="infoFoodIntroChevron">

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -3987,6 +3987,36 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
 [data-theme="dark"] .consequence-card { background:var(--surface); }
 [data-theme="dark"] .cons-severe { background:var(--surface-amber); }
 
+/* ── food-effects v2 Phase γ — persistent encourage (nut-introduction) card ──
+   Polarity→color (V-3): SAGE leads (encourage); the severe strip borrows the
+   shared .cons-severe AMBER (serious-without-alarm); rose stays reserved for
+   acute-toxin. The benefit banner is the only top-of-card affirmer — green-topped
+   reads pre-literately as "do this," never "avoid." */
+.enc-benefit { background:var(--surface-sage); border-left:3px solid var(--sage-deepest); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); margin-bottom:var(--sp-16); }
+.enc-benefit-h { display:flex; align-items:center; gap:var(--sp-8); font-size:var(--fs-sm); font-weight:700; color:var(--sage-deepest); text-transform:uppercase; letter-spacing:0.3px; margin-bottom:var(--sp-8); }
+.enc-benefit-h .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--sage-deepest); }
+.enc-claim { font-size:var(--fs-base); font-weight:700; color:var(--text); line-height:var(--lh-relaxed); margin:0 0 var(--sp-4); }
+.enc-evidence { font-size:var(--fs-sm); color:var(--light); line-height:var(--lh-relaxed); margin:0 0 var(--sp-8); }
+.enc-why-list { margin:0; padding-left:var(--sp-20); }
+.enc-why-list li { font-size:var(--fs-base); color:var(--text); margin:var(--sp-4) 0; line-height:var(--lh-relaxed); }
+.enc-block { margin-bottom:var(--sp-16); }
+.enc-block-h { display:flex; align-items:center; gap:var(--sp-8); font-size:var(--fs-sm); font-weight:700; color:var(--text); text-transform:uppercase; letter-spacing:0.3px; margin-bottom:var(--sp-8); }
+.enc-block-h .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--tc-sage); }
+.enc-proto { margin:0 0 var(--sp-12); display:flex; flex-direction:column; gap:var(--sp-4); }
+.enc-proto-row { font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); }
+.enc-proto-row b { color:var(--sage-deepest); }
+.enc-form { background:var(--surface-sage); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); }
+.enc-form-sub { font-size:var(--fs-sm); font-weight:700; color:var(--text); text-transform:uppercase; letter-spacing:0.3px; margin:0 0 var(--sp-8); }
+.enc-form-list { margin:0 0 var(--sp-8); padding-left:var(--sp-20); }
+.enc-form-list li { font-size:var(--fs-base); color:var(--text); margin:var(--sp-4) 0; line-height:var(--lh-relaxed); }
+.enc-form-list.enc-never li { color:var(--rose-deep); }
+.enc-form-note { font-size:var(--fs-base); font-weight:700; color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-8) 0 0; }
+.enc-highrisk { font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-12) 0 0; padding:var(--sp-8) var(--sp-12); background:var(--surface-amber); border-radius:var(--r-sm); }
+.enc-emergency { display:flex; align-items:flex-start; gap:var(--sp-8); font-size:var(--fs-sm); color:var(--amber-deepest); margin:var(--sp-8) 0 0; line-height:var(--lh-relaxed); }
+.enc-emergency .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--amber-deep); margin-top:3px; }
+.enc-myth { display:flex; align-items:flex-start; gap:var(--sp-8); font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-16) 0 0; padding:var(--sp-12) var(--sp-16); background:var(--surface-lav); border-radius:var(--r-md); }
+.enc-myth .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--tc-lav); margin-top:3px; }
+
 /* ── Viz detail popup (PR-I — viz interactivity layer) ── */
 /* Tap affordance: every wired data element (SVG dot/cell/bar/segment or
    HTML cell) gets a pointer cursor without a per-element class. */
@@ -12483,6 +12513,23 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 
       <!-- ─── FOOD INTELLIGENCE ─── -->
       <div class="home-section-label sec-t3 col-full">Food Intelligence</div>
+
+      <!-- Introducing nuts early (food-effects v2 Phase γ — persistent encourage card).
+           Emergency-floor invariant (§4.3, A-1/V-1): the severe-reaction strip must
+           never sit inside an accordion. So the always-visible summary slot
+           (#infoNutIntro) carries benefit → introduce-safely → SEVERE STRIP → myth,
+           and only the calm MILD watch-fors (§4.4) live in the collapse body. The
+           chevron toggles the mild block alone; the severe strip is never folded. -->
+      <div class="card card-daily col-full" id="infoNutIntroCard">
+        <div class="card-header" data-collapse-target="infoNutIntroBody" data-collapse-chevron="infoNutIntroChevron">
+          <div class="card-title"><div class="icon icon-sage"><svg class="zi"><use href="#zi-sprout"/></svg></div> Introducing nuts early</div>
+          <span class="collapse-chevron" id="infoNutIntroChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
+        </div>
+        <div id="infoNutIntro" class="mt-4"></div>
+        <div id="infoNutIntroBody" class="collapse-body fx-col g8" style="display:none;">
+          <div id="infoNutIntroMore" class="mt-4"></div>
+        </div>
+      </div>
 
       <!-- Food Introduction Rate -->
       <div class="card card-daily col-full" id="infoFoodIntroCard">
@@ -70027,6 +70074,7 @@ function renderInfoMilestoneSleepCorrelation() {
 }
 
 function renderInfo() {
+  renderInfoNutIntro();
   renderInfoFoodIntro();
   renderInfoNutrientHeatmap();
   renderInfoComboFreq();
@@ -70079,6 +70127,135 @@ function renderInfo() {
   // boundary) per spec §Sort implementation F4+F6 IMPL-note: visible-reflow
   // avoidance + .card:nth-child(N) animation-delay alignment.
   _sortInfoTabByPriority();
+}
+
+// ════════════════════════════════════════
+// Persistent encourage card — guided introduction (food-effects v2 Phase γ)
+// ════════════════════════════════════════
+// Surfaces the peanut + tree-nut FOOD_EFFECTS records as ONE benefit-first
+// Info-tab card, so an age-appropriate parent (Ziva is past the 6-month floor)
+// reaches the benefit / safe-form / watch-for guidance that the log-time
+// consequence card only fires BELOW the gate — the γ gap. Spec §4.
+//
+// Invariants enforced here:
+//   • All copy is sourced from FOOD_EFFECTS — no hardcoded safety claim
+//     (the research→manifest→FOOD_EFFECTS pipeline is the canonical path).
+//   • Emergency floor (A-1/V-1): the severeSigns strip + the emergency action
+//     render UNCONDITIONALLY and NON-COLLAPSIBLY (the card has no accordion;
+//     see the template note). Benefit may lead, but it never moves the floor.
+//   • Form gate (A-2): the "grinding removes choking, NOT allergy / never whole"
+//     note renders whenever a record carries it — never suppressed by benefit.
+//   • Polarity→color (V-3): sage benefit banner; amber severe strip (shared
+//     .cons-severe); rose stays reserved for acute-toxin.
+function renderInfoNutIntro() {
+  var host = document.getElementById('infoNutIntro');       // always-visible summary
+  var moreHost = document.getElementById('infoNutIntroMore'); // collapse body (mild)
+  if (!host) return;
+  var FE = (typeof FOOD_EFFECTS !== 'undefined') ? FOOD_EFFECTS : null;
+  var peanut  = FE ? FE['peanut']   : null;
+  var treeNut = FE ? FE['tree nut'] : null;
+  // Need at least one record to say anything truthful; otherwise leave the card
+  // empty and drop it to ambient so the priority sort de-emphasises it.
+  if (!peanut && !treeNut) {
+    host.innerHTML = '';
+    if (moreHost) moreHost.innerHTML = '';
+    _setCardPriority('infoNutIntroCard', 'ambient');
+    return;
+  }
+  var lead = peanut || treeNut;          // peanut carries the strongest (LEAP) evidence
+  var foods = [peanut, treeNut].filter(Boolean);
+  var html = '';
+
+  // ── Section 1: Benefit banner (sage, encourage polarity — V-3) ──
+  var benefit = (lead.earlyIntroBenefit && lead.earlyIntroBenefit.claim) ? lead.earlyIntroBenefit : null;
+  html += '<div class="enc-benefit">';
+  html += '<div class="enc-benefit-h">' + zi('sprout') + '<span>Why introduce early</span></div>';
+  if (benefit) {
+    html += '<p class="enc-claim">' + escHtml(benefit.claim) + '</p>';
+    if (benefit.evidence) html += '<p class="enc-evidence">' + escHtml(benefit.evidence) + '</p>';
+  }
+  // Each food's own cited nutrition line (no fabricated merge across records).
+  var whyItems = foods.filter(function(f){ return f.whyGood; })
+    .map(function(f){ return '<li>' + escHtml(f.whyGood) + '</li>'; }).join('');
+  if (whyItems) html += '<ul class="enc-why-list">' + whyItems + '</ul>';
+  html += '</div>';
+
+  // ── Section 2: Introduce-safely block (protocol + non-suppressible form gate, A-2) ──
+  html += '<div class="enc-block">';
+  html += '<div class="enc-block-h">' + zi('spoon') + '<span>How to introduce safely</span></div>';
+  var hti = lead.howToIntroduce || {};
+  html += '<div class="enc-proto">';
+  if (hti.amount)   html += '<div class="enc-proto-row"><b>Amount:</b> ' + escHtml(hti.amount) + '</div>';
+  if (hti.when)     html += '<div class="enc-proto-row"><b>When:</b> ' + escHtml(hti.when) + '</div>';
+  if (hti.watch)    html += '<div class="enc-proto-row"><b>Watch:</b> ' + escHtml(hti.watch) + '</div>';
+  if (hti.thenWhat) html += '<div class="enc-proto-row"><b>Keep offering:</b> ' + escHtml(hti.thenWhat) + '</div>';
+  html += '</div>';
+  // Safe-form gate — union the cited ok/never lists across both records (dedup),
+  // then the non-suppressible note (Maren A-2: grinding removes choking, NOT allergy).
+  var okSet = [], neverSet = [], note = '';
+  foods.forEach(function(f){
+    var sf = f.safeForm || {};
+    (sf.ok || []).forEach(function(x){ if (okSet.indexOf(x) === -1) okSet.push(x); });
+    (sf.never || []).forEach(function(x){ if (neverSet.indexOf(x) === -1) neverSet.push(x); });
+    if (!note && sf.note) note = sf.note;
+  });
+  if (okSet.length || neverSet.length || note) {
+    html += '<div class="enc-form">';
+    if (okSet.length) {
+      html += '<div class="enc-form-sub">Safe forms</div><ul class="enc-form-list">' +
+        okSet.map(function(x){ return '<li>' + escHtml(x) + '</li>'; }).join('') + '</ul>';
+    }
+    if (neverSet.length) {
+      html += '<div class="enc-form-sub">Never</div><ul class="enc-form-list enc-never">' +
+        neverSet.map(function(x){ return '<li>' + escHtml(x) + '</li>'; }).join('') + '</ul>';
+    }
+    if (note) html += '<p class="enc-form-note">' + escHtml(note) + '</p>';
+    html += '</div>';
+  }
+  // High-risk cohort note (Maren §9.2 — non-suppressible when applicable).
+  if (hti.highRiskNote) html += '<p class="enc-highrisk">' + escHtml(hti.highRiskNote) + '</p>';
+  html += '</div>';
+
+  // ── Section 3: Severe-reaction strip — the emergency floor (A-1/V-1) ──
+  // Unconditional, non-collapsible, amber. Reuses the shipped .cons-severe
+  // pattern verbatim so this card and the log-time card read identically.
+  // slice() first — never mutate the FOOD_EFFECTS source array.
+  var severe = (lead.severeSigns && lead.severeSigns.length) ? lead.severeSigns.slice() : [];
+  foods.forEach(function(f){
+    (f.severeSigns || []).forEach(function(s){ if (severe.indexOf(s) === -1) severe.push(s); });
+  });
+  if (severe.length) {
+    html += '<div class="cons-severe"><div class="cons-severe-h">' + zi('siren') +
+      '<span>If this happens, it’s an emergency</span></div><ul class="cons-severe-list">' +
+      severe.map(function(s){ return '<li>' + escHtml(s) + '</li>'; }).join('') + '</ul>';
+    if (lead.seekCare) {
+      html += '<p class="enc-emergency">' + zi('siren') + '<span>' + escHtml(lead.seekCare) + '</span></p>';
+    }
+    html += '</div>';
+  }
+
+  // ── Section 4a: the "delay" myth — stays in the always-visible summary.
+  // It is the highest-value relative-facing line (spec §4.4), so it is never
+  // folded into the collapse body.
+  var myth = (benefit && benefit.paradigm) ? benefit.paradigm : '';
+  if (myth) {
+    html += '<div class="enc-myth">' + zi('bulb') + '<span>' + escHtml(myth) + '</span></div>';
+  }
+
+  host.innerHTML = html;
+
+  // ── Section 4b: mild watch-fors — calm-secondary (spec §4.4), so they live in
+  // the collapse body the chevron toggles. The SEVERE strip above is never here.
+  var mild = (lead.watchFor && lead.watchFor.length) ? lead.watchFor.slice() : [];
+  if (moreHost) {
+    moreHost.innerHTML = mild.length
+      ? '<div class="cons-watch"><div class="cons-watch-h">Milder signs to watch for</div><ul class="cons-watch-list">' +
+          mild.map(function(w){ return '<li>' + escHtml(w) + '</li>'; }).join('') + '</ul></div>'
+      : '';
+  }
+
+  // Encourage cards map to card-priority 'notable' (spec §4); honey → 'urgent'.
+  _setCardPriority('infoNutIntroCard', 'notable');
 }
 
 function renderInfoFoodIntro() {

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -4011,7 +4011,10 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
 .enc-form-list li { font-size:var(--fs-base); color:var(--text); margin:var(--sp-4) 0; line-height:var(--lh-relaxed); }
 .enc-form-list.enc-never li { color:var(--rose-deep); }
 .enc-form-note { font-size:var(--fs-base); font-weight:700; color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-8) 0 0; }
-.enc-highrisk { font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-12) 0 0; padding:var(--sp-8) var(--sp-12); background:var(--surface-amber); border-radius:var(--r-sm); }
+/* V-V-γ-1 (Vela): advisory, NOT emergency — a neutral fill + calm left accent
+   keeps the amber register reserved for the severe strip (caution-and-up), so
+   the two no longer blur at the §2/§3 seam. */
+.enc-highrisk { font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-12) 0 0; padding:var(--sp-8) var(--sp-12); background:var(--surface-neutral); border-left:3px solid var(--border-subtle); border-radius:var(--r-sm); }
 .enc-emergency { display:flex; align-items:flex-start; gap:var(--sp-8); font-size:var(--fs-sm); color:var(--amber-deepest); margin:var(--sp-8) 0 0; line-height:var(--lh-relaxed); }
 .enc-emergency .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--amber-deep); margin-top:3px; }
 .enc-myth { display:flex; align-items:flex-start; gap:var(--sp-8); font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-16) 0 0; padding:var(--sp-12) var(--sp-16); background:var(--surface-lav); border-radius:var(--r-md); }
@@ -70185,10 +70188,22 @@ function renderInfoNutIntro() {
   html += '<div class="enc-block-h">' + zi('spoon') + '<span>How to introduce safely</span></div>';
   var hti = lead.howToIntroduce || {};
   html += '<div class="enc-proto">';
+  // Amount / when / watch are materially identical across the records — source
+  // the shared first-exposure rhythm from lead.
   if (hti.amount)   html += '<div class="enc-proto-row"><b>Amount:</b> ' + escHtml(hti.amount) + '</div>';
   if (hti.when)     html += '<div class="enc-proto-row"><b>When:</b> ' + escHtml(hti.when) + '</div>';
   if (hti.watch)    html += '<div class="enc-proto-row"><b>Watch:</b> ' + escHtml(hti.watch) + '</div>';
-  if (hti.thenWhat) html += '<div class="enc-proto-row"><b>Keep offering:</b> ' + escHtml(hti.thenWhat) + '</div>';
+  // Keep-offering guidance is PER-FOOD (Maren M-γ-1): tree nut carries the
+  // load-bearing "introduce each nut on its own, a few days apart" attribution
+  // line that peanut's does not. A combined card must never drop one food's
+  // distinct guidance — render each present food's own thenWhat, labelled, so
+  // the parent doesn't apply peanut's rhythm to a mixed-nut paste.
+  var keepOffering = [{ rec: peanut, label: 'Peanut' }, { rec: treeNut, label: 'Tree nuts' }]
+    .filter(function(x){ return x.rec && x.rec.howToIntroduce && x.rec.howToIntroduce.thenWhat; });
+  keepOffering.forEach(function(x){
+    html += '<div class="enc-proto-row"><b>Keep offering — ' + escHtml(x.label) + ':</b> ' +
+      escHtml(x.rec.howToIntroduce.thenWhat) + '</div>';
+  });
   html += '</div>';
   // Safe-form gate — union the cited ok/never lists across both records (dedup),
   // then the non-suppressible note (Maren A-2: grinding removes choking, NOT allergy).

--- a/tests/e2e/food-effects-v2-encourage-card.spec.ts
+++ b/tests/e2e/food-effects-v2-encourage-card.spec.ts
@@ -93,6 +93,17 @@ test.describe('food-effects-v2 — the encourage card (Phase γ)', () => {
     await expect(page.locator('#infoNutIntro .enc-form-list.enc-never li').first()).toBeVisible();
   });
 
+  test('M-γ-1: tree-nut attribution guidance is not dropped by the combined card', async ({ page }) => {
+    // A combined peanut+tree-nut card must still surface tree nut's distinct
+    // "introduce each nut on its own, a few days apart" guidance — otherwise a
+    // parent could offer a mixed almond/walnut/cashew paste at once and lose
+    // the ability to attribute a reaction. Sourced per-food from the records.
+    const proto = page.locator('#infoNutIntro .enc-proto');
+    await expect(proto).toContainText(/each nut on its own|few days apart/i);
+    // Both foods' keep-offering lines are labelled (no single peanut-only rhythm).
+    await expect(proto.locator('.enc-proto-row', { hasText: /Keep offering — Tree nuts/ })).toHaveCount(1);
+  });
+
   test('benefit content is record-sourced (LEAP); honey gets no benefit banner here', async ({ page }) => {
     // The cited evidence reaches the surface.
     await expect(page.locator('#infoNutIntro .enc-evidence')).toContainText(/LEAP/);

--- a/tests/e2e/food-effects-v2-encourage-card.spec.ts
+++ b/tests/e2e/food-effects-v2-encourage-card.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from '@playwright/test';
+
+// food-effects-v2 Phase γ — the persistent ENCOURAGE Info-tab card
+// (renderInfoNutIntro → #infoNutIntro). This is the surface that closes the γ
+// gap: for an age-appropriate baby (Ziva is past the 6-month soft floor) the
+// log-time consequence card never fires, so the benefit / safe-form / watch-for
+// guidance lived in FOOD_EFFECTS but was unreachable. This card renders it.
+//
+// What this guards (spec §4 + the synthesis spine):
+//   1. The card renders BENEFIT-FIRST — the sage benefit banner leads, above
+//      the severe strip, with an AFFIRMING icon (zi-sprout), never zi-warn (V-3).
+//   2. The emergency floor never moves (A-1/V-1): the severeSigns strip renders
+//      UNCONDITIONALLY and NON-COLLAPSIBLY — the card has no accordion, the strip
+//      has no collapse-body / <details> ancestor, all three red flags present.
+//   3. The form-gate invariant (A-2): the "grinding removes choking NOT allergy /
+//      never whole" note renders and is not suppressed by the benefit framing.
+//   4. Content is sourced from the records (LEAP evidence surfaces); this is an
+//      encourage-ONLY surface — honey (acute-toxin) is not given a benefit banner.
+//   5. The "delay" myth (the paradigm reversal) and the high-risk cohort note
+//      both reach the parent.
+
+test.describe('food-effects-v2 — the encourage card (Phase γ)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/index.html?nosync');
+    await page.waitForFunction(() =>
+      typeof (window as any).renderInfoNutIntro === 'function'
+      && typeof (window as any).getFoodEffect === 'function'
+      && Array.isArray((window as any)._CARD_PRIORITY_TIERS), null, { timeout: 10_000 });
+    // Activate the Info tab so the panel paints, then render — the card is
+    // persistent and age-independent, sourcing only FOOD_EFFECTS constants
+    // (no feeding data required).
+    await page.evaluate(() => {
+      if (typeof (window as any).switchTab === 'function') (window as any).switchTab('info');
+      if (typeof (window as any).renderInfo === 'function') (window as any).renderInfo();
+    });
+    await page.waitForTimeout(150);
+  });
+
+  test('renders benefit-first, with an affirming (non-warn) icon', async ({ page }) => {
+    const host = page.locator('#infoNutIntro');
+    await expect(host.locator('.enc-benefit')).toBeVisible();
+    // The benefit banner leads the affirming sprout icon — never the warn glyph.
+    await expect(host.locator('.enc-benefit-h use[href="#zi-sprout"]')).toHaveCount(1);
+    await expect(host.locator('.enc-benefit use[href="#zi-warn"]')).toHaveCount(0);
+    // Benefit banner sits ABOVE the severe strip in DOM/reading order.
+    const order = await page.evaluate(() => {
+      const h = document.getElementById('infoNutIntro')!;
+      const benefit = h.querySelector('.enc-benefit');
+      const severe = h.querySelector('.cons-severe');
+      if (!benefit || !severe) return 'missing';
+      // DOCUMENT_POSITION_FOLLOWING (4) → severe comes after benefit.
+      return (benefit.compareDocumentPosition(severe) & 4) ? 'benefit-first' : 'severe-first';
+    });
+    expect(order).toBe('benefit-first');
+  });
+
+  test('the severe-reaction strip is unconditional and non-collapsible (A-1/V-1)', async ({ page }) => {
+    const strip = page.locator('#infoNutIntro .cons-severe');
+    await expect(strip).toBeVisible();
+    // All three anaphylaxis red flags present.
+    await expect(strip.locator('.cons-severe-list li')).toHaveCount(3);
+    // The card DOES collapse (uniform with every info card), but the strip lives
+    // in the always-visible summary slot — NEVER inside the collapse body. So
+    // even while the body is collapsed (default) the strip is fully visible.
+    await expect(page.locator('#infoNutIntroBody .cons-severe')).toHaveCount(0);
+    const bodyCollapsed = await page.evaluate(() => {
+      const b = document.getElementById('infoNutIntroBody');
+      return b ? getComputedStyle(b).display === 'none' : false;
+    });
+    expect(bodyCollapsed, 'collapse body starts collapsed').toBe(true);
+    await expect(strip).toBeVisible(); // ...and the strip is still visible
+    // No <details> accordion, and no hidden ancestor between strip and card.
+    expect(await strip.locator('xpath=ancestor::details').count()).toBe(0);
+    const hiddenAncestor = await page.evaluate(() => {
+      let n: HTMLElement | null = document.querySelector('#infoNutIntro .cons-severe');
+      while (n && n.id !== 'infoNutIntroCard') {
+        if (getComputedStyle(n).display === 'none') return true;
+        n = n.parentElement;
+      }
+      return false;
+    });
+    expect(hiddenAncestor).toBe(false);
+    // The emergency action (call 112) co-locates with the strip.
+    await expect(page.locator('#infoNutIntro .enc-emergency')).toContainText(/112/);
+  });
+
+  test('the form-gate invariant renders and is not suppressed (A-2)', async ({ page }) => {
+    const note = page.locator('#infoNutIntro .enc-form-note');
+    await expect(note).toBeVisible();
+    // The load-bearing distinction: form removes CHOKING, not ALLERGY.
+    await expect(note).toContainText(/allergy/i);
+    // The "never whole" list is present and emphasised.
+    await expect(page.locator('#infoNutIntro .enc-form-list.enc-never li').first()).toBeVisible();
+  });
+
+  test('benefit content is record-sourced (LEAP); honey gets no benefit banner here', async ({ page }) => {
+    // The cited evidence reaches the surface.
+    await expect(page.locator('#infoNutIntro .enc-evidence')).toContainText(/LEAP/);
+    // This is an encourage-only surface: the acute-toxin honey card is not folded
+    // in, so its title never appears with a sage benefit banner (V-3 polarity).
+    const honeyTitle = await page.evaluate(() => (window as any).getFoodEffect('honey')?.title);
+    await expect(page.locator('#infoNutIntro')).not.toContainText(honeyTitle);
+  });
+
+  test('the "delay" myth and the high-risk cohort note both reach the parent', async ({ page }) => {
+    await expect(page.locator('#infoNutIntro .enc-myth')).toBeVisible();
+    await expect(page.locator('#infoNutIntro .enc-myth')).toContainText(/delay/i);
+    // High-risk note (eczema / known egg allergy → ask paediatrician) is present.
+    await expect(page.locator('#infoNutIntro .enc-highrisk')).toContainText(/eczema/i);
+  });
+});


### PR DESCRIPTION
## Phase γ — the persistent *encourage* card

Closes the **γ gap**: for an age-appropriate baby (Ziva is past the 6-month soft floor) the log-time consequence card never fires, so the benefit / safe-form / watch-for guidance for peanut + tree nut lived in `FOOD_EFFECTS` but was **unreachable**. This adds a persistent, benefit-first Info-tab card that surfaces it — per `docs/specs/food-effects-v2-guided-introduction.md` §4.

### What it does
A single combined "Introducing nuts early" card (Food Intelligence section) sourcing **all** copy from the `peanut` + `tree nut` records — no hardcoded safety claim. Composition, fixed order:
1. **Benefit banner** (sage) — `whyGood` + `earlyIntroBenefit.claim`/`.evidence`, affirming `zi('sprout')` icon (never `zi('warn')`).
2. **Introduce-safely block** — `howToIntroduce` (amount/when/watch/keep-offering) + the non-suppressible `safeForm` form-gate note (grinding removes choking, **not** allergy; never whole), + the high-risk cohort note.
3. **Severe-reaction strip** — `severeSigns[]` + the emergency action, **unconditional, non-collapsible, amber** (reuses the shipped `.cons-severe`).
4. **The "delay" myth** (visible) + the calm mild watch-fors (in the collapse body).

### The emergency-floor invariant, mechanically
The card uses the standard collapsible shell (uniform with every Info card — the v3-6 priority contract assumes a collapse body), but the **severe strip lives in the always-visible summary slot, never inside the accordion** (§4.3 / A-1 / V-1). The chevron toggles only the mild-watch block. An e2e guard asserts the strip stays visible while the body is collapsed and is never a descendant of `#infoNutIntroBody`.

### Polarity → color (V-3)
Sage encourage · amber caution strip · rose reserved for acute-toxin (honey, which this encourage-only surface does not give a benefit banner).

### Verification
- `pnpm build` clean; **12 audit gates pass** (incl. `audit-food-effects-sync-v1`, `audit-card-priority-v3-6`).
- New spec `food-effects-v2-encourage-card.spec.ts` — 5 guards — green; the peanut/tree-nut and v3-6 card-priority specs green (the latter caught and fixed a first-cut interaction where a non-collapsible card broke the "first info card has a body" assumption).

### canon-cc-008 status
**Draft until the chain runs.** Shared-module touch (`template.html` + `styles.css`) → triple-Gov (Maren → Kael → Vela), Vela-primary on the render layer, Maren on the surfaced safety-copy, **Cipher Edict V terminal**. Chain run pending.

https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK)_