### PR TITLE
fix(γ card): make the encourage card collapse meaningfully

### DIFF
--- a/index.html
+++ b/index.html
@@ -12518,11 +12518,13 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
       <div class="home-section-label sec-t3 col-full">Food Intelligence</div>
 
       <!-- Introducing nuts early (food-effects v2 Phase γ — persistent encourage card).
-           Emergency-floor invariant (§4.3, A-1/V-1): the severe-reaction strip must
-           never sit inside an accordion. So the always-visible summary slot
-           (#infoNutIntro) carries benefit → introduce-safely → SEVERE STRIP → myth,
-           and only the calm MILD watch-fors (§4.4) live in the collapse body. The
-           chevron toggles the mild block alone; the severe strip is never folded. -->
+           Emergency-floor invariant (§4.3, A-1/V-1): the severe-reaction strip — and
+           the never-whole/choking form-gate (A-2) — must never sit inside an accordion.
+           So the always-visible PINNED slot (#infoNutIntro) carries benefit → safe-form
+           gate → SEVERE STRIP, while the collapse body (#infoNutIntroBody) carries the
+           how-to protocol → high-risk note → MILD watch-fors → the "delay" myth (§4.4
+           calm-secondary). The chevron toggles the body (the bulk); the pinned floor +
+           choking gate are never folded. renderInfoNutIntro() fills both slots. -->
       <div class="card card-daily col-full" id="infoNutIntroCard">
         <div class="card-header" data-collapse-target="infoNutIntroBody" data-collapse-chevron="infoNutIntroChevron">
           <div class="card-title"><div class="icon icon-sage"><svg class="zi"><use href="#zi-sprout"/></svg></div> Introducing nuts early</div>
@@ -70151,8 +70153,8 @@ function renderInfo() {
 //   • Polarity→color (V-3): sage benefit banner; amber severe strip (shared
 //     .cons-severe); rose stays reserved for acute-toxin.
 function renderInfoNutIntro() {
-  var host = document.getElementById('infoNutIntro');       // always-visible summary
-  var moreHost = document.getElementById('infoNutIntroMore'); // collapse body (mild)
+  var host = document.getElementById('infoNutIntro');         // always-visible (pinned)
+  var moreHost = document.getElementById('infoNutIntroMore'); // collapse body
   if (!host) return;
   var FE = (typeof FOOD_EFFECTS !== 'undefined') ? FOOD_EFFECTS : null;
   var peanut  = FE ? FE['peanut']   : null;
@@ -70167,46 +70169,35 @@ function renderInfoNutIntro() {
   }
   var lead = peanut || treeNut;          // peanut carries the strongest (LEAP) evidence
   var foods = [peanut, treeNut].filter(Boolean);
-  var html = '';
 
-  // ── Section 1: Benefit banner (sage, encourage polarity — V-3) ──
+  // The card collapses like every other Info card, but the must-see content is
+  // PINNED in the always-visible host and never folds:
+  //   pinned  → benefit banner (encourage leads) + the never-whole/choking form
+  //             gate (A-2) + the severe emergency strip (A-1/V-1).
+  //   body    → the how-to protocol, the high-risk advisory, the mild watch-fors,
+  //             and the "delay" myth — the detail a parent expands for.
+  // So the chevron does meaningful work (the body is the bulk) while the
+  // emergency floor + the choking gate are unmissable in both states.
+  var pinned = '';
+  var body = '';
+
+  // ── Benefit banner (sage, encourage polarity — V-3) → PINNED ──
   var benefit = (lead.earlyIntroBenefit && lead.earlyIntroBenefit.claim) ? lead.earlyIntroBenefit : null;
-  html += '<div class="enc-benefit">';
-  html += '<div class="enc-benefit-h">' + zi('sprout') + '<span>Why introduce early</span></div>';
+  pinned += '<div class="enc-benefit">';
+  pinned += '<div class="enc-benefit-h">' + zi('sprout') + '<span>Why introduce early</span></div>';
   if (benefit) {
-    html += '<p class="enc-claim">' + escHtml(benefit.claim) + '</p>';
-    if (benefit.evidence) html += '<p class="enc-evidence">' + escHtml(benefit.evidence) + '</p>';
+    pinned += '<p class="enc-claim">' + escHtml(benefit.claim) + '</p>';
+    if (benefit.evidence) pinned += '<p class="enc-evidence">' + escHtml(benefit.evidence) + '</p>';
   }
   // Each food's own cited nutrition line (no fabricated merge across records).
   var whyItems = foods.filter(function(f){ return f.whyGood; })
     .map(function(f){ return '<li>' + escHtml(f.whyGood) + '</li>'; }).join('');
-  if (whyItems) html += '<ul class="enc-why-list">' + whyItems + '</ul>';
-  html += '</div>';
+  if (whyItems) pinned += '<ul class="enc-why-list">' + whyItems + '</ul>';
+  pinned += '</div>';
 
-  // ── Section 2: Introduce-safely block (protocol + non-suppressible form gate, A-2) ──
-  html += '<div class="enc-block">';
-  html += '<div class="enc-block-h">' + zi('spoon') + '<span>How to introduce safely</span></div>';
-  var hti = lead.howToIntroduce || {};
-  html += '<div class="enc-proto">';
-  // Amount / when / watch are materially identical across the records — source
-  // the shared first-exposure rhythm from lead.
-  if (hti.amount)   html += '<div class="enc-proto-row"><b>Amount:</b> ' + escHtml(hti.amount) + '</div>';
-  if (hti.when)     html += '<div class="enc-proto-row"><b>When:</b> ' + escHtml(hti.when) + '</div>';
-  if (hti.watch)    html += '<div class="enc-proto-row"><b>Watch:</b> ' + escHtml(hti.watch) + '</div>';
-  // Keep-offering guidance is PER-FOOD (Maren M-γ-1): tree nut carries the
-  // load-bearing "introduce each nut on its own, a few days apart" attribution
-  // line that peanut's does not. A combined card must never drop one food's
-  // distinct guidance — render each present food's own thenWhat, labelled, so
-  // the parent doesn't apply peanut's rhythm to a mixed-nut paste.
-  var keepOffering = [{ rec: peanut, label: 'Peanut' }, { rec: treeNut, label: 'Tree nuts' }]
-    .filter(function(x){ return x.rec && x.rec.howToIntroduce && x.rec.howToIntroduce.thenWhat; });
-  keepOffering.forEach(function(x){
-    html += '<div class="enc-proto-row"><b>Keep offering — ' + escHtml(x.label) + ':</b> ' +
-      escHtml(x.rec.howToIntroduce.thenWhat) + '</div>';
-  });
-  html += '</div>';
-  // Safe-form gate — union the cited ok/never lists across both records (dedup),
-  // then the non-suppressible note (Maren A-2: grinding removes choking, NOT allergy).
+  // ── Safe-form gate (A-2) → PINNED. The "grinding removes choking NOT allergy /
+  // never whole" rule is a choking-safety line, so it stays visible when the card
+  // is collapsed. Union the cited ok/never lists across both records (dedup). ──
   var okSet = [], neverSet = [], note = '';
   foods.forEach(function(f){
     var sf = f.safeForm || {};
@@ -70215,59 +70206,79 @@ function renderInfoNutIntro() {
     if (!note && sf.note) note = sf.note;
   });
   if (okSet.length || neverSet.length || note) {
-    html += '<div class="enc-form">';
+    pinned += '<div class="enc-form">';
     if (okSet.length) {
-      html += '<div class="enc-form-sub">Safe forms</div><ul class="enc-form-list">' +
+      pinned += '<div class="enc-form-sub">Safe forms</div><ul class="enc-form-list">' +
         okSet.map(function(x){ return '<li>' + escHtml(x) + '</li>'; }).join('') + '</ul>';
     }
     if (neverSet.length) {
-      html += '<div class="enc-form-sub">Never</div><ul class="enc-form-list enc-never">' +
+      pinned += '<div class="enc-form-sub">Never</div><ul class="enc-form-list enc-never">' +
         neverSet.map(function(x){ return '<li>' + escHtml(x) + '</li>'; }).join('') + '</ul>';
     }
-    if (note) html += '<p class="enc-form-note">' + escHtml(note) + '</p>';
-    html += '</div>';
+    if (note) pinned += '<p class="enc-form-note">' + escHtml(note) + '</p>';
+    pinned += '</div>';
   }
-  // High-risk cohort note (Maren §9.2 — non-suppressible when applicable).
-  if (hti.highRiskNote) html += '<p class="enc-highrisk">' + escHtml(hti.highRiskNote) + '</p>';
-  html += '</div>';
 
-  // ── Section 3: Severe-reaction strip — the emergency floor (A-1/V-1) ──
+  // ── Severe-reaction strip — the emergency floor (A-1/V-1) → PINNED ──
   // Unconditional, non-collapsible, amber. Reuses the shipped .cons-severe
-  // pattern verbatim so this card and the log-time card read identically.
-  // slice() first — never mutate the FOOD_EFFECTS source array.
+  // pattern verbatim. slice() first — never mutate the FOOD_EFFECTS source array.
   var severe = (lead.severeSigns && lead.severeSigns.length) ? lead.severeSigns.slice() : [];
   foods.forEach(function(f){
     (f.severeSigns || []).forEach(function(s){ if (severe.indexOf(s) === -1) severe.push(s); });
   });
   if (severe.length) {
-    html += '<div class="cons-severe"><div class="cons-severe-h">' + zi('siren') +
+    pinned += '<div class="cons-severe"><div class="cons-severe-h">' + zi('siren') +
       '<span>If this happens, it’s an emergency</span></div><ul class="cons-severe-list">' +
       severe.map(function(s){ return '<li>' + escHtml(s) + '</li>'; }).join('') + '</ul>';
     if (lead.seekCare) {
-      html += '<p class="enc-emergency">' + zi('siren') + '<span>' + escHtml(lead.seekCare) + '</span></p>';
+      pinned += '<p class="enc-emergency">' + zi('siren') + '<span>' + escHtml(lead.seekCare) + '</span></p>';
     }
-    html += '</div>';
+    pinned += '</div>';
   }
 
-  // ── Section 4a: the "delay" myth — stays in the always-visible summary.
-  // It is the highest-value relative-facing line (spec §4.4), so it is never
-  // folded into the collapse body.
+  // ── How-to protocol (the introduce-safely steps) → BODY ──
+  var hti = lead.howToIntroduce || {};
+  body += '<div class="enc-block">';
+  body += '<div class="enc-block-h">' + zi('spoon') + '<span>How to introduce safely</span></div>';
+  body += '<div class="enc-proto">';
+  // Amount / when / watch are materially identical across the records — source
+  // the shared first-exposure rhythm from lead.
+  if (hti.amount)   body += '<div class="enc-proto-row"><b>Amount:</b> ' + escHtml(hti.amount) + '</div>';
+  if (hti.when)     body += '<div class="enc-proto-row"><b>When:</b> ' + escHtml(hti.when) + '</div>';
+  if (hti.watch)    body += '<div class="enc-proto-row"><b>Watch:</b> ' + escHtml(hti.watch) + '</div>';
+  // Keep-offering guidance is PER-FOOD (Maren M-γ-1): tree nut carries the
+  // load-bearing "introduce each nut on its own, a few days apart" attribution
+  // line that peanut's does not. A combined card must never drop one food's
+  // distinct guidance — render each present food's own thenWhat, labelled, so
+  // the parent doesn't apply peanut's rhythm to a mixed-nut paste.
+  var keepOffering = [{ rec: peanut, label: 'Peanut' }, { rec: treeNut, label: 'Tree nuts' }]
+    .filter(function(x){ return x.rec && x.rec.howToIntroduce && x.rec.howToIntroduce.thenWhat; });
+  keepOffering.forEach(function(x){
+    body += '<div class="enc-proto-row"><b>Keep offering — ' + escHtml(x.label) + ':</b> ' +
+      escHtml(x.rec.howToIntroduce.thenWhat) + '</div>';
+  });
+  body += '</div>';
+  // High-risk cohort note (Maren §9.2). Advisory + self-gating ("IF your baby has
+  // severe eczema…"), so it sits in the body; when a per-baby high-risk signal
+  // exists (future), pin it.
+  if (hti.highRiskNote) body += '<p class="enc-highrisk">' + escHtml(hti.highRiskNote) + '</p>';
+  body += '</div>';
+
+  // ── Mild watch-fors — calm-secondary (spec §4.4) → BODY ──
+  var mild = (lead.watchFor && lead.watchFor.length) ? lead.watchFor.slice() : [];
+  if (mild.length) {
+    body += '<div class="cons-watch"><div class="cons-watch-h">Milder signs to watch for</div><ul class="cons-watch-list">' +
+      mild.map(function(w){ return '<li>' + escHtml(w) + '</li>'; }).join('') + '</ul></div>';
+  }
+
+  // ── The "delay" myth (the paradigm reversal) → BODY ──
   var myth = (benefit && benefit.paradigm) ? benefit.paradigm : '';
   if (myth) {
-    html += '<div class="enc-myth">' + zi('bulb') + '<span>' + escHtml(myth) + '</span></div>';
+    body += '<div class="enc-myth">' + zi('bulb') + '<span>' + escHtml(myth) + '</span></div>';
   }
 
-  host.innerHTML = html;
-
-  // ── Section 4b: mild watch-fors — calm-secondary (spec §4.4), so they live in
-  // the collapse body the chevron toggles. The SEVERE strip above is never here.
-  var mild = (lead.watchFor && lead.watchFor.length) ? lead.watchFor.slice() : [];
-  if (moreHost) {
-    moreHost.innerHTML = mild.length
-      ? '<div class="cons-watch"><div class="cons-watch-h">Milder signs to watch for</div><ul class="cons-watch-list">' +
-          mild.map(function(w){ return '<li>' + escHtml(w) + '</li>'; }).join('') + '</ul></div>'
-      : '';
-  }
+  host.innerHTML = pinned;
+  if (moreHost) moreHost.innerHTML = body;
 
   // Encourage cards map to card-priority 'notable' (spec §4); honey → 'urgent'.
   _setCardPriority('infoNutIntroCard', 'notable');

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.31-11",
+  "version": "2026.05.31-13",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/intelligence-cards.js
+++ b/split/intelligence-cards.js
@@ -1309,8 +1309,8 @@ function renderInfo() {
 //   • Polarity→color (V-3): sage benefit banner; amber severe strip (shared
 //     .cons-severe); rose stays reserved for acute-toxin.
 function renderInfoNutIntro() {
-  var host = document.getElementById('infoNutIntro');       // always-visible summary
-  var moreHost = document.getElementById('infoNutIntroMore'); // collapse body (mild)
+  var host = document.getElementById('infoNutIntro');         // always-visible (pinned)
+  var moreHost = document.getElementById('infoNutIntroMore'); // collapse body
   if (!host) return;
   var FE = (typeof FOOD_EFFECTS !== 'undefined') ? FOOD_EFFECTS : null;
   var peanut  = FE ? FE['peanut']   : null;
@@ -1325,46 +1325,35 @@ function renderInfoNutIntro() {
   }
   var lead = peanut || treeNut;          // peanut carries the strongest (LEAP) evidence
   var foods = [peanut, treeNut].filter(Boolean);
-  var html = '';
 
-  // ── Section 1: Benefit banner (sage, encourage polarity — V-3) ──
+  // The card collapses like every other Info card, but the must-see content is
+  // PINNED in the always-visible host and never folds:
+  //   pinned  → benefit banner (encourage leads) + the never-whole/choking form
+  //             gate (A-2) + the severe emergency strip (A-1/V-1).
+  //   body    → the how-to protocol, the high-risk advisory, the mild watch-fors,
+  //             and the "delay" myth — the detail a parent expands for.
+  // So the chevron does meaningful work (the body is the bulk) while the
+  // emergency floor + the choking gate are unmissable in both states.
+  var pinned = '';
+  var body = '';
+
+  // ── Benefit banner (sage, encourage polarity — V-3) → PINNED ──
   var benefit = (lead.earlyIntroBenefit && lead.earlyIntroBenefit.claim) ? lead.earlyIntroBenefit : null;
-  html += '<div class="enc-benefit">';
-  html += '<div class="enc-benefit-h">' + zi('sprout') + '<span>Why introduce early</span></div>';
+  pinned += '<div class="enc-benefit">';
+  pinned += '<div class="enc-benefit-h">' + zi('sprout') + '<span>Why introduce early</span></div>';
   if (benefit) {
-    html += '<p class="enc-claim">' + escHtml(benefit.claim) + '</p>';
-    if (benefit.evidence) html += '<p class="enc-evidence">' + escHtml(benefit.evidence) + '</p>';
+    pinned += '<p class="enc-claim">' + escHtml(benefit.claim) + '</p>';
+    if (benefit.evidence) pinned += '<p class="enc-evidence">' + escHtml(benefit.evidence) + '</p>';
   }
   // Each food's own cited nutrition line (no fabricated merge across records).
   var whyItems = foods.filter(function(f){ return f.whyGood; })
     .map(function(f){ return '<li>' + escHtml(f.whyGood) + '</li>'; }).join('');
-  if (whyItems) html += '<ul class="enc-why-list">' + whyItems + '</ul>';
-  html += '</div>';
+  if (whyItems) pinned += '<ul class="enc-why-list">' + whyItems + '</ul>';
+  pinned += '</div>';
 
-  // ── Section 2: Introduce-safely block (protocol + non-suppressible form gate, A-2) ──
-  html += '<div class="enc-block">';
-  html += '<div class="enc-block-h">' + zi('spoon') + '<span>How to introduce safely</span></div>';
-  var hti = lead.howToIntroduce || {};
-  html += '<div class="enc-proto">';
-  // Amount / when / watch are materially identical across the records — source
-  // the shared first-exposure rhythm from lead.
-  if (hti.amount)   html += '<div class="enc-proto-row"><b>Amount:</b> ' + escHtml(hti.amount) + '</div>';
-  if (hti.when)     html += '<div class="enc-proto-row"><b>When:</b> ' + escHtml(hti.when) + '</div>';
-  if (hti.watch)    html += '<div class="enc-proto-row"><b>Watch:</b> ' + escHtml(hti.watch) + '</div>';
-  // Keep-offering guidance is PER-FOOD (Maren M-γ-1): tree nut carries the
-  // load-bearing "introduce each nut on its own, a few days apart" attribution
-  // line that peanut's does not. A combined card must never drop one food's
-  // distinct guidance — render each present food's own thenWhat, labelled, so
-  // the parent doesn't apply peanut's rhythm to a mixed-nut paste.
-  var keepOffering = [{ rec: peanut, label: 'Peanut' }, { rec: treeNut, label: 'Tree nuts' }]
-    .filter(function(x){ return x.rec && x.rec.howToIntroduce && x.rec.howToIntroduce.thenWhat; });
-  keepOffering.forEach(function(x){
-    html += '<div class="enc-proto-row"><b>Keep offering — ' + escHtml(x.label) + ':</b> ' +
-      escHtml(x.rec.howToIntroduce.thenWhat) + '</div>';
-  });
-  html += '</div>';
-  // Safe-form gate — union the cited ok/never lists across both records (dedup),
-  // then the non-suppressible note (Maren A-2: grinding removes choking, NOT allergy).
+  // ── Safe-form gate (A-2) → PINNED. The "grinding removes choking NOT allergy /
+  // never whole" rule is a choking-safety line, so it stays visible when the card
+  // is collapsed. Union the cited ok/never lists across both records (dedup). ──
   var okSet = [], neverSet = [], note = '';
   foods.forEach(function(f){
     var sf = f.safeForm || {};
@@ -1373,59 +1362,79 @@ function renderInfoNutIntro() {
     if (!note && sf.note) note = sf.note;
   });
   if (okSet.length || neverSet.length || note) {
-    html += '<div class="enc-form">';
+    pinned += '<div class="enc-form">';
     if (okSet.length) {
-      html += '<div class="enc-form-sub">Safe forms</div><ul class="enc-form-list">' +
+      pinned += '<div class="enc-form-sub">Safe forms</div><ul class="enc-form-list">' +
         okSet.map(function(x){ return '<li>' + escHtml(x) + '</li>'; }).join('') + '</ul>';
     }
     if (neverSet.length) {
-      html += '<div class="enc-form-sub">Never</div><ul class="enc-form-list enc-never">' +
+      pinned += '<div class="enc-form-sub">Never</div><ul class="enc-form-list enc-never">' +
         neverSet.map(function(x){ return '<li>' + escHtml(x) + '</li>'; }).join('') + '</ul>';
     }
-    if (note) html += '<p class="enc-form-note">' + escHtml(note) + '</p>';
-    html += '</div>';
+    if (note) pinned += '<p class="enc-form-note">' + escHtml(note) + '</p>';
+    pinned += '</div>';
   }
-  // High-risk cohort note (Maren §9.2 — non-suppressible when applicable).
-  if (hti.highRiskNote) html += '<p class="enc-highrisk">' + escHtml(hti.highRiskNote) + '</p>';
-  html += '</div>';
 
-  // ── Section 3: Severe-reaction strip — the emergency floor (A-1/V-1) ──
+  // ── Severe-reaction strip — the emergency floor (A-1/V-1) → PINNED ──
   // Unconditional, non-collapsible, amber. Reuses the shipped .cons-severe
-  // pattern verbatim so this card and the log-time card read identically.
-  // slice() first — never mutate the FOOD_EFFECTS source array.
+  // pattern verbatim. slice() first — never mutate the FOOD_EFFECTS source array.
   var severe = (lead.severeSigns && lead.severeSigns.length) ? lead.severeSigns.slice() : [];
   foods.forEach(function(f){
     (f.severeSigns || []).forEach(function(s){ if (severe.indexOf(s) === -1) severe.push(s); });
   });
   if (severe.length) {
-    html += '<div class="cons-severe"><div class="cons-severe-h">' + zi('siren') +
+    pinned += '<div class="cons-severe"><div class="cons-severe-h">' + zi('siren') +
       '<span>If this happens, it’s an emergency</span></div><ul class="cons-severe-list">' +
       severe.map(function(s){ return '<li>' + escHtml(s) + '</li>'; }).join('') + '</ul>';
     if (lead.seekCare) {
-      html += '<p class="enc-emergency">' + zi('siren') + '<span>' + escHtml(lead.seekCare) + '</span></p>';
+      pinned += '<p class="enc-emergency">' + zi('siren') + '<span>' + escHtml(lead.seekCare) + '</span></p>';
     }
-    html += '</div>';
+    pinned += '</div>';
   }
 
-  // ── Section 4a: the "delay" myth — stays in the always-visible summary.
-  // It is the highest-value relative-facing line (spec §4.4), so it is never
-  // folded into the collapse body.
+  // ── How-to protocol (the introduce-safely steps) → BODY ──
+  var hti = lead.howToIntroduce || {};
+  body += '<div class="enc-block">';
+  body += '<div class="enc-block-h">' + zi('spoon') + '<span>How to introduce safely</span></div>';
+  body += '<div class="enc-proto">';
+  // Amount / when / watch are materially identical across the records — source
+  // the shared first-exposure rhythm from lead.
+  if (hti.amount)   body += '<div class="enc-proto-row"><b>Amount:</b> ' + escHtml(hti.amount) + '</div>';
+  if (hti.when)     body += '<div class="enc-proto-row"><b>When:</b> ' + escHtml(hti.when) + '</div>';
+  if (hti.watch)    body += '<div class="enc-proto-row"><b>Watch:</b> ' + escHtml(hti.watch) + '</div>';
+  // Keep-offering guidance is PER-FOOD (Maren M-γ-1): tree nut carries the
+  // load-bearing "introduce each nut on its own, a few days apart" attribution
+  // line that peanut's does not. A combined card must never drop one food's
+  // distinct guidance — render each present food's own thenWhat, labelled, so
+  // the parent doesn't apply peanut's rhythm to a mixed-nut paste.
+  var keepOffering = [{ rec: peanut, label: 'Peanut' }, { rec: treeNut, label: 'Tree nuts' }]
+    .filter(function(x){ return x.rec && x.rec.howToIntroduce && x.rec.howToIntroduce.thenWhat; });
+  keepOffering.forEach(function(x){
+    body += '<div class="enc-proto-row"><b>Keep offering — ' + escHtml(x.label) + ':</b> ' +
+      escHtml(x.rec.howToIntroduce.thenWhat) + '</div>';
+  });
+  body += '</div>';
+  // High-risk cohort note (Maren §9.2). Advisory + self-gating ("IF your baby has
+  // severe eczema…"), so it sits in the body; when a per-baby high-risk signal
+  // exists (future), pin it.
+  if (hti.highRiskNote) body += '<p class="enc-highrisk">' + escHtml(hti.highRiskNote) + '</p>';
+  body += '</div>';
+
+  // ── Mild watch-fors — calm-secondary (spec §4.4) → BODY ──
+  var mild = (lead.watchFor && lead.watchFor.length) ? lead.watchFor.slice() : [];
+  if (mild.length) {
+    body += '<div class="cons-watch"><div class="cons-watch-h">Milder signs to watch for</div><ul class="cons-watch-list">' +
+      mild.map(function(w){ return '<li>' + escHtml(w) + '</li>'; }).join('') + '</ul></div>';
+  }
+
+  // ── The "delay" myth (the paradigm reversal) → BODY ──
   var myth = (benefit && benefit.paradigm) ? benefit.paradigm : '';
   if (myth) {
-    html += '<div class="enc-myth">' + zi('bulb') + '<span>' + escHtml(myth) + '</span></div>';
+    body += '<div class="enc-myth">' + zi('bulb') + '<span>' + escHtml(myth) + '</span></div>';
   }
 
-  host.innerHTML = html;
-
-  // ── Section 4b: mild watch-fors — calm-secondary (spec §4.4), so they live in
-  // the collapse body the chevron toggles. The SEVERE strip above is never here.
-  var mild = (lead.watchFor && lead.watchFor.length) ? lead.watchFor.slice() : [];
-  if (moreHost) {
-    moreHost.innerHTML = mild.length
-      ? '<div class="cons-watch"><div class="cons-watch-h">Milder signs to watch for</div><ul class="cons-watch-list">' +
-          mild.map(function(w){ return '<li>' + escHtml(w) + '</li>'; }).join('') + '</ul></div>'
-      : '';
-  }
+  host.innerHTML = pinned;
+  if (moreHost) moreHost.innerHTML = body;
 
   // Encourage cards map to card-priority 'notable' (spec §4); honey → 'urgent'.
   _setCardPriority('infoNutIntroCard', 'notable');

--- a/split/template.html
+++ b/split/template.html
@@ -1728,11 +1728,13 @@
       <div class="home-section-label sec-t3 col-full">Food Intelligence</div>
 
       <!-- Introducing nuts early (food-effects v2 Phase γ — persistent encourage card).
-           Emergency-floor invariant (§4.3, A-1/V-1): the severe-reaction strip must
-           never sit inside an accordion. So the always-visible summary slot
-           (#infoNutIntro) carries benefit → introduce-safely → SEVERE STRIP → myth,
-           and only the calm MILD watch-fors (§4.4) live in the collapse body. The
-           chevron toggles the mild block alone; the severe strip is never folded. -->
+           Emergency-floor invariant (§4.3, A-1/V-1): the severe-reaction strip — and
+           the never-whole/choking form-gate (A-2) — must never sit inside an accordion.
+           So the always-visible PINNED slot (#infoNutIntro) carries benefit → safe-form
+           gate → SEVERE STRIP, while the collapse body (#infoNutIntroBody) carries the
+           how-to protocol → high-risk note → MILD watch-fors → the "delay" myth (§4.4
+           calm-secondary). The chevron toggles the body (the bulk); the pinned floor +
+           choking gate are never folded. renderInfoNutIntro() fills both slots. -->
       <div class="card card-daily col-full" id="infoNutIntroCard">
         <div class="card-header" data-collapse-target="infoNutIntroBody" data-collapse-chevron="infoNutIntroChevron">
           <div class="card-title"><div class="icon icon-sage"><svg class="zi"><use href="#zi-sprout"/></svg></div> Introducing nuts early</div>

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -12518,11 +12518,13 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
       <div class="home-section-label sec-t3 col-full">Food Intelligence</div>
 
       <!-- Introducing nuts early (food-effects v2 Phase γ — persistent encourage card).
-           Emergency-floor invariant (§4.3, A-1/V-1): the severe-reaction strip must
-           never sit inside an accordion. So the always-visible summary slot
-           (#infoNutIntro) carries benefit → introduce-safely → SEVERE STRIP → myth,
-           and only the calm MILD watch-fors (§4.4) live in the collapse body. The
-           chevron toggles the mild block alone; the severe strip is never folded. -->
+           Emergency-floor invariant (§4.3, A-1/V-1): the severe-reaction strip — and
+           the never-whole/choking form-gate (A-2) — must never sit inside an accordion.
+           So the always-visible PINNED slot (#infoNutIntro) carries benefit → safe-form
+           gate → SEVERE STRIP, while the collapse body (#infoNutIntroBody) carries the
+           how-to protocol → high-risk note → MILD watch-fors → the "delay" myth (§4.4
+           calm-secondary). The chevron toggles the body (the bulk); the pinned floor +
+           choking gate are never folded. renderInfoNutIntro() fills both slots. -->
       <div class="card card-daily col-full" id="infoNutIntroCard">
         <div class="card-header" data-collapse-target="infoNutIntroBody" data-collapse-chevron="infoNutIntroChevron">
           <div class="card-title"><div class="icon icon-sage"><svg class="zi"><use href="#zi-sprout"/></svg></div> Introducing nuts early</div>
@@ -70151,8 +70153,8 @@ function renderInfo() {
 //   • Polarity→color (V-3): sage benefit banner; amber severe strip (shared
 //     .cons-severe); rose stays reserved for acute-toxin.
 function renderInfoNutIntro() {
-  var host = document.getElementById('infoNutIntro');       // always-visible summary
-  var moreHost = document.getElementById('infoNutIntroMore'); // collapse body (mild)
+  var host = document.getElementById('infoNutIntro');         // always-visible (pinned)
+  var moreHost = document.getElementById('infoNutIntroMore'); // collapse body
   if (!host) return;
   var FE = (typeof FOOD_EFFECTS !== 'undefined') ? FOOD_EFFECTS : null;
   var peanut  = FE ? FE['peanut']   : null;
@@ -70167,46 +70169,35 @@ function renderInfoNutIntro() {
   }
   var lead = peanut || treeNut;          // peanut carries the strongest (LEAP) evidence
   var foods = [peanut, treeNut].filter(Boolean);
-  var html = '';
 
-  // ── Section 1: Benefit banner (sage, encourage polarity — V-3) ──
+  // The card collapses like every other Info card, but the must-see content is
+  // PINNED in the always-visible host and never folds:
+  //   pinned  → benefit banner (encourage leads) + the never-whole/choking form
+  //             gate (A-2) + the severe emergency strip (A-1/V-1).
+  //   body    → the how-to protocol, the high-risk advisory, the mild watch-fors,
+  //             and the "delay" myth — the detail a parent expands for.
+  // So the chevron does meaningful work (the body is the bulk) while the
+  // emergency floor + the choking gate are unmissable in both states.
+  var pinned = '';
+  var body = '';
+
+  // ── Benefit banner (sage, encourage polarity — V-3) → PINNED ──
   var benefit = (lead.earlyIntroBenefit && lead.earlyIntroBenefit.claim) ? lead.earlyIntroBenefit : null;
-  html += '<div class="enc-benefit">';
-  html += '<div class="enc-benefit-h">' + zi('sprout') + '<span>Why introduce early</span></div>';
+  pinned += '<div class="enc-benefit">';
+  pinned += '<div class="enc-benefit-h">' + zi('sprout') + '<span>Why introduce early</span></div>';
   if (benefit) {
-    html += '<p class="enc-claim">' + escHtml(benefit.claim) + '</p>';
-    if (benefit.evidence) html += '<p class="enc-evidence">' + escHtml(benefit.evidence) + '</p>';
+    pinned += '<p class="enc-claim">' + escHtml(benefit.claim) + '</p>';
+    if (benefit.evidence) pinned += '<p class="enc-evidence">' + escHtml(benefit.evidence) + '</p>';
   }
   // Each food's own cited nutrition line (no fabricated merge across records).
   var whyItems = foods.filter(function(f){ return f.whyGood; })
     .map(function(f){ return '<li>' + escHtml(f.whyGood) + '</li>'; }).join('');
-  if (whyItems) html += '<ul class="enc-why-list">' + whyItems + '</ul>';
-  html += '</div>';
+  if (whyItems) pinned += '<ul class="enc-why-list">' + whyItems + '</ul>';
+  pinned += '</div>';
 
-  // ── Section 2: Introduce-safely block (protocol + non-suppressible form gate, A-2) ──
-  html += '<div class="enc-block">';
-  html += '<div class="enc-block-h">' + zi('spoon') + '<span>How to introduce safely</span></div>';
-  var hti = lead.howToIntroduce || {};
-  html += '<div class="enc-proto">';
-  // Amount / when / watch are materially identical across the records — source
-  // the shared first-exposure rhythm from lead.
-  if (hti.amount)   html += '<div class="enc-proto-row"><b>Amount:</b> ' + escHtml(hti.amount) + '</div>';
-  if (hti.when)     html += '<div class="enc-proto-row"><b>When:</b> ' + escHtml(hti.when) + '</div>';
-  if (hti.watch)    html += '<div class="enc-proto-row"><b>Watch:</b> ' + escHtml(hti.watch) + '</div>';
-  // Keep-offering guidance is PER-FOOD (Maren M-γ-1): tree nut carries the
-  // load-bearing "introduce each nut on its own, a few days apart" attribution
-  // line that peanut's does not. A combined card must never drop one food's
-  // distinct guidance — render each present food's own thenWhat, labelled, so
-  // the parent doesn't apply peanut's rhythm to a mixed-nut paste.
-  var keepOffering = [{ rec: peanut, label: 'Peanut' }, { rec: treeNut, label: 'Tree nuts' }]
-    .filter(function(x){ return x.rec && x.rec.howToIntroduce && x.rec.howToIntroduce.thenWhat; });
-  keepOffering.forEach(function(x){
-    html += '<div class="enc-proto-row"><b>Keep offering — ' + escHtml(x.label) + ':</b> ' +
-      escHtml(x.rec.howToIntroduce.thenWhat) + '</div>';
-  });
-  html += '</div>';
-  // Safe-form gate — union the cited ok/never lists across both records (dedup),
-  // then the non-suppressible note (Maren A-2: grinding removes choking, NOT allergy).
+  // ── Safe-form gate (A-2) → PINNED. The "grinding removes choking NOT allergy /
+  // never whole" rule is a choking-safety line, so it stays visible when the card
+  // is collapsed. Union the cited ok/never lists across both records (dedup). ──
   var okSet = [], neverSet = [], note = '';
   foods.forEach(function(f){
     var sf = f.safeForm || {};
@@ -70215,59 +70206,79 @@ function renderInfoNutIntro() {
     if (!note && sf.note) note = sf.note;
   });
   if (okSet.length || neverSet.length || note) {
-    html += '<div class="enc-form">';
+    pinned += '<div class="enc-form">';
     if (okSet.length) {
-      html += '<div class="enc-form-sub">Safe forms</div><ul class="enc-form-list">' +
+      pinned += '<div class="enc-form-sub">Safe forms</div><ul class="enc-form-list">' +
         okSet.map(function(x){ return '<li>' + escHtml(x) + '</li>'; }).join('') + '</ul>';
     }
     if (neverSet.length) {
-      html += '<div class="enc-form-sub">Never</div><ul class="enc-form-list enc-never">' +
+      pinned += '<div class="enc-form-sub">Never</div><ul class="enc-form-list enc-never">' +
         neverSet.map(function(x){ return '<li>' + escHtml(x) + '</li>'; }).join('') + '</ul>';
     }
-    if (note) html += '<p class="enc-form-note">' + escHtml(note) + '</p>';
-    html += '</div>';
+    if (note) pinned += '<p class="enc-form-note">' + escHtml(note) + '</p>';
+    pinned += '</div>';
   }
-  // High-risk cohort note (Maren §9.2 — non-suppressible when applicable).
-  if (hti.highRiskNote) html += '<p class="enc-highrisk">' + escHtml(hti.highRiskNote) + '</p>';
-  html += '</div>';
 
-  // ── Section 3: Severe-reaction strip — the emergency floor (A-1/V-1) ──
+  // ── Severe-reaction strip — the emergency floor (A-1/V-1) → PINNED ──
   // Unconditional, non-collapsible, amber. Reuses the shipped .cons-severe
-  // pattern verbatim so this card and the log-time card read identically.
-  // slice() first — never mutate the FOOD_EFFECTS source array.
+  // pattern verbatim. slice() first — never mutate the FOOD_EFFECTS source array.
   var severe = (lead.severeSigns && lead.severeSigns.length) ? lead.severeSigns.slice() : [];
   foods.forEach(function(f){
     (f.severeSigns || []).forEach(function(s){ if (severe.indexOf(s) === -1) severe.push(s); });
   });
   if (severe.length) {
-    html += '<div class="cons-severe"><div class="cons-severe-h">' + zi('siren') +
+    pinned += '<div class="cons-severe"><div class="cons-severe-h">' + zi('siren') +
       '<span>If this happens, it’s an emergency</span></div><ul class="cons-severe-list">' +
       severe.map(function(s){ return '<li>' + escHtml(s) + '</li>'; }).join('') + '</ul>';
     if (lead.seekCare) {
-      html += '<p class="enc-emergency">' + zi('siren') + '<span>' + escHtml(lead.seekCare) + '</span></p>';
+      pinned += '<p class="enc-emergency">' + zi('siren') + '<span>' + escHtml(lead.seekCare) + '</span></p>';
     }
-    html += '</div>';
+    pinned += '</div>';
   }
 
-  // ── Section 4a: the "delay" myth — stays in the always-visible summary.
-  // It is the highest-value relative-facing line (spec §4.4), so it is never
-  // folded into the collapse body.
+  // ── How-to protocol (the introduce-safely steps) → BODY ──
+  var hti = lead.howToIntroduce || {};
+  body += '<div class="enc-block">';
+  body += '<div class="enc-block-h">' + zi('spoon') + '<span>How to introduce safely</span></div>';
+  body += '<div class="enc-proto">';
+  // Amount / when / watch are materially identical across the records — source
+  // the shared first-exposure rhythm from lead.
+  if (hti.amount)   body += '<div class="enc-proto-row"><b>Amount:</b> ' + escHtml(hti.amount) + '</div>';
+  if (hti.when)     body += '<div class="enc-proto-row"><b>When:</b> ' + escHtml(hti.when) + '</div>';
+  if (hti.watch)    body += '<div class="enc-proto-row"><b>Watch:</b> ' + escHtml(hti.watch) + '</div>';
+  // Keep-offering guidance is PER-FOOD (Maren M-γ-1): tree nut carries the
+  // load-bearing "introduce each nut on its own, a few days apart" attribution
+  // line that peanut's does not. A combined card must never drop one food's
+  // distinct guidance — render each present food's own thenWhat, labelled, so
+  // the parent doesn't apply peanut's rhythm to a mixed-nut paste.
+  var keepOffering = [{ rec: peanut, label: 'Peanut' }, { rec: treeNut, label: 'Tree nuts' }]
+    .filter(function(x){ return x.rec && x.rec.howToIntroduce && x.rec.howToIntroduce.thenWhat; });
+  keepOffering.forEach(function(x){
+    body += '<div class="enc-proto-row"><b>Keep offering — ' + escHtml(x.label) + ':</b> ' +
+      escHtml(x.rec.howToIntroduce.thenWhat) + '</div>';
+  });
+  body += '</div>';
+  // High-risk cohort note (Maren §9.2). Advisory + self-gating ("IF your baby has
+  // severe eczema…"), so it sits in the body; when a per-baby high-risk signal
+  // exists (future), pin it.
+  if (hti.highRiskNote) body += '<p class="enc-highrisk">' + escHtml(hti.highRiskNote) + '</p>';
+  body += '</div>';
+
+  // ── Mild watch-fors — calm-secondary (spec §4.4) → BODY ──
+  var mild = (lead.watchFor && lead.watchFor.length) ? lead.watchFor.slice() : [];
+  if (mild.length) {
+    body += '<div class="cons-watch"><div class="cons-watch-h">Milder signs to watch for</div><ul class="cons-watch-list">' +
+      mild.map(function(w){ return '<li>' + escHtml(w) + '</li>'; }).join('') + '</ul></div>';
+  }
+
+  // ── The "delay" myth (the paradigm reversal) → BODY ──
   var myth = (benefit && benefit.paradigm) ? benefit.paradigm : '';
   if (myth) {
-    html += '<div class="enc-myth">' + zi('bulb') + '<span>' + escHtml(myth) + '</span></div>';
+    body += '<div class="enc-myth">' + zi('bulb') + '<span>' + escHtml(myth) + '</span></div>';
   }
 
-  host.innerHTML = html;
-
-  // ── Section 4b: mild watch-fors — calm-secondary (spec §4.4), so they live in
-  // the collapse body the chevron toggles. The SEVERE strip above is never here.
-  var mild = (lead.watchFor && lead.watchFor.length) ? lead.watchFor.slice() : [];
-  if (moreHost) {
-    moreHost.innerHTML = mild.length
-      ? '<div class="cons-watch"><div class="cons-watch-h">Milder signs to watch for</div><ul class="cons-watch-list">' +
-          mild.map(function(w){ return '<li>' + escHtml(w) + '</li>'; }).join('') + '</ul></div>'
-      : '';
-  }
+  host.innerHTML = pinned;
+  if (moreHost) moreHost.innerHTML = body;
 
   // Encourage cards map to card-priority 'notable' (spec §4); honey → 'urgent'.
   _setCardPriority('infoNutIntroCard', 'notable');

--- a/tests/e2e/food-effects-v2-encourage-card.spec.ts
+++ b/tests/e2e/food-effects-v2-encourage-card.spec.ts
@@ -98,7 +98,7 @@ test.describe('food-effects-v2 — the encourage card (Phase γ)', () => {
     // "introduce each nut on its own, a few days apart" guidance — otherwise a
     // parent could offer a mixed almond/walnut/cashew paste at once and lose
     // the ability to attribute a reaction. Sourced per-food from the records.
-    const proto = page.locator('#infoNutIntro .enc-proto');
+    const proto = page.locator('#infoNutIntroCard .enc-proto');
     await expect(proto).toContainText(/each nut on its own|few days apart/i);
     // Both foods' keep-offering lines are labelled (no single peanut-only rhythm).
     await expect(proto.locator('.enc-proto-row', { hasText: /Keep offering — Tree nuts/ })).toHaveCount(1);
@@ -114,9 +114,36 @@ test.describe('food-effects-v2 — the encourage card (Phase γ)', () => {
   });
 
   test('the "delay" myth and the high-risk cohort note both reach the parent', async ({ page }) => {
-    await expect(page.locator('#infoNutIntro .enc-myth')).toBeVisible();
-    await expect(page.locator('#infoNutIntro .enc-myth')).toContainText(/delay/i);
+    // Both live in the collapse body (calm-secondary detail) — expand it, then
+    // assert they are reachable and correct.
+    await page.evaluate(() => {
+      const b = document.getElementById('infoNutIntroBody');
+      if (b) { b.classList.add('open'); (b as HTMLElement).style.display = ''; }
+    });
+    const myth = page.locator('#infoNutIntroCard .enc-myth');
+    await expect(myth).toBeVisible();
+    await expect(myth).toContainText(/delay/i);
     // High-risk note (eczema / known egg allergy → ask paediatrician) is present.
-    await expect(page.locator('#infoNutIntro .enc-highrisk')).toContainText(/eczema/i);
+    await expect(page.locator('#infoNutIntroCard .enc-highrisk')).toContainText(/eczema/i);
+  });
+
+  test('the card collapses meaningfully: the how-to detail is in the body, the floor is pinned', async ({ page }) => {
+    // The complaint γ-fix addresses: the card must collapse to a compact form,
+    // not sit permanently expanded. The how-to protocol (the bulk) is in the
+    // collapse body and hidden by default; the benefit + form gate + severe
+    // strip stay pinned and visible.
+    const proto = page.locator('#infoNutIntroBody .enc-proto');
+    await expect(proto).toHaveCount(1);            // the bulk IS in the collapse body
+    await expect(proto).toBeHidden();              // ...and collapsed by default
+    // Pinned essentials remain visible while collapsed:
+    await expect(page.locator('#infoNutIntro .enc-benefit')).toBeVisible();     // benefit leads
+    await expect(page.locator('#infoNutIntro .enc-form-note')).toBeVisible();   // never-whole / choking gate
+    await expect(page.locator('#infoNutIntro .cons-severe')).toBeVisible();     // emergency floor
+    // Expanding reveals the how-to detail.
+    await page.evaluate(() => {
+      const b = document.getElementById('infoNutIntroBody');
+      if (b) { b.classList.add('open'); (b as HTMLElement).style.display = ''; }
+    });
+    await expect(proto).toBeVisible();
   });
 });


### PR DESCRIPTION
## The report
The Phase γ encourage card (#187) read as **"always expanded and unable to collapse"** — it pinned benefit + introduce-safely + severe + myth all in the always-visible summary and left only the small mild-watch block in the collapse body, so the chevron toggled almost nothing.

## The fix (render-only — `intelligence-cards.js`)
Re-slot so the card collapses like every other Info card while the must-see content stays pinned and unfoldable:
- **Pinned (always visible):** benefit banner (encourage leads) → the **safe-form / never-whole choking gate** (A-2) → the **severe emergency strip** (A-1/V-1).
- **Collapse body (default collapsed):** the how-to protocol (amount/when/watch + per-food keep-offering) → high-risk advisory note → mild watch-fors → the "delay" myth.

It can't collapse to a single line like a generic card — the emergency floor *and* the choking gate must always be visible — but the chevron now toggles the bulk. Collapsed = why / what-not-to-do / emergency; expand for the how-to detail.

## canon-cc-008
Render-only (Vela's Region) + a **safety-pinning decision** (Maren's). Both audited the diff:
- **Vela** `clear-with-notes` — floor + choking gate genuinely pinned outside the accordion; collapse now meaningful; order coherent; one fold (V-δ-1, stale template comment) → folded.
- **Maren** `clear-with-notes` — traced the toggle end-to-end (the pinned `#infoNutIntro` is a *sibling* of the collapse body; the toggle can't reach it). Floor + choking gate hold (gate is "genuinely stronger"). Mild/high-risk collapse is Care-safe today because the **pinned `seekCare` line already names "a mild rash" + the action**; logged **M-δ-3** as a standing watch-item (pin the mild list if a per-baby high-risk signal is added or comprehension testing fails). **M-δ-4** §9.2 trip-wire correctly armed in-code for the future high-risk signal.
- **Cipher** Edict V — pending (this PR stays draft until it clears).

## Verification
`pnpm build` clean, 12 gates pass; γ spec **7/7** (incl. a new collapse-behavior guard: how-to in the body & hidden by default, benefit/form-gate/severe pinned-visible); v3-6 card-priority **22/22**; full suite pending.

https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK)_