### PR TITLE
Enforce repo rules via hooks (not a .clauderules file)

### DIFF
--- a/.claude/hooks/guard-bash.sh
+++ b/.claude/hooks/guard-bash.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) guard — blocks documented build antipatterns BEFORE they run.
+#
+# Claude Code hook protocol: tool JSON arrives on stdin; exit 2 + a stderr
+# message BLOCKS the tool call and shows the message to the agent. Any other
+# exit (incl. 0) allows it. FAIL-OPEN: any parse failure or unexpected input
+# exits 0 (allow) — a guard bug must never brick the agent.
+
+cmd="$(python3 -c 'import json,sys;
+try:
+    print(json.load(sys.stdin).get("tool_input",{}).get("command",""))
+except Exception:
+    pass' 2>/dev/null || true)"
+
+[ -z "${cmd:-}" ] && exit 0
+
+# PR #118 class: build.sh with merged STDERR leaks audit text into the HTML bundle.
+if printf '%s' "$cmd" | grep -qE 'build\.sh' && printf '%s' "$cmd" | grep -qE '2>&1'; then
+  echo "BLOCKED (PR #118 class): never invoke build.sh with 2>&1 — STDERR audit text leaks into the HTML and pollutes the rendered page. Use 'pnpm build' (split/build-safe.sh enforces the safe redirection)." >&2
+  exit 2
+fi
+
+# "NEVER use raw cat" to assemble the bundle (CLAUDE.md Build section).
+if printf '%s' "$cmd" | grep -qE '\bcat\b' && printf '%s' "$cmd" | grep -qE '(>>?)[[:space:]]*(\.\./)?(index|sproutlab)\.html'; then
+  echo "BLOCKED: do not assemble the bundle with raw cat. Use 'pnpm build' — the build injects DOCTYPE, <style>/<script> tags, and the Chart.js-then-Motion-One CDN order that a raw cat cannot reproduce." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/guard-edit.sh
+++ b/.claude/hooks/guard-edit.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# PreToolUse(Edit|Write) guard — protects the generated bundle from hand-edits.
+#
+# The root index.html / sproutlab.html are BUILD OUTPUTS (generated from split/*
+# by pnpm build). Hand-editing them is overwritten on the next build and bypasses
+# the audit gates. This guard blocks Edit/Write to those files specifically.
+#
+# Protocol: tool JSON on stdin; exit 2 + stderr = block. FAIL-OPEN on any error.
+
+fp="$(python3 -c 'import json,sys;
+try:
+    print(json.load(sys.stdin).get("tool_input",{}).get("file_path",""))
+except Exception:
+    pass' 2>/dev/null || true)"
+
+[ -z "${fp:-}" ] && exit 0
+
+base="$(basename "$fp")"
+case "$base" in
+  index.html|sproutlab.html)
+    # Only block the BUNDLE root copies: a sibling split/ dir is the reliable
+    # signal that this is the build-output root (not some unrelated index.html).
+    dir="$(cd "$(dirname "$fp")" 2>/dev/null && pwd || dirname "$fp")"
+    if [ -d "$dir/split" ]; then
+      echo "BLOCKED: $base is a BUILD OUTPUT (generated from split/* by 'pnpm build'). Edit the split/ source module and rebuild — a hand-edit here is overwritten on the next build and bypasses the audit gates." >&2
+      exit 2
+    fi
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -29,6 +29,18 @@
 
 set -euo pipefail
 
+# ── 0. Enforcement: activate this repo's git hooks (.githooks) every session ──
+# The hooks are DORMANT by default — git only honors .githooks after an explicit
+# `git config core.hooksPath .githooks`, which is per-clone and easy to forget.
+# Without it the pre-commit (HR-1/HR-12/icon-text) and pre-push (bundle-sync)
+# gates silently do not run. Activate idempotently for the repo this hook lives in.
+_SS_REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd || true)"
+if [ -n "${_SS_REPO:-}" ] && [ -e "$_SS_REPO/.git" ] && [ -d "$_SS_REPO/.githooks" ]; then
+  if git -C "$_SS_REPO" config core.hooksPath .githooks 2>/dev/null; then
+    echo "[hooks] git enforcement active: core.hooksPath -> .githooks ($_SS_REPO)" >&2
+  fi
+fi
+
 # ── 1. Locate the SproutLab repo (source of the Province mirror specs) ──
 _self_repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd || true)"
 SPROUTLAB=""

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,26 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-bash.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-edit.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,28 +1,39 @@
 #!/usr/bin/env bash
-# pre-commit — HR-1 emoji audit gate
-# Per Cipher Edict V round 2 §10 + Maren V-M-10 (PR #74 carry-forward).
+# pre-commit — fast universal HR audit gate (canon-cc-008 Gate-2 subset).
+# Per Cipher Edict V round 2 §10 + Maren V-M-10 (PR #74 carry-forward),
+# extended to the universal fast-audit set under the hook-enforcement work.
 #
-# One-time activation (per clone):
-#   git config core.hooksPath .githooks
+# Runs the cheap, always-valid audits on every commit and BLOCKS on violation:
+#   - audit-emoji.sh      HR-1   (no emoji)
+#   - audit-hr12-v3-3.sh  HR-12  (timezone-safe date construction)
+#   - audit-icon-text.sh         (icon/text integrity)
+# Heavier, feature-specific audits (food-effects-sync, card-priority, chip-
+# taxonomy, ...) stay at build time (build.sh), where they have full context.
 #
-# Runs split/audit-emoji.sh on the working tree before each commit and blocks
-# commits that introduce HR-1 violations. Catches the issue at the developer
-# feedback loop, before push.
-#
-# Emergency bypass: git commit --no-verify  (do NOT push HR-1 violations).
+# Activation: `git config core.hooksPath .githooks` — the SessionStart hook does
+# this automatically each Claude Code session. Emergency bypass: git commit
+# --no-verify  (do NOT push HR violations).
 
 set -e
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-AUDIT="$REPO_ROOT/split/audit-emoji.sh"
+GATES=(audit-emoji audit-hr12-v3-3 audit-icon-text)
 
-if [ ! -x "$AUDIT" ]; then
-  echo "pre-commit: split/audit-emoji.sh not found or not executable; skipping HR-1 audit" >&2
-  exit 0
-fi
+failed=0
+for g in "${GATES[@]}"; do
+  AUDIT="$REPO_ROOT/split/$g.sh"
+  if [ ! -x "$AUDIT" ]; then
+    echo "pre-commit: split/$g.sh missing or not executable; skipping that gate" >&2
+    continue
+  fi
+  if ! bash "$AUDIT"; then
+    echo "pre-commit: gate '$g' FAILED" >&2
+    failed=1
+  fi
+done
 
-if ! bash "$AUDIT"; then
+if [ "$failed" -ne 0 ]; then
   echo "" >&2
-  echo "pre-commit BLOCKED: HR-1 audit failed. Fix the violations listed above before committing." >&2
-  echo "Emergency bypass: git commit --no-verify  (do NOT push HR-1 violations)." >&2
+  echo "pre-commit BLOCKED: one or more HR audits failed (see above). Fix before committing." >&2
+  echo "Emergency bypass: git commit --no-verify  (do NOT push HR violations)." >&2
   exit 1
 fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# pre-push — bundle-sync + integrity gate.
+#
+# Catches the "edited split/ but forgot to rebuild" failure: if any BUNDLED
+# split source changed in the pushed range but root index.html was NOT rebuilt
+# in that same range, the deployed bundle would be stale. Also rejects a
+# structurally corrupt bundle. NON-MUTATING by design: it never runs build.sh
+# (which would bump manifest.json + regenerate docs) — it only inspects git.
+#
+# Activation via core.hooksPath (SessionStart hook sets it). Bypass: git push --no-verify.
+#
+# stdin protocol (git): <local_ref> <local_sha> <remote_ref> <remote_sha> per line.
+
+set -uo pipefail
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Files build.sh concatenates into the bundle (NOT the .sh/.mjs tooling).
+BUNDLE_RE='^split/(config|data|core|home|diet|medical|intelligence-[a-z-]+|sync|start)\.js$|^split/styles\.css$|^split/template\.html$'
+
+fail=0
+while read -r local_ref local_sha remote_ref remote_sha; do
+  [ -z "${local_sha:-}" ] && continue
+  # ref deletion (all-zero local sha) → nothing to check
+  case "$local_sha" in *[!0]*) : ;; *) continue ;; esac
+
+  if printf '%s' "${remote_sha:-}" | grep -qE '^0+$'; then
+    # new branch on remote: diff against the merge-base with origin/main
+    base="$(git merge-base origin/main "$local_sha" 2>/dev/null || true)"
+  else
+    base="$remote_sha"
+  fi
+
+  if [ -n "${base:-}" ]; then
+    range_files="$(git diff --name-only "$base" "$local_sha" 2>/dev/null || true)"
+  else
+    range_files="$(git show --pretty=format: --name-only "$local_sha" 2>/dev/null || true)"
+  fi
+
+  bundle_changed=0; index_changed=0
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    printf '%s\n' "$f" | grep -qE "$BUNDLE_RE" && bundle_changed=1
+    [ "$f" = "index.html" ] && index_changed=1
+  done <<EOF
+$range_files
+EOF
+
+  if [ "$bundle_changed" -eq 1 ] && [ "$index_changed" -eq 0 ]; then
+    echo "pre-push BLOCKED: bundled split/ sources changed but root index.html was NOT rebuilt in this push range ($local_ref)." >&2
+    echo "  The deployed bundle would be stale. Run:  pnpm build  &&  git add index.html sproutlab.html  &&  commit, then re-push." >&2
+    fail=1
+  fi
+done
+
+# Structural integrity of the committed bundle at the pushed tip (HEAD tree).
+if [ -f index.html ]; then
+  first="$(head -1 index.html)"; last="$(tail -1 index.html)"; size="$(wc -c < index.html)"
+  if [ "$first" != "<!DOCTYPE html>" ] || [ "$last" != "</html>" ] || [ "$size" -lt 102400 ]; then
+    echo "pre-push BLOCKED: root index.html is structurally invalid (DOCTYPE='$first', closing='$last', size=$size; need >100KB)." >&2
+    fail=1
+  fi
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "Emergency bypass: git push --no-verify." >&2
+  exit 1
+fi
+exit 0

--- a/docs/HOOK_ENFORCEMENT.md
+++ b/docs/HOOK_ENFORCEMENT.md
@@ -1,0 +1,52 @@
+# Hook Enforcement — SproutLab
+
+Rules in `CLAUDE.md` / `AGENTS.md` are *prose an agent may follow*. The hooks
+below are *gates that actually block*. Two layers: **git hooks** (block bad
+commits/pushes) and **Claude Code hooks** (block bad agent actions).
+
+> There is intentionally **no `.clauderules` file** — Claude Code reads
+> `CLAUDE.md`, not `.clauderules`; a third rules file would be inert and would
+> drift from the canon. Enforcement lives in hooks, not in a prose file.
+
+## Activation
+
+Git hooks are dormant until `core.hooksPath` points at `.githooks`. This is now
+**automatic**: `.claude/hooks/session-start.sh` runs
+`git config core.hooksPath .githooks` at the start of every Claude Code session
+(local and remote). For a plain terminal with no Claude session, activate once
+per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+## What is enforced
+
+### git: `.githooks/pre-commit` — fast universal HR audits (blocking)
+Runs on every commit; blocks on any violation:
+- `audit-emoji.sh` — **HR-1** (no emoji)
+- `audit-hr12-v3-3.sh` — **HR-12** (timezone-safe date construction)
+- `audit-icon-text.sh` — icon/text integrity
+
+Heavier, feature-specific audits (food-effects-sync, card-priority, chip-
+taxonomy, …) stay at build time (`build.sh`), where they have full context.
+
+Bypass (emergency only): `git commit --no-verify`.
+
+### git: `.githooks/pre-push` — bundle-sync + integrity (blocking, non-mutating)
+- **Stale-bundle:** if a *bundled* `split/` source (the `.js` modules + `styles.css` + `template.html`) changed in the pushed range but root `index.html` was not rebuilt in that range, the push is blocked — the deployed bundle would be stale. Fix: `pnpm build`, commit the rebuilt `index.html`/`sproutlab.html`, re-push.
+- **Integrity:** blocks if root `index.html` is not `<!DOCTYPE html>` … `</html>` and > 100 KB.
+
+It never runs `build.sh` (which would bump `manifest.json` + regenerate docs) — it only inspects git, so it cannot mutate your tree.
+
+Bypass: `git push --no-verify`.
+
+### Claude Code: `.claude/settings.json` PreToolUse guards (blocking, fail-open)
+- `guard-bash.sh` (matcher `Bash`) — blocks `build.sh … 2>&1` (the PR #118 STDERR-leak class) and raw-`cat` bundle assembly.
+- `guard-edit.sh` (matcher `Edit|Write`) — blocks hand-edits to the build outputs `index.html` / `sproutlab.html` (edit `split/` + rebuild instead).
+
+**Fail-open by design:** any parse error or unexpected input exits 0 (allow). A guard bug must never brick the agent — enforcement degrades to "no enforcement", never to "everything blocked".
+
+## Design notes
+- The pre-commit/pre-push scan the working tree / git ranges, not just the staged set — consistent with the existing emoji gate.
+- Guards block the *documented* "never do this" rules only; they are deliberately narrow to avoid false positives on legitimate commands.


### PR DESCRIPTION
## What & why

You asked for a `.clauderules` file. My take: that file is **inert** in Claude Code (which reads `CLAUDE.md`, not `.clauderules`) and would be a third rules source competing with the existing `CLAUDE.md` + `AGENTS.md` — a drift hazard against this repo's single-source doctrine. You agreed the real goal is **enforced rules → hooks**: rules that *block*, not prose an agent may ignore.

This wires that enforcement across two layers — **git hooks** (block bad commits/pushes) and **Claude Code hooks** (block bad agent actions).

## The gap this closes

Your git hooks were **dormant by default** — `.githooks/pre-commit` only fires after a manual per-clone `git config core.hooksPath .githooks` (the hook's own header says so). On a fresh clone, even HR-1 wasn't enforced. And only 1 of 12 audits ran at commit; the agent's documented "never do this" rules had zero mechanical guard.

## What's enforced

| Layer | Hook | Enforces |
|---|---|---|
| Activation | `session-start.sh` | runs `git config core.hooksPath .githooks` every session (local + remote) — gates are no longer dormant |
| git pre-commit | `.githooks/pre-commit` | HR-1 (emoji) + HR-12 (dates) + icon-text — blocks the commit |
| git pre-push | `.githooks/pre-push` | **bundle-sync** (bundled `split/` source changed but `index.html` not rebuilt → block) + DOCTYPE/closing-tag/size integrity. Non-mutating (never runs `build.sh`) |
| Claude PreToolUse | `guard-bash.sh` | blocks `build.sh … 2>&1` (PR #118 class) + raw-`cat` bundle assembly |
| Claude PreToolUse | `guard-edit.sh` | blocks hand-edits to built `index.html` / `sproutlab.html` |

Plus `docs/HOOK_ENFORCEMENT.md` (what/activation/bypass) and a note that there is deliberately **no `.clauderules`**.

## Tested (all paths)

- guards: block-bad (rc 2), allow-good (rc 0), **fail-open on malformed input** (rc 0 — a guard bug must never brick the agent)
- pre-commit: passes on clean tree; runs all 3 audits
- pre-push: **blocks** a stale-bundle range (core.js changed, index.html not rebuilt); allows clean ranges + integrity
- session-start: unset `core.hooksPath` → run → re-set to `.githooks`
- **dogfooded:** this PR's own commit cleared the new 3-gate pre-commit; the push cleared the new pre-push

## Notes

- Branched off `main`, separate from the graphify PR #186 (per your call) — independent concern, independent review.
- Bypass for emergencies: `git commit --no-verify` / `git push --no-verify`.
- This is hooks + docs only; no `split/` module or app bundle touched.

https://claude.ai/code/session_012RRaL72vn5NqRfYFsRZb5r

---
_Generated by [Claude Code](https://claude.ai/code/session_012RRaL72vn5NqRfYFsRZb5r)_