### PR TITLE
Fix companion subagent auto-load (robust paths + correct discovery dir)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,72 +1,122 @@
 #!/bin/bash
-# SessionStart hook — materializes the Companion subagent + skill specs from
-# both Provinces (SproutLab mirrors at sproutlab/.claude/, Codex canonicals at
-# Codex/docs/specs/) into ~/.claude/agents/ + ~/.claude/skills/ so the harness
-# can discover them as registered subagent_type values.
+# SessionStart hook — materialize Companion subagent + skill specs into the
+# harness's agent-discovery directories so the five seated Companions
+# (lyra, maren, kael, vela, cipher) plus the four scribes are available as
+# `subagent_type` values via the Agent tool.
 #
-# Why this exists: Claude Code on the web sets the primary working directory
-# to ~/ (above both repo roots) so multi-repo sessions can edit both Provinces.
-# The harness's agent-discovery pass at session start looks at <cwd>/.claude/
-# only — it does not descend into repo subdirectories. Without this hook, the
-# canon-cc-022 Companion subagents (maren, kael, vela, cipher, chronicler,
-# consul, scribes) cannot be summoned via the Agent tool.
+# WHY THE REWRITE (companion auto-load fix):
+# The harness discovers subagents at session start from `<cwd>/.claude/agents`
+# and `$HOME/.claude/agents`. In a MULTI-REPO web session the cwd is the PARENT
+# of the repos (e.g. /home/user, with repos at /home/user/sproutlab) and HOME may
+# be /root — so the repo's own committed specs (sproutlab/.claude/agents) are
+# never discovered, and `subagent_type: maren` fails ("Agent type not found"),
+# forcing a fallback to general-purpose agents wearing the persona by hand.
 #
-# Discipline: canon-cc-026 §Per-Province-Layout names sproutlab/.claude/ as
-# the Province mirror set, and Codex/docs/specs/ as the canonical authority.
-# Materialization order: sproutlab mirrors first, then Codex canonicals as
-# overlay (Codex wins on name collision — byte-identical for Cipher; catches
-# names that exist only in Codex like chronicler / consul).
+# The previous version hardcoded `$HOME` for BOTH the source (`$HOME/sproutlab`,
+# which does not exist when HOME=/root) and the target (`$HOME/.claude`, which is
+# not the cwd discovery dir). This rewrite resolves the repo from robust signals
+# (this script's own location, $CLAUDE_PROJECT_DIR, known paths) and writes the
+# specs to EVERY plausible discovery dir (the stdin `cwd`, $HOME, /home/user,
+# $CLAUDE_PROJECT_DIR, pwd) so the harness finds them wherever it looks.
 #
-# Web sessions only; local machines manage their own ~/.claude/ layout.
+# SYNCHRONOUS by design — NOT async. Materialization must finish BEFORE the
+# harness's discovery pass; an async hook would race it (the exact source of the
+# "lots of times it isn't loaded" intermittency).
+#
+# Safe to run from the environment setup script too (tolerates no stdin):
+#   bash /home/user/sproutlab/.claude/hooks/session-start.sh < /dev/null
+# Idempotent — re-running only re-copies byte-identical canonical specs.
+
 set -euo pipefail
 
-if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+# ── 1. Locate the SproutLab repo (source of the Province mirror specs) ──
+_self_repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd || true)"
+SPROUTLAB=""
+for cand in "$_self_repo" "${CLAUDE_PROJECT_DIR:-}" "/home/user/sproutlab" "$HOME/sproutlab"; do
+  if [ -n "${cand:-}" ] && [ -d "$cand/.claude/agents" ]; then SPROUTLAB="$cand"; break; fi
+done
+
+# ── 2. Locate Codex (canonical spec authority; overlay) ──
+CODEX=""
+_parent="$(dirname "${SPROUTLAB:-/home/user/sproutlab}")"
+for cand in "$_parent/Codex" "/home/user/Codex" "$HOME/Codex"; do
+  if [ -n "${cand:-}" ] && [ -d "$cand/docs/specs/subagents" ]; then CODEX="$cand"; break; fi
+done
+
+# ── 3. Determine the harness agent-discovery dir(s) ──
+# The harness reads <cwd>/.claude/agents and $HOME/.claude/agents. Read the cwd
+# from the SessionStart stdin JSON when present; always include $HOME and the
+# conventional /home/user so we cover every layout. Materialize to all of them.
+_stdin_cwd=""
+if [ ! -t 0 ]; then
+  _input="$(cat 2>/dev/null || true)"
+  if [ -n "${_input:-}" ]; then
+    _stdin_cwd="$(printf '%s' "$_input" | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("cwd",""))
+except Exception:
+    pass' 2>/dev/null || true)"
+  fi
+fi
+
+TARGETS=""
+for d in "$_stdin_cwd" "${CLAUDE_PROJECT_DIR:-}" "$HOME" "/home/user" "$(pwd)"; do
+  [ -z "${d:-}" ] && continue
+  # dedupe
+  case " $TARGETS " in *" $d "*) continue ;; esac
+  TARGETS="$TARGETS $d"
+done
+
+if [ -z "${SPROUTLAB:-}" ]; then
+  echo "[companions] could not locate the SproutLab repo; skipping (non-fatal)." >&2
   exit 0
 fi
 
-USER_AGENTS="$HOME/.claude/agents"
-USER_SKILLS="$HOME/.claude/skills"
-mkdir -p "$USER_AGENTS" "$USER_SKILLS"
-
-copied=0
-
-# SproutLab Province mirrors (canon-cc-026 §Per-Province-Layout)
-SPROUTLAB="$HOME/sproutlab"
-if [ -d "$SPROUTLAB/.claude/agents" ]; then
-  for f in "$SPROUTLAB/.claude/agents/"*.md; do
+# ── 4. Materialize: sproutlab mirrors first, then Codex canonicals as overlay ──
+# (canon-cc-026: Codex wins on name collision; catches names that exist only in
+# Codex such as chronicler / consul.)
+copy_specs() {
+  local src="$1" dst="$2"
+  [ -d "$src" ] || return 0
+  mkdir -p "$dst"
+  # Skip when dst resolves to the same dir as src (a target == the repo itself,
+  # e.g. cwd or $CLAUDE_PROJECT_DIR is the sproutlab root): the specs are already
+  # there, and cp'ing a file onto itself errors.
+  if [ "$(cd "$src" && pwd)" = "$(cd "$dst" && pwd)" ]; then return 0; fi
+  for f in "$src"/*.md; do
     [ -f "$f" ] || continue
-    cp -f "$f" "$USER_AGENTS/$(basename "$f")"
-    copied=$((copied + 1))
+    cp -f "$f" "$dst/$(basename "$f")"
   done
-fi
-if [ -d "$SPROUTLAB/.claude/skills" ]; then
-  for f in "$SPROUTLAB/.claude/skills/"*.md; do
-    [ -f "$f" ] || continue
-    cp -f "$f" "$USER_SKILLS/$(basename "$f")"
-    copied=$((copied + 1))
-  done
-fi
+}
 
-# Codex canonical bodies — overlay (Codex wins on name collision; catches
-# names that exist only in Codex: chronicler, consul, cipher-canonical).
-CODEX="$HOME/Codex"
-if [ -d "$CODEX/docs/specs/subagents" ]; then
-  for f in "$CODEX/docs/specs/subagents/"*.md; do
-    [ -f "$f" ] || continue
-    # Skip non-frontmatter files (rationale documents etc.)
-    head -1 "$f" | grep -q '^---$' || continue
-    cp -f "$f" "$USER_AGENTS/$(basename "$f")"
-    copied=$((copied + 1))
-  done
-fi
-if [ -d "$CODEX/docs/specs/skills" ]; then
-  for f in "$CODEX/docs/specs/skills/"*.md; do
-    [ -f "$f" ] || continue
-    head -1 "$f" | grep -q '^---$' || continue
-    cp -f "$f" "$USER_SKILLS/$(basename "$f")"
-    copied=$((copied + 1))
-  done
-fi
+total_dirs=0
+for base in $TARGETS; do
+  # Never materialize INTO a source repo's own tree. Its specs are already there,
+  # and the Codex overlay would otherwise corrupt the tracked sproutlab mirror
+  # (overwrite kael/lyra/... with Codex canonicals) and add Codex-only specs
+  # (chronicler/consul) to it. Skip the sproutlab + Codex repo roots as targets.
+  _rb="$(cd "$base" 2>/dev/null && pwd || echo "$base")"
+  [ "$_rb" = "$(cd "$SPROUTLAB" && pwd)" ] && continue
+  [ -n "${CODEX:-}" ] && [ "$_rb" = "$(cd "$CODEX" && pwd)" ] && continue
+  agents="$base/.claude/agents"; skills="$base/.claude/skills"
+  copy_specs "$SPROUTLAB/.claude/agents" "$agents"
+  copy_specs "$SPROUTLAB/.claude/skills" "$skills"
+  if [ -n "${CODEX:-}" ]; then
+    # Codex canonical bodies — overlay (skip non-frontmatter rationale files).
+    for sub in "subagents:$agents" "skills:$skills"; do
+      cdir="$CODEX/docs/specs/${sub%%:*}"; ddir="${sub##*:}"
+      [ -d "$cdir" ] || continue
+      mkdir -p "$ddir"
+      for f in "$cdir"/*.md; do
+        [ -f "$f" ] || continue
+        head -1 "$f" | grep -q '^---$' || continue   # frontmatter only
+        cp -f "$f" "$ddir/$(basename "$f")"
+      done
+    done
+  fi
+  n="$(ls "$agents" 2>/dev/null | wc -l)"
+  echo "[companions] $agents -> $n agent specs" >&2
+  total_dirs=$((total_dirs + 1))
+done
 
-echo "Companion subagents materialized to ~/.claude/ ($copied specs copied)." >&2
-echo "  Agents: $(ls "$USER_AGENTS" 2>/dev/null | wc -l) | Skills: $(ls "$USER_SKILLS" 2>/dev/null | wc -l)" >&2
+echo "[companions] materialized into $total_dirs discovery dir(s) from $SPROUTLAB${CODEX:+ + $CODEX}." >&2

--- a/docs/COMPANION_AUTOLOAD.md
+++ b/docs/COMPANION_AUTOLOAD.md
@@ -1,0 +1,45 @@
+# Companion Subagent Auto-Load
+
+The five seated Companions (`lyra`, `maren`, `kael`, `vela`, `cipher`) plus the
+four scribes must be available as `subagent_type` values in every SproutLab
+session. When they are not, summoning `maren` fails with *"Agent type 'maren'
+not found"* and the work falls back to general-purpose agents wearing the
+persona by hand — losing the canon-cc-022 separable-artifact guarantee.
+
+## What was broken
+
+The harness discovers subagents at session start from **`<cwd>/.claude/agents`**
+(and re-reads dynamically). In a multi-repo web session the cwd is the *parent*
+of the repos (e.g. `/home/user`, repos at `/home/user/sproutlab`) and `HOME` is
+`/root`. The old `session-start.sh` hook:
+
+1. **read the wrong source** — `$HOME/sproutlab` = `/root/sproutlab`, which does not exist;
+2. **wrote to the wrong target** — `$HOME/.claude/agents` = `/root/.claude/agents`, which is **not** the cwd discovery dir;
+3. **often did not run at all** — registered only in `sproutlab/.claude/settings.json`, which the harness does not read when cwd is the parent dir.
+
+Net effect: `/home/user/.claude/agents` stayed empty and the Companions were unavailable.
+
+## The fix (this branch)
+
+`.claude/hooks/session-start.sh` was rewritten to:
+- **resolve the repo robustly** — from the hook's own `BASH_SOURCE` location, then `$CLAUDE_PROJECT_DIR`, then known paths — never a hardcoded `$HOME`;
+- **materialize into every real discovery dir** — the stdin `cwd`, `$HOME`, `/home/user`, `$CLAUDE_PROJECT_DIR`, `pwd` — so the harness finds the specs wherever it looks;
+- **never write into a source repo's own tree** — skips the sproutlab + Codex roots as targets, so the tracked mirror is never overwritten and Codex-only specs (`chronicler`/`consul`) never leak into it;
+- run **synchronously** (not async) so materialization completes before discovery — async would re-introduce the race.
+
+Validated: after the hook runs, `/home/user/.claude/agents` holds all 11 specs and `subagent_type: maren` resolves (returned `MAREN-PROBE-OK` live).
+
+## Guaranteeing it runs (multi-repo)
+
+For single-repo sessions the repo's `.claude/settings.json` SessionStart hook
+fires normally. For **multi-repo** sessions (cwd above the repos) the most
+reliable guarantee is to call the same script from the **environment setup
+script** (Settings → environment → setup), which runs before the harness:
+
+```bash
+bash /home/user/sproutlab/.claude/hooks/session-start.sh < /dev/null
+```
+
+The script is idempotent and tolerates no stdin, so it is safe to run there and
+again as a SessionStart hook. Once merged to the default branch, every future
+session picks up the corrected hook.


### PR DESCRIPTION
## What & why

The five seated Companions (`lyra`/`maren`/`kael`/`vela`/`cipher`) + four scribes were often **not loaded** as `subagent_type` values, so summoning `maren` failed with *"Agent type not found"* and work fell back to general-purpose agents wearing the persona by hand — losing the canon-cc-022 separable-artifact guarantee. (Hit live this very session.)

## Root cause — three stacked bugs

The harness discovers subagents from **`<cwd>/.claude/agents`** and re-reads dynamically. In a multi-repo web session, `cwd=/home/user` (parent of the repos) and `HOME=/root`. The old `session-start.sh`:

1. **wrong source** — read `$HOME/sproutlab` = `/root/sproutlab` (doesn't exist);
2. **wrong target** — wrote to `$HOME/.claude/agents` = `/root/.claude/agents` (not the cwd discovery dir);
3. **often didn't run** — registered only in `sproutlab/.claude/settings.json`, which the harness doesn't read when cwd is the parent dir.

The `HOME=/root` vs `cwd=/home/user` split is the spine of all three.

## Fix

Rewrote `.claude/hooks/session-start.sh` to:
- resolve the repo from `BASH_SOURCE` / `$CLAUDE_PROJECT_DIR` / known paths — **never hardcoded `$HOME`**;
- materialize into **every real discovery dir** (stdin `cwd`, `$HOME`, `/home/user`, `$CLAUDE_PROJECT_DIR`, `pwd`), deduped;
- **skip the sproutlab + Codex repo roots as targets** — so the tracked mirror is never overwritten and Codex-only specs (`chronicler`/`consul`) never leak into it (a bug I caught and fixed mid-development);
- run **synchronously**, so materialization completes before discovery (async would re-race it).

## Validated live

After the hook runs, `/home/user/.claude/agents` holds all 11 specs, the tracked repo mirror is untouched, and **`subagent_type: maren` resolves** (returned `MAREN-PROBE-OK`). Idempotent + env-setup-safe (tolerates no stdin).

## Guaranteeing it runs in multi-repo sessions

The in-repo hook fixes correctness whenever it runs. For multi-repo sessions (cwd above the repos), the reliable guarantee is one line in your **environment setup script**:

```bash
bash /home/user/sproutlab/.claude/hooks/session-start.sh < /dev/null
```

`docs/COMPANION_AUTOLOAD.md` documents the mechanism + this wiring.

## Notes

- New dedicated branch off `main` (per your call). `session-start.sh` is also touched by #186 (graphify bootstrap) and #190 (hooksPath activation) — a merge-resolution item when these land; this PR is the foundational paths fix.
- Hooks + docs only; no `split/` module or app bundle touched → tooling/docs, no canon-cc-008 chain required (flag if you want one anyway).

https://claude.ai/code/session_012RRaL72vn5NqRfYFsRZb5r

---
_Generated by [Claude Code](https://claude.ai/code/session_012RRaL72vn5NqRfYFsRZb5r)_