### PR TITLE
chore: refresh PROVINCE_MAP.html graph artifact

### DIFF
--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-05-31 &middot; graph @ <code>4689ed42a6cd</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-05-31 &middot; graph @ <code>d68016bef50d</code></div>
   <div class="sub" style="margin-top:8px">
     <span class="stat"><b>1,713</b> symbols</span>
-    <span class="stat"><b>5,082</b> relations</span>
-    <span class="stat"><b>79,991</b> LOC</span>
+    <span class="stat"><b>5,086</b> relations</span>
+    <span class="stat"><b>80,194</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -98,15 +98,15 @@
       <div class="cgov">Governor: <b>Vela</b></div>
       <div class="nums">
         <span><b>2</b> modules</span>
-        <span><b>180</b> symbols</span>
-        <span><b>8,428</b> LOC</span>
+        <span><b>181</b> symbols</span>
+        <span><b>8,579</b> LOC</span>
       </div>
       
-      <div class="bar" title="8,428 of 30,000 LOC">
-        <div class="fill " style="width:28%"></div>
-        <span class="barlbl">28% to 30K frontier</span>
+      <div class="bar" title="8,579 of 30,000 LOC">
+        <div class="fill " style="width:29%"></div>
+        <span class="barlbl">29% to 30K frontier</span>
       </div>
-      <div class="hd">21,572 LOC headroom</div>
+      <div class="hd">21,421 LOC headroom</div>
       <div class="mods">i-quicklog.js, i-cards.js</div>
     </div>
     <div class="card" style="border-top:5px solid #e8b86d">
@@ -116,7 +116,7 @@
       <div class="nums">
         <span><b>2</b> modules</span>
         <span><b>0</b> symbols</span>
-        <span><b>13,964</b> LOC</span>
+        <span><b>14,016</b> LOC</span>
       </div>
       <div class="note">Unsurveyed &mdash; code-only extraction. Set a backend and rebuild for symbols.</div>
       <div class="mods">styles.css, template.html</div>
@@ -127,7 +127,7 @@
       <div class="cgov">Governor: <b>(tooling)</b></div>
       <div class="nums">
         <span><b>21</b> modules</span>
-        <span><b>138</b> symbols</span>
+        <span><b>137</b> symbols</span>
         <span><b>3,683</b> LOC</span>
       </div>
       
@@ -137,13 +137,13 @@
   <h2>Cross-province coupling (highest-traffic calls across jurisdiction borders)</h2>
   <table>
     <thead><tr><th>Module</th><th>Module</th><th class="num">Calls</th><th>Border</th></tr></thead>
-    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">118</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">31</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
+    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">118</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">33</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
   </table>
 
   <h2>Connectivity hubs (highest call-degree symbols per module)</h2>
   <table>
     <thead><tr><th>Symbol</th><th>Module</th><th>Province</th><th class="num">Degree (calls)</th></tr></thead>
-    <tbody><tr><td><code>zi()</code></td><td>core.js</td><td>Intelligence</td><td class="num">323</td></tr><tr><td><code>showQLToast()</code></td><td>i-quicklog.js</td><td>Surfacing</td><td class="num">69</td></tr><tr><td><code>qaExecuteQuery()</code></td><td>i-qa.js</td><td>Intelligence</td><td class="num">50</td></tr><tr><td><code>renderInfo()</code></td><td>i-cards.js</td><td>Surfacing</td><td class="num">49</td></tr><tr><td><code>renderHome()</code></td><td>home.js</td><td>Care</td><td class="num">47</td></tr><tr><td><code>getDailySleepScore()</code></td><td>medical.js</td><td>Care</td><td class="num">33</td></tr><tr><td><code>_islMarkDirty()</code></td><td>i-isl.js</td><td>Intelligence</td><td class="num">28</td></tr><tr><td><code>ctHandleOverlayAction()</code></td><td>i-caretickets.js</td><td>Intelligence</td><td class="num">27</td></tr><tr><td><code>renderFeverEpisodeCard()</code></td><td>i-illness.js</td><td>Intelligence</td><td class="num">23</td></tr></tbody>
+    <tbody><tr><td><code>zi()</code></td><td>core.js</td><td>Intelligence</td><td class="num">324</td></tr><tr><td><code>showQLToast()</code></td><td>i-quicklog.js</td><td>Surfacing</td><td class="num">69</td></tr><tr><td><code>renderInfo()</code></td><td>i-cards.js</td><td>Surfacing</td><td class="num">50</td></tr><tr><td><code>qaExecuteQuery()</code></td><td>i-qa.js</td><td>Intelligence</td><td class="num">50</td></tr><tr><td><code>renderHome()</code></td><td>home.js</td><td>Care</td><td class="num">47</td></tr><tr><td><code>getDailySleepScore()</code></td><td>medical.js</td><td>Care</td><td class="num">33</td></tr><tr><td><code>_islMarkDirty()</code></td><td>i-isl.js</td><td>Intelligence</td><td class="num">28</td></tr><tr><td><code>ctHandleOverlayAction()</code></td><td>i-caretickets.js</td><td>Intelligence</td><td class="num">27</td></tr><tr><td><code>renderFeverEpisodeCard()</code></td><td>i-illness.js</td><td>Intelligence</td><td class="num">23</td></tr></tbody>
   </table>
 </main>
 <footer>


### PR DESCRIPTION
## Summary

Refreshes the auto-generated, graph-derived `docs/PROVINCE_MAP.html` exec summary — the only committed graph artifact per CLAUDE.md. A build regenerated it (most likely during environment setup) and updated its numbers; no `split/` source files changed.

### What shifted
- graph hash `4689ed42…` → `d68016bef50d`
- LOC `79,991` → `80,194`, relations `5,082` → `5,086`
- Vela (Surfacing) region +1 symbol / +151 LOC; minor call-degree count updates (`zi()` 323→324, `renderInfo()` 49→50)

### QA gate (canon-cc-008)
Build-artifact-only change — no source module touched, so the Governor audit is **waived** (docs/generated-only). Pre-commit audit gates passed: HR-1 emoji (0 violations), HR-12 date construction (PASS), icon-text (PASS).

Draft until an Architect confirms.

https://claude.ai/code/session_01RTXACxPARA6zsh5MRsFmQ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTXACxPARA6zsh5MRsFmQ9)_