### PR TITLE
R0: negation-leak guard in _lookupByFoodName (food-effects v2 #189)

### DIFF
--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-05-31 &middot; graph @ <code>b14e26fa914b</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-05-31 &middot; graph @ <code>e7a1dfcdf7bd</code></div>
   <div class="sub" style="margin-top:8px">
     <span class="stat"><b>1,714</b> symbols</span>
     <span class="stat"><b>5,086</b> relations</span>
-    <span class="stat"><b>80,208</b> LOC</span>
+    <span class="stat"><b>80,214</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -65,14 +65,14 @@
       <div class="nums">
         <span><b>11</b> modules</span>
         <span><b>729</b> symbols</span>
-        <span><b>27,044</b> LOC</span>
+        <span><b>27,050</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,044 of 30,000 LOC">
+      <div class="bar" title="27,050 of 30,000 LOC">
         <div class="fill hot" style="width:90%"></div>
         <span class="barlbl">90% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,956 LOC headroom</div>
+      <div class="hd">2,950 LOC headroom</div>
       <div class="mods">core.js, i-illness.js, i-caretickets.js, i-qa-handlers.js, sync.js, data.js, i-qa.js, i-isl.js, config.js, i-correlate.js, start.js</div>
     </div>
     <div class="card" style="border-top:5px solid #b5d5c5">

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-05-31 &middot; graph @ <code>d68016bef50d</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-05-31 &middot; graph @ <code>b14e26fa914b</code></div>
   <div class="sub" style="margin-top:8px">
-    <span class="stat"><b>1,713</b> symbols</span>
+    <span class="stat"><b>1,714</b> symbols</span>
     <span class="stat"><b>5,086</b> relations</span>
-    <span class="stat"><b>80,194</b> LOC</span>
+    <span class="stat"><b>80,208</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -64,15 +64,15 @@
       <div class="cgov">Governor: <b>Kael</b></div>
       <div class="nums">
         <span><b>11</b> modules</span>
-        <span><b>728</b> symbols</span>
-        <span><b>27,024</b> LOC</span>
+        <span><b>729</b> symbols</span>
+        <span><b>27,044</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,024 of 30,000 LOC">
+      <div class="bar" title="27,044 of 30,000 LOC">
         <div class="fill hot" style="width:90%"></div>
         <span class="barlbl">90% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,976 LOC headroom</div>
+      <div class="hd">2,956 LOC headroom</div>
       <div class="mods">core.js, i-illness.js, i-caretickets.js, i-qa-handlers.js, sync.js, data.js, i-qa.js, i-isl.js, config.js, i-correlate.js, start.js</div>
     </div>
     <div class="card" style="border-top:5px solid #b5d5c5">
@@ -81,15 +81,15 @@
       <div class="cgov">Governor: <b>Maren</b></div>
       <div class="nums">
         <span><b>3</b> modules</span>
-        <span><b>667</b> symbols</span>
-        <span><b>26,892</b> LOC</span>
+        <span><b>668</b> symbols</span>
+        <span><b>27,021</b> LOC</span>
       </div>
       
-      <div class="bar" title="26,892 of 30,000 LOC">
+      <div class="bar" title="27,021 of 30,000 LOC">
         <div class="fill hot" style="width:90%"></div>
         <span class="barlbl">90% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">3,108 LOC headroom</div>
+      <div class="hd">2,979 LOC headroom</div>
       <div class="mods">home.js, medical.js, diet.js</div>
     </div>
     <div class="card" style="border-top:5px solid #c9b8e8">
@@ -98,15 +98,15 @@
       <div class="cgov">Governor: <b>Vela</b></div>
       <div class="nums">
         <span><b>2</b> modules</span>
-        <span><b>181</b> symbols</span>
-        <span><b>8,579</b> LOC</span>
+        <span><b>180</b> symbols</span>
+        <span><b>8,428</b> LOC</span>
       </div>
       
-      <div class="bar" title="8,579 of 30,000 LOC">
-        <div class="fill " style="width:29%"></div>
-        <span class="barlbl">29% to 30K frontier</span>
+      <div class="bar" title="8,428 of 30,000 LOC">
+        <div class="fill " style="width:28%"></div>
+        <span class="barlbl">28% to 30K frontier</span>
       </div>
-      <div class="hd">21,421 LOC headroom</div>
+      <div class="hd">21,572 LOC headroom</div>
       <div class="mods">i-quicklog.js, i-cards.js</div>
     </div>
     <div class="card" style="border-top:5px solid #e8b86d">
@@ -116,7 +116,7 @@
       <div class="nums">
         <span><b>2</b> modules</span>
         <span><b>0</b> symbols</span>
-        <span><b>14,016</b> LOC</span>
+        <span><b>14,017</b> LOC</span>
       </div>
       <div class="note">Unsurveyed &mdash; code-only extraction. Set a backend and rebuild for symbols.</div>
       <div class="mods">styles.css, template.html</div>
@@ -128,7 +128,7 @@
       <div class="nums">
         <span><b>21</b> modules</span>
         <span><b>137</b> symbols</span>
-        <span><b>3,683</b> LOC</span>
+        <span><b>3,698</b> LOC</span>
       </div>
       
       <div class="mods">build-province-map.mjs, build-poop-reference.mjs, QA_GATE_SPEC.md, build-careticket-state-machine.mjs, audit-food-library-wiring-v1.sh, bump-version.mjs, build-graph.sh, audit-activity-categories-v1.sh, audit-card-priority-v3-6.sh, audit-chip-taxonomy-v3-5.sh, audit-emoji.sh, audit-feed-sheet-wiring-v1.sh, audit-food-effects-sync-v1.sh, audit-hr12-v3-3.sh, audit-icon-text.sh, audit-no-personalised-prediction-v1.sh, audit-resolve-shield.sh, audit-viz-smoke.sh, build-safe.sh, build.sh, qa-route.sh</div>
@@ -137,13 +137,13 @@
   <h2>Cross-province coupling (highest-traffic calls across jurisdiction borders)</h2>
   <table>
     <thead><tr><th>Module</th><th>Module</th><th class="num">Calls</th><th>Border</th></tr></thead>
-    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">118</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">33</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
+    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">120</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">31</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
   </table>
 
   <h2>Connectivity hubs (highest call-degree symbols per module)</h2>
   <table>
     <thead><tr><th>Symbol</th><th>Module</th><th>Province</th><th class="num">Degree (calls)</th></tr></thead>
-    <tbody><tr><td><code>zi()</code></td><td>core.js</td><td>Intelligence</td><td class="num">324</td></tr><tr><td><code>showQLToast()</code></td><td>i-quicklog.js</td><td>Surfacing</td><td class="num">69</td></tr><tr><td><code>renderInfo()</code></td><td>i-cards.js</td><td>Surfacing</td><td class="num">50</td></tr><tr><td><code>qaExecuteQuery()</code></td><td>i-qa.js</td><td>Intelligence</td><td class="num">50</td></tr><tr><td><code>renderHome()</code></td><td>home.js</td><td>Care</td><td class="num">47</td></tr><tr><td><code>getDailySleepScore()</code></td><td>medical.js</td><td>Care</td><td class="num">33</td></tr><tr><td><code>_islMarkDirty()</code></td><td>i-isl.js</td><td>Intelligence</td><td class="num">28</td></tr><tr><td><code>ctHandleOverlayAction()</code></td><td>i-caretickets.js</td><td>Intelligence</td><td class="num">27</td></tr><tr><td><code>renderFeverEpisodeCard()</code></td><td>i-illness.js</td><td>Intelligence</td><td class="num">23</td></tr></tbody>
+    <tbody><tr><td><code>zi()</code></td><td>core.js</td><td>Intelligence</td><td class="num">324</td></tr><tr><td><code>showQLToast()</code></td><td>i-quicklog.js</td><td>Surfacing</td><td class="num">69</td></tr><tr><td><code>qaExecuteQuery()</code></td><td>i-qa.js</td><td>Intelligence</td><td class="num">50</td></tr><tr><td><code>renderInfo()</code></td><td>i-cards.js</td><td>Surfacing</td><td class="num">49</td></tr><tr><td><code>renderHome()</code></td><td>home.js</td><td>Care</td><td class="num">47</td></tr><tr><td><code>getDailySleepScore()</code></td><td>medical.js</td><td>Care</td><td class="num">33</td></tr><tr><td><code>_islMarkDirty()</code></td><td>i-isl.js</td><td>Intelligence</td><td class="num">28</td></tr><tr><td><code>ctHandleOverlayAction()</code></td><td>i-caretickets.js</td><td>Intelligence</td><td class="num">27</td></tr><tr><td><code>renderFeverEpisodeCard()</code></td><td>i-illness.js</td><td>Intelligence</td><td class="num">23</td></tr></tbody>
   </table>
 </main>
 <footer>

--- a/index.html
+++ b/index.html
@@ -23328,6 +23328,25 @@ function confirmAction(msg, callback, btnText) {
 // without `aliases` (honey, every legacy AGE_RULES/ALLERGENS entry) are
 // unchanged. Kept self-contained (no external helper) because the build audit
 // gate extracts and evals this function in isolation.
+// food-effects v2 R0 (spec §6) — negation-leak guard. The word-boundary tier in
+// _lookupByFoodName treats '-' as a boundary, so a bare \bpeanut\b matches inside
+// "peanut-free" and \bgroundnut\b inside "no groundnut" — a logged/queried
+// AVOIDANCE then resolves to the food (a green "introduce peanut" + anaphylaxis
+// floor on a food the parent EXCLUDED is strictly worse than the legacy caution).
+// This returns true when `token` is governed by an exclusion in `hay`. Keyed on
+// the SPECIFIC matched token, so a non-negated food in the same string still
+// resolves ("apple (no nuts)" → apple; "(no nuts)" alone → nothing).
+function _foodNameNegated(hay, token) {
+  if (!hay || !token) return false;
+  const t = String(token).toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // suffix form: "<token>-free" / "<token> free"  (peanut-free, nut free, dairy-free)
+  if (new RegExp('\\b' + t + '[\\s-]+free\\b').test(hay)) return true;
+  // prefix form: "no <token>" / "without <token>" / "free of|from <token>"
+  // (tolerates up to two filler words: "no added nuts", "without any peanut")
+  if (new RegExp('\\b(?:no|without|free\\s+of|free\\s+from)\\b(?:\\s+\\w+){0,2}\\s+' + t + '\\b').test(hay)) return true;
+  return false;
+}
+
 function _lookupByFoodName(table, name) {
   if (!table || !name) return null;
   const n = String(name).toLowerCase().trim();
@@ -23335,10 +23354,11 @@ function _lookupByFoodName(table, name) {
   const dep = n.replace(/s$/, '');
   if (table[dep]) return table[dep];
   const wb = (token) => new RegExp('\\b' + String(token).replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b').test(n);
-  const byKey = Object.entries(table).find(([k]) => wb(k));
+  // R0: the word-boundary tiers must skip any candidate negated in `n` (§6).
+  const byKey = Object.entries(table).find(([k]) => wb(k) && !_foodNameNegated(n, k));
   if (byKey) return byKey[1];
   const byAlias = Object.values(table).find(v =>
-    v && Array.isArray(v.aliases) && v.aliases.some(a => wb(a)));
+    v && Array.isArray(v.aliases) && v.aliases.some(a => wb(a) && !_foodNameNegated(n, a)));
   return byAlias || null;
 }
 

--- a/index.html
+++ b/index.html
@@ -23341,9 +23341,15 @@ function _foodNameNegated(hay, token) {
   const t = String(token).toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   // suffix form: "<token>-free" / "<token> free"  (peanut-free, nut free, dairy-free)
   if (new RegExp('\\b' + t + '[\\s-]+free\\b').test(hay)) return true;
-  // prefix form: "no <token>" / "without <token>" / "free of|from <token>"
-  // (tolerates up to two filler words: "no added nuts", "without any peanut")
-  if (new RegExp('\\b(?:no|without|free\\s+of|free\\s+from)\\b(?:\\s+\\w+){0,2}\\s+' + t + '\\b').test(hay)) return true;
+  // prefix form: "no <token>" / "without <token>" / "free of|from <token>". Only a
+  // pure intensifier ("added"/"any") may sit between the negator and the token —
+  // NOT an arbitrary filler window. M-R0-N (Maren, R0 ripple): a {0,2}-word window
+  // let "no" bind ACROSS an unrelated noun to a real food ("no salt almond" →
+  // almond was GIVEN, just salt-free) and drop its allergen record — a dropped
+  // warning, worse than the spurious match R0 fixes. The negator must govern the
+  // token directly: "no added nuts" / "without any peanut" still match;
+  // "no salt almond" / "no added sugar peanut" must NOT (those are exposures).
+  if (new RegExp('\\b(?:no|without|free\\s+of|free\\s+from)\\s+(?:added\\s+|any\\s+)?' + t + '\\b').test(hay)) return true;
   return false;
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.31-14",
+  "version": "2026.05.31-15",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.31-15",
+  "version": "2026.05.31-21",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/audit-food-effects-sync-v1.sh
+++ b/split/audit-food-effects-sync-v1.sh
@@ -135,13 +135,28 @@ function fail2(msg) { console.log(msg); process.exit(2); }
 let _lookupByFoodName;
 try {
   const coreSrc = fs.readFileSync(CORE, 'utf8');
+  // Pull the full source of any helper the resolver depends on (R0 negation
+  // guard, food-effects v2 §6: _lookupByFoodName now calls _foodNameNegated).
+  // The dependency must be in scope when the extracted resolver runs, or the
+  // self-test throws ReferenceError. Extract each present helper verbatim and
+  // declare it inside the eval IIFE the resolver closes over.
+  const extractFn = (name) => {
+    const s = coreSrc.indexOf('function ' + name);
+    if (s < 0) return '';
+    const b = extractBalanced(coreSrc, s, '{', '}');
+    const h = coreSrc.indexOf('{', s);
+    if (!b || h < 0) throw new Error('could not brace-match ' + name + ' body');
+    return coreSrc.slice(s, h) + b;
+  };
+  const deps = ['_foodNameNegated'].map(extractFn).filter(Boolean).join('\n');
   const fnStart = coreSrc.indexOf('function _lookupByFoodName');
   if (fnStart < 0) throw new Error('function _lookupByFoodName not found in ' + CORE);
   const body = extractBalanced(coreSrc, fnStart, '{', '}');
   const headerEnd = coreSrc.indexOf('{', fnStart);
   if (!body || headerEnd < 0) throw new Error('could not brace-match _lookupByFoodName body');
   const header = coreSrc.slice(fnStart, headerEnd); // "function _lookupByFoodName(table, name) "
-  _lookupByFoodName = eval('(' + header + body + ')'); // eslint-disable-line no-eval
+  // eslint-disable-next-line no-eval
+  _lookupByFoodName = eval('(function(){ ' + deps + '\nreturn (' + header + body + '); })()');
 } catch (e) {
   fail2('audit-food-effects-sync-v1: SELF-TEST FAIL — could not extract _lookupByFoodName from ' +
         CORE + ' (' + e.message + '). The audit cannot verify resolution without the live resolver.');

--- a/split/core.js
+++ b/split/core.js
@@ -4000,6 +4000,25 @@ function confirmAction(msg, callback, btnText) {
 // without `aliases` (honey, every legacy AGE_RULES/ALLERGENS entry) are
 // unchanged. Kept self-contained (no external helper) because the build audit
 // gate extracts and evals this function in isolation.
+// food-effects v2 R0 (spec §6) — negation-leak guard. The word-boundary tier in
+// _lookupByFoodName treats '-' as a boundary, so a bare \bpeanut\b matches inside
+// "peanut-free" and \bgroundnut\b inside "no groundnut" — a logged/queried
+// AVOIDANCE then resolves to the food (a green "introduce peanut" + anaphylaxis
+// floor on a food the parent EXCLUDED is strictly worse than the legacy caution).
+// This returns true when `token` is governed by an exclusion in `hay`. Keyed on
+// the SPECIFIC matched token, so a non-negated food in the same string still
+// resolves ("apple (no nuts)" → apple; "(no nuts)" alone → nothing).
+function _foodNameNegated(hay, token) {
+  if (!hay || !token) return false;
+  const t = String(token).toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // suffix form: "<token>-free" / "<token> free"  (peanut-free, nut free, dairy-free)
+  if (new RegExp('\\b' + t + '[\\s-]+free\\b').test(hay)) return true;
+  // prefix form: "no <token>" / "without <token>" / "free of|from <token>"
+  // (tolerates up to two filler words: "no added nuts", "without any peanut")
+  if (new RegExp('\\b(?:no|without|free\\s+of|free\\s+from)\\b(?:\\s+\\w+){0,2}\\s+' + t + '\\b').test(hay)) return true;
+  return false;
+}
+
 function _lookupByFoodName(table, name) {
   if (!table || !name) return null;
   const n = String(name).toLowerCase().trim();
@@ -4007,10 +4026,11 @@ function _lookupByFoodName(table, name) {
   const dep = n.replace(/s$/, '');
   if (table[dep]) return table[dep];
   const wb = (token) => new RegExp('\\b' + String(token).replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b').test(n);
-  const byKey = Object.entries(table).find(([k]) => wb(k));
+  // R0: the word-boundary tiers must skip any candidate negated in `n` (§6).
+  const byKey = Object.entries(table).find(([k]) => wb(k) && !_foodNameNegated(n, k));
   if (byKey) return byKey[1];
   const byAlias = Object.values(table).find(v =>
-    v && Array.isArray(v.aliases) && v.aliases.some(a => wb(a)));
+    v && Array.isArray(v.aliases) && v.aliases.some(a => wb(a) && !_foodNameNegated(n, a)));
   return byAlias || null;
 }
 

--- a/split/core.js
+++ b/split/core.js
@@ -4013,9 +4013,15 @@ function _foodNameNegated(hay, token) {
   const t = String(token).toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   // suffix form: "<token>-free" / "<token> free"  (peanut-free, nut free, dairy-free)
   if (new RegExp('\\b' + t + '[\\s-]+free\\b').test(hay)) return true;
-  // prefix form: "no <token>" / "without <token>" / "free of|from <token>"
-  // (tolerates up to two filler words: "no added nuts", "without any peanut")
-  if (new RegExp('\\b(?:no|without|free\\s+of|free\\s+from)\\b(?:\\s+\\w+){0,2}\\s+' + t + '\\b').test(hay)) return true;
+  // prefix form: "no <token>" / "without <token>" / "free of|from <token>". Only a
+  // pure intensifier ("added"/"any") may sit between the negator and the token —
+  // NOT an arbitrary filler window. M-R0-N (Maren, R0 ripple): a {0,2}-word window
+  // let "no" bind ACROSS an unrelated noun to a real food ("no salt almond" →
+  // almond was GIVEN, just salt-free) and drop its allergen record — a dropped
+  // warning, worse than the spurious match R0 fixes. The negator must govern the
+  // token directly: "no added nuts" / "without any peanut" still match;
+  // "no salt almond" / "no added sugar peanut" must NOT (those are exposures).
+  if (new RegExp('\\b(?:no|without|free\\s+of|free\\s+from)\\s+(?:added\\s+|any\\s+)?' + t + '\\b').test(hay)) return true;
   return false;
 }
 

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -23328,6 +23328,25 @@ function confirmAction(msg, callback, btnText) {
 // without `aliases` (honey, every legacy AGE_RULES/ALLERGENS entry) are
 // unchanged. Kept self-contained (no external helper) because the build audit
 // gate extracts and evals this function in isolation.
+// food-effects v2 R0 (spec §6) — negation-leak guard. The word-boundary tier in
+// _lookupByFoodName treats '-' as a boundary, so a bare \bpeanut\b matches inside
+// "peanut-free" and \bgroundnut\b inside "no groundnut" — a logged/queried
+// AVOIDANCE then resolves to the food (a green "introduce peanut" + anaphylaxis
+// floor on a food the parent EXCLUDED is strictly worse than the legacy caution).
+// This returns true when `token` is governed by an exclusion in `hay`. Keyed on
+// the SPECIFIC matched token, so a non-negated food in the same string still
+// resolves ("apple (no nuts)" → apple; "(no nuts)" alone → nothing).
+function _foodNameNegated(hay, token) {
+  if (!hay || !token) return false;
+  const t = String(token).toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  // suffix form: "<token>-free" / "<token> free"  (peanut-free, nut free, dairy-free)
+  if (new RegExp('\\b' + t + '[\\s-]+free\\b').test(hay)) return true;
+  // prefix form: "no <token>" / "without <token>" / "free of|from <token>"
+  // (tolerates up to two filler words: "no added nuts", "without any peanut")
+  if (new RegExp('\\b(?:no|without|free\\s+of|free\\s+from)\\b(?:\\s+\\w+){0,2}\\s+' + t + '\\b').test(hay)) return true;
+  return false;
+}
+
 function _lookupByFoodName(table, name) {
   if (!table || !name) return null;
   const n = String(name).toLowerCase().trim();
@@ -23335,10 +23354,11 @@ function _lookupByFoodName(table, name) {
   const dep = n.replace(/s$/, '');
   if (table[dep]) return table[dep];
   const wb = (token) => new RegExp('\\b' + String(token).replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b').test(n);
-  const byKey = Object.entries(table).find(([k]) => wb(k));
+  // R0: the word-boundary tiers must skip any candidate negated in `n` (§6).
+  const byKey = Object.entries(table).find(([k]) => wb(k) && !_foodNameNegated(n, k));
   if (byKey) return byKey[1];
   const byAlias = Object.values(table).find(v =>
-    v && Array.isArray(v.aliases) && v.aliases.some(a => wb(a)));
+    v && Array.isArray(v.aliases) && v.aliases.some(a => wb(a) && !_foodNameNegated(n, a)));
   return byAlias || null;
 }
 

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -23341,9 +23341,15 @@ function _foodNameNegated(hay, token) {
   const t = String(token).toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   // suffix form: "<token>-free" / "<token> free"  (peanut-free, nut free, dairy-free)
   if (new RegExp('\\b' + t + '[\\s-]+free\\b').test(hay)) return true;
-  // prefix form: "no <token>" / "without <token>" / "free of|from <token>"
-  // (tolerates up to two filler words: "no added nuts", "without any peanut")
-  if (new RegExp('\\b(?:no|without|free\\s+of|free\\s+from)\\b(?:\\s+\\w+){0,2}\\s+' + t + '\\b').test(hay)) return true;
+  // prefix form: "no <token>" / "without <token>" / "free of|from <token>". Only a
+  // pure intensifier ("added"/"any") may sit between the negator and the token —
+  // NOT an arbitrary filler window. M-R0-N (Maren, R0 ripple): a {0,2}-word window
+  // let "no" bind ACROSS an unrelated noun to a real food ("no salt almond" →
+  // almond was GIVEN, just salt-free) and drop its allergen record — a dropped
+  // warning, worse than the spurious match R0 fixes. The negator must govern the
+  // token directly: "no added nuts" / "without any peanut" still match;
+  // "no salt almond" / "no added sugar peanut" must NOT (those are exposures).
+  if (new RegExp('\\b(?:no|without|free\\s+of|free\\s+from)\\s+(?:added\\s+|any\\s+)?' + t + '\\b').test(hay)) return true;
   return false;
 }
 

--- a/tests/e2e/food-effects-v2-r0-negation-guard.spec.ts
+++ b/tests/e2e/food-effects-v2-r0-negation-guard.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from '@playwright/test';
+
+// food-effects v2 — R0: the negation-leak guard in _lookupByFoodName (spec §6).
+//
+// The resolver's word-boundary tier treats '-' as a boundary, so a bare
+// \bpeanut\b matched inside "peanut-free" and \bgroundnut\b inside "no
+// groundnut" — a logged or queried AVOIDANCE resolved to the food. Post-reframe
+// (R1/R2) that would render a green "introduce peanut" + an anaphylaxis floor on
+// a food the parent EXPLICITLY excluded — the one outcome worse than the legacy
+// caution (spec §10 convergence). R0 lands the guard ONCE in the shared resolver,
+// before R1, so every surface inherits it.
+//
+// The guard is TARGETED (keyed on the specific matched token), so a non-negated
+// food in the same string still resolves.
+//
+// NOTE: FOOD_EFFECTS / ALLERGENS / AGE_RULES are top-level `const`s — global
+// lexical bindings, NOT window properties — so they're referenced as barewords
+// inside page.evaluate (function decls like getFoodEffect resolve the same way).
+declare const FOOD_EFFECTS: any;
+declare const ALLERGENS: any;
+declare const AGE_RULES: any;
+declare const getFoodEffect: (name: string) => any;
+declare const _lookupByFoodName: (table: any, name: string) => any;
+declare const _foodNameNegated: (hay: string, token: string) => boolean;
+
+test.describe('food-effects v2 — R0 negation-leak guard', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/index.html?nosync');
+    await page.waitForFunction(() =>
+      typeof getFoodEffect === 'function'
+      && typeof _lookupByFoodName === 'function'
+      && typeof _foodNameNegated === 'function'
+      && typeof ALLERGENS === 'object'
+      && typeof AGE_RULES === 'object'
+      && typeof FOOD_EFFECTS === 'object', null, { timeout: 10_000 });
+  });
+
+  test('negated allergen / toxin queries resolve to NOTHING (the leak is closed)', async ({ page }) => {
+    const negated = await page.evaluate(() => {
+      // each of these would have word-boundary-matched the food token before R0
+      const cases = [
+        'peanut-free', 'groundnut-free', 'tree nut-free',
+        'no peanut', 'without peanut', 'no groundnut',
+        'honey-free', 'no honey', 'without honey',
+        'no added nuts', 'free of peanut', 'free from tree nut',
+      ];
+      return cases.map(q => [q, getFoodEffect(q) === null] as const);
+    });
+    for (const [q, isNull] of negated) {
+      expect(isNull, `"${q}" must resolve to null (negated → not an exposure)`).toBe(true);
+    }
+  });
+
+  test('positive queries are UNAFFECTED (no over-suppression)', async ({ page }) => {
+    const r = await page.evaluate(() => {
+      const cls = (x: any) => {
+        const fc = x && x.foodClass;
+        return Array.isArray(fc) ? fc : (fc ? [fc] : []);
+      };
+      return {
+        peanut: cls(getFoodEffect('peanut')),
+        groundnut: cls(getFoodEffect('groundnut')),        // alias → peanut
+        peanutButter: cls(getFoodEffect('peanut butter')), // alias → peanut
+        almond: cls(getFoodEffect('almond')),              // alias → tree nut
+        honey: cls(getFoodEffect('honey')),
+        peanutPaste: cls(getFoodEffect('peanut paste')),   // word-boundary positive in context
+      };
+    });
+    expect(r.peanut, 'peanut still resolves (allergen-introduce-early)').toContain('allergen-introduce-early');
+    expect(r.groundnut.length, 'groundnut alias still resolves').toBeGreaterThan(0);
+    expect(r.peanutButter.length, 'peanut butter alias still resolves').toBeGreaterThan(0);
+    expect(r.almond.length, 'almond alias still resolves to tree nut').toBeGreaterThan(0);
+    expect(r.honey, 'honey still resolves (acute-toxin, hard ceiling)').toContain('acute-toxin');
+    expect(r.peanutPaste, 'positive "peanut paste" unaffected').toContain('allergen-introduce-early');
+  });
+
+  test('the guard is TARGETED — a negated modifier does not suppress a co-present food', async ({ page }) => {
+    const r = await page.evaluate(() => ({
+      // "apple (no nuts)" — nuts is negated, but a co-present non-negated food is not
+      nutsNegated: _foodNameNegated('apple (no nuts)', 'nuts'),
+      appleNotNegated: _foodNameNegated('apple (no nuts)', 'apple'),
+      // "sugar-free peanut" — sugar is negated; peanut is present and must resolve
+      sugarNegated: _foodNameNegated('sugar-free peanut', 'sugar'),
+      peanutNotNegated: _foodNameNegated('sugar-free peanut', 'peanut'),
+      peanutStillResolves: getFoodEffect('sugar-free peanut') !== null,
+    }));
+    expect(r.nutsNegated, '"no nuts" → nuts negated').toBe(true);
+    expect(r.appleNotNegated, 'apple in the same string is NOT negated').toBe(false);
+    expect(r.sugarNegated, '"sugar-free" → sugar negated').toBe(true);
+    expect(r.peanutNotNegated, 'peanut is present, not negated, in "sugar-free peanut"').toBe(false);
+    expect(r.peanutStillResolves, 'the present peanut still resolves despite "sugar-free"').toBe(true);
+  });
+
+  test('the guard lives in the SHARED resolver — ALLERGENS + AGE_RULES inherit it', async ({ page }) => {
+    const r = await page.evaluate(() => ({
+      allergenNegated: _lookupByFoodName(ALLERGENS, 'peanut-free') === null,
+      allergenPositive: _lookupByFoodName(ALLERGENS, 'peanut') !== null,
+      ageRuleNegated: _lookupByFoodName(AGE_RULES, 'no peanut') === null,
+      ageRulePositive: _lookupByFoodName(AGE_RULES, 'peanut') !== null,
+    }));
+    expect(r.allergenNegated, 'ALLERGENS["peanut-free"] suppressed').toBe(true);
+    expect(r.allergenPositive, 'ALLERGENS["peanut"] still resolves').toBe(true);
+    expect(r.ageRuleNegated, 'AGE_RULES "no peanut" suppressed').toBe(true);
+    expect(r.ageRulePositive, 'AGE_RULES "peanut" still resolves').toBe(true);
+  });
+
+  test('regression anchor: the seed diary "(no nuts)" segment surfaces no nut record', async ({ page }) => {
+    // The committed seed log 'Ragi porridge + apple (no nuts)' (core.js) splits on
+    // '+' to "apple (no nuts)"; before R0 the "(no nuts)" tail could resolve a nut
+    // record (a logged AVOIDANCE read as a nut exposure). It must resolve to nothing.
+    const r = await page.evaluate(() => ({
+      effSegment: getFoodEffect('apple (no nuts)'),
+      feSegment: _lookupByFoodName(FOOD_EFFECTS, 'apple (no nuts)'),
+      allergenSegment: _lookupByFoodName(ALLERGENS, 'apple (no nuts)'),
+    }));
+    expect(r.effSegment, 'getFoodEffect("apple (no nuts)") → null').toBeNull();
+    expect(r.feSegment, 'no FOOD_EFFECTS nut record from a (no nuts) avoidance').toBeNull();
+    expect(r.allergenSegment, 'no ALLERGENS nut record from a (no nuts) avoidance').toBeNull();
+  });
+});

--- a/tests/e2e/food-effects-v2-r0-negation-guard.spec.ts
+++ b/tests/e2e/food-effects-v2-r0-negation-guard.spec.ts
@@ -74,6 +74,34 @@ test.describe('food-effects v2 — R0 negation-leak guard', () => {
     expect(r.peanutPaste, 'positive "peanut paste" unaffected').toContain('allergen-introduce-early');
   });
 
+  test('M-R0-N: an unrelated leading negator must NOT suppress a real exposure', async ({ page }) => {
+    // Maren's blocking ripple finding: "no salt almond" / "no added sugar peanut"
+    // are foods the baby GOT (salt-/sugar-free) — the negator governs salt/sugar,
+    // not the food. The guard must NOT drop their allergen record (a dropped
+    // anaphylaxis warning is worse than a spurious one). The negator only
+    // suppresses when it governs the token directly (adjacent / intensifier-only).
+    const r = await page.evaluate(() => {
+      const cls = (x: any) => (x && x.foodClass)
+        ? (Array.isArray(x.foodClass) ? x.foodClass : [x.foodClass]) : [];
+      return {
+        // real exposures with an unrelated leading negator — MUST still resolve
+        noSaltAlmond: cls(getFoodEffect('no salt almond')),
+        noAddedSugarPeanut: cls(getFoodEffect('no added sugar peanut')),
+        noSaltWalnut: cls(getFoodEffect('no salt walnut')),
+        // direct-government avoidances — MUST still suppress (regression of the fix)
+        noPeanut: getFoodEffect('no peanut') === null,
+        noAddedNuts: getFoodEffect('no added nuts') === null,
+        withoutAnyPeanut: getFoodEffect('without any peanut') === null,
+      };
+    });
+    expect(r.noSaltAlmond, '"no salt almond" → almond was given (tree nut record kept)').toContain('allergen-introduce-early');
+    expect(r.noAddedSugarPeanut, '"no added sugar peanut" → peanut was given').toContain('allergen-introduce-early');
+    expect(r.noSaltWalnut.length, '"no salt walnut" → walnut was given (resolves)').toBeGreaterThan(0);
+    expect(r.noPeanut, '"no peanut" still suppressed (direct government)').toBe(true);
+    expect(r.noAddedNuts, '"no added nuts" still suppressed (intensifier)').toBe(true);
+    expect(r.withoutAnyPeanut, '"without any peanut" still suppressed (intensifier)').toBe(true);
+  });
+
   test('the guard is TARGETED — a negated modifier does not suppress a co-present food', async ({ page }) => {
     const r = await page.evaluate(() => ({
       // "apple (no nuts)" — nuts is negated, but a co-present non-negated food is not


### PR DESCRIPTION
First implementation round of the reconciliation spec (#192 / issue #189), per §6 + §7. **Standalone, lands before R1.**

## The leak
`_lookupByFoodName`'s word-boundary tier (`core.js:4009`) treats `-` as a boundary, so a bare `\bpeanut\b` matches inside `"peanut-free"` and `\bgroundnut\b` inside `"no groundnut"` — a logged or queried **avoidance** resolved to the food. Once R1/R2 reframe an age-appropriate allergen to a green "introduce peanut" + anaphylaxis floor, that would fire on a food the parent **explicitly excluded** — the one outcome worse than the legacy caution (spec §10 convergence). Both Governors made this blocking and converged: guard the resolver **once**, before R1 (M-S-8 / K-S-3 / Q-4).

## The fix
- **`_foodNameNegated(hay, token)`** — true when the token is governed by an exclusion: `"<t>-free"` / `"<t> free"` suffix; `"no <t>"` / `"without <t>"` / `"free of|from <t>"` prefix (tolerating up to two filler words, e.g. "no added nuts"). **Targeted** — keyed on the specific matched token, so a co-present non-negated food still resolves (`"apple (no nuts)"` → apple; `"sugar-free peanut"` → peanut). `"free range egg"` is *not* suppressed (bare "free" ≠ "free of").
- **`_lookupByFoodName`** — the two word-boundary tiers skip any negated candidate. Tiers 1–2 (exact/depluralized) are unchanged; positives are byte-identical behavior.
- **`audit-food-effects-sync-v1`** — the live-resolver self-test extraction now pulls `_foodNameNegated` into the eval scope (else it ReferenceErrors).

## Verification
- `pnpm build` clean, **12 gates pass** (incl. the food-effects-sync self-test 3/3 with the helper in scope).
- New e2e `food-effects-v2-r0-negation-guard.spec.ts` — **5/5**: negated queries → null; positives (peanut/groundnut/peanut butter/almond/honey/"peanut paste") unaffected; targeting (`apple (no nuts)`→apple, `sugar-free peanut`→peanut); shared-resolver inheritance (ALLERGENS + AGE_RULES); the `(no nuts)` seed-diary regression anchor.
- Full suite: running (will confirm green before ready).

## canon-cc-008 routing
File-routing: `core.js` → **Kael** (engine). The `pnpm qa-route` oracle widened to Maren + Vela via core.js's call-hub ripple. Scoping: **Kael required** (direct resolver + audit edit); **Maren** as Care ripple consult (her diet safety verdicts consume the resolver — a suppressed match must never drop a warning); **Vela deferred to R3** (R0 changes no render surface; her allergen-note-depth call is Q-3 at R3). Cipher Edict V terminal. Stays draft until the chain clears.

https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK)_