### PR TITLE
R1: reconcile the combo checker onto FOOD_EFFECTS (food-effects v2 #189)

### DIFF
--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-05-31 &middot; graph @ <code>6c94eb7b926c</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-05-31 &middot; graph @ <code>98ab58425afb</code></div>
   <div class="sub" style="margin-top:8px">
     <span class="stat"><b>1,716</b> symbols</span>
     <span class="stat"><b>5,091</b> relations</span>
-    <span class="stat"><b>80,314</b> LOC</span>
+    <span class="stat"><b>80,335</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -65,14 +65,14 @@
       <div class="nums">
         <span><b>11</b> modules</span>
         <span><b>731</b> symbols</span>
-        <span><b>27,076</b> LOC</span>
+        <span><b>27,090</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,076 of 30,000 LOC">
+      <div class="bar" title="27,090 of 30,000 LOC">
         <div class="fill hot" style="width:90%"></div>
         <span class="barlbl">90% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,924 LOC headroom</div>
+      <div class="hd">2,910 LOC headroom</div>
       <div class="mods">core.js, i-illness.js, i-caretickets.js, i-qa-handlers.js, sync.js, data.js, i-qa.js, i-isl.js, config.js, i-correlate.js, start.js</div>
     </div>
     <div class="card" style="border-top:5px solid #b5d5c5">
@@ -82,14 +82,14 @@
       <div class="nums">
         <span><b>3</b> modules</span>
         <span><b>668</b> symbols</span>
-        <span><b>27,095</b> LOC</span>
+        <span><b>27,102</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,095 of 30,000 LOC">
+      <div class="bar" title="27,102 of 30,000 LOC">
         <div class="fill hot" style="width:90%"></div>
         <span class="barlbl">90% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,905 LOC headroom</div>
+      <div class="hd">2,898 LOC headroom</div>
       <div class="mods">home.js, medical.js, diet.js</div>
     </div>
     <div class="card" style="border-top:5px solid #c9b8e8">

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-05-31 &middot; graph @ <code>e7a1dfcdf7bd</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-05-31 &middot; graph @ <code>6c94eb7b926c</code></div>
   <div class="sub" style="margin-top:8px">
-    <span class="stat"><b>1,714</b> symbols</span>
-    <span class="stat"><b>5,086</b> relations</span>
-    <span class="stat"><b>80,214</b> LOC</span>
+    <span class="stat"><b>1,716</b> symbols</span>
+    <span class="stat"><b>5,091</b> relations</span>
+    <span class="stat"><b>80,314</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -64,15 +64,15 @@
       <div class="cgov">Governor: <b>Kael</b></div>
       <div class="nums">
         <span><b>11</b> modules</span>
-        <span><b>729</b> symbols</span>
-        <span><b>27,050</b> LOC</span>
+        <span><b>731</b> symbols</span>
+        <span><b>27,076</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,050 of 30,000 LOC">
+      <div class="bar" title="27,076 of 30,000 LOC">
         <div class="fill hot" style="width:90%"></div>
         <span class="barlbl">90% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,950 LOC headroom</div>
+      <div class="hd">2,924 LOC headroom</div>
       <div class="mods">core.js, i-illness.js, i-caretickets.js, i-qa-handlers.js, sync.js, data.js, i-qa.js, i-isl.js, config.js, i-correlate.js, start.js</div>
     </div>
     <div class="card" style="border-top:5px solid #b5d5c5">
@@ -82,14 +82,14 @@
       <div class="nums">
         <span><b>3</b> modules</span>
         <span><b>668</b> symbols</span>
-        <span><b>27,021</b> LOC</span>
+        <span><b>27,095</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,021 of 30,000 LOC">
+      <div class="bar" title="27,095 of 30,000 LOC">
         <div class="fill hot" style="width:90%"></div>
         <span class="barlbl">90% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,979 LOC headroom</div>
+      <div class="hd">2,905 LOC headroom</div>
       <div class="mods">home.js, medical.js, diet.js</div>
     </div>
     <div class="card" style="border-top:5px solid #c9b8e8">
@@ -143,7 +143,7 @@
   <h2>Connectivity hubs (highest call-degree symbols per module)</h2>
   <table>
     <thead><tr><th>Symbol</th><th>Module</th><th>Province</th><th class="num">Degree (calls)</th></tr></thead>
-    <tbody><tr><td><code>zi()</code></td><td>core.js</td><td>Intelligence</td><td class="num">324</td></tr><tr><td><code>showQLToast()</code></td><td>i-quicklog.js</td><td>Surfacing</td><td class="num">69</td></tr><tr><td><code>qaExecuteQuery()</code></td><td>i-qa.js</td><td>Intelligence</td><td class="num">50</td></tr><tr><td><code>renderInfo()</code></td><td>i-cards.js</td><td>Surfacing</td><td class="num">49</td></tr><tr><td><code>renderHome()</code></td><td>home.js</td><td>Care</td><td class="num">47</td></tr><tr><td><code>getDailySleepScore()</code></td><td>medical.js</td><td>Care</td><td class="num">33</td></tr><tr><td><code>_islMarkDirty()</code></td><td>i-isl.js</td><td>Intelligence</td><td class="num">28</td></tr><tr><td><code>ctHandleOverlayAction()</code></td><td>i-caretickets.js</td><td>Intelligence</td><td class="num">27</td></tr><tr><td><code>renderFeverEpisodeCard()</code></td><td>i-illness.js</td><td>Intelligence</td><td class="num">23</td></tr></tbody>
+    <tbody><tr><td><code>zi()</code></td><td>core.js</td><td>Intelligence</td><td class="num">325</td></tr><tr><td><code>showQLToast()</code></td><td>i-quicklog.js</td><td>Surfacing</td><td class="num">69</td></tr><tr><td><code>qaExecuteQuery()</code></td><td>i-qa.js</td><td>Intelligence</td><td class="num">50</td></tr><tr><td><code>renderInfo()</code></td><td>i-cards.js</td><td>Surfacing</td><td class="num">49</td></tr><tr><td><code>renderHome()</code></td><td>home.js</td><td>Care</td><td class="num">47</td></tr><tr><td><code>getDailySleepScore()</code></td><td>medical.js</td><td>Care</td><td class="num">33</td></tr><tr><td><code>_islMarkDirty()</code></td><td>i-isl.js</td><td>Intelligence</td><td class="num">28</td></tr><tr><td><code>ctHandleOverlayAction()</code></td><td>i-caretickets.js</td><td>Intelligence</td><td class="num">27</td></tr><tr><td><code>renderFeverEpisodeCard()</code></td><td>i-illness.js</td><td>Intelligence</td><td class="num">23</td></tr></tbody>
   </table>
 </main>
 <footer>

--- a/index.html
+++ b/index.html
@@ -19988,7 +19988,13 @@ function init() {
       const ci = document.getElementById('comboInput');
       if (ci) ci.value = arg;
       const hit = comboHistory.find(x => x.q === arg);
-      if (hit) renderComboResult(hit.result);
+      // M-R1-1: a stale (pre-R1-schema) cached result lacks the emergency floor —
+      // never render it directly; recompute so the floor stays reachable.
+      if (hit && hit.result && hit.result._schema === COMBO_RESULT_SCHEMA) {
+        renderComboResult(hit.result);
+      } else if (typeof checkFoodCombo === 'function') {
+        checkFoodCombo();
+      }
     }
     else if (action === 'openFeedingDay') {
       const fd = document.getElementById('feedingDate');
@@ -23373,6 +23379,14 @@ function _lookupByFoodName(table, name) {
 function getFoodEffect(name) {
   return (typeof FOOD_EFFECTS !== 'undefined') ? _lookupByFoodName(FOOD_EFFECTS, name) : null;
 }
+
+// Combo-result schema tag (food-effects v2 R1, M-R1-1). The combo checker caches
+// results in localStorage (comboHistory, unversioned). A result cached BEFORE R1
+// lacks the emergency-floor fields (toxin / severe_floors / encourage); rendering
+// it directly would drop the floor — the silent-floor-drop §10 names worse than
+// the legacy verdict. Stamp every fresh result with this tag; both read paths
+// (checkFoodCombo cache short-circuit + showComboHistory) recompute when it's absent.
+const COMBO_RESULT_SCHEMA = 'r1-fe';
 
 // foodClass membership test (food-effects v2 §3.0, M-S-5/K-S-4). foodClass is
 // multi-valued (peanut/tree nut carry ['allergen-introduce-early','choking-by-form'];
@@ -39043,9 +39057,15 @@ function checkFoodCombo() {
 
   const resultEl = document.getElementById('comboResult');
 
-  // Check cache
-  const cached = comboHistory.find(h => h.q.toLowerCase() === query.toLowerCase());
-  if (cached) { renderComboResult(cached.result); return; }
+  // Check cache. M-R1-1: a result cached before R1 lacks the emergency-floor
+  // fields — never render it directly (that drops the floor). Drop the stale
+  // entry and fall through to recompute, so the floor is always reachable.
+  const cachedIdx = comboHistory.findIndex(h => h.q.toLowerCase() === query.toLowerCase());
+  if (cachedIdx !== -1) {
+    const cached = comboHistory[cachedIdx];
+    if (cached.result && cached.result._schema === COMBO_RESULT_SCHEMA) { renderComboResult(cached.result); return; }
+    comboHistory.splice(cachedIdx, 1); // stale schema → recompute below
+  }
 
   // Parse foods from query
   const rawFoods = query.split(/[+,&]|with|and/).map(f => f.trim().toLowerCase()).filter(f => f.length > 0);
@@ -39268,6 +39288,7 @@ function checkFoodCombo() {
     severe_floors: severeFloors,
     toxin,
     encourage,
+    _schema: COMBO_RESULT_SCHEMA,   // M-R1-1: marks an R1-floor-bearing result
   };
 
   // Cache

--- a/index.html
+++ b/index.html
@@ -23374,6 +23374,41 @@ function getFoodEffect(name) {
   return (typeof FOOD_EFFECTS !== 'undefined') ? _lookupByFoodName(FOOD_EFFECTS, name) : null;
 }
 
+// foodClass membership test (food-effects v2 §3.0, M-S-5/K-S-4). foodClass is
+// multi-valued (peanut/tree nut carry ['allergen-introduce-early','choking-by-form'];
+// honey is the bare string 'acute-toxin'). A `===` check silently fails the array
+// case and drops an allergen to the legacy branch — losing BOTH the reframe and
+// the floor. Always membership-test, never ===.
+function _effHasClass(eff, cls) {
+  if (!eff || !eff.foodClass) return false;
+  return Array.isArray(eff.foodClass) ? eff.foodClass.indexOf(cls) !== -1 : eff.foodClass === cls;
+}
+
+// Shared emergency-floor renderer (food-effects v2 §3.0, M-S-7). The severe
+// anaphylaxis strip + the mild watch-fors + the seek-care line, sourced from a
+// FOOD_EFFECTS-shaped record. A-4 (Maren): each block renders on field PRESENCE
+// only — never gated on a class/severity string, so a schema change can't
+// silently drop a floor (honey carries watchFor+seekCare and no severeSigns; the
+// nuts carry all three). Reused by foodConsequenceCard (log-time card), the combo
+// checker (R1), and the allergen note (R3) — ONE floor, no bespoke drift. Returns
+// '' when the record carries no floor fields.
+function _severeFloorHtml(eff) {
+  if (!eff) return '';
+  let h = '';
+  if (Array.isArray(eff.severeSigns) && eff.severeSigns.length) {
+    h += `<div class="cons-severe"><div class="cons-severe-h">${zi('siren')} If this happens, it's an emergency</div><ul class="cons-severe-list">${
+      eff.severeSigns.map(s => `<li>${escHtml(s)}</li>`).join('')}</ul></div>`;
+  }
+  if (Array.isArray(eff.watchFor) && eff.watchFor.length) {
+    h += `<div class="cons-watch"><div class="cons-watch-h">Watch for</div><ul class="cons-watch-list">${
+      eff.watchFor.map(w => `<li>${escHtml(w)}</li>`).join('')}</ul></div>`;
+  }
+  if (eff.seekCare) {
+    h += `<p class="cons-seek">${zi('siren')} <span>${escHtml(eff.seekCare)}</span></p>`;
+  }
+  return h;
+}
+
 // Finding A — age-gate consequence surface. When a parent marks an age-gated
 // food tried below its gate, warn-and-allow: surface the consequence, then let
 // them proceed via onProceed. NEVER blocks — a parent may be recording an
@@ -23392,19 +23427,10 @@ function foodConsequenceCard(detail, onProceed) {
   const critical = detail.severity === 'critical';
   let inner = `<div class="cons-head">${zi('warn')}<h3 class="cons-title">${escHtml(detail.title || 'Worth a pause')}</h3></div>`;
   if (detail.why) inner += `<p class="cons-why">${escHtml(detail.why)}</p>`;
-  // Severe-reaction strip (A-1/V-1): unconditional, non-collapsible, amber.
-  if (Array.isArray(detail.severeSigns) && detail.severeSigns.length) {
-    inner += `<div class="cons-severe"><div class="cons-severe-h">${zi('siren')} If this happens, it's an emergency</div><ul class="cons-severe-list">${
-      detail.severeSigns.map(s => `<li>${escHtml(s)}</li>`).join('')}</ul></div>`;
-  }
-  // Mild watch-fors — present whenever the record carries them (A-4 decouple).
-  if (Array.isArray(detail.watchFor) && detail.watchFor.length) {
-    inner += `<div class="cons-watch"><div class="cons-watch-h">Watch for</div><ul class="cons-watch-list">${
-      detail.watchFor.map(w => `<li>${escHtml(w)}</li>`).join('')}</ul></div>`;
-  }
-  if (detail.seekCare) {
-    inner += `<p class="cons-seek">${zi('siren')} <span>${escHtml(detail.seekCare)}</span></p>`;
-  }
+  // Emergency floor (A-1/V-1 severe strip + A-4 mild watch-fors + seek-care) via
+  // the shared renderer (M-S-7) — one floor across the log-time card, the combo
+  // checker, and the allergen note. `detail` carries the same field shape.
+  inner += _severeFloorHtml(detail);
   // Affordance (Vela V-V-1/V-V-2): the SAFE action carries the visual weight and
   // sits rightmost (the resting-thumb target), so a half-awake parent skimming
   // for the dismiss tap can't mistake the loud button for "proceed". "Log it
@@ -39053,12 +39079,50 @@ function checkFoodCombo() {
     }
   });
 
-  // ── 2. Check allergens ──
+  // ── 2. Allergen flags + food-effects polarity (food-effects v2 R1, §3.0/§3.1) ──
+  // Legacy behaviour flipped ANY allergen-flagged food to `caution`. Under the
+  // model an age-appropriate allergen-introduce-early food (peanut, tree nut) is an
+  // ENCOURAGE, not a caution — the flag becomes safe-form guidance, not a wariness
+  // verdict (K-S-5). Honey (acute-toxin) is a hard avoid (Invariant 2, never
+  // softened). The emergency floor is collected for EVERY food carrying one,
+  // OUTSIDE the polarity branch, keyed on field presence (A-4 / M-S-5) — so it can
+  // never fall out of a branch. Floor placement/render: renderComboResult, above
+  // the fold (M-S-3).
+  const severeFloors = [];   // {food, eff} per food carrying a floor (M-S-3, per-food)
+  let toxin = null;          // {title, why}                — acute-toxin (honey)
+  let encourage = null;      // {title, whyGood, safeFormNote} — age-appropriate allergen
   rawFoods.forEach(food => {
+    const eff = (typeof getFoodEffect === 'function') ? getFoodEffect(food) : null;
+    const rule = _fdAgeRule(food);
+    const belowFloor = !!(rule && mo < rule.minMonth);
+
+    // Emergency floor — present-only (A-4), every food, any polarity or age.
+    if (eff && ((Array.isArray(eff.severeSigns) && eff.severeSigns.length) ||
+                (Array.isArray(eff.watchFor) && eff.watchFor.length) || eff.seekCare)) {
+      severeFloors.push({ food, eff: { severeSigns: eff.severeSigns, watchFor: eff.watchFor, seekCare: eff.seekCare } });
+    }
+
+    // Legacy terse ALLERGENS note, with the caution-flip gated (K-S-5). HR-4 (M-S-9).
     const alert = _lookupByFoodName(ALLERGENS, food);
+    const introEarlyOk = !!(eff && _effHasClass(eff, 'allergen-introduce-early') && !belowFloor);
     if (alert) {
-      allergenNotes.push(`${zi('warn')} ${food}: ${alert}`);
-      if (verdict === 'safe') { verdict = 'caution'; verdictEmoji = zi('warn'); }
+      allergenNotes.push(`${zi('warn')} ${escHtml(food)}: ${escHtml(alert)}`);
+      if (verdict === 'safe' && !introEarlyOk) { verdict = 'caution'; verdictEmoji = zi('warn'); }
+    }
+
+    // Polarity verdict. Precedence: acute-toxin avoid (hard) > below-floor avoid
+    // (step 1) > encourage safe. The reframe is ATOMIC with the floor (M-S-1) —
+    // the safe verdict and the collected floor are set in the same pass.
+    if (eff && _effHasClass(eff, 'acute-toxin')) {
+      verdict = 'avoid'; verdictEmoji = zi('warn');
+      toxin = { title: eff.title || '', why: eff.why || '' };
+    } else if (introEarlyOk) {
+      if (verdict !== 'avoid') { verdict = 'safe'; verdictEmoji = zi('check'); }
+      encourage = {
+        title: eff.title || '',
+        whyGood: eff.whyGood || '',
+        safeFormNote: (eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : '',
+      };
     }
   });
 
@@ -39173,10 +39237,20 @@ function checkFoodCombo() {
   // Vegetarian check
   const nonVeg = rawFoods.filter(f => ['chicken','fish','mutton','lamb','pork','prawn','shrimp','crab','meat'].includes(f));
   if (nonVeg.length > 0) {
-    verdict = 'caution';
-    verdictEmoji = zi('warn');
+    if (verdict !== 'avoid') { verdict = 'caution'; verdictEmoji = zi('warn'); }  // never downgrade an acute-toxin/below-floor avoid
     warnings.push(`Ziva follows a vegetarian diet. ${nonVeg.join(', ')} is non-vegetarian.`);
     headline = `Note: ${nonVeg.join(', ')} is non-vegetarian — Ziva\'s diet is vegetarian`;
+  }
+
+  // ── 8b. food-effects headline (food-effects v2 §3.1, M-S-2) ──
+  // Source the headline from the record's own title — never synthesize a bare
+  // "X is safe" next to a food name. acute-toxin leads with the hazard; an
+  // age-appropriate allergen leads with the encourage title. Precedence: toxin
+  // (the hard avoid) over encourage.
+  if (toxin && toxin.title) {
+    headline = toxin.title;
+  } else if (encourage && verdict === 'safe' && encourage.title) {
+    headline = encourage.title;
   }
 
   const result = {
@@ -39189,6 +39263,11 @@ function checkFoodCombo() {
     dos, donts,
     pairs_well_with: pairsWellWith,
     _queryFoods: rawFoods,
+    // food-effects v2 R1: the emergency floor (per-food, M-S-3), the acute-toxin
+    // hazard, and the encourage benefit/safe-form gate — rendered above the fold.
+    severe_floors: severeFloors,
+    toxin,
+    encourage,
   };
 
   // Cache
@@ -39398,7 +39477,28 @@ function renderComboResult(r) {
   const vTextClass = r.verdict === 'safe' ? 'safe' : r.verdict === 'caution' ? 'caution' : 'avoid';
 
   let html = `<div class="combo-result${vClass}">`;
-  html += `<div class="combo-verdict ${vTextClass}">${r.verdict_emoji || zi('check')} ${r.headline}</div>`;
+  html += `<div class="combo-verdict ${vTextClass}">${r.verdict_emoji || zi('check')} ${escHtml(r.headline)}</div>`;
+
+  // food-effects v2 R1 (§3.1, M-S-3): the emergency floor co-located with the
+  // verdict, ABOVE all nutrition/recipe/pairing/history — compact governs visual
+  // weight, never position or reachability. acute-toxin hazard → each food's floor
+  // (per-food, multi-food safe) → the encourage safe-form gate (A-2) → a compact
+  // benefit. Floor render via the shared _severeFloorHtml (M-S-7). Guarded so
+  // pre-R1 cached results (no these fields) render unchanged.
+  if (r.toxin && r.toxin.why) {
+    html += `<div class="combo-section"><div class="combo-body">${escHtml(r.toxin.why)}</div></div>`;
+  }
+  if (Array.isArray(r.severe_floors)) {
+    r.severe_floors.forEach(f => {
+      const floorHtml = (f && f.eff && typeof _severeFloorHtml === 'function') ? _severeFloorHtml(f.eff) : '';
+      if (floorHtml) html += `<div class="combo-section">${floorHtml}</div>`;
+    });
+  }
+  if (r.encourage) {
+    if (r.encourage.safeFormNote) html += `<div class="combo-section"><div class="combo-section-title">${zi('sprout')} Safe form</div><div class="combo-body">${escHtml(r.encourage.safeFormNote)}</div></div>`;
+    if (r.encourage.whyGood) html += `<div class="combo-section"><div class="combo-body">${escHtml(r.encourage.whyGood)}</div></div>`;
+  }
+
   if (r.explanation) html += `<div class="combo-body">${escHtml(r.explanation).replace(/\n/g,'<br>')}</div>`;
 
   if (r.nutrition_highlights) {
@@ -39406,7 +39506,7 @@ function renderComboResult(r) {
   }
 
   if (r.new_foods && r.new_foods.length > 0) {
-    html += `<div class="combo-section"><div class="combo-section-title">${zi('sparkle')} New foods to introduce first</div><div class="combo-body">${r.new_foods.join(', ')} — introduce each alone for 3 days before combining.</div></div>`;
+    html += `<div class="combo-section"><div class="combo-section-title">${zi('sparkle')} New foods to introduce first</div><div class="combo-body">${r.new_foods.map(escHtml).join(', ')} — introduce each alone for 3 days before combining.</div></div>`;
   }
 
   if (r.allergen_notes && r.allergen_notes.length > 0) {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.31-21",
+  "version": "2026.05.31-22",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.31-22",
+  "version": "2026.05.31-34",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -660,7 +660,13 @@ function init() {
       const ci = document.getElementById('comboInput');
       if (ci) ci.value = arg;
       const hit = comboHistory.find(x => x.q === arg);
-      if (hit) renderComboResult(hit.result);
+      // M-R1-1: a stale (pre-R1-schema) cached result lacks the emergency floor —
+      // never render it directly; recompute so the floor stays reachable.
+      if (hit && hit.result && hit.result._schema === COMBO_RESULT_SCHEMA) {
+        renderComboResult(hit.result);
+      } else if (typeof checkFoodCombo === 'function') {
+        checkFoodCombo();
+      }
     }
     else if (action === 'openFeedingDay') {
       const fd = document.getElementById('feedingDate');
@@ -4045,6 +4051,14 @@ function _lookupByFoodName(table, name) {
 function getFoodEffect(name) {
   return (typeof FOOD_EFFECTS !== 'undefined') ? _lookupByFoodName(FOOD_EFFECTS, name) : null;
 }
+
+// Combo-result schema tag (food-effects v2 R1, M-R1-1). The combo checker caches
+// results in localStorage (comboHistory, unversioned). A result cached BEFORE R1
+// lacks the emergency-floor fields (toxin / severe_floors / encourage); rendering
+// it directly would drop the floor — the silent-floor-drop §10 names worse than
+// the legacy verdict. Stamp every fresh result with this tag; both read paths
+// (checkFoodCombo cache short-circuit + showComboHistory) recompute when it's absent.
+const COMBO_RESULT_SCHEMA = 'r1-fe';
 
 // foodClass membership test (food-effects v2 §3.0, M-S-5/K-S-4). foodClass is
 // multi-valued (peanut/tree nut carry ['allergen-introduce-early','choking-by-form'];

--- a/split/core.js
+++ b/split/core.js
@@ -4046,6 +4046,41 @@ function getFoodEffect(name) {
   return (typeof FOOD_EFFECTS !== 'undefined') ? _lookupByFoodName(FOOD_EFFECTS, name) : null;
 }
 
+// foodClass membership test (food-effects v2 §3.0, M-S-5/K-S-4). foodClass is
+// multi-valued (peanut/tree nut carry ['allergen-introduce-early','choking-by-form'];
+// honey is the bare string 'acute-toxin'). A `===` check silently fails the array
+// case and drops an allergen to the legacy branch — losing BOTH the reframe and
+// the floor. Always membership-test, never ===.
+function _effHasClass(eff, cls) {
+  if (!eff || !eff.foodClass) return false;
+  return Array.isArray(eff.foodClass) ? eff.foodClass.indexOf(cls) !== -1 : eff.foodClass === cls;
+}
+
+// Shared emergency-floor renderer (food-effects v2 §3.0, M-S-7). The severe
+// anaphylaxis strip + the mild watch-fors + the seek-care line, sourced from a
+// FOOD_EFFECTS-shaped record. A-4 (Maren): each block renders on field PRESENCE
+// only — never gated on a class/severity string, so a schema change can't
+// silently drop a floor (honey carries watchFor+seekCare and no severeSigns; the
+// nuts carry all three). Reused by foodConsequenceCard (log-time card), the combo
+// checker (R1), and the allergen note (R3) — ONE floor, no bespoke drift. Returns
+// '' when the record carries no floor fields.
+function _severeFloorHtml(eff) {
+  if (!eff) return '';
+  let h = '';
+  if (Array.isArray(eff.severeSigns) && eff.severeSigns.length) {
+    h += `<div class="cons-severe"><div class="cons-severe-h">${zi('siren')} If this happens, it's an emergency</div><ul class="cons-severe-list">${
+      eff.severeSigns.map(s => `<li>${escHtml(s)}</li>`).join('')}</ul></div>`;
+  }
+  if (Array.isArray(eff.watchFor) && eff.watchFor.length) {
+    h += `<div class="cons-watch"><div class="cons-watch-h">Watch for</div><ul class="cons-watch-list">${
+      eff.watchFor.map(w => `<li>${escHtml(w)}</li>`).join('')}</ul></div>`;
+  }
+  if (eff.seekCare) {
+    h += `<p class="cons-seek">${zi('siren')} <span>${escHtml(eff.seekCare)}</span></p>`;
+  }
+  return h;
+}
+
 // Finding A — age-gate consequence surface. When a parent marks an age-gated
 // food tried below its gate, warn-and-allow: surface the consequence, then let
 // them proceed via onProceed. NEVER blocks — a parent may be recording an
@@ -4064,19 +4099,10 @@ function foodConsequenceCard(detail, onProceed) {
   const critical = detail.severity === 'critical';
   let inner = `<div class="cons-head">${zi('warn')}<h3 class="cons-title">${escHtml(detail.title || 'Worth a pause')}</h3></div>`;
   if (detail.why) inner += `<p class="cons-why">${escHtml(detail.why)}</p>`;
-  // Severe-reaction strip (A-1/V-1): unconditional, non-collapsible, amber.
-  if (Array.isArray(detail.severeSigns) && detail.severeSigns.length) {
-    inner += `<div class="cons-severe"><div class="cons-severe-h">${zi('siren')} If this happens, it's an emergency</div><ul class="cons-severe-list">${
-      detail.severeSigns.map(s => `<li>${escHtml(s)}</li>`).join('')}</ul></div>`;
-  }
-  // Mild watch-fors — present whenever the record carries them (A-4 decouple).
-  if (Array.isArray(detail.watchFor) && detail.watchFor.length) {
-    inner += `<div class="cons-watch"><div class="cons-watch-h">Watch for</div><ul class="cons-watch-list">${
-      detail.watchFor.map(w => `<li>${escHtml(w)}</li>`).join('')}</ul></div>`;
-  }
-  if (detail.seekCare) {
-    inner += `<p class="cons-seek">${zi('siren')} <span>${escHtml(detail.seekCare)}</span></p>`;
-  }
+  // Emergency floor (A-1/V-1 severe strip + A-4 mild watch-fors + seek-care) via
+  // the shared renderer (M-S-7) — one floor across the log-time card, the combo
+  // checker, and the allergen note. `detail` carries the same field shape.
+  inner += _severeFloorHtml(detail);
   // Affordance (Vela V-V-1/V-V-2): the SAFE action carries the visual weight and
   // sits rightmost (the resting-thumb target), so a half-awake parent skimming
   // for the dismiss tap can't mistake the loud button for "proceed". "Log it

--- a/split/diet.js
+++ b/split/diet.js
@@ -1296,9 +1296,15 @@ function checkFoodCombo() {
 
   const resultEl = document.getElementById('comboResult');
 
-  // Check cache
-  const cached = comboHistory.find(h => h.q.toLowerCase() === query.toLowerCase());
-  if (cached) { renderComboResult(cached.result); return; }
+  // Check cache. M-R1-1: a result cached before R1 lacks the emergency-floor
+  // fields — never render it directly (that drops the floor). Drop the stale
+  // entry and fall through to recompute, so the floor is always reachable.
+  const cachedIdx = comboHistory.findIndex(h => h.q.toLowerCase() === query.toLowerCase());
+  if (cachedIdx !== -1) {
+    const cached = comboHistory[cachedIdx];
+    if (cached.result && cached.result._schema === COMBO_RESULT_SCHEMA) { renderComboResult(cached.result); return; }
+    comboHistory.splice(cachedIdx, 1); // stale schema → recompute below
+  }
 
   // Parse foods from query
   const rawFoods = query.split(/[+,&]|with|and/).map(f => f.trim().toLowerCase()).filter(f => f.length > 0);
@@ -1521,6 +1527,7 @@ function checkFoodCombo() {
     severe_floors: severeFloors,
     toxin,
     encourage,
+    _schema: COMBO_RESULT_SCHEMA,   // M-R1-1: marks an R1-floor-bearing result
   };
 
   // Cache

--- a/split/diet.js
+++ b/split/diet.js
@@ -1332,12 +1332,50 @@ function checkFoodCombo() {
     }
   });
 
-  // ── 2. Check allergens ──
+  // ── 2. Allergen flags + food-effects polarity (food-effects v2 R1, §3.0/§3.1) ──
+  // Legacy behaviour flipped ANY allergen-flagged food to `caution`. Under the
+  // model an age-appropriate allergen-introduce-early food (peanut, tree nut) is an
+  // ENCOURAGE, not a caution — the flag becomes safe-form guidance, not a wariness
+  // verdict (K-S-5). Honey (acute-toxin) is a hard avoid (Invariant 2, never
+  // softened). The emergency floor is collected for EVERY food carrying one,
+  // OUTSIDE the polarity branch, keyed on field presence (A-4 / M-S-5) — so it can
+  // never fall out of a branch. Floor placement/render: renderComboResult, above
+  // the fold (M-S-3).
+  const severeFloors = [];   // {food, eff} per food carrying a floor (M-S-3, per-food)
+  let toxin = null;          // {title, why}                — acute-toxin (honey)
+  let encourage = null;      // {title, whyGood, safeFormNote} — age-appropriate allergen
   rawFoods.forEach(food => {
+    const eff = (typeof getFoodEffect === 'function') ? getFoodEffect(food) : null;
+    const rule = _fdAgeRule(food);
+    const belowFloor = !!(rule && mo < rule.minMonth);
+
+    // Emergency floor — present-only (A-4), every food, any polarity or age.
+    if (eff && ((Array.isArray(eff.severeSigns) && eff.severeSigns.length) ||
+                (Array.isArray(eff.watchFor) && eff.watchFor.length) || eff.seekCare)) {
+      severeFloors.push({ food, eff: { severeSigns: eff.severeSigns, watchFor: eff.watchFor, seekCare: eff.seekCare } });
+    }
+
+    // Legacy terse ALLERGENS note, with the caution-flip gated (K-S-5). HR-4 (M-S-9).
     const alert = _lookupByFoodName(ALLERGENS, food);
+    const introEarlyOk = !!(eff && _effHasClass(eff, 'allergen-introduce-early') && !belowFloor);
     if (alert) {
-      allergenNotes.push(`${zi('warn')} ${food}: ${alert}`);
-      if (verdict === 'safe') { verdict = 'caution'; verdictEmoji = zi('warn'); }
+      allergenNotes.push(`${zi('warn')} ${escHtml(food)}: ${escHtml(alert)}`);
+      if (verdict === 'safe' && !introEarlyOk) { verdict = 'caution'; verdictEmoji = zi('warn'); }
+    }
+
+    // Polarity verdict. Precedence: acute-toxin avoid (hard) > below-floor avoid
+    // (step 1) > encourage safe. The reframe is ATOMIC with the floor (M-S-1) —
+    // the safe verdict and the collected floor are set in the same pass.
+    if (eff && _effHasClass(eff, 'acute-toxin')) {
+      verdict = 'avoid'; verdictEmoji = zi('warn');
+      toxin = { title: eff.title || '', why: eff.why || '' };
+    } else if (introEarlyOk) {
+      if (verdict !== 'avoid') { verdict = 'safe'; verdictEmoji = zi('check'); }
+      encourage = {
+        title: eff.title || '',
+        whyGood: eff.whyGood || '',
+        safeFormNote: (eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : '',
+      };
     }
   });
 
@@ -1452,10 +1490,20 @@ function checkFoodCombo() {
   // Vegetarian check
   const nonVeg = rawFoods.filter(f => ['chicken','fish','mutton','lamb','pork','prawn','shrimp','crab','meat'].includes(f));
   if (nonVeg.length > 0) {
-    verdict = 'caution';
-    verdictEmoji = zi('warn');
+    if (verdict !== 'avoid') { verdict = 'caution'; verdictEmoji = zi('warn'); }  // never downgrade an acute-toxin/below-floor avoid
     warnings.push(`Ziva follows a vegetarian diet. ${nonVeg.join(', ')} is non-vegetarian.`);
     headline = `Note: ${nonVeg.join(', ')} is non-vegetarian — Ziva\'s diet is vegetarian`;
+  }
+
+  // ── 8b. food-effects headline (food-effects v2 §3.1, M-S-2) ──
+  // Source the headline from the record's own title — never synthesize a bare
+  // "X is safe" next to a food name. acute-toxin leads with the hazard; an
+  // age-appropriate allergen leads with the encourage title. Precedence: toxin
+  // (the hard avoid) over encourage.
+  if (toxin && toxin.title) {
+    headline = toxin.title;
+  } else if (encourage && verdict === 'safe' && encourage.title) {
+    headline = encourage.title;
   }
 
   const result = {
@@ -1468,6 +1516,11 @@ function checkFoodCombo() {
     dos, donts,
     pairs_well_with: pairsWellWith,
     _queryFoods: rawFoods,
+    // food-effects v2 R1: the emergency floor (per-food, M-S-3), the acute-toxin
+    // hazard, and the encourage benefit/safe-form gate — rendered above the fold.
+    severe_floors: severeFloors,
+    toxin,
+    encourage,
   };
 
   // Cache
@@ -1677,7 +1730,28 @@ function renderComboResult(r) {
   const vTextClass = r.verdict === 'safe' ? 'safe' : r.verdict === 'caution' ? 'caution' : 'avoid';
 
   let html = `<div class="combo-result${vClass}">`;
-  html += `<div class="combo-verdict ${vTextClass}">${r.verdict_emoji || zi('check')} ${r.headline}</div>`;
+  html += `<div class="combo-verdict ${vTextClass}">${r.verdict_emoji || zi('check')} ${escHtml(r.headline)}</div>`;
+
+  // food-effects v2 R1 (§3.1, M-S-3): the emergency floor co-located with the
+  // verdict, ABOVE all nutrition/recipe/pairing/history — compact governs visual
+  // weight, never position or reachability. acute-toxin hazard → each food's floor
+  // (per-food, multi-food safe) → the encourage safe-form gate (A-2) → a compact
+  // benefit. Floor render via the shared _severeFloorHtml (M-S-7). Guarded so
+  // pre-R1 cached results (no these fields) render unchanged.
+  if (r.toxin && r.toxin.why) {
+    html += `<div class="combo-section"><div class="combo-body">${escHtml(r.toxin.why)}</div></div>`;
+  }
+  if (Array.isArray(r.severe_floors)) {
+    r.severe_floors.forEach(f => {
+      const floorHtml = (f && f.eff && typeof _severeFloorHtml === 'function') ? _severeFloorHtml(f.eff) : '';
+      if (floorHtml) html += `<div class="combo-section">${floorHtml}</div>`;
+    });
+  }
+  if (r.encourage) {
+    if (r.encourage.safeFormNote) html += `<div class="combo-section"><div class="combo-section-title">${zi('sprout')} Safe form</div><div class="combo-body">${escHtml(r.encourage.safeFormNote)}</div></div>`;
+    if (r.encourage.whyGood) html += `<div class="combo-section"><div class="combo-body">${escHtml(r.encourage.whyGood)}</div></div>`;
+  }
+
   if (r.explanation) html += `<div class="combo-body">${escHtml(r.explanation).replace(/\n/g,'<br>')}</div>`;
 
   if (r.nutrition_highlights) {
@@ -1685,7 +1759,7 @@ function renderComboResult(r) {
   }
 
   if (r.new_foods && r.new_foods.length > 0) {
-    html += `<div class="combo-section"><div class="combo-section-title">${zi('sparkle')} New foods to introduce first</div><div class="combo-body">${r.new_foods.join(', ')} — introduce each alone for 3 days before combining.</div></div>`;
+    html += `<div class="combo-section"><div class="combo-section-title">${zi('sparkle')} New foods to introduce first</div><div class="combo-body">${r.new_foods.map(escHtml).join(', ')} — introduce each alone for 3 days before combining.</div></div>`;
   }
 
   if (r.allergen_notes && r.allergen_notes.length > 0) {

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -19988,7 +19988,13 @@ function init() {
       const ci = document.getElementById('comboInput');
       if (ci) ci.value = arg;
       const hit = comboHistory.find(x => x.q === arg);
-      if (hit) renderComboResult(hit.result);
+      // M-R1-1: a stale (pre-R1-schema) cached result lacks the emergency floor —
+      // never render it directly; recompute so the floor stays reachable.
+      if (hit && hit.result && hit.result._schema === COMBO_RESULT_SCHEMA) {
+        renderComboResult(hit.result);
+      } else if (typeof checkFoodCombo === 'function') {
+        checkFoodCombo();
+      }
     }
     else if (action === 'openFeedingDay') {
       const fd = document.getElementById('feedingDate');
@@ -23373,6 +23379,14 @@ function _lookupByFoodName(table, name) {
 function getFoodEffect(name) {
   return (typeof FOOD_EFFECTS !== 'undefined') ? _lookupByFoodName(FOOD_EFFECTS, name) : null;
 }
+
+// Combo-result schema tag (food-effects v2 R1, M-R1-1). The combo checker caches
+// results in localStorage (comboHistory, unversioned). A result cached BEFORE R1
+// lacks the emergency-floor fields (toxin / severe_floors / encourage); rendering
+// it directly would drop the floor — the silent-floor-drop §10 names worse than
+// the legacy verdict. Stamp every fresh result with this tag; both read paths
+// (checkFoodCombo cache short-circuit + showComboHistory) recompute when it's absent.
+const COMBO_RESULT_SCHEMA = 'r1-fe';
 
 // foodClass membership test (food-effects v2 §3.0, M-S-5/K-S-4). foodClass is
 // multi-valued (peanut/tree nut carry ['allergen-introduce-early','choking-by-form'];
@@ -39043,9 +39057,15 @@ function checkFoodCombo() {
 
   const resultEl = document.getElementById('comboResult');
 
-  // Check cache
-  const cached = comboHistory.find(h => h.q.toLowerCase() === query.toLowerCase());
-  if (cached) { renderComboResult(cached.result); return; }
+  // Check cache. M-R1-1: a result cached before R1 lacks the emergency-floor
+  // fields — never render it directly (that drops the floor). Drop the stale
+  // entry and fall through to recompute, so the floor is always reachable.
+  const cachedIdx = comboHistory.findIndex(h => h.q.toLowerCase() === query.toLowerCase());
+  if (cachedIdx !== -1) {
+    const cached = comboHistory[cachedIdx];
+    if (cached.result && cached.result._schema === COMBO_RESULT_SCHEMA) { renderComboResult(cached.result); return; }
+    comboHistory.splice(cachedIdx, 1); // stale schema → recompute below
+  }
 
   // Parse foods from query
   const rawFoods = query.split(/[+,&]|with|and/).map(f => f.trim().toLowerCase()).filter(f => f.length > 0);
@@ -39268,6 +39288,7 @@ function checkFoodCombo() {
     severe_floors: severeFloors,
     toxin,
     encourage,
+    _schema: COMBO_RESULT_SCHEMA,   // M-R1-1: marks an R1-floor-bearing result
   };
 
   // Cache

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -23374,6 +23374,41 @@ function getFoodEffect(name) {
   return (typeof FOOD_EFFECTS !== 'undefined') ? _lookupByFoodName(FOOD_EFFECTS, name) : null;
 }
 
+// foodClass membership test (food-effects v2 §3.0, M-S-5/K-S-4). foodClass is
+// multi-valued (peanut/tree nut carry ['allergen-introduce-early','choking-by-form'];
+// honey is the bare string 'acute-toxin'). A `===` check silently fails the array
+// case and drops an allergen to the legacy branch — losing BOTH the reframe and
+// the floor. Always membership-test, never ===.
+function _effHasClass(eff, cls) {
+  if (!eff || !eff.foodClass) return false;
+  return Array.isArray(eff.foodClass) ? eff.foodClass.indexOf(cls) !== -1 : eff.foodClass === cls;
+}
+
+// Shared emergency-floor renderer (food-effects v2 §3.0, M-S-7). The severe
+// anaphylaxis strip + the mild watch-fors + the seek-care line, sourced from a
+// FOOD_EFFECTS-shaped record. A-4 (Maren): each block renders on field PRESENCE
+// only — never gated on a class/severity string, so a schema change can't
+// silently drop a floor (honey carries watchFor+seekCare and no severeSigns; the
+// nuts carry all three). Reused by foodConsequenceCard (log-time card), the combo
+// checker (R1), and the allergen note (R3) — ONE floor, no bespoke drift. Returns
+// '' when the record carries no floor fields.
+function _severeFloorHtml(eff) {
+  if (!eff) return '';
+  let h = '';
+  if (Array.isArray(eff.severeSigns) && eff.severeSigns.length) {
+    h += `<div class="cons-severe"><div class="cons-severe-h">${zi('siren')} If this happens, it's an emergency</div><ul class="cons-severe-list">${
+      eff.severeSigns.map(s => `<li>${escHtml(s)}</li>`).join('')}</ul></div>`;
+  }
+  if (Array.isArray(eff.watchFor) && eff.watchFor.length) {
+    h += `<div class="cons-watch"><div class="cons-watch-h">Watch for</div><ul class="cons-watch-list">${
+      eff.watchFor.map(w => `<li>${escHtml(w)}</li>`).join('')}</ul></div>`;
+  }
+  if (eff.seekCare) {
+    h += `<p class="cons-seek">${zi('siren')} <span>${escHtml(eff.seekCare)}</span></p>`;
+  }
+  return h;
+}
+
 // Finding A — age-gate consequence surface. When a parent marks an age-gated
 // food tried below its gate, warn-and-allow: surface the consequence, then let
 // them proceed via onProceed. NEVER blocks — a parent may be recording an
@@ -23392,19 +23427,10 @@ function foodConsequenceCard(detail, onProceed) {
   const critical = detail.severity === 'critical';
   let inner = `<div class="cons-head">${zi('warn')}<h3 class="cons-title">${escHtml(detail.title || 'Worth a pause')}</h3></div>`;
   if (detail.why) inner += `<p class="cons-why">${escHtml(detail.why)}</p>`;
-  // Severe-reaction strip (A-1/V-1): unconditional, non-collapsible, amber.
-  if (Array.isArray(detail.severeSigns) && detail.severeSigns.length) {
-    inner += `<div class="cons-severe"><div class="cons-severe-h">${zi('siren')} If this happens, it's an emergency</div><ul class="cons-severe-list">${
-      detail.severeSigns.map(s => `<li>${escHtml(s)}</li>`).join('')}</ul></div>`;
-  }
-  // Mild watch-fors — present whenever the record carries them (A-4 decouple).
-  if (Array.isArray(detail.watchFor) && detail.watchFor.length) {
-    inner += `<div class="cons-watch"><div class="cons-watch-h">Watch for</div><ul class="cons-watch-list">${
-      detail.watchFor.map(w => `<li>${escHtml(w)}</li>`).join('')}</ul></div>`;
-  }
-  if (detail.seekCare) {
-    inner += `<p class="cons-seek">${zi('siren')} <span>${escHtml(detail.seekCare)}</span></p>`;
-  }
+  // Emergency floor (A-1/V-1 severe strip + A-4 mild watch-fors + seek-care) via
+  // the shared renderer (M-S-7) — one floor across the log-time card, the combo
+  // checker, and the allergen note. `detail` carries the same field shape.
+  inner += _severeFloorHtml(detail);
   // Affordance (Vela V-V-1/V-V-2): the SAFE action carries the visual weight and
   // sits rightmost (the resting-thumb target), so a half-awake parent skimming
   // for the dismiss tap can't mistake the loud button for "proceed". "Log it
@@ -39053,12 +39079,50 @@ function checkFoodCombo() {
     }
   });
 
-  // ── 2. Check allergens ──
+  // ── 2. Allergen flags + food-effects polarity (food-effects v2 R1, §3.0/§3.1) ──
+  // Legacy behaviour flipped ANY allergen-flagged food to `caution`. Under the
+  // model an age-appropriate allergen-introduce-early food (peanut, tree nut) is an
+  // ENCOURAGE, not a caution — the flag becomes safe-form guidance, not a wariness
+  // verdict (K-S-5). Honey (acute-toxin) is a hard avoid (Invariant 2, never
+  // softened). The emergency floor is collected for EVERY food carrying one,
+  // OUTSIDE the polarity branch, keyed on field presence (A-4 / M-S-5) — so it can
+  // never fall out of a branch. Floor placement/render: renderComboResult, above
+  // the fold (M-S-3).
+  const severeFloors = [];   // {food, eff} per food carrying a floor (M-S-3, per-food)
+  let toxin = null;          // {title, why}                — acute-toxin (honey)
+  let encourage = null;      // {title, whyGood, safeFormNote} — age-appropriate allergen
   rawFoods.forEach(food => {
+    const eff = (typeof getFoodEffect === 'function') ? getFoodEffect(food) : null;
+    const rule = _fdAgeRule(food);
+    const belowFloor = !!(rule && mo < rule.minMonth);
+
+    // Emergency floor — present-only (A-4), every food, any polarity or age.
+    if (eff && ((Array.isArray(eff.severeSigns) && eff.severeSigns.length) ||
+                (Array.isArray(eff.watchFor) && eff.watchFor.length) || eff.seekCare)) {
+      severeFloors.push({ food, eff: { severeSigns: eff.severeSigns, watchFor: eff.watchFor, seekCare: eff.seekCare } });
+    }
+
+    // Legacy terse ALLERGENS note, with the caution-flip gated (K-S-5). HR-4 (M-S-9).
     const alert = _lookupByFoodName(ALLERGENS, food);
+    const introEarlyOk = !!(eff && _effHasClass(eff, 'allergen-introduce-early') && !belowFloor);
     if (alert) {
-      allergenNotes.push(`${zi('warn')} ${food}: ${alert}`);
-      if (verdict === 'safe') { verdict = 'caution'; verdictEmoji = zi('warn'); }
+      allergenNotes.push(`${zi('warn')} ${escHtml(food)}: ${escHtml(alert)}`);
+      if (verdict === 'safe' && !introEarlyOk) { verdict = 'caution'; verdictEmoji = zi('warn'); }
+    }
+
+    // Polarity verdict. Precedence: acute-toxin avoid (hard) > below-floor avoid
+    // (step 1) > encourage safe. The reframe is ATOMIC with the floor (M-S-1) —
+    // the safe verdict and the collected floor are set in the same pass.
+    if (eff && _effHasClass(eff, 'acute-toxin')) {
+      verdict = 'avoid'; verdictEmoji = zi('warn');
+      toxin = { title: eff.title || '', why: eff.why || '' };
+    } else if (introEarlyOk) {
+      if (verdict !== 'avoid') { verdict = 'safe'; verdictEmoji = zi('check'); }
+      encourage = {
+        title: eff.title || '',
+        whyGood: eff.whyGood || '',
+        safeFormNote: (eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : '',
+      };
     }
   });
 
@@ -39173,10 +39237,20 @@ function checkFoodCombo() {
   // Vegetarian check
   const nonVeg = rawFoods.filter(f => ['chicken','fish','mutton','lamb','pork','prawn','shrimp','crab','meat'].includes(f));
   if (nonVeg.length > 0) {
-    verdict = 'caution';
-    verdictEmoji = zi('warn');
+    if (verdict !== 'avoid') { verdict = 'caution'; verdictEmoji = zi('warn'); }  // never downgrade an acute-toxin/below-floor avoid
     warnings.push(`Ziva follows a vegetarian diet. ${nonVeg.join(', ')} is non-vegetarian.`);
     headline = `Note: ${nonVeg.join(', ')} is non-vegetarian — Ziva\'s diet is vegetarian`;
+  }
+
+  // ── 8b. food-effects headline (food-effects v2 §3.1, M-S-2) ──
+  // Source the headline from the record's own title — never synthesize a bare
+  // "X is safe" next to a food name. acute-toxin leads with the hazard; an
+  // age-appropriate allergen leads with the encourage title. Precedence: toxin
+  // (the hard avoid) over encourage.
+  if (toxin && toxin.title) {
+    headline = toxin.title;
+  } else if (encourage && verdict === 'safe' && encourage.title) {
+    headline = encourage.title;
   }
 
   const result = {
@@ -39189,6 +39263,11 @@ function checkFoodCombo() {
     dos, donts,
     pairs_well_with: pairsWellWith,
     _queryFoods: rawFoods,
+    // food-effects v2 R1: the emergency floor (per-food, M-S-3), the acute-toxin
+    // hazard, and the encourage benefit/safe-form gate — rendered above the fold.
+    severe_floors: severeFloors,
+    toxin,
+    encourage,
   };
 
   // Cache
@@ -39398,7 +39477,28 @@ function renderComboResult(r) {
   const vTextClass = r.verdict === 'safe' ? 'safe' : r.verdict === 'caution' ? 'caution' : 'avoid';
 
   let html = `<div class="combo-result${vClass}">`;
-  html += `<div class="combo-verdict ${vTextClass}">${r.verdict_emoji || zi('check')} ${r.headline}</div>`;
+  html += `<div class="combo-verdict ${vTextClass}">${r.verdict_emoji || zi('check')} ${escHtml(r.headline)}</div>`;
+
+  // food-effects v2 R1 (§3.1, M-S-3): the emergency floor co-located with the
+  // verdict, ABOVE all nutrition/recipe/pairing/history — compact governs visual
+  // weight, never position or reachability. acute-toxin hazard → each food's floor
+  // (per-food, multi-food safe) → the encourage safe-form gate (A-2) → a compact
+  // benefit. Floor render via the shared _severeFloorHtml (M-S-7). Guarded so
+  // pre-R1 cached results (no these fields) render unchanged.
+  if (r.toxin && r.toxin.why) {
+    html += `<div class="combo-section"><div class="combo-body">${escHtml(r.toxin.why)}</div></div>`;
+  }
+  if (Array.isArray(r.severe_floors)) {
+    r.severe_floors.forEach(f => {
+      const floorHtml = (f && f.eff && typeof _severeFloorHtml === 'function') ? _severeFloorHtml(f.eff) : '';
+      if (floorHtml) html += `<div class="combo-section">${floorHtml}</div>`;
+    });
+  }
+  if (r.encourage) {
+    if (r.encourage.safeFormNote) html += `<div class="combo-section"><div class="combo-section-title">${zi('sprout')} Safe form</div><div class="combo-body">${escHtml(r.encourage.safeFormNote)}</div></div>`;
+    if (r.encourage.whyGood) html += `<div class="combo-section"><div class="combo-body">${escHtml(r.encourage.whyGood)}</div></div>`;
+  }
+
   if (r.explanation) html += `<div class="combo-body">${escHtml(r.explanation).replace(/\n/g,'<br>')}</div>`;
 
   if (r.nutrition_highlights) {
@@ -39406,7 +39506,7 @@ function renderComboResult(r) {
   }
 
   if (r.new_foods && r.new_foods.length > 0) {
-    html += `<div class="combo-section"><div class="combo-section-title">${zi('sparkle')} New foods to introduce first</div><div class="combo-body">${r.new_foods.join(', ')} — introduce each alone for 3 days before combining.</div></div>`;
+    html += `<div class="combo-section"><div class="combo-section-title">${zi('sparkle')} New foods to introduce first</div><div class="combo-body">${r.new_foods.map(escHtml).join(', ')} — introduce each alone for 3 days before combining.</div></div>`;
   }
 
   if (r.allergen_notes && r.allergen_notes.length > 0) {

--- a/tests/e2e/food-effects-v2-r1-combo-checker.spec.ts
+++ b/tests/e2e/food-effects-v2-r1-combo-checker.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from '@playwright/test';
+
+// food-effects v2 — R1: the "Can I give this?" combo checker reconciled onto
+// FOOD_EFFECTS (spec §3.1). BOTH polarities + the co-located emergency floor.
+//
+//   • acute-toxin (honey)        → verdict avoid (hard, never softened) + the
+//                                  botulism watch-fors/seek-care floor + hazard.
+//   • allergen-introduce-early   → verdict SAFE (encourage, the legacy allergen→
+//     (age-appropriate peanut/nut)  caution flip SUPPRESSED) + safe-form gate +
+//                                  compact whyGood + the severe anaphylaxis floor,
+//                                  co-located ABOVE nutrition/recipe (M-S-3).
+//   • below the soft floor       → age avoid AND the floor still renders (M-S-4).
+//   • multi-food                 → avoid dominates the verdict; EACH food's floor
+//                                  renders (Invariant 1 is per-food).
+//   • "peanut-free"              → R0 guard: no match, no floor, no encourage.
+//   • HR-4 (M-S-9)               → user food tokens are escaped at render.
+//
+// Driven via checkFoodCombo() and inspected on #comboResult structurally (counts /
+// DOM order / class), not through tab chrome (avoids the active-panel race).
+declare const checkFoodCombo: () => void;
+declare const getFoodEffect: (name: string) => any;
+declare const getAgeInMonths: () => number;
+
+async function runCombo(page: any, query: string) {
+  return page.evaluate((q: string) => {
+    const inp = document.getElementById('comboInput') as HTMLInputElement;
+    inp.value = q;
+    checkFoodCombo();
+    const el = document.getElementById('comboResult')!;
+    const firstFloor = el.querySelector('.cons-severe, .cons-watch, .cons-seek');
+    const nutTitle = Array.from(el.querySelectorAll('.combo-section-title'))
+      .find(t => /Nutrition/i.test(t.textContent || ''));
+    return {
+      html: el.innerHTML,
+      resultClass: (el.querySelector('.combo-result') as HTMLElement)?.className || '',
+      verdictClass: (el.querySelector('.combo-verdict') as HTMLElement)?.className || '',
+      verdictText: (el.querySelector('.combo-verdict') as HTMLElement)?.textContent || '',
+      severeCount: el.querySelectorAll('.cons-severe').length,
+      watchCount: el.querySelectorAll('.cons-watch').length,
+      seekCount: el.querySelectorAll('.cons-seek').length,
+      imgCount: el.querySelectorAll('img').length,
+      // floor co-located above nutrition (M-S-3): the first floor block precedes
+      // the Nutrition section in DOM order (or nutrition is absent → trivially OK).
+      floorAboveNutrition: !firstFloor ? null
+        : (!nutTitle ? true : !!(firstFloor.compareDocumentPosition(nutTitle) & 4)),
+    };
+  }, query);
+}
+
+test.describe('food-effects v2 — R1 combo checker (both poles + floor)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/index.html?nosync');
+    await page.waitForFunction(() =>
+      typeof checkFoodCombo === 'function'
+      && typeof getFoodEffect === 'function'
+      && typeof getAgeInMonths === 'function'
+      && !!document.getElementById('comboInput'), null, { timeout: 10_000 });
+    // Sanity: Ziva is between the nut floor (6mo) and the honey ceiling (12mo),
+    // so "peanut" is age-appropriate and "honey" is below its floor.
+    const mo = await page.evaluate(() => getAgeInMonths());
+    expect(mo, 'test relies on 6 < age < 12 months').toBeGreaterThan(6);
+    expect(mo).toBeLessThan(12);
+  });
+
+  test('honey → hard AVOID + the botulism floor + hazard (acute-toxin, never softened)', async ({ page }) => {
+    const r = await runCombo(page, 'honey');
+    expect(r.resultClass, 'avoid chrome').toContain('avoid');
+    expect(r.verdictText, 'headline is the record hazard title, never bare "safe"').toContain('Honey before 12 months');
+    expect(r.html.toLowerCase(), 'botulism hazard surfaced (toxin.why)').toContain('botulism');
+    expect(r.watchCount, 'botulism watch-fors render').toBeGreaterThan(0);
+    expect(r.seekCount, 'seek-care renders').toBeGreaterThan(0);
+    expect(r.severeCount, 'honey has no anaphylaxis severeSigns').toBe(0);
+    expect(r.html, 'no encourage/introduce-early framing for an acute-toxin').not.toContain('introduce early');
+  });
+
+  test('age-appropriate peanut → SAFE + encourage, floor co-located above the fold', async ({ page }) => {
+    const r = await runCombo(page, 'peanut');
+    // legacy allergen→caution flip SUPPRESSED (K-S-5): verdict is safe, not caution.
+    expect(r.verdictClass, 'safe verdict (caution flip suppressed)').toContain('safe');
+    expect(r.verdictClass).not.toContain('caution');
+    // headline from eff.title — never a synthesized bare "safe" (M-S-2).
+    expect(r.verdictText).toContain('good to introduce early');
+    // the severe anaphylaxis floor renders…
+    expect(r.severeCount, 'anaphylaxis severe strip present').toBeGreaterThan(0);
+    expect(r.seekCount).toBeGreaterThan(0);
+    // …above the nutrition section (M-S-3).
+    expect(r.floorAboveNutrition, 'floor co-located above nutrition (M-S-3)').toBe(true);
+    // the safe-form gate (A-2) + a compact benefit are surfaced.
+    expect(r.html, 'safe-form gate (never-whole / not the allergy risk)').toMatch(/does not remove the allergy risk|Safe form/i);
+    expect(r.html.toLowerCase(), 'compact whyGood benefit').toContain('plant protein');
+  });
+
+  test('below the soft floor → age AVOID, and the floor still renders (M-S-4)', async ({ page }) => {
+    // "whole almond" hits the 60-month choking gate (well above Ziva's age), so it
+    // is a below-floor avoid — but the tree-nut record's floor must still surface.
+    const r = await runCombo(page, 'whole almond');
+    expect(r.resultClass, 'below-floor → avoid').toContain('avoid');
+    expect(r.severeCount + r.watchCount + r.seekCount, 'the floor still renders below the floor').toBeGreaterThan(0);
+  });
+
+  test('multi-food "peanut with honey" → AVOID dominates, BOTH floors render (per-food)', async ({ page }) => {
+    const r = await runCombo(page, 'peanut with honey');
+    expect(r.resultClass, 'honey avoid dominates the top-level verdict').toContain('avoid');
+    expect(r.verdictText, 'hazard headline (honey)').toContain('Honey before 12 months');
+    expect(r.severeCount, "peanut's anaphylaxis floor is not suppressed by honey's avoid").toBeGreaterThan(0);
+    expect(r.watchCount, "honey's botulism floor renders too").toBeGreaterThan(0);
+  });
+
+  test('"peanut-free" → R0 guard holds in the combo checker (no match, no floor, no encourage)', async ({ page }) => {
+    const r = await runCombo(page, 'peanut-free');
+    expect(r.severeCount + r.watchCount, 'a negated query surfaces no floor').toBe(0);
+    expect(r.html, 'no encourage framing on an excluded food').not.toContain('good to introduce early');
+    expect(r.resultClass, 'not an acute-toxin avoid').not.toContain('avoid');
+  });
+
+  test('HR-4 (M-S-9): a script-y food token is escaped, not injected', async ({ page }) => {
+    const r = await runCombo(page, '<img src=x onerror=alert(1)> + apple');
+    expect(r.imgCount, 'no live <img> injected from the query').toBe(0);
+    expect(r.html, 'the token is HTML-escaped').toContain('&lt;img');
+  });
+});

--- a/tests/e2e/food-effects-v2-r1-combo-checker.spec.ts
+++ b/tests/e2e/food-effects-v2-r1-combo-checker.spec.ts
@@ -113,6 +113,27 @@ test.describe('food-effects v2 — R1 combo checker (both poles + floor)', () =>
     expect(r.resultClass, 'not an acute-toxin avoid').not.toContain('avoid');
   });
 
+  test('M-R1-1: a pre-R1 cached result (no floor) recomputes, never renders floorless', async ({ page }) => {
+    // Seed localStorage with a result cached BEFORE R1 — honey avoid, but no floor
+    // fields and no _schema tag — then reload so it loads into comboHistory. The
+    // cache short-circuit must treat it as stale and recompute, surfacing the
+    // botulism floor (the §10 silent-floor-drop guard).
+    await page.evaluate(() => {
+      const stale = [{
+        q: 'honey',
+        result: { verdict: 'avoid', verdict_emoji: '', headline: 'honey: OLD STALE caution', explanation: 'stale', _queryFoods: ['honey'] },
+        ts: new Date().toISOString(),
+      }];
+      localStorage.setItem('ziva_combo_history', JSON.stringify(stale));
+    });
+    await page.reload();
+    await page.waitForFunction(() => typeof checkFoodCombo === 'function' && !!document.getElementById('comboInput'), null, { timeout: 10_000 });
+    const r = await runCombo(page, 'honey');
+    expect(r.watchCount, 'stale honey recomputed → botulism floor present').toBeGreaterThan(0);
+    expect(r.verdictText, 'recomputed hazard headline, not the stale one').toContain('Honey before 12 months');
+    expect(r.html, 'the stale floorless result is not shown').not.toContain('OLD STALE');
+  });
+
   test('HR-4 (M-S-9): a script-y food token is escaped, not injected', async ({ page }) => {
     const r = await runCombo(page, '<img src=x onerror=alert(1)> + apple');
     expect(r.imgCount, 'no live <img> injected from the query').toBe(0);


### PR DESCRIPTION
Second implementation round of the reconciliation (#192 / issue #189), spec §3.1. Builds on R0 (the negation guard). **Both polarities + the co-located emergency floor.**

## What changed
**`core.js` (Kael):**
- `_effHasClass(eff, cls)` — foodClass membership test (M-S-5): nuts carry the array `['allergen-introduce-early','choking-by-form']`, honey the string `'acute-toxin'`; a `===` would drop the array case and lose both reframe and floor.
- `_severeFloorHtml(eff)` — the **one** shared floor renderer (M-S-7): severe strip + watch-fors + seek-care, present-only (A-4). `foodConsequenceCard` refactored to call it (**byte-identical output** — the log-time card is unchanged; it's now DRY).

**`diet.js` `checkFoodCombo` (Maren):**
- **acute-toxin (honey)** → hard `avoid` (never softened, Invariant 2) + the hazard (`why`) + the botulism floor.
- **age-appropriate allergen-introduce-early (peanut/nut)** → `safe` (encourage) with the **legacy allergen→caution flip SUPPRESSED** (K-S-5), the safe-form gate (A-2) + compact `whyGood`, **atomic with the floor** (M-S-1). Headline from `eff.title`, never a synthesized bare "safe" (M-S-2).
- **below the soft floor** → age `avoid` AND the floor still renders (M-S-4).
- Floor collected **outside** the polarity branch on field presence (A-4/M-S-5), **per-food** — multi-food "peanut with honey" → avoid dominates, **both** floors render. Non-veg no longer downgrades an `avoid`.

**`renderComboResult`:** floor + hazard + safe-form + benefit rendered **immediately after the verdict, above nutrition/recipe/pairing** (M-S-3); pre-R1 cached results guarded.

**HR-4 (M-S-9):** the user food tokens in the headline / allergen note / new-foods were unescaped at the `innerHTML` boundary — now escaped.

## Verification
- `pnpm build` clean, **12 gates pass**.
- New e2e `food-effects-v2-r1-combo-checker.spec.ts` — **6/6**: honey avoid+botulism+hazard; age-appropriate peanut safe+encourage+floor-above-fold; below-floor avoid+floor; multi-food both floors; `"peanut-free"` R0 no-match; HR-4 escaping.
- Full suite re-verify running (no existing spec drives the combo checker; the `severity:'caution'` hits elsewhere are record-chrome, not the verdict).

## canon-cc-008 routing
`diet.js` → **Maren** (primary, the verdict-state-machine + Care invariants M-S-1…9); `core.js` → **Kael** (the two helpers + the `foodConsequenceCard` refactor byte-identity). No `intelligence-*` / shared-module touch → no Vela / no triple-Gov. Cipher Edict V terminal. Stays draft until the chain clears.

https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK)_