### PR TITLE
fix: make chip-taxonomy + card-priority audits path-separator portable

### DIFF
--- a/split/audit-card-priority-v3-6.sh
+++ b/split/audit-card-priority-v3-6.sh
@@ -49,7 +49,7 @@ class_hits_total = 0
 class_hits_per_file = {}
 
 for entry in sorted(os.listdir(SCAN_DIR)):
-    path = os.path.join(SCAN_DIR, entry)
+    path = os.path.join(SCAN_DIR, entry).replace(os.sep, '/')
     if not os.path.isfile(path):
         continue
     if path in EXEMPT:

--- a/split/audit-chip-taxonomy-v3-5.sh
+++ b/split/audit-chip-taxonomy-v3-5.sh
@@ -54,7 +54,7 @@ total_hits = 0
 per_file = {}
 
 for entry in sorted(os.listdir(SCAN_DIR)):
-    path = os.path.join(SCAN_DIR, entry)
+    path = os.path.join(SCAN_DIR, entry).replace(os.sep, '/')
     if not os.path.isfile(path):
         continue
     if path in EXEMPT:


### PR DESCRIPTION
@
## What

Normalize the joined scan path in two build-audit gates so they run correctly on Windows:

- `split/audit-chip-taxonomy-v3-5.sh`
- `split/audit-card-priority-v3-6.sh`

Both build scan paths with `os.path.join(SCAN_DIR, entry)` (→ `split\styles.css` on Windows) but compare against a hardcoded forward-slash `EXEMPT` set (`split/styles.css`). On Windows the exemption never matched, so `styles.css` was scanned and its **historical block comments** surfaced as false HR violations — breaking `pnpm build` (and the pre-commit hook) on the Windows dev machine.

Fix: append `.replace(os.sep, /)` to the join — a **no-op on Linux/Termux**, correct on Windows.

```diff
- path = os.path.join(SCAN_DIR, entry)
+ path = os.path.join(SCAN_DIR, entry).replace(os.sep, /)
```

## Why it is safe

- Pure cross-platform portability fix in build tooling; **no app behaviour changes**.
- **No Governor jurisdiction touched** — these are audit shell scripts, not `home/diet/medical`, `intelligence-*`, `core/data/sync`, `cards/quicklog`, or `styles.css`/`template.html`.
- Identical audit semantics on Linux (where `os.sep == "/"`, so the `.replace` is a no-op).

## QA gate (canon-cc-008)

**Tooling/test-only diff** → Governor audit **waived** per the test/tooling-only carve-out. Pre-commit HR gates (emoji / hr12 / icon-text) pass. No Capital app module changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@