### PR TITLE
docs: correct live-site URL to lowercase /sproutlab/ after repo rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md — SproutLab
 **Companion:** Lyra (The Weaver)
 **Tone:** Pattern-seeking, warm but precise. Sees connections others miss.
-**Repo:** rishabh1804.github.io/SproutLab/
+**Repo:** rishabh1804.github.io/sproutlab/
 
 ---
 
@@ -79,7 +79,7 @@ Baby development tracker for **Ziva Jain** (born 4 Sep 2025). Architecture: spli
 
 **Design brief:** Warm, sturdy, calm. A cozy nursery journal, not a clinical health app.
 
-**Live:** https://rishabh1804.github.io/SproutLab/
+**Live:** https://rishabh1804.github.io/sproutlab/
 
 ## Architecture
 

--- a/docs/AT_SMOKE_PASS.md
+++ b/docs/AT_SMOKE_PASS.md
@@ -55,7 +55,7 @@ primary; NVDA is the named older-AT double-announce risk and is free.
 | 3 | Windows | JAWS | If available |
 | 3 | macOS / Safari | VoiceOver | Cmd+F5 |
 
-Test against the **live deploy** (https://rishabh1804.github.io/SproutLab/) so the
+Test against the **live deploy** (https://rishabh1804.github.io/sproutlab/) so the
 service-worker / PWA path is real, not a local file.
 
 ---

--- a/docs/SPROUTLAB_PHASE_2_CHARTER.md
+++ b/docs/SPROUTLAB_PHASE_2_CHARTER.md
@@ -43,7 +43,7 @@
 Three properties of this SW:
 
 1. **Blob URL registration.** SW source is a string, blobbed at runtime, registered from a `blob:` URL. Some user-agents reject `scope` for `blob:`-origin SWs entirely.
-2. **Scope `/sproutlab/beta/`.** Live deploy is `https://rishabh1804.github.io/SproutLab/` (capital S, no `/beta/`). Lowercase `/sproutlab/beta/` matches `beta/beta-manifest.json`. On production the registration's `.catch()` swallows the scope-mismatch failure — **the SW never activates.** Production has no live SW.
+2. **Scope `/sproutlab/beta/`.** Live deploy is `https://rishabh1804.github.io/sproutlab/` (lowercase, no `/beta/`); the `/sproutlab/beta/` scope matches `beta/beta-manifest.json`, the beta sub-app. Production pages at `/sproutlab/` sit *above* that scope, so a worker scoped to `/sproutlab/beta/` could never control them — and the registration's `.catch()` swallows the failure regardless. **The SW never activates on production. Production has no live SW.**
 3. **Caches: empty.** `caches.open` repo-wide: 0 hits. No precache, no `addAll`, no runtime cache. Fetch handler is pure passthrough with a 503 fallback. There is no cache to invalidate.
 
 ### Finding B — Build emits a single ~3 MB monolithic HTML; no separate assets to cache-bust


### PR DESCRIPTION
@
## What

The repo was renamed to lowercase `sproutlab`. GitHub Pages project URLs are **case-sensitive on the repo-name segment**, so the old `/SproutLab/` path now 404s while `/sproutlab/` serves:

```
/sproutlab/manifest.json  -> HTTP 200
/SproutLab/manifest.json  -> HTTP 404 ("Site not found")
```

Update the **living** doc references to the live deploy:

- **`CLAUDE.md`** — `Repo:` + `Live:` URLs → lowercase.
- **`docs/AT_SMOKE_PASS.md`** — the AT smoke-test "test against the live deploy" target → lowercase (it was pointing testers at the now-404 URL).
- **`docs/SPROUTLAB_PHASE_2_CHARTER.md`** Finding A.2 — corrected the production URL **and the reasoning**. The conclusion ("SW never activates / production has no live SW") stands, but its premise was a capital-vs-lowercase *scope mismatch* that no longer exists. Reframed as the real **path-depth** mismatch: production at `/sproutlab/` sits *above* the `/sproutlab/beta/` SW scope, so the beta-scoped worker can never control production pages.

## Deliberately not touched

The 8 `SESSION_HANDOFF_*` files still reference `/SproutLab/` — these are **point-in-time chronicle records**, accurate as-written. Rewriting them would falsify history.

## QA gate (canon-cc-008)

**Docs-only diff → gate-exempt.** Pre-commit HR audits (emoji / hr12 / icon-text) pass. No `split/` app module touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@