### PR TITLE
R2: reconcile the Q&A food-safety answer onto FOOD_EFFECTS (food-effects v2 #189)

### DIFF
--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-05-31 &middot; graph @ <code>8ae3b3bce324</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-05-31 &middot; graph @ <code>78b77205c0ea</code></div>
   <div class="sub" style="margin-top:8px">
     <span class="stat"><b>1,716</b> symbols</span>
     <span class="stat"><b>5,094</b> relations</span>
-    <span class="stat"><b>80,395</b> LOC</span>
+    <span class="stat"><b>80,409</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -65,14 +65,14 @@
       <div class="nums">
         <span><b>11</b> modules</span>
         <span><b>731</b> symbols</span>
-        <span><b>27,150</b> LOC</span>
+        <span><b>27,151</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,150 of 30,000 LOC">
+      <div class="bar" title="27,151 of 30,000 LOC">
         <div class="fill hot" style="width:91%"></div>
         <span class="barlbl">91% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,850 LOC headroom</div>
+      <div class="hd">2,849 LOC headroom</div>
       <div class="mods">core.js, i-illness.js, i-caretickets.js, i-qa-handlers.js, sync.js, data.js, i-qa.js, i-isl.js, config.js, i-correlate.js, start.js</div>
     </div>
     <div class="card" style="border-top:5px solid #b5d5c5">
@@ -116,7 +116,7 @@
       <div class="nums">
         <span><b>2</b> modules</span>
         <span><b>0</b> symbols</span>
-        <span><b>14,017</b> LOC</span>
+        <span><b>14,030</b> LOC</span>
       </div>
       <div class="note">Unsurveyed &mdash; code-only extraction. Set a backend and rebuild for symbols.</div>
       <div class="mods">styles.css, template.html</div>

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-05-31 &middot; graph @ <code>98ab58425afb</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-05-31 &middot; graph @ <code>8ae3b3bce324</code></div>
   <div class="sub" style="margin-top:8px">
     <span class="stat"><b>1,716</b> symbols</span>
-    <span class="stat"><b>5,091</b> relations</span>
-    <span class="stat"><b>80,335</b> LOC</span>
+    <span class="stat"><b>5,094</b> relations</span>
+    <span class="stat"><b>80,395</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -65,14 +65,14 @@
       <div class="nums">
         <span><b>11</b> modules</span>
         <span><b>731</b> symbols</span>
-        <span><b>27,090</b> LOC</span>
+        <span><b>27,150</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,090 of 30,000 LOC">
-        <div class="fill hot" style="width:90%"></div>
-        <span class="barlbl">90% to 30K frontier &middot; CONTESTED</span>
+      <div class="bar" title="27,150 of 30,000 LOC">
+        <div class="fill hot" style="width:91%"></div>
+        <span class="barlbl">91% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,910 LOC headroom</div>
+      <div class="hd">2,850 LOC headroom</div>
       <div class="mods">core.js, i-illness.js, i-caretickets.js, i-qa-handlers.js, sync.js, data.js, i-qa.js, i-isl.js, config.js, i-correlate.js, start.js</div>
     </div>
     <div class="card" style="border-top:5px solid #b5d5c5">

--- a/index.html
+++ b/index.html
@@ -7890,6 +7890,19 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 .qa-item-action .qa-item-signal { color:var(--tc-indigo); }
 .qa-item-info .qa-item-signal { color:var(--tc-sky); }
 .qa-item-neutral .qa-item-signal { color:var(--mid); }
+/* food-effects v2 R2 (V-R2-N1/N2): the Q&A emergency-floor section must carry the
+   weight of the .cons-severe log-time floor a parent has already learned — not the
+   muted nutrition-section chrome. Amber surface + amber-deep bold label/siren (V-3:
+   serious-without-alarm; rose reserved for the acute-toxin seek-care line). Applied
+   via sec.tone==='floor' in qaRenderAnswer; reachability/order are unchanged. */
+.qa-section-floor { background:var(--surface-amber); border-left:3px solid var(--amber-deep); border-radius:var(--r-md); margin:var(--sp-4) var(--sp-16) var(--sp-12); padding:var(--sp-12); }
+.qa-section-floor .qa-section-label { color:var(--amber-deep); }
+.qa-section-floor .qa-section-label-icon { color:var(--amber-deep); }
+/* watch-fors inside a floor read at warn weight, not the calm 'info' sky-blue (V-R2-N2) */
+.qa-section-floor .qa-item-info .qa-item-signal { color:var(--amber-deep); }
+/* the seek-care line carries the rose-deep alarm in its TEXT, not just its icon */
+.qa-section-floor .qa-item-seek { color:var(--rose-deep); font-weight:600; }
+.qa-section-floor .qa-item-seek .qa-item-signal { color:var(--rose-deep); }
 .qa-confidence {
   padding:var(--sp-8) var(--sp-16) var(--sp-12);
   font-size:var(--fs-2xs); color:var(--light);
@@ -55918,18 +55931,19 @@ function qaHandleFoodSafety(classified) {
   // section), sourced from FOOD_EFFECTS (Invariant 4). The hazard leads for an
   // acute-toxin; the safe-form gate + benefit follow for an encourage.
   if (toxin && toxin.why) {
-    sections.push({ label: 'WHY', icon: zi('siren'), items: [{ text: toxin.why, signal: 'warn' }] });
+    sections.push({ label: 'WHY', icon: zi('siren'), tone: 'floor', items: [{ text: toxin.why, signal: 'warn' }] });
   }
   severeFloors.forEach(function(sf) {
     var eff = sf.eff;
     var items = [];
     (eff.severeSigns || []).forEach(function(s) { items.push({ text: s, signal: 'warn' }); });
     (eff.watchFor || []).forEach(function(w) { items.push({ text: w, signal: 'info' }); });
-    if (eff.seekCare) items.push({ text: eff.seekCare, signal: 'warn' });
+    if (eff.seekCare) items.push({ text: eff.seekCare, signal: 'warn', cls: 'qa-item-seek' });
     if (items.length) {
       var hasSevere = !!(eff.severeSigns && eff.severeSigns.length);
       var label = (hasSevere ? 'IF THIS HAPPENS, EMERGENCY' : 'WATCH FOR') + (rawFoods.length > 1 ? ' — ' + sf.food : '');
-      sections.push({ label: label, icon: zi('siren'), items: items });
+      // tone:'floor' → the emergency chrome (V-R2-N1) so the strip is unmissable.
+      sections.push({ label: label, icon: zi('siren'), tone: 'floor', items: items });
     }
   });
   if (encourage) {
@@ -56520,13 +56534,13 @@ function qaRenderAnswer(container, answer) {
   // Sections
   if (answer.sections) {
     answer.sections.forEach(function(sec) {
-      html += '<div class="qa-section">';
+      html += '<div class="qa-section' + (sec.tone === 'floor' ? ' qa-section-floor' : '') + '">';
       html += '<div class="qa-section-label"><span class="qa-section-label-icon">' + sec.icon + '</span> ' + escHtml(sec.label) + '</div>';
       if (sec.items) {
         sec.items.forEach(function(item) {
           var cls = signalClasses[item.signal] || 'qa-item-neutral';
           var icon = item.icon || signalIcons[item.signal] || '·';
-          html += '<div class="qa-item ' + cls + '">';
+          html += '<div class="qa-item ' + cls + (item.cls ? ' ' + item.cls : '') + '">';
           html += '<span class="qa-item-signal">' + icon + '</span>';
           html += '<span class="qa-item-text">' + escHtml(item.text) + '</span>';
           html += '</div>';

--- a/index.html
+++ b/index.html
@@ -55780,23 +55780,50 @@ function qaHandleFoodSafety(classified) {
   var allergenNotes = [];
   var newFoods = [];
 
-  // 1. Age safety
+  // 1+2. Age safety + allergens + food-effects polarity (food-effects v2 R2, §3.2).
+  // K-S-2: route the age + allergen lookups through _lookupByFoodName (alias +
+  // word-boundary + the R0 negation guard), fed the RAW post-split token — the
+  // bare AGE_RULES[base]/ALLERGENS[base] lookups silently MISSED aliases (badam,
+  // groundnut, akhrot, kaju) and under-warned. K-S-5: an age-appropriate
+  // allergen-introduce-early food (peanut/nut) is an ENCOURAGE (safe), not a
+  // caution — the flag becomes safe-form guidance; honey (acute-toxin) is a hard
+  // avoid (Invariant 2). The emergency floor is collected per-food on field
+  // presence (A-4 / M-S-5), OUTSIDE the polarity branch.
+  var severeFloors = [];   // {food, eff} per food carrying a floor (Invariant 1, per-food)
+  var toxin = null;        // {title, why}                — acute-toxin (honey)
+  var encourage = null;    // {title, whyGood, safeFormNote} — age-appropriate allergen
   rawFoods.forEach(function(food) {
-    var base = _baseFoodName(food);
-    var rule = AGE_RULES[base] || AGE_RULES[food];
-    if (rule && mo < rule.minMonth) {
+    var rule = _lookupByFoodName(AGE_RULES, food);
+    var belowFloor = !!(rule && mo < rule.minMonth);
+    if (belowFloor) {
       verdict = 'avoid';
       warnings.push(food + ': ' + rule.reason);
     }
-  });
 
-  // 2. Allergens
-  rawFoods.forEach(function(food) {
-    var base = _baseFoodName(food);
-    var alert = ALLERGENS[base] || ALLERGENS[food];
+    var eff = (typeof getFoodEffect === 'function') ? getFoodEffect(food) : null;
+    if (eff && ((eff.severeSigns && eff.severeSigns.length) ||
+                (eff.watchFor && eff.watchFor.length) || eff.seekCare)) {
+      severeFloors.push({ food: food, eff: eff });
+    }
+
+    var alert = _lookupByFoodName(ALLERGENS, food);
+    var introEarlyOk = !!(eff && _effHasClass(eff, 'allergen-introduce-early') && !belowFloor);
     if (alert) {
       allergenNotes.push(food + ': ' + alert);
-      if (verdict === 'safe') verdict = 'caution';
+      if (verdict === 'safe' && !introEarlyOk) verdict = 'caution';
+    }
+
+    // Polarity (precedence: acute-toxin avoid (hard) > below-floor avoid > encourage safe).
+    if (eff && _effHasClass(eff, 'acute-toxin')) {
+      verdict = 'avoid';
+      toxin = { title: eff.title || '', why: eff.why || '' };
+    } else if (introEarlyOk) {
+      if (verdict !== 'avoid') verdict = 'safe';
+      encourage = {
+        title: eff.title || '',
+        whyGood: eff.whyGood || '',
+        safeFormNote: (eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : ''
+      };
     }
   });
 
@@ -55884,6 +55911,34 @@ function qaHandleFoodSafety(classified) {
   }
   sections.push({ label: 'SAFETY', icon: zi('shield'), items: safetyItems });
 
+  // Emergency floor (food-effects v2 §3.2, K-S-4) — pushed immediately after
+  // SAFETY, BEFORE nutrition/pairings/history, so it is never ordered below
+  // benefit content (Invariant 1; qaRenderAnswer renders sections flat/
+  // non-collapsibly). Per-food (multi-food: each food's floor in its own
+  // section), sourced from FOOD_EFFECTS (Invariant 4). The hazard leads for an
+  // acute-toxin; the safe-form gate + benefit follow for an encourage.
+  if (toxin && toxin.why) {
+    sections.push({ label: 'WHY', icon: zi('siren'), items: [{ text: toxin.why, signal: 'warn' }] });
+  }
+  severeFloors.forEach(function(sf) {
+    var eff = sf.eff;
+    var items = [];
+    (eff.severeSigns || []).forEach(function(s) { items.push({ text: s, signal: 'warn' }); });
+    (eff.watchFor || []).forEach(function(w) { items.push({ text: w, signal: 'info' }); });
+    if (eff.seekCare) items.push({ text: eff.seekCare, signal: 'warn' });
+    if (items.length) {
+      var hasSevere = !!(eff.severeSigns && eff.severeSigns.length);
+      var label = (hasSevere ? 'IF THIS HAPPENS, EMERGENCY' : 'WATCH FOR') + (rawFoods.length > 1 ? ' — ' + sf.food : '');
+      sections.push({ label: label, icon: zi('siren'), items: items });
+    }
+  });
+  if (encourage) {
+    var encItems = [];
+    if (encourage.safeFormNote) encItems.push({ text: encourage.safeFormNote, signal: 'info' });
+    if (encourage.whyGood) encItems.push({ text: encourage.whyGood, signal: 'good' });
+    if (encItems.length) sections.push({ label: 'SAFE FORM', icon: zi('sprout'), items: encItems });
+  }
+
   // Nutrition section
   if (benefits.length > 0) {
     sections.push({
@@ -55915,7 +55970,12 @@ function qaHandleFoodSafety(classified) {
     icon: 'shield',
     domain: 'peach',
     title: rawFoods.length === 1 ? 'Can she eat ' + rawFoods[0] + '?' : 'Food safety check',
-    headline: verdictText + (verdict === 'safe' ? ' \u2014 good to go' : ''),
+    // headline from the record (food-effects v2 \u00a73.1/\u00a73.2, M-S-2): the hazard for
+    // an acute-toxin, the encourage title for an age-appropriate allergen \u2014 never
+    // a bare "Safe" synthesized next to the food name. Falls back to the verdict.
+    headline: (toxin && toxin.title) ? toxin.title
+            : (encourage && verdict === 'safe' && encourage.title) ? encourage.title
+            : verdictText + (verdict === 'safe' ? ' \u2014 good to go' : ''),
     sections: sections,
     confidence: null,
     dataGap: null

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.31-34",
+  "version": "2026.05.31-35",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.31-35",
+  "version": "2026.05.31-39",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/intelligence-qa.js
+++ b/split/intelligence-qa.js
@@ -1162,18 +1162,19 @@ function qaHandleFoodSafety(classified) {
   // section), sourced from FOOD_EFFECTS (Invariant 4). The hazard leads for an
   // acute-toxin; the safe-form gate + benefit follow for an encourage.
   if (toxin && toxin.why) {
-    sections.push({ label: 'WHY', icon: zi('siren'), items: [{ text: toxin.why, signal: 'warn' }] });
+    sections.push({ label: 'WHY', icon: zi('siren'), tone: 'floor', items: [{ text: toxin.why, signal: 'warn' }] });
   }
   severeFloors.forEach(function(sf) {
     var eff = sf.eff;
     var items = [];
     (eff.severeSigns || []).forEach(function(s) { items.push({ text: s, signal: 'warn' }); });
     (eff.watchFor || []).forEach(function(w) { items.push({ text: w, signal: 'info' }); });
-    if (eff.seekCare) items.push({ text: eff.seekCare, signal: 'warn' });
+    if (eff.seekCare) items.push({ text: eff.seekCare, signal: 'warn', cls: 'qa-item-seek' });
     if (items.length) {
       var hasSevere = !!(eff.severeSigns && eff.severeSigns.length);
       var label = (hasSevere ? 'IF THIS HAPPENS, EMERGENCY' : 'WATCH FOR') + (rawFoods.length > 1 ? ' — ' + sf.food : '');
-      sections.push({ label: label, icon: zi('siren'), items: items });
+      // tone:'floor' → the emergency chrome (V-R2-N1) so the strip is unmissable.
+      sections.push({ label: label, icon: zi('siren'), tone: 'floor', items: items });
     }
   });
   if (encourage) {
@@ -1764,13 +1765,13 @@ function qaRenderAnswer(container, answer) {
   // Sections
   if (answer.sections) {
     answer.sections.forEach(function(sec) {
-      html += '<div class="qa-section">';
+      html += '<div class="qa-section' + (sec.tone === 'floor' ? ' qa-section-floor' : '') + '">';
       html += '<div class="qa-section-label"><span class="qa-section-label-icon">' + sec.icon + '</span> ' + escHtml(sec.label) + '</div>';
       if (sec.items) {
         sec.items.forEach(function(item) {
           var cls = signalClasses[item.signal] || 'qa-item-neutral';
           var icon = item.icon || signalIcons[item.signal] || '·';
-          html += '<div class="qa-item ' + cls + '">';
+          html += '<div class="qa-item ' + cls + (item.cls ? ' ' + item.cls : '') + '">';
           html += '<span class="qa-item-signal">' + icon + '</span>';
           html += '<span class="qa-item-text">' + escHtml(item.text) + '</span>';
           html += '</div>';

--- a/split/intelligence-qa.js
+++ b/split/intelligence-qa.js
@@ -1024,23 +1024,50 @@ function qaHandleFoodSafety(classified) {
   var allergenNotes = [];
   var newFoods = [];
 
-  // 1. Age safety
+  // 1+2. Age safety + allergens + food-effects polarity (food-effects v2 R2, §3.2).
+  // K-S-2: route the age + allergen lookups through _lookupByFoodName (alias +
+  // word-boundary + the R0 negation guard), fed the RAW post-split token — the
+  // bare AGE_RULES[base]/ALLERGENS[base] lookups silently MISSED aliases (badam,
+  // groundnut, akhrot, kaju) and under-warned. K-S-5: an age-appropriate
+  // allergen-introduce-early food (peanut/nut) is an ENCOURAGE (safe), not a
+  // caution — the flag becomes safe-form guidance; honey (acute-toxin) is a hard
+  // avoid (Invariant 2). The emergency floor is collected per-food on field
+  // presence (A-4 / M-S-5), OUTSIDE the polarity branch.
+  var severeFloors = [];   // {food, eff} per food carrying a floor (Invariant 1, per-food)
+  var toxin = null;        // {title, why}                — acute-toxin (honey)
+  var encourage = null;    // {title, whyGood, safeFormNote} — age-appropriate allergen
   rawFoods.forEach(function(food) {
-    var base = _baseFoodName(food);
-    var rule = AGE_RULES[base] || AGE_RULES[food];
-    if (rule && mo < rule.minMonth) {
+    var rule = _lookupByFoodName(AGE_RULES, food);
+    var belowFloor = !!(rule && mo < rule.minMonth);
+    if (belowFloor) {
       verdict = 'avoid';
       warnings.push(food + ': ' + rule.reason);
     }
-  });
 
-  // 2. Allergens
-  rawFoods.forEach(function(food) {
-    var base = _baseFoodName(food);
-    var alert = ALLERGENS[base] || ALLERGENS[food];
+    var eff = (typeof getFoodEffect === 'function') ? getFoodEffect(food) : null;
+    if (eff && ((eff.severeSigns && eff.severeSigns.length) ||
+                (eff.watchFor && eff.watchFor.length) || eff.seekCare)) {
+      severeFloors.push({ food: food, eff: eff });
+    }
+
+    var alert = _lookupByFoodName(ALLERGENS, food);
+    var introEarlyOk = !!(eff && _effHasClass(eff, 'allergen-introduce-early') && !belowFloor);
     if (alert) {
       allergenNotes.push(food + ': ' + alert);
-      if (verdict === 'safe') verdict = 'caution';
+      if (verdict === 'safe' && !introEarlyOk) verdict = 'caution';
+    }
+
+    // Polarity (precedence: acute-toxin avoid (hard) > below-floor avoid > encourage safe).
+    if (eff && _effHasClass(eff, 'acute-toxin')) {
+      verdict = 'avoid';
+      toxin = { title: eff.title || '', why: eff.why || '' };
+    } else if (introEarlyOk) {
+      if (verdict !== 'avoid') verdict = 'safe';
+      encourage = {
+        title: eff.title || '',
+        whyGood: eff.whyGood || '',
+        safeFormNote: (eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : ''
+      };
     }
   });
 
@@ -1128,6 +1155,34 @@ function qaHandleFoodSafety(classified) {
   }
   sections.push({ label: 'SAFETY', icon: zi('shield'), items: safetyItems });
 
+  // Emergency floor (food-effects v2 §3.2, K-S-4) — pushed immediately after
+  // SAFETY, BEFORE nutrition/pairings/history, so it is never ordered below
+  // benefit content (Invariant 1; qaRenderAnswer renders sections flat/
+  // non-collapsibly). Per-food (multi-food: each food's floor in its own
+  // section), sourced from FOOD_EFFECTS (Invariant 4). The hazard leads for an
+  // acute-toxin; the safe-form gate + benefit follow for an encourage.
+  if (toxin && toxin.why) {
+    sections.push({ label: 'WHY', icon: zi('siren'), items: [{ text: toxin.why, signal: 'warn' }] });
+  }
+  severeFloors.forEach(function(sf) {
+    var eff = sf.eff;
+    var items = [];
+    (eff.severeSigns || []).forEach(function(s) { items.push({ text: s, signal: 'warn' }); });
+    (eff.watchFor || []).forEach(function(w) { items.push({ text: w, signal: 'info' }); });
+    if (eff.seekCare) items.push({ text: eff.seekCare, signal: 'warn' });
+    if (items.length) {
+      var hasSevere = !!(eff.severeSigns && eff.severeSigns.length);
+      var label = (hasSevere ? 'IF THIS HAPPENS, EMERGENCY' : 'WATCH FOR') + (rawFoods.length > 1 ? ' — ' + sf.food : '');
+      sections.push({ label: label, icon: zi('siren'), items: items });
+    }
+  });
+  if (encourage) {
+    var encItems = [];
+    if (encourage.safeFormNote) encItems.push({ text: encourage.safeFormNote, signal: 'info' });
+    if (encourage.whyGood) encItems.push({ text: encourage.whyGood, signal: 'good' });
+    if (encItems.length) sections.push({ label: 'SAFE FORM', icon: zi('sprout'), items: encItems });
+  }
+
   // Nutrition section
   if (benefits.length > 0) {
     sections.push({
@@ -1159,7 +1214,12 @@ function qaHandleFoodSafety(classified) {
     icon: 'shield',
     domain: 'peach',
     title: rawFoods.length === 1 ? 'Can she eat ' + rawFoods[0] + '?' : 'Food safety check',
-    headline: verdictText + (verdict === 'safe' ? ' \u2014 good to go' : ''),
+    // headline from the record (food-effects v2 \u00a73.1/\u00a73.2, M-S-2): the hazard for
+    // an acute-toxin, the encourage title for an age-appropriate allergen \u2014 never
+    // a bare "Safe" synthesized next to the food name. Falls back to the verdict.
+    headline: (toxin && toxin.title) ? toxin.title
+            : (encourage && verdict === 'safe' && encourage.title) ? encourage.title
+            : verdictText + (verdict === 'safe' ? ' \u2014 good to go' : ''),
     sections: sections,
     confidence: null,
     dataGap: null

--- a/split/styles.css
+++ b/split/styles.css
@@ -7883,6 +7883,19 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 .qa-item-action .qa-item-signal { color:var(--tc-indigo); }
 .qa-item-info .qa-item-signal { color:var(--tc-sky); }
 .qa-item-neutral .qa-item-signal { color:var(--mid); }
+/* food-effects v2 R2 (V-R2-N1/N2): the Q&A emergency-floor section must carry the
+   weight of the .cons-severe log-time floor a parent has already learned — not the
+   muted nutrition-section chrome. Amber surface + amber-deep bold label/siren (V-3:
+   serious-without-alarm; rose reserved for the acute-toxin seek-care line). Applied
+   via sec.tone==='floor' in qaRenderAnswer; reachability/order are unchanged. */
+.qa-section-floor { background:var(--surface-amber); border-left:3px solid var(--amber-deep); border-radius:var(--r-md); margin:var(--sp-4) var(--sp-16) var(--sp-12); padding:var(--sp-12); }
+.qa-section-floor .qa-section-label { color:var(--amber-deep); }
+.qa-section-floor .qa-section-label-icon { color:var(--amber-deep); }
+/* watch-fors inside a floor read at warn weight, not the calm 'info' sky-blue (V-R2-N2) */
+.qa-section-floor .qa-item-info .qa-item-signal { color:var(--amber-deep); }
+/* the seek-care line carries the rose-deep alarm in its TEXT, not just its icon */
+.qa-section-floor .qa-item-seek { color:var(--rose-deep); font-weight:600; }
+.qa-section-floor .qa-item-seek .qa-item-signal { color:var(--rose-deep); }
 .qa-confidence {
   padding:var(--sp-8) var(--sp-16) var(--sp-12);
   font-size:var(--fs-2xs); color:var(--light);

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -7890,6 +7890,19 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 .qa-item-action .qa-item-signal { color:var(--tc-indigo); }
 .qa-item-info .qa-item-signal { color:var(--tc-sky); }
 .qa-item-neutral .qa-item-signal { color:var(--mid); }
+/* food-effects v2 R2 (V-R2-N1/N2): the Q&A emergency-floor section must carry the
+   weight of the .cons-severe log-time floor a parent has already learned — not the
+   muted nutrition-section chrome. Amber surface + amber-deep bold label/siren (V-3:
+   serious-without-alarm; rose reserved for the acute-toxin seek-care line). Applied
+   via sec.tone==='floor' in qaRenderAnswer; reachability/order are unchanged. */
+.qa-section-floor { background:var(--surface-amber); border-left:3px solid var(--amber-deep); border-radius:var(--r-md); margin:var(--sp-4) var(--sp-16) var(--sp-12); padding:var(--sp-12); }
+.qa-section-floor .qa-section-label { color:var(--amber-deep); }
+.qa-section-floor .qa-section-label-icon { color:var(--amber-deep); }
+/* watch-fors inside a floor read at warn weight, not the calm 'info' sky-blue (V-R2-N2) */
+.qa-section-floor .qa-item-info .qa-item-signal { color:var(--amber-deep); }
+/* the seek-care line carries the rose-deep alarm in its TEXT, not just its icon */
+.qa-section-floor .qa-item-seek { color:var(--rose-deep); font-weight:600; }
+.qa-section-floor .qa-item-seek .qa-item-signal { color:var(--rose-deep); }
 .qa-confidence {
   padding:var(--sp-8) var(--sp-16) var(--sp-12);
   font-size:var(--fs-2xs); color:var(--light);
@@ -55918,18 +55931,19 @@ function qaHandleFoodSafety(classified) {
   // section), sourced from FOOD_EFFECTS (Invariant 4). The hazard leads for an
   // acute-toxin; the safe-form gate + benefit follow for an encourage.
   if (toxin && toxin.why) {
-    sections.push({ label: 'WHY', icon: zi('siren'), items: [{ text: toxin.why, signal: 'warn' }] });
+    sections.push({ label: 'WHY', icon: zi('siren'), tone: 'floor', items: [{ text: toxin.why, signal: 'warn' }] });
   }
   severeFloors.forEach(function(sf) {
     var eff = sf.eff;
     var items = [];
     (eff.severeSigns || []).forEach(function(s) { items.push({ text: s, signal: 'warn' }); });
     (eff.watchFor || []).forEach(function(w) { items.push({ text: w, signal: 'info' }); });
-    if (eff.seekCare) items.push({ text: eff.seekCare, signal: 'warn' });
+    if (eff.seekCare) items.push({ text: eff.seekCare, signal: 'warn', cls: 'qa-item-seek' });
     if (items.length) {
       var hasSevere = !!(eff.severeSigns && eff.severeSigns.length);
       var label = (hasSevere ? 'IF THIS HAPPENS, EMERGENCY' : 'WATCH FOR') + (rawFoods.length > 1 ? ' — ' + sf.food : '');
-      sections.push({ label: label, icon: zi('siren'), items: items });
+      // tone:'floor' → the emergency chrome (V-R2-N1) so the strip is unmissable.
+      sections.push({ label: label, icon: zi('siren'), tone: 'floor', items: items });
     }
   });
   if (encourage) {
@@ -56520,13 +56534,13 @@ function qaRenderAnswer(container, answer) {
   // Sections
   if (answer.sections) {
     answer.sections.forEach(function(sec) {
-      html += '<div class="qa-section">';
+      html += '<div class="qa-section' + (sec.tone === 'floor' ? ' qa-section-floor' : '') + '">';
       html += '<div class="qa-section-label"><span class="qa-section-label-icon">' + sec.icon + '</span> ' + escHtml(sec.label) + '</div>';
       if (sec.items) {
         sec.items.forEach(function(item) {
           var cls = signalClasses[item.signal] || 'qa-item-neutral';
           var icon = item.icon || signalIcons[item.signal] || '·';
-          html += '<div class="qa-item ' + cls + '">';
+          html += '<div class="qa-item ' + cls + (item.cls ? ' ' + item.cls : '') + '">';
           html += '<span class="qa-item-signal">' + icon + '</span>';
           html += '<span class="qa-item-text">' + escHtml(item.text) + '</span>';
           html += '</div>';

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -55780,23 +55780,50 @@ function qaHandleFoodSafety(classified) {
   var allergenNotes = [];
   var newFoods = [];
 
-  // 1. Age safety
+  // 1+2. Age safety + allergens + food-effects polarity (food-effects v2 R2, §3.2).
+  // K-S-2: route the age + allergen lookups through _lookupByFoodName (alias +
+  // word-boundary + the R0 negation guard), fed the RAW post-split token — the
+  // bare AGE_RULES[base]/ALLERGENS[base] lookups silently MISSED aliases (badam,
+  // groundnut, akhrot, kaju) and under-warned. K-S-5: an age-appropriate
+  // allergen-introduce-early food (peanut/nut) is an ENCOURAGE (safe), not a
+  // caution — the flag becomes safe-form guidance; honey (acute-toxin) is a hard
+  // avoid (Invariant 2). The emergency floor is collected per-food on field
+  // presence (A-4 / M-S-5), OUTSIDE the polarity branch.
+  var severeFloors = [];   // {food, eff} per food carrying a floor (Invariant 1, per-food)
+  var toxin = null;        // {title, why}                — acute-toxin (honey)
+  var encourage = null;    // {title, whyGood, safeFormNote} — age-appropriate allergen
   rawFoods.forEach(function(food) {
-    var base = _baseFoodName(food);
-    var rule = AGE_RULES[base] || AGE_RULES[food];
-    if (rule && mo < rule.minMonth) {
+    var rule = _lookupByFoodName(AGE_RULES, food);
+    var belowFloor = !!(rule && mo < rule.minMonth);
+    if (belowFloor) {
       verdict = 'avoid';
       warnings.push(food + ': ' + rule.reason);
     }
-  });
 
-  // 2. Allergens
-  rawFoods.forEach(function(food) {
-    var base = _baseFoodName(food);
-    var alert = ALLERGENS[base] || ALLERGENS[food];
+    var eff = (typeof getFoodEffect === 'function') ? getFoodEffect(food) : null;
+    if (eff && ((eff.severeSigns && eff.severeSigns.length) ||
+                (eff.watchFor && eff.watchFor.length) || eff.seekCare)) {
+      severeFloors.push({ food: food, eff: eff });
+    }
+
+    var alert = _lookupByFoodName(ALLERGENS, food);
+    var introEarlyOk = !!(eff && _effHasClass(eff, 'allergen-introduce-early') && !belowFloor);
     if (alert) {
       allergenNotes.push(food + ': ' + alert);
-      if (verdict === 'safe') verdict = 'caution';
+      if (verdict === 'safe' && !introEarlyOk) verdict = 'caution';
+    }
+
+    // Polarity (precedence: acute-toxin avoid (hard) > below-floor avoid > encourage safe).
+    if (eff && _effHasClass(eff, 'acute-toxin')) {
+      verdict = 'avoid';
+      toxin = { title: eff.title || '', why: eff.why || '' };
+    } else if (introEarlyOk) {
+      if (verdict !== 'avoid') verdict = 'safe';
+      encourage = {
+        title: eff.title || '',
+        whyGood: eff.whyGood || '',
+        safeFormNote: (eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : ''
+      };
     }
   });
 
@@ -55884,6 +55911,34 @@ function qaHandleFoodSafety(classified) {
   }
   sections.push({ label: 'SAFETY', icon: zi('shield'), items: safetyItems });
 
+  // Emergency floor (food-effects v2 §3.2, K-S-4) — pushed immediately after
+  // SAFETY, BEFORE nutrition/pairings/history, so it is never ordered below
+  // benefit content (Invariant 1; qaRenderAnswer renders sections flat/
+  // non-collapsibly). Per-food (multi-food: each food's floor in its own
+  // section), sourced from FOOD_EFFECTS (Invariant 4). The hazard leads for an
+  // acute-toxin; the safe-form gate + benefit follow for an encourage.
+  if (toxin && toxin.why) {
+    sections.push({ label: 'WHY', icon: zi('siren'), items: [{ text: toxin.why, signal: 'warn' }] });
+  }
+  severeFloors.forEach(function(sf) {
+    var eff = sf.eff;
+    var items = [];
+    (eff.severeSigns || []).forEach(function(s) { items.push({ text: s, signal: 'warn' }); });
+    (eff.watchFor || []).forEach(function(w) { items.push({ text: w, signal: 'info' }); });
+    if (eff.seekCare) items.push({ text: eff.seekCare, signal: 'warn' });
+    if (items.length) {
+      var hasSevere = !!(eff.severeSigns && eff.severeSigns.length);
+      var label = (hasSevere ? 'IF THIS HAPPENS, EMERGENCY' : 'WATCH FOR') + (rawFoods.length > 1 ? ' — ' + sf.food : '');
+      sections.push({ label: label, icon: zi('siren'), items: items });
+    }
+  });
+  if (encourage) {
+    var encItems = [];
+    if (encourage.safeFormNote) encItems.push({ text: encourage.safeFormNote, signal: 'info' });
+    if (encourage.whyGood) encItems.push({ text: encourage.whyGood, signal: 'good' });
+    if (encItems.length) sections.push({ label: 'SAFE FORM', icon: zi('sprout'), items: encItems });
+  }
+
   // Nutrition section
   if (benefits.length > 0) {
     sections.push({
@@ -55915,7 +55970,12 @@ function qaHandleFoodSafety(classified) {
     icon: 'shield',
     domain: 'peach',
     title: rawFoods.length === 1 ? 'Can she eat ' + rawFoods[0] + '?' : 'Food safety check',
-    headline: verdictText + (verdict === 'safe' ? ' \u2014 good to go' : ''),
+    // headline from the record (food-effects v2 \u00a73.1/\u00a73.2, M-S-2): the hazard for
+    // an acute-toxin, the encourage title for an age-appropriate allergen \u2014 never
+    // a bare "Safe" synthesized next to the food name. Falls back to the verdict.
+    headline: (toxin && toxin.title) ? toxin.title
+            : (encourage && verdict === 'safe' && encourage.title) ? encourage.title
+            : verdictText + (verdict === 'safe' ? ' \u2014 good to go' : ''),
     sections: sections,
     confidence: null,
     dataGap: null

--- a/tests/e2e/food-effects-v2-r2-qa-food-safety.spec.ts
+++ b/tests/e2e/food-effects-v2-r2-qa-food-safety.spec.ts
@@ -30,6 +30,9 @@ async function ask(page: any, raw: string) {
       safeFormIdx: labelIdx(/safe form/i),
       hasEmergency: sections.some((s: any) => /emergency/i.test(s.label)),
       hasWatch: sections.some((s: any) => /watch for|^why$/i.test(s.label)),
+      // V-R2-N1: floor sections must carry the emergency tone (rendered loud).
+      floorToned: (a.sections || []).filter((s: any) => /emergency|watch for|^why$/i.test(s.label)).every((s: any) => s.tone === 'floor'),
+      anyFloorToned: (a.sections || []).some((s: any) => s.tone === 'floor'),
     };
   }, raw);
 }
@@ -53,12 +56,15 @@ test.describe('food-effects v2 — R2 Q&A food-safety (both poles + floor)', () 
     expect(a.allText).toMatch(/constipation|weak cry|floppiness/);
     // floor ordered before nutrition (K-S-4); nutrition may be absent (-1).
     if (a.nutritionIdx !== -1) expect(a.floorIdx).toBeLessThan(a.nutritionIdx);
+    // V-R2-N1: the floor carries the loud emergency tone, not muted section chrome.
+    expect(a.floorToned, 'floor sections carry tone:floor (emergency chrome)').toBe(true);
   });
 
   test('"can i give peanut?" → SAFE encourage (caution suppressed) + severe floor + safe-form', async ({ page }) => {
     const a = await ask(page, 'can i give peanut');
     expect(a.headline, 'encourage title, never bare "safe"').toContain('good to introduce early');
     expect(a.hasEmergency, 'anaphylaxis emergency floor section present').toBe(true);
+    expect(a.anyFloorToned, 'the anaphylaxis floor carries emergency chrome (V-R2-N1)').toBe(true);
     expect(a.safeFormIdx, 'safe-form gate section present').toBeGreaterThan(-1);
     expect(a.allText, 'compact whyGood benefit').toContain('plant protein');
     // the SAFETY section must NOT read "Caution" (legacy allergen flip suppressed, K-S-5)

--- a/tests/e2e/food-effects-v2-r2-qa-food-safety.spec.ts
+++ b/tests/e2e/food-effects-v2-r2-qa-food-safety.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test';
+
+// food-effects v2 — R2: the Smart Q&A food-safety answer (qaHandleFoodSafety)
+// reconciled onto FOOD_EFFECTS (spec §3.2). Both polarities + the floor SECTION
+// ordered before nutrition (K-S-4), via the resolver (K-S-2 alias-miss fix) and
+// the verdict state-machine (K-S-5).
+//
+// Driven by calling qaHandleFoodSafety({mode:'food_safety', raw}) and inspecting
+// the returned answer object (qaRenderAnswer escHtml's every field + renders
+// sections flat/non-collapsibly, so HR-4 + floor non-collapsibility are the
+// renderer's contract — confirmed in code).
+declare const qaHandleFoodSafety: (classified: any) => any;
+declare const getFoodEffect: (name: string) => any;
+declare const getAgeInMonths: () => number;
+
+async function ask(page: any, raw: string) {
+  return page.evaluate((q: string) => {
+    const a = qaHandleFoodSafety({ mode: 'food_safety', raw: q });
+    if (!a) return null;
+    const sections = (a.sections || []).map((s: any) => ({
+      label: s.label, texts: (s.items || []).map((i: any) => i.text),
+    }));
+    const labelIdx = (re: RegExp) => sections.findIndex((s: any) => re.test(s.label));
+    return {
+      headline: a.headline || '',
+      labels: sections.map((s: any) => s.label),
+      allText: JSON.stringify(sections).toLowerCase(),
+      floorIdx: labelIdx(/emergency|watch for|^why$/i),
+      nutritionIdx: labelIdx(/nutrition/i),
+      safeFormIdx: labelIdx(/safe form/i),
+      hasEmergency: sections.some((s: any) => /emergency/i.test(s.label)),
+      hasWatch: sections.some((s: any) => /watch for|^why$/i.test(s.label)),
+    };
+  }, raw);
+}
+
+test.describe('food-effects v2 — R2 Q&A food-safety (both poles + floor)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/index.html?nosync');
+    await page.waitForFunction(() =>
+      typeof qaHandleFoodSafety === 'function'
+      && typeof getFoodEffect === 'function'
+      && typeof getAgeInMonths === 'function', null, { timeout: 10_000 });
+    const mo = await page.evaluate(() => getAgeInMonths());
+    expect(mo).toBeGreaterThan(6); expect(mo).toBeLessThan(12);
+  });
+
+  test('"can i give honey?" → AVOID + botulism floor + hazard, floor before nutrition', async ({ page }) => {
+    const a = await ask(page, 'can i give honey');
+    expect(a.headline, 'hazard headline from the record').toContain('Honey before 12 months');
+    expect(a.allText, 'botulism named (toxin.why)').toContain('botulism');
+    expect(a.hasWatch, 'botulism watch-fors / why floor section present').toBe(true);
+    expect(a.allText).toMatch(/constipation|weak cry|floppiness/);
+    // floor ordered before nutrition (K-S-4); nutrition may be absent (-1).
+    if (a.nutritionIdx !== -1) expect(a.floorIdx).toBeLessThan(a.nutritionIdx);
+  });
+
+  test('"can i give peanut?" → SAFE encourage (caution suppressed) + severe floor + safe-form', async ({ page }) => {
+    const a = await ask(page, 'can i give peanut');
+    expect(a.headline, 'encourage title, never bare "safe"').toContain('good to introduce early');
+    expect(a.hasEmergency, 'anaphylaxis emergency floor section present').toBe(true);
+    expect(a.safeFormIdx, 'safe-form gate section present').toBeGreaterThan(-1);
+    expect(a.allText, 'compact whyGood benefit').toContain('plant protein');
+    // the SAFETY section must NOT read "Caution" (legacy allergen flip suppressed, K-S-5)
+    const safety = JSON.stringify(a.labels) + a.allText;
+    expect(a.allText, 'verdict is Safe, not Caution').toContain('safe for');
+    expect(a.allText).not.toContain('caution for');
+    // floor before nutrition (K-S-4)
+    if (a.nutritionIdx !== -1) expect(a.floorIdx).toBeLessThan(a.nutritionIdx);
+  });
+
+  test('K-S-2: alias "badam" now resolves (was a silent bare-key MISS)', async ({ page }) => {
+    // Before R2, AGE_RULES["badam"]/ALLERGENS["badam"] were undefined (bare key) →
+    // the tree-nut record was never reached → no floor, no warning. The resolver
+    // (alias-aware) now surfaces it.
+    const a = await ask(page, 'can i give badam');
+    expect(a.hasEmergency, 'badam → tree-nut anaphylaxis floor now surfaced').toBe(true);
+    expect(a.headline.toLowerCase(), 'resolves to the tree-nut record').toContain('tree nut');
+    // and the peanut alias path too
+    const g = await ask(page, 'can i give groundnut');
+    expect(g.hasEmergency, 'groundnut → peanut record floor').toBe(true);
+  });
+
+  test('"honeydew" ≠ honey (resolver word-boundary precision)', async ({ page }) => {
+    const a = await ask(page, 'can i give honeydew');
+    expect(a.headline, 'honeydew is not honey').not.toContain('Honey before 12 months');
+    expect(a.allText, 'no botulism hazard for a melon').not.toContain('botulism');
+  });
+
+  test('multi-food "peanut with honey" → AVOID dominates, BOTH per-food floors render', async ({ page }) => {
+    const a = await ask(page, 'can i give peanut with honey');
+    expect(a.headline, 'honey hazard headline dominates').toContain('Honey before 12 months');
+    expect(a.hasEmergency, "peanut's anaphylaxis floor renders").toBe(true);
+    expect(a.allText, "honey's botulism floor renders too").toMatch(/constipation|weak cry|floppiness/);
+  });
+
+  test('"peanut-free" → R0 guard holds in the Q&A path (no floor, no encourage)', async ({ page }) => {
+    const a = await ask(page, 'can i give peanut-free bread');
+    expect(a.hasEmergency, 'a negated query surfaces no anaphylaxis floor').toBe(false);
+    expect(a.headline, 'no encourage framing on an excluded food').not.toContain('good to introduce early');
+  });
+});


### PR DESCRIPTION
Third implementation round (#192 / issue #189), spec §3.2. Builds on R0+R1. The Smart Q&A "can I give X?" answer now speaks the model.

## What changed (`intelligence-qa.js`, `qaHandleFoodSafety` — the live path; `qaAnswerFoodSafety` is the dead recorded-history handler, out of scope per K-S-1)
- **K-S-2 (resolver / #182 parity):** the age + allergen lookups now route through `_lookupByFoodName` (alias + word-boundary + the R0 negation guard), fed the **raw** post-split token. The bare `AGE_RULES[base]`/`ALLERGENS[base]` lookups silently **MISSED** aliases — `badam`/`groundnut`/`akhrot`/`kaju` returned no warning (the #182 silent-fail under-warn). Now they resolve.
- **K-S-5 (verdict state-machine):** acute-toxin (honey) → hard `avoid` + hazard + botulism floor; age-appropriate allergen-introduce-early → `safe` (encourage, **legacy allergen→caution flip SUPPRESSED**) + safe-form gate + `whyGood`; below-floor → `avoid` + floor. Floor collected outside the polarity branch on presence (A-4), **per-food** — multi-food "peanut with honey" → avoid dominates, each food's floor in its own section.
- **K-S-4 (section order):** the floor section is pushed immediately after SAFETY, **before** nutrition/pairings/history. `qaRenderAnswer` renders sections flat / **non-collapsibly** and escHtml's every field (HR-4 by the renderer).
- **Headline** from `eff.title` (M-S-2), never a bare "Safe" next to the food name.

## Verification
- `pnpm build` clean, **12 gates pass**.
- New e2e `food-effects-v2-r2-qa-food-safety.spec.ts` — **6/6**: honey avoid+botulism+floor-before-nutrition; peanut safe+encourage+floor+safe-form (caution suppressed); **K-S-2 `badam` alias now resolves**; honeydew≠honey; multi-food both floors; "peanut-free" R0.
- Full suite re-verify running.

## canon-cc-008 routing
`intelligence-qa.js` → **Kael** (primary, the verdict state-machine + resolver fix). `pnpm qa-route` adds **Maren** (ripple: home.js→qa). **Vela** co-confirm per spec §3.2 (floor-section non-collapsibility / 2 AM legibility). Cipher Edict V terminal. Draft until the chain clears.

https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK)_