### PR TITLE
fix: repair chronicler agent frontmatter so Aurelius loads (#193 regression)

### DIFF
--- a/.claude/agents/chronicler.md
+++ b/.claude/agents/chronicler.md
@@ -1,6 +1,6 @@
 ---
 name: chronicler
-description: Cross-cluster institutional memory of the Republic. Two subagent modes — committee synthesis clerk (produces collective proposals at cc-024 Stage 2, preserving consensus and dissent) and retrospective interaction-artifact drafting (authors cc-017 artifacts at session close when participants did not draft). Invocation produces a separable, attributable record entering the cc-018 lifecycle. Voice: Aurelius. The skill-mode counterpart — in-session journal / log / canon / lore authoring — lives at docs/specs/skills/chronicler.md; do not summon this subagent when the caller wants in-transcript chronicling that does not need separable attribution.
+description: "Cross-cluster institutional memory of the Republic. Two subagent modes — committee synthesis clerk (produces collective proposals at cc-024 Stage 2, preserving consensus and dissent) and retrospective interaction-artifact drafting (authors cc-017 artifacts at session close when participants did not draft). Invocation produces a separable, attributable record entering the cc-018 lifecycle. Voice: Aurelius. The skill-mode counterpart — in-session journal / log / canon / lore authoring — lives at docs/specs/skills/chronicler.md; do not summon this subagent when the caller wants in-transcript chronicling that does not need separable attribution."
 tools: Read, Grep, Glob, Bash
 ---
 
@@ -12,6 +12,20 @@ Amendment path: canon-cc-027 signing chain, with the institutional-spec
 collapse at Rungs 2 and 3 — both performed by the Consul as two distinct
 reviews (architectural pass, then per-block working-ratification),
 chronicled separately on the draft's interaction-artifact.
+-->
+
+<!--
+canon-cc-026 BYTE-IDENTICAL EXCEPTION — logged 2026-06-01 (SproutLab session).
+The `description:` frontmatter value above was wrapped in double quotes to
+fix a YAML ScannerError ("mapping values are not allowed here") triggered by
+the embedded ": " in "Voice: Aurelius." — an unquoted colon-space that a
+strict YAML parser reads as a nested mapping key. The defect made Claude
+Code's agent loader silently skip this file, so Aurelius never appeared in
+/agents or as a summonable subagent_type. The Codex canonical source carries
+the SAME defect and must be corrected at Codex/docs/specs/subagents/
+chronicler.md (and the skill twin if affected), then re-deployed. Until that
+canonical fix lands, THIS mirror is intentionally NOT byte-identical to canon
+— a documented, temporary canon-cc-026 §Per-Province-Layout exception.
 -->
 
 # Chronicler — Institutional Memory of the Republic


### PR DESCRIPTION
@
## Symptom

Aurelius / Chronicler never appeared in `/agents` or as a summonable `subagent_type`, despite `.claude/agents/chronicler.md` being present and committed since #193.

## Root cause

The frontmatter `description:` value carried an unquoted **`Voice: Aurelius.`**. That embedded `: ` (colon-space) is read by a strict YAML parser as a nested mapping key:

```
ScannerError: mapping values are not allowed here  (line 2, col 411)
   ... cc-018 lifecycle. Voice: Aurelius. The skill-mode count ...
```

Claude Code **silently skips** agent files whose frontmatter fails to parse, so the agent was dropped. The other 9 agents have no embedded colon-space and load fine.

## Fix

Wrap the `description` value in double quotes (verified with PyYAML — parses OK, `Voice: Aurelius` text preserved). Also future-proofs the field against other punctuation.

> ⚠️ Takes effect only after a Claude Code restart — the agent registry is read at startup.

## canon-cc-026 byte-identical exception

`chronicler.md` is a *byte-identical Codex-canon mirror*, so the defect originates upstream. Investigation results:

| File | Status |
|------|--------|
| `Codex/docs/specs/subagents/chronicler.md` (canonical subagent) | ❌ **has the defect** — upstream fix needed here |
| `Codex/docs/specs/skills/chronicler.md` (canonical skill twin) | ✅ clean |
| `SproutLab/.claude/skills/chronicler.md` (local skill mirror) | ✅ clean |

An inline HTML-comment **exception note** documents this local divergence. The exception closes once the Codex canonical subagent source is fixed and re-deployed. The user-global `~/.claude/agents/chronicler.md` was patched identically out-of-band (not in this repo).

## QA gate

canon-cc-008: agent-config diff under `.claude/`, not `split/` Capital code — no Governor jurisdiction touched. Pre-commit HR audits (emoji / hr12 / icon-text) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@