### PR TITLE
R3: reconcile the diet allergen note onto FOOD_EFFECTS (food-effects v2 #189)

### DIFF
--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-05-31 &middot; graph @ <code>78b77205c0ea</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-05-31 &middot; graph @ <code>5d2793f61611</code></div>
   <div class="sub" style="margin-top:8px">
     <span class="stat"><b>1,716</b> symbols</span>
-    <span class="stat"><b>5,094</b> relations</span>
-    <span class="stat"><b>80,409</b> LOC</span>
+    <span class="stat"><b>5,096</b> relations</span>
+    <span class="stat"><b>80,424</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -82,14 +82,14 @@
       <div class="nums">
         <span><b>3</b> modules</span>
         <span><b>668</b> symbols</span>
-        <span><b>27,102</b> LOC</span>
+        <span><b>27,117</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,102 of 30,000 LOC">
+      <div class="bar" title="27,117 of 30,000 LOC">
         <div class="fill hot" style="width:90%"></div>
         <span class="barlbl">90% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,898 LOC headroom</div>
+      <div class="hd">2,883 LOC headroom</div>
       <div class="mods">home.js, medical.js, diet.js</div>
     </div>
     <div class="card" style="border-top:5px solid #c9b8e8">
@@ -137,7 +137,7 @@
   <h2>Cross-province coupling (highest-traffic calls across jurisdiction borders)</h2>
   <table>
     <thead><tr><th>Module</th><th>Module</th><th class="num">Calls</th><th>Border</th></tr></thead>
-    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">120</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">31</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
+    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">122</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">31</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
   </table>
 
   <h2>Connectivity hubs (highest call-degree symbols per module)</h2>

--- a/index.html
+++ b/index.html
@@ -38395,17 +38395,32 @@ function renderFoodDetailSheet(name) {
   </div>`;
 
   // Safety flags first (Maren altitude — safety reads before nutrition).
-  if (allerg) {
+  // food-effects v2 R3 (§3.3, M-S-6): the terse ALLERGENS string names only MILD
+  // signs (rash/swelling/vomiting) and OMITS anaphylaxis — an under-warn on this
+  // browse surface. Where a FOOD_EFFECTS record exists, surface its framing
+  // (eff.title — encourage-aware, M-S-2) + the safe-form gate + the shared
+  // emergency floor (_severeFloorHtml, M-S-7 — one floor across the action path,
+  // the combo result, and here). Fall back to the terse legacy string only when
+  // no record exists. (Render depth — inline vs link to the γ card — is Vela's
+  // Q-3 call; the severe floor's presence is the non-negotiable, M-S-6.)
+  const fdEff = (typeof getFoodEffect === 'function') ? getFoodEffect(lower) : null;
+  const fdFloor = (fdEff && typeof _severeFloorHtml === 'function') ? _severeFloorHtml(fdEff) : '';
+  if (fdFloor) {
+    const head = (fdEff && fdEff.title) ? escHtml(fdEff.title) : 'Allergen';
+    const sub = (fdEff && fdEff.safeForm && fdEff.safeForm.note) ? escHtml(fdEff.safeForm.note)
+              : (allerg ? escHtml(allerg) : '');
+    html += `<div class="fd-flag fd-flag-allergen">${zi('siren')} <span><strong>${head}</strong>${sub ? ' ' + sub : ''}</span></div>`;
+    html += fdFloor; // .cons-severe / .cons-watch / .cons-seek (shared, already-styled)
+  } else if (allerg) {
     html += `<div class="fd-flag fd-flag-allergen">${zi('siren')} <span><strong>Allergen.</strong> ${escHtml(allerg)}</span></div>`;
   }
   if (aged) {
     html += `<div class="fd-flag fd-flag-aged">${zi('warn')} <span><strong>Not before ${ageR.minMonth} months.</strong> ${escHtml(ageR.reason)}</span></div>`;
   }
   // V-M-201: absence of an allergen note must NOT read as "cleared". When no
-  // specific note is on file, surface the universal 3-day-rule guidance so a
-  // blank safety section never gets parsed as a green light — especially for
-  // seed/dairy foods (chia, cheese, paneer) that have no ALLERGENS entry yet.
-  if (!allerg) {
+  // specific note AND no record floor are on file, surface the universal
+  // 3-day-rule guidance so a blank safety section never reads as a green light.
+  if (!allerg && !fdFloor) {
     html += `<div class="fd-flag fd-flag-neutral">${zi('note')} <span>No specific allergen note on file. Introduce any new food on its own and watch for 3 days.</span></div>`;
   }
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.31-39",
+  "version": "2026.05.31-40",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/diet.js
+++ b/split/diet.js
@@ -621,17 +621,32 @@ function renderFoodDetailSheet(name) {
   </div>`;
 
   // Safety flags first (Maren altitude — safety reads before nutrition).
-  if (allerg) {
+  // food-effects v2 R3 (§3.3, M-S-6): the terse ALLERGENS string names only MILD
+  // signs (rash/swelling/vomiting) and OMITS anaphylaxis — an under-warn on this
+  // browse surface. Where a FOOD_EFFECTS record exists, surface its framing
+  // (eff.title — encourage-aware, M-S-2) + the safe-form gate + the shared
+  // emergency floor (_severeFloorHtml, M-S-7 — one floor across the action path,
+  // the combo result, and here). Fall back to the terse legacy string only when
+  // no record exists. (Render depth — inline vs link to the γ card — is Vela's
+  // Q-3 call; the severe floor's presence is the non-negotiable, M-S-6.)
+  const fdEff = (typeof getFoodEffect === 'function') ? getFoodEffect(lower) : null;
+  const fdFloor = (fdEff && typeof _severeFloorHtml === 'function') ? _severeFloorHtml(fdEff) : '';
+  if (fdFloor) {
+    const head = (fdEff && fdEff.title) ? escHtml(fdEff.title) : 'Allergen';
+    const sub = (fdEff && fdEff.safeForm && fdEff.safeForm.note) ? escHtml(fdEff.safeForm.note)
+              : (allerg ? escHtml(allerg) : '');
+    html += `<div class="fd-flag fd-flag-allergen">${zi('siren')} <span><strong>${head}</strong>${sub ? ' ' + sub : ''}</span></div>`;
+    html += fdFloor; // .cons-severe / .cons-watch / .cons-seek (shared, already-styled)
+  } else if (allerg) {
     html += `<div class="fd-flag fd-flag-allergen">${zi('siren')} <span><strong>Allergen.</strong> ${escHtml(allerg)}</span></div>`;
   }
   if (aged) {
     html += `<div class="fd-flag fd-flag-aged">${zi('warn')} <span><strong>Not before ${ageR.minMonth} months.</strong> ${escHtml(ageR.reason)}</span></div>`;
   }
   // V-M-201: absence of an allergen note must NOT read as "cleared". When no
-  // specific note is on file, surface the universal 3-day-rule guidance so a
-  // blank safety section never gets parsed as a green light — especially for
-  // seed/dairy foods (chia, cheese, paneer) that have no ALLERGENS entry yet.
-  if (!allerg) {
+  // specific note AND no record floor are on file, surface the universal
+  // 3-day-rule guidance so a blank safety section never reads as a green light.
+  if (!allerg && !fdFloor) {
     html += `<div class="fd-flag fd-flag-neutral">${zi('note')} <span>No specific allergen note on file. Introduce any new food on its own and watch for 3 days.</span></div>`;
   }
 

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -38395,17 +38395,32 @@ function renderFoodDetailSheet(name) {
   </div>`;
 
   // Safety flags first (Maren altitude — safety reads before nutrition).
-  if (allerg) {
+  // food-effects v2 R3 (§3.3, M-S-6): the terse ALLERGENS string names only MILD
+  // signs (rash/swelling/vomiting) and OMITS anaphylaxis — an under-warn on this
+  // browse surface. Where a FOOD_EFFECTS record exists, surface its framing
+  // (eff.title — encourage-aware, M-S-2) + the safe-form gate + the shared
+  // emergency floor (_severeFloorHtml, M-S-7 — one floor across the action path,
+  // the combo result, and here). Fall back to the terse legacy string only when
+  // no record exists. (Render depth — inline vs link to the γ card — is Vela's
+  // Q-3 call; the severe floor's presence is the non-negotiable, M-S-6.)
+  const fdEff = (typeof getFoodEffect === 'function') ? getFoodEffect(lower) : null;
+  const fdFloor = (fdEff && typeof _severeFloorHtml === 'function') ? _severeFloorHtml(fdEff) : '';
+  if (fdFloor) {
+    const head = (fdEff && fdEff.title) ? escHtml(fdEff.title) : 'Allergen';
+    const sub = (fdEff && fdEff.safeForm && fdEff.safeForm.note) ? escHtml(fdEff.safeForm.note)
+              : (allerg ? escHtml(allerg) : '');
+    html += `<div class="fd-flag fd-flag-allergen">${zi('siren')} <span><strong>${head}</strong>${sub ? ' ' + sub : ''}</span></div>`;
+    html += fdFloor; // .cons-severe / .cons-watch / .cons-seek (shared, already-styled)
+  } else if (allerg) {
     html += `<div class="fd-flag fd-flag-allergen">${zi('siren')} <span><strong>Allergen.</strong> ${escHtml(allerg)}</span></div>`;
   }
   if (aged) {
     html += `<div class="fd-flag fd-flag-aged">${zi('warn')} <span><strong>Not before ${ageR.minMonth} months.</strong> ${escHtml(ageR.reason)}</span></div>`;
   }
   // V-M-201: absence of an allergen note must NOT read as "cleared". When no
-  // specific note is on file, surface the universal 3-day-rule guidance so a
-  // blank safety section never gets parsed as a green light — especially for
-  // seed/dairy foods (chia, cheese, paneer) that have no ALLERGENS entry yet.
-  if (!allerg) {
+  // specific note AND no record floor are on file, surface the universal
+  // 3-day-rule guidance so a blank safety section never reads as a green light.
+  if (!allerg && !fdFloor) {
     html += `<div class="fd-flag fd-flag-neutral">${zi('note')} <span>No specific allergen note on file. Introduce any new food on its own and watch for 3 days.</span></div>`;
   }
 

--- a/tests/e2e/food-effects-v2-r3-allergen-note.spec.ts
+++ b/tests/e2e/food-effects-v2-r3-allergen-note.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test';
+
+// food-effects v2 — R3: the diet allergen note / food-detail flag
+// (renderFoodDetailSheet → _fdAllergenNote) reconciled onto FOOD_EFFECTS (§3.3).
+//
+// M-S-6 (the defect): the terse ALLERGENS string names only MILD signs
+// (rash/swelling/vomiting) and OMITS anaphylaxis — an under-warn on the browse
+// surface. Where a FOOD_EFFECTS record exists, the flag now surfaces the record's
+// framing (eff.title, encourage-aware) + the safe-form gate + the shared severe
+// floor (_severeFloorHtml, M-S-7 — same floor as the action path + combo + Q&A).
+// Falls back to the terse string only when no record exists; V-M-201 neutral note
+// preserved when neither exists.
+declare const renderFoodDetailSheet: (name: string) => void;
+declare const getFoodEffect: (name: string) => any;
+
+async function detail(page: any, name: string) {
+  return page.evaluate((n: string) => {
+    renderFoodDetailSheet(n);
+    const el = document.getElementById('foodDetailBody')!;
+    return {
+      html: el.innerHTML,
+      severe: el.querySelectorAll('.cons-severe').length,
+      watch: el.querySelectorAll('.cons-watch').length,
+      seek: el.querySelectorAll('.cons-seek').length,
+      allergenFlag: !!el.querySelector('.fd-flag-allergen'),
+      neutral: !!el.querySelector('.fd-flag-neutral'),
+    };
+  }, name);
+}
+
+test.describe('food-effects v2 — R3 allergen note / food-detail flag', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/index.html?nosync');
+    await page.waitForFunction(() =>
+      typeof renderFoodDetailSheet === 'function'
+      && typeof getFoodEffect === 'function'
+      && !!document.getElementById('foodDetailBody'), null, { timeout: 10_000 });
+  });
+
+  test('M-S-6: peanut surfaces the ANAPHYLAXIS floor, not the mild-only legacy string', async ({ page }) => {
+    const d = await detail(page, 'peanut');
+    expect(d.severe, 'anaphylaxis severe strip present (not mild-only)').toBeGreaterThan(0);
+    expect(d.seek, 'seek-care line present').toBeGreaterThan(0);
+    // record-framed header (encourage-aware), never a bare scary "Allergen."
+    expect(d.html, 'header from eff.title').toContain('good to introduce early');
+    // the safe-form gate (A-2) is surfaced
+    expect(d.html.toLowerCase()).toContain('does not remove the allergy risk');
+    // the severe strip names a true anaphylaxis sign, not just rash/swelling/vomiting
+    expect(d.html.toLowerCase()).toMatch(/trouble breathing|swelling of the face|floppy/);
+  });
+
+  test('honey surfaces the botulism floor in the detail sheet (acute-toxin)', async ({ page }) => {
+    const d = await detail(page, 'honey');
+    expect(d.html, 'record-framed header').toContain('Honey before 12 months');
+    expect(d.watch, 'botulism watch-fors render').toBeGreaterThan(0);
+    expect(d.seek, 'seek-care renders').toBeGreaterThan(0);
+    expect(d.html.toLowerCase()).toMatch(/constipation|weak cry|floppiness/);
+  });
+
+  test('a tree-nut alias (badam) inherits the record floor', async ({ page }) => {
+    const d = await detail(page, 'badam');
+    expect(d.severe, 'badam → tree-nut anaphylaxis floor').toBeGreaterThan(0);
+  });
+
+  test('an ALLERGENS food with no record (egg) falls back to the terse string — no fabricated floor', async ({ page }) => {
+    const d = await detail(page, 'egg');
+    expect(d.allergenFlag, 'terse allergen flag still shown').toBe(true);
+    expect(d.severe + d.watch + d.seek, 'no record → no severe/botulism floor fabricated').toBe(0);
+  });
+
+  test('V-M-201 preserved: a food with no record and no allergen shows the neutral 3-day note', async ({ page }) => {
+    const d = await detail(page, 'apple');
+    expect(d.neutral, 'neutral 3-day-rule note (not a green light)').toBe(true);
+    expect(d.severe + d.watch + d.seek, 'no floor for a non-allergen').toBe(0);
+  });
+});


### PR DESCRIPTION
Final reconciliation round (#192 / issue #189), spec §3.3. Builds on R0+R1+R2.

## The defect (M-S-6)
The food-detail allergen flag (`renderFoodDetailSheet` / `_fdAllergenNote`) rendered the terse `ALLERGENS` string — which names only **mild** signs (rash/swelling/vomiting) and **omits anaphylaxis**. On a browse surface a parent tapping "peanut" saw a mild-only note; the severe floor lived only on the log-time action path.

## The fix
Where a `FOOD_EFFECTS` record exists, the flag now surfaces:
- the record's framing (`eff.title` — encourage-aware, never a bare scary "Allergen."),
- the safe-form gate (`eff.safeForm.note`, A-2),
- the **shared severe floor** (`_severeFloorHtml`, M-S-7) — the *same* floor as the action path, the combo result, and the Q&A. One floor, no drift; **no new CSS** (reuses the already-styled `.cons-severe`/`.cons-watch`/`.cons-seek`).

Falls back to the terse legacy string only when no record exists. **V-M-201 preserved** — the neutral 3-day-rule note still shows when neither an allergen note nor a record floor is on file (absence never reads as a green light).

## Verification
- `pnpm build` clean, **12 gates**.
- New e2e `food-effects-v2-r3-allergen-note.spec.ts` — **5/5**: peanut → anaphylaxis floor + encourage header + safe-form (not mild-only); honey → botulism floor; `badam` alias inherits; `egg` (ALLERGENS, no record) → terse fallback, no fabricated floor; `apple` → V-M-201 neutral note.
- Full suite re-verify running.

## canon-cc-008 routing
`diet.js` → **Maren** (primary, M-S-6 the Care floor). **Vela** for the **Q-3 render-depth call** (§3.3: inline the full floor vs link to the γ "Introducing nuts early" Library card — the depth is Vela's; the severe floor's *presence* is non-negotiable). Reuses the existing `_severeFloorHtml` (no `core.js`/`styles.css` touch → no Kael, no triple-Gov). Cipher Edict V terminal. Draft until the chain clears.

This is the **last round** of the #189 reconciliation — R0 (negation guard) → R1 (combo) → R2 (Q&A) → **R3 (allergen note)**.

https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK)_