### PR TITLE
Analytics prototype (LOCKED REFERENCE): Allergen Introduction Info-tab card

### DIFF
--- a/docs/CARETICKET_STATE_MACHINE.html
+++ b/docs/CARETICKET_STATE_MACHINE.html
@@ -91,7 +91,7 @@ code { font-family: var(--mono); font-size: 12px; color: var(--ink); }
 </head>
 <body>
 <h1>CareTicket State Machine</h1>
-<p class="subtitle">SproutLab — 6-transition lifecycle, spec vs implementation. Generated <code>2026-05-31</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on transition-layout snapshots</strong>; <code>CARETICKETS_SPEC_v5.md</code> wins on transition rationale; CLAUDE.md wins on rules, HRs, build commands, persona.</p>
+<p class="subtitle">SproutLab — 6-transition lifecycle, spec vs implementation. Generated <code>2026-06-01</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on transition-layout snapshots</strong>; <code>CARETICKETS_SPEC_v5.md</code> wins on transition rationale; CLAUDE.md wins on rules, HRs, build commands, persona.</p>
 
 <div class="diagram-wrap">
 <svg viewBox="0 0 520 420" width="520" height="420">

--- a/docs/POOP_COLOR_REFERENCE.html
+++ b/docs/POOP_COLOR_REFERENCE.html
@@ -108,7 +108,7 @@ code { font-family: var(--mono); font-size: 12px; color: var(--ink-soft); }
 </head>
 <body>
 <h1>Poop-Color Reference</h1>
-<p class="subtitle">SproutLab — token + render + contrast + lexicon snapshot. Generated <code>2026-05-31</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on token-value snapshots</strong>; CLAUDE.md wins on usage rules.</p>
+<p class="subtitle">SproutLab — token + render + contrast + lexicon snapshot. Generated <code>2026-06-01</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on token-value snapshots</strong>; CLAUDE.md wins on usage rules.</p>
 
 <div class="meta-bar">
   <span>light <code>--warm</code> <code>#fef6f0</code></span>

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-06-01 &middot; graph @ <code>b73bc499267c</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-01 &middot; graph @ <code>318c084ce805</code></div>
   <div class="sub" style="margin-top:8px">
-    <span class="stat"><b>1,719</b> symbols</span>
-    <span class="stat"><b>5,111</b> relations</span>
-    <span class="stat"><b>80,584</b> LOC</span>
+    <span class="stat"><b>1,720</b> symbols</span>
+    <span class="stat"><b>5,118</b> relations</span>
+    <span class="stat"><b>80,615</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -98,15 +98,15 @@
       <div class="cgov">Governor: <b>Vela</b></div>
       <div class="nums">
         <span><b>2</b> modules</span>
-        <span><b>183</b> symbols</span>
-        <span><b>8,575</b> LOC</span>
+        <span><b>184</b> symbols</span>
+        <span><b>8,606</b> LOC</span>
       </div>
       
-      <div class="bar" title="8,575 of 30,000 LOC">
+      <div class="bar" title="8,606 of 30,000 LOC">
         <div class="fill " style="width:29%"></div>
         <span class="barlbl">29% to 30K frontier</span>
       </div>
-      <div class="hd">21,425 LOC headroom</div>
+      <div class="hd">21,394 LOC headroom</div>
       <div class="mods">i-quicklog.js, i-cards.js</div>
     </div>
     <div class="card" style="border-top:5px solid #e8b86d">
@@ -137,7 +137,7 @@
   <h2>Cross-province coupling (highest-traffic calls across jurisdiction borders)</h2>
   <table>
     <thead><tr><th>Module</th><th>Module</th><th class="num">Calls</th><th>Border</th></tr></thead>
-    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">122</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">39</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
+    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">122</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">42</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
   </table>
 
   <h2>Connectivity hubs (highest call-degree symbols per module)</h2>

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-06-01 &middot; graph @ <code>852361ac5c7c</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-01 &middot; graph @ <code>b73bc499267c</code></div>
   <div class="sub" style="margin-top:8px">
     <span class="stat"><b>1,719</b> symbols</span>
     <span class="stat"><b>5,111</b> relations</span>
-    <span class="stat"><b>80,582</b> LOC</span>
+    <span class="stat"><b>80,584</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -99,14 +99,14 @@
       <div class="nums">
         <span><b>2</b> modules</span>
         <span><b>183</b> symbols</span>
-        <span><b>8,573</b> LOC</span>
+        <span><b>8,575</b> LOC</span>
       </div>
       
-      <div class="bar" title="8,573 of 30,000 LOC">
+      <div class="bar" title="8,575 of 30,000 LOC">
         <div class="fill " style="width:29%"></div>
         <span class="barlbl">29% to 30K frontier</span>
       </div>
-      <div class="hd">21,427 LOC headroom</div>
+      <div class="hd">21,425 LOC headroom</div>
       <div class="mods">i-quicklog.js, i-cards.js</div>
     </div>
     <div class="card" style="border-top:5px solid #e8b86d">

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-05-31 &middot; graph @ <code>5d2793f61611</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-01 &middot; graph @ <code>852361ac5c7c</code></div>
   <div class="sub" style="margin-top:8px">
-    <span class="stat"><b>1,716</b> symbols</span>
-    <span class="stat"><b>5,096</b> relations</span>
-    <span class="stat"><b>80,424</b> LOC</span>
+    <span class="stat"><b>1,719</b> symbols</span>
+    <span class="stat"><b>5,111</b> relations</span>
+    <span class="stat"><b>80,582</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -98,15 +98,15 @@
       <div class="cgov">Governor: <b>Vela</b></div>
       <div class="nums">
         <span><b>2</b> modules</span>
-        <span><b>180</b> symbols</span>
-        <span><b>8,428</b> LOC</span>
+        <span><b>183</b> symbols</span>
+        <span><b>8,573</b> LOC</span>
       </div>
       
-      <div class="bar" title="8,428 of 30,000 LOC">
-        <div class="fill " style="width:28%"></div>
-        <span class="barlbl">28% to 30K frontier</span>
+      <div class="bar" title="8,573 of 30,000 LOC">
+        <div class="fill " style="width:29%"></div>
+        <span class="barlbl">29% to 30K frontier</span>
       </div>
-      <div class="hd">21,572 LOC headroom</div>
+      <div class="hd">21,427 LOC headroom</div>
       <div class="mods">i-quicklog.js, i-cards.js</div>
     </div>
     <div class="card" style="border-top:5px solid #e8b86d">
@@ -116,7 +116,7 @@
       <div class="nums">
         <span><b>2</b> modules</span>
         <span><b>0</b> symbols</span>
-        <span><b>14,030</b> LOC</span>
+        <span><b>14,043</b> LOC</span>
       </div>
       <div class="note">Unsurveyed &mdash; code-only extraction. Set a backend and rebuild for symbols.</div>
       <div class="mods">styles.css, template.html</div>
@@ -137,13 +137,13 @@
   <h2>Cross-province coupling (highest-traffic calls across jurisdiction borders)</h2>
   <table>
     <thead><tr><th>Module</th><th>Module</th><th class="num">Calls</th><th>Border</th></tr></thead>
-    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">122</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">31</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
+    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">122</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">39</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
   </table>
 
   <h2>Connectivity hubs (highest call-degree symbols per module)</h2>
   <table>
     <thead><tr><th>Symbol</th><th>Module</th><th>Province</th><th class="num">Degree (calls)</th></tr></thead>
-    <tbody><tr><td><code>zi()</code></td><td>core.js</td><td>Intelligence</td><td class="num">325</td></tr><tr><td><code>showQLToast()</code></td><td>i-quicklog.js</td><td>Surfacing</td><td class="num">69</td></tr><tr><td><code>qaExecuteQuery()</code></td><td>i-qa.js</td><td>Intelligence</td><td class="num">50</td></tr><tr><td><code>renderInfo()</code></td><td>i-cards.js</td><td>Surfacing</td><td class="num">49</td></tr><tr><td><code>renderHome()</code></td><td>home.js</td><td>Care</td><td class="num">47</td></tr><tr><td><code>getDailySleepScore()</code></td><td>medical.js</td><td>Care</td><td class="num">33</td></tr><tr><td><code>_islMarkDirty()</code></td><td>i-isl.js</td><td>Intelligence</td><td class="num">28</td></tr><tr><td><code>ctHandleOverlayAction()</code></td><td>i-caretickets.js</td><td>Intelligence</td><td class="num">27</td></tr><tr><td><code>renderFeverEpisodeCard()</code></td><td>i-illness.js</td><td>Intelligence</td><td class="num">23</td></tr></tbody>
+    <tbody><tr><td><code>zi()</code></td><td>core.js</td><td>Intelligence</td><td class="num">325</td></tr><tr><td><code>showQLToast()</code></td><td>i-quicklog.js</td><td>Surfacing</td><td class="num">69</td></tr><tr><td><code>renderInfo()</code></td><td>i-cards.js</td><td>Surfacing</td><td class="num">50</td></tr><tr><td><code>qaExecuteQuery()</code></td><td>i-qa.js</td><td>Intelligence</td><td class="num">50</td></tr><tr><td><code>renderHome()</code></td><td>home.js</td><td>Care</td><td class="num">47</td></tr><tr><td><code>getDailySleepScore()</code></td><td>medical.js</td><td>Care</td><td class="num">33</td></tr><tr><td><code>_islMarkDirty()</code></td><td>i-isl.js</td><td>Intelligence</td><td class="num">28</td></tr><tr><td><code>ctHandleOverlayAction()</code></td><td>i-caretickets.js</td><td>Intelligence</td><td class="num">27</td></tr><tr><td><code>renderFeverEpisodeCard()</code></td><td>i-illness.js</td><td>Intelligence</td><td class="num">23</td></tr></tbody>
   </table>
 </main>
 <footer>

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-06-01 &middot; graph @ <code>318c084ce805</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-01 &middot; graph @ <code>a6207d0b0e99</code></div>
   <div class="sub" style="margin-top:8px">
-    <span class="stat"><b>1,720</b> symbols</span>
-    <span class="stat"><b>5,118</b> relations</span>
-    <span class="stat"><b>80,615</b> LOC</span>
+    <span class="stat"><b>1,721</b> symbols</span>
+    <span class="stat"><b>5,123</b> relations</span>
+    <span class="stat"><b>80,641</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -98,15 +98,15 @@
       <div class="cgov">Governor: <b>Vela</b></div>
       <div class="nums">
         <span><b>2</b> modules</span>
-        <span><b>184</b> symbols</span>
-        <span><b>8,606</b> LOC</span>
+        <span><b>185</b> symbols</span>
+        <span><b>8,632</b> LOC</span>
       </div>
       
-      <div class="bar" title="8,606 of 30,000 LOC">
+      <div class="bar" title="8,632 of 30,000 LOC">
         <div class="fill " style="width:29%"></div>
         <span class="barlbl">29% to 30K frontier</span>
       </div>
-      <div class="hd">21,394 LOC headroom</div>
+      <div class="hd">21,368 LOC headroom</div>
       <div class="mods">i-quicklog.js, i-cards.js</div>
     </div>
     <div class="card" style="border-top:5px solid #e8b86d">
@@ -137,7 +137,7 @@
   <h2>Cross-province coupling (highest-traffic calls across jurisdiction borders)</h2>
   <table>
     <thead><tr><th>Module</th><th>Module</th><th class="num">Calls</th><th>Border</th></tr></thead>
-    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">122</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">42</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
+    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">122</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">44</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
   </table>
 
   <h2>Connectivity hubs (highest call-degree symbols per module)</h2>

--- a/docs/specs/info-tab-analysis-layer-v1.md
+++ b/docs/specs/info-tab-analysis-layer-v1.md
@@ -1,0 +1,154 @@
+# Info-Tab Analysis Layer — v1 (Allergen Introduction card as exhibit A)
+
+**Companion:** Lyra (The Weaver)
+**Status:** DRAFT — authored from the locked reference prototype (PR #203, commit `2ce5584`). Awaiting Governor spec-review folding (Vela render + Maren care-read) and Architect ratification.
+**Date opened:** 2026-06-01.
+**Descends from:** `docs/specs/food-effects-v2-guided-introduction.md` (the `FOOD_EFFECTS` resolver spine this card reads) · the prototype-then-spec loop the Architect ran across two iteration rounds on PR #203.
+**Spec type:** Feature Spec (new user-facing card) + a thin Architecture note (§7), because this card seeds a *layer pattern* future cards inherit.
+
+---
+
+## 1. The problem this spec exists to solve
+
+The Info tab renders ~20 `renderInfo*` cards (dispatched by `renderInfo()` at `intelligence-cards.js:1414`, itself called from `switchTab()`). They answer *"what happened"* (variety, pace, intake, correlations). **None answers a journey question:** *"where am I in the high-allergen-introduction sequence, and what should I offer next?"*
+
+That question matters because the allergen-introduction window is **time-boxed and protective** (LEAP/EAT: early, sustained exposure reduces allergy risk ~81% for peanut). A parent who can't see *where they are* in the sequence can't act on a window that closes. The food-effects-v2 layer made each food's introduce-early guidance correct **at log time**; this card makes the **whole journey legible** at a glance, on the Info tab, between meals.
+
+This is **card #1 of an Info-tab *analysis* layer** — cards that synthesize a derived state across many logged events, as opposed to the existing *report* cards that summarize raw activity. §7 names the pattern so card #2 inherits it.
+
+---
+
+## 2. Data flow (no new storage; all derived)
+
+The card writes **nothing**. It derives its entire state at render time from three existing sources, all resolved through the **same `FOOD_EFFECTS` spine** the food-effects-v2 spec established, so aliases are correct (logging *almond* counts as *Tree nuts*):
+
+| Source | Used for | Resolver |
+|---|---|---|
+| `foods` (the deduped tried-list) | intro **date** + **reaction flag** + tried/untried | `_aiFoodRecordFor` → `getFoodEffect` / `_baseFoodName` |
+| `feedingData` + `extractDayFoods(date)` (the per-meal log) | **exposure count** — days the allergen appeared at a meal | `_aiExposureDays` → `getFoodEffect` / `_baseFoodName` |
+| `AGE_RULES` (`_lookupByFoodName`) | the **intro-month** floor per allergen | `_lookupByFoodName(AGE_RULES, key)` |
+
+**Why two food sources, not one.** `foods` is deduped to one entry per food — it carries the *first* intro date and any reaction flag, which drives the watch window. `feedingData` is the per-meal event log — it carries *repetition*, which is the keep-offering signal. They are complementary and must not be conflated: the date/watch comes from `foods`; the "offered N days" comes from `feedingData`. **Honesty constraint:** `extractDayFoods` dedups within a day, so the count is *days offered*, never *number of tastes*. The copy says "offered N **days**" — it must never imply a per-taste count the data can't support.
+
+The allergen set (frozen): **peanut, tree nuts, egg, sesame, soy, wheat** (`AI_ALLERGEN_SET`). Each row resolves independently; no cross-allergen inference.
+
+---
+
+## 3. State machine (derived per allergen, never hardcoded)
+
+Each allergen resolves to exactly one state, in this precedence:
+
+```
+has a foods record?
+├── reaction === 'watch'        → REACTION   (surfaced, never silently tolerated)
+├── has date, < 3 days ago      → WATCHING   (the 3-day watch window)
+├── has date, ≥ 3 days ago      → TOLERATED
+└── tried but no date           → INTRODUCED
+no record?
+├── age ≥ intro-month           → READY      (actionable nudge)
+└── age < intro-month           → NOT YET
+```
+
+| State | Pill | Polarity | Meta line |
+|---|---|---|---|
+| Ready to try | `cd-pill-pos` (sage) | encourage | safe-form note, or "Good to introduce now, in a safe form" |
+| Not yet | `cd-pill-neutral` | calm | "From {introMonth} months" |
+| Watching | `cd-pill-neutral` | calm-attentive | "Day {n} of 3 — watch for reactions" |
+| Tolerated | `cd-pill-pos` (sage) | affirming | "offered {N} days · keep it in rotation" (drops the count if 0) |
+| Introduced | `cd-pill-pos` (sage) | affirming | "Keep offering to hold tolerance" |
+| Reaction noted | `cd-pill-neg` (rose) | attention | "Reaction flagged {date} — tap to review" |
+
+**Reaction is never suppressed** (inherits Maren A-3 from food-effects-v2): a `reaction:'watch'` flag always surfaces as its own state, above tolerated, never folded into "introduced."
+
+---
+
+## 4. Wireframe (the locked reference)
+
+```
+┌─ Allergen Introduction ───────────────────────────── ⌄ ─┐
+│ 3 of 6 introduced · 3 ready to try · 1 watching          │  ← summary (always visible)
+│ Progress  ▓▓▓▓▓▓▓▓▓▓░░░░░░░░░░  3 / 6                      │  ← sage _cdBarHtml proportional bar
+├──────────────────────────────────────────────────────────┤
+│ HIGH-PRIORITY ALLERGENS                                   │
+│ Sesame      [Ready to try]  Good to introduce now…        │  ← ordered by actionability:
+│ Soy         [Ready to try]  Good to introduce now…        │     ready → watching → reaction
+│ Wheat       [Ready to try]  Good to introduce now…        │     → introduced/tolerated → not-yet
+│ Peanut      [Watching]      Day 2 of 3 — watch for…       │     (stable within tier)
+│ Egg         [Reaction noted] Reaction flagged … — tap…    │
+│ Tree nuts   [Tolerated]     offered 5 days · keep it in…  │
+├──────────────────────────────────────────────────────────┤
+│ WHAT THIS MEANS                                           │
+│ Early introduction in a safe form is protective. Good to  │  ← insight, derived from the
+│ start now: Sesame, Soy, Wheat. One at a time, watch 3 days.│     dominant actionable state
+└──────────────────────────────────────────────────────────┘
+```
+
+**Three composition rules** (the iteration-2 refinements, now invariants):
+1. **Order by actionability.** Rows sort `ready(0) → watching(1) → reaction(2) → introduced/tolerated(3) → not-yet(4)`, stable within a tier (so set order — peanut, tree nut, egg… — is preserved among ties). What to act on floats up; settled states sink.
+2. **Glanceable progress.** The summary carries a sage `_cdBarHtml('Progress', introduced, total, ' / '+total)` proportional bar — comprehension before a single row is read. Reuses the existing `cd-bar-*` vocabulary; **no `styles.css`.**
+3. **Keep-offering is the affirming close.** Tolerated/introduced rows don't dead-end at "done" — they carry the exposure count and "keep it in rotation," because tolerance is sustained, not one-and-done (EAT per-protocol lesson).
+
+**Tap-through.** Each row is `data-action="foodLibDetail" data-arg="{key}"` → the food's detail sheet (the R3 floor + safe-form for the resolved food). The card is the *glance*; the sheet is the *depth*. This layering is deliberate: the keep-offering `thenWhat` guidance and severe-reaction floor live in the sheet, not crammed into the row.
+
+---
+
+## 5. Card priority (inherits v3-6)
+
+Composite card → **never urgent**. `_setCardPriority('infoAllergenIntroCard', …)`:
+- **notable** when `ready > 0 || watching > 0` (there is something to act on);
+- **ambient** otherwise (all tolerated / all not-yet — nothing to do, stays calm).
+
+A reaction-only state is *not* urgent here — the acute floor is the food detail sheet's job (Maren A-1/V-1 from food-effects-v2: the "call 112" strip lives at log time and in the sheet, not in an Info-tab journey card). This card points at the reaction ("tap to review"); it does not try to be the emergency surface.
+
+---
+
+## 6. Edge cases (decided, so the builder doesn't)
+
+| Case | Decision |
+|---|---|
+| No `foods`, no `feedingData` (fresh install) | All 6 → ready or not-yet by age alone; bar at 0/6; insight = the from-6-months line. |
+| Food logged but never at a meal (`foods` has it, `feedingData` doesn't) | State/date from `foods`; exposure count = 0 → tolerated row reads "keep it in rotation" with no count. Both sources honored independently. |
+| Allergen with no `FOOD_EFFECTS` record (egg/soy/wheat) | Resolver falls back to `_baseFoodName` match; intro-month falls back to 6 where `AGE_RULES` has no per-food rule (a general window, **not** an invented per-food claim). |
+| `feedingData` carries the app's seeded defaults | Counted as real exposure — it *is* the meal log. (Tests clear it to assert in isolation; production does not.) |
+| Age unavailable (`getAgeInMonths` absent) | Defaults to 0 → everything not-yet. Fails safe (never nudges to introduce below a floor it can't confirm). |
+| Singular/plural | "offered 1 day" vs "offered N days" — handled. |
+
+---
+
+## 7. The analysis-layer pattern (what card #2 inherits)
+
+This card establishes a reusable shape for Info-tab **analysis** cards (distinct from report cards):
+
+1. **A pure `_aiCompute*()`** that returns `{ items, total, …rollups }` — no DOM, no writes, fully testable in isolation (this is what the e2e asserts against directly).
+2. **A `renderInfo*()`** that consumes the compute output: summary + progress + actionability-ordered rows + a derived "what this means" line.
+3. **Resolve every food through the shared spine** (`getFoodEffect`/`_baseFoodName`) so aliases are correct — never raw-name matching.
+4. **Two-source honesty:** when state and repetition come from different stores, keep them separate and label each for exactly what it measures.
+5. **Glance → tap → depth:** the card never crams the detail sheet's content; it points at it.
+
+Card #2 candidates (future, not this spec): an iron/nutrient-window journey card; a milestone-window card. Each would reuse 1–5 above.
+
+---
+
+## 8. What this does NOT include (scope fence)
+
+- **No new storage, no writes, no migration.** Pure derive-at-render.
+- **No `styles.css` or `template.html` change.** Reuses `cd-*` / `cd-pill-*` / `cd-bar-*` and the existing Info-tab container. *(If a future iteration needs a per-state segmented bar — considered and rejected for v1 — that becomes a triple-Gov styles change in its own spec.)*
+- **No engine/data edit.** `data.js` `AGE_RULES`/`FOOD_EFFECTS` and `core.js` resolvers are read, not modified.
+- **No per-taste exposure count.** The meal log dedups within a day; v1 reports days, not tastes. A true taste-count would require a new event store — out of scope.
+- **Not an emergency surface.** Reaction states point to the food detail sheet; the acute floor stays where food-effects-v2 put it.
+- **No CareTicket creation.** This is an ambient/notable journey card, never a ticket (inherits V-4).
+
+---
+
+## 9. Verification contract
+
+- `pnpm build` clean (HR-1/HR-12/icon-text audits pass).
+- `tests/e2e/analytics-allergen-intro.spec.ts` — 8 cases: empty→all-ready, almond→tree-nut tolerated, peanut→watching, reaction surfacing, mixed render + notable tier + progress bar, exposure-count roll-up (alias-correct), actionability ordering, tap-through to the R3 floor.
+- **Routing for the canon-cc-008 chain:** `intelligence-cards.js` edited → **Vela** (render). The compute *reads* `feedingData` + `extractDayFoods` (Maren's diet region) without editing them → `pnpm qa-route` ripple widens the summon-set to **Maren** (cross-Province read). No `styles.css`/`template.html` → not triple-Gov. Lyra synthesizes; **Cipher** runs the Edict V final-pass.
+
+---
+
+## 10. Open for the Architect
+
+- **§7 pattern naming** — is "Info-tab analysis layer" the right frame, and do we want card #2 queued now or is this a one-off that happens to be reusable?
+- **Exposure window** — "offered N days" counts *all* logged history. Should it window (e.g. last 30 days) so "keep it in rotation" reflects *recent* offering, not lifetime? (Deferred to a §10 decision; v1 ships lifetime.)

--- a/docs/specs/info-tab-analysis-layer-v1.md
+++ b/docs/specs/info-tab-analysis-layer-v1.md
@@ -8,6 +8,26 @@
 
 ---
 
+## 0. Governor spec-review record (2026-06-01)
+
+All three Governors audited the implementation against this spec under canon-cc-008 (triple-Gov: `template.html` is a shared file). All three returned **`amended`**; findings folded below.
+
+**Maren (Care) — `amended`.** Cleared reaction-precedence, two-source honesty, and fail-safe-on-missing-age. One blocker + two sharpenings:
+- **M-1** (blocking) → §3/§4: egg's gate is right (7mo via `AGE_RULES 'egg yolk'`) but egg has **no `FOOD_EFFECTS` record**, so the "Ready to try" row fell to the generic "in a safe form" — for the one allergen where safe form means *cook well, yolk first*. **Folded:** `safeForm` now falls back to the allergen's own `AGE_RULES.reason` before the generic string. No `data.js` edit (so no Kael re-summon).
+- **M-2/M-3** (sharpening): confirmed the tap-through is not an empty dead-end for soy/wheat/sesame (all present in `data.js`); the watching row now carries an explicit "tap for signs" cue.
+
+**Kael (Intelligence engine) — `amended`.** Confirmed the compute is pure, null-guards complete, and the `=== canonEff` identity comparison sound. One blocker, adjudicated down after empirical verification:
+- **B-1** (blocking, **partially accepted**): Kael reported the alias spine broken on the exposure path and the two readers disagreeing. **Empirical ground-truth eval falsified the headline** — tree-nut via "almond" resolves `tried=true, exposure=2` on *both* readers (matching the green e2e); there is no two-source disagreement. The *real* residual: egg/soy/wheat/sesame resolve by base-name only (no culinary-synonym alias table exists anywhere — "tofu"→soy, "roti"→wheat miss on *both* readers, symmetrically). **Folded:** the two readers now share one matcher (`_aiFoodMatches`) so they provably cannot drift (+ a `getFoodEffect(base)` improvement, + the by-reference invariant comment, Kael S-2); the culinary-synonym gap is documented as a known limitation (§6/§9) and a follow-up `data.js` alias task, not closed here (out of the read-only fence). S-3 (per-day resolve hoist) deferred — bounded at one-baby scale.
+
+**Vela (Surfacing) — `amended`.** Praised the compute/render split and the §7 pattern. One blocker + three sharpenings:
+- **V-V-1** (blocking) → §3: the `introduced` rollup was `items.filter(tried)`, which **included the reaction state** — so the summary + progress bar counted a flagged-reaction food as a win, contradicting its own row and re-merging at the *count* what the state machine separated. **Folded:** `introduced` now means *settled* (tried & not reaction); a new `reactions` rollup surfaces flagged work as its own "N flagged" in the summary.
+- **V-V-2** (→ engine) → guard future-dated entries: **folded** — `daysSince` clamps to 0 for a future date instead of `abs()`-counting a watch window that hasn't started.
+- **V-V-3/V-V-4** (sharpening): the full date (with year) was the longest meta and wrapped — **folded** by dropping the date from the reaction row (it lives in the detail sheet); the `watching` count is now `<strong>` like its siblings.
+
+**Synthesis (Lyra).** The two real blockers were one theme from two jurisdictions — *a flagged reaction must never read as success* (Maren at the safe-form floor, Vela at the rollup count). Both folded. Kael's B-1 was adjudicated against an empirical eval rather than a static trace; the verifiable part (reader unification + honest scoping) is folded, the unverifiable headline (two-source disagreement) was shown not to occur. All 11 e2e cases green. Remaining for the Architect: §10.
+
+---
+
 ## 1. The problem this spec exists to solve
 
 The Info tab renders ~20 `renderInfo*` cards (dispatched by `renderInfo()` at `intelligence-cards.js:1414`, itself called from `switchTab()`). They answer *"what happened"* (variety, pace, intake, correlations). **None answers a journey question:** *"where am I in the high-allergen-introduction sequence, and what should I offer next?"*
@@ -31,6 +51,8 @@ The card writes **nothing**. It derives its entire state at render time from thr
 **Why two food sources, not one.** `foods` is deduped to one entry per food — it carries the *first* intro date and any reaction flag, which drives the watch window. `feedingData` is the per-meal event log — it carries *repetition*, which is the keep-offering signal. They are complementary and must not be conflated: the date/watch comes from `foods`; the "offered N days" comes from `feedingData`. **Honesty constraint:** `extractDayFoods` dedups within a day, so the count is *days offered*, never *number of tastes*. The copy says "offered N **days**" — it must never imply a per-taste count the data can't support.
 
 The allergen set (frozen): **peanut, tree nuts, egg, sesame, soy, wheat** (`AI_ALLERGEN_SET`). Each row resolves independently; no cross-allergen inference.
+
+**Alias coverage — honest scope (Kael B-1).** Both readers run every food token through *one* matcher (`_aiFoodMatches`), so the tried-state and the exposure-count provably cannot disagree about what counts as a given allergen. That matcher is **`FOOD_EFFECTS`-alias-correct** for peanut and tree nuts (logging *almond*/*cashew* resolves to Tree nuts) and resolves egg via its `AGE_RULES` entry. It is **base-name-only for soy/wheat/sesame** — the app carries no culinary-synonym alias table, so logging *tofu* (→ soy), *roti* (→ wheat), or *scrambled egg* does **not** resolve on *either* reader. This is a symmetric miss (the card stays internally consistent — both readers agree the food wasn't logged-as-that-allergen), not a contradiction. Closing it is a `data.js` alias-table follow-up, out of this card's read-only fence.
 
 ---
 
@@ -108,7 +130,7 @@ A reaction-only state is *not* urgent here — the acute floor is the food detai
 |---|---|
 | No `foods`, no `feedingData` (fresh install) | All 6 → ready or not-yet by age alone; bar at 0/6; insight = the from-6-months line. |
 | Food logged but never at a meal (`foods` has it, `feedingData` doesn't) | State/date from `foods`; exposure count = 0 → tolerated row reads "keep it in rotation" with no count. Both sources honored independently. |
-| Allergen with no `FOOD_EFFECTS` record (egg/soy/wheat) | Resolver falls back to `_baseFoodName` match; intro-month falls back to 6 where `AGE_RULES` has no per-food rule (a general window, **not** an invented per-food claim). |
+| Allergen with no `FOOD_EFFECTS` record (egg/soy/wheat/sesame) | Resolver falls back to `_baseFoodName` match (canonical name only — culinary synonyms like *tofu*/*roti* do not resolve, §2). Intro-month falls back to 6 where `AGE_RULES` has no per-food rule (a general window, **not** an invented per-food claim). Egg is the exception: `AGE_RULES 'egg yolk'` supplies both its 7-month floor and its `reason` (the safe-form fallback, M-1). |
 | `feedingData` carries the app's seeded defaults | Counted as real exposure — it *is* the meal log. (Tests clear it to assert in isolation; production does not.) |
 | Age unavailable (`getAgeInMonths` absent) | Defaults to 0 → everything not-yet. Fails safe (never nudges to introduce below a floor it can't confirm). |
 | Singular/plural | "offered 1 day" vs "offered N days" — handled. |
@@ -122,7 +144,7 @@ This card establishes a reusable shape for Info-tab **analysis** cards (distinct
 1. **A pure `_aiCompute*()`** that returns `{ items, total, …rollups }` — no DOM, no writes, fully testable in isolation (this is what the e2e asserts against directly).
 2. **A `renderInfo*()`** that consumes the compute output: summary + progress + actionability-ordered rows + a derived "what this means" line.
 3. **Resolve every food through the shared spine** (`getFoodEffect`/`_baseFoodName`) so aliases are correct — never raw-name matching.
-4. **Two-source honesty:** when state and repetition come from different stores, keep them separate and label each for exactly what it measures.
+4. **Two-source honesty:** when state and repetition come from different stores, keep them separate, run them through *one* resolver so they cannot drift, and label each for exactly what it measures. **A rollup label is a surface claim, not a field name** (Vela V-V-1): "introduced" must count only what a parent would call introduced — a flagged reaction is open work, never folded into the success count, at the row *or* the rollup.
 5. **Glance → tap → depth:** the card never crams the detail sheet's content; it points at it.
 
 Card #2 candidates (future, not this spec): an iron/nutrient-window journey card; a milestone-window card. Each would reuse 1–5 above.
@@ -143,7 +165,7 @@ Card #2 candidates (future, not this spec): an iron/nutrient-window journey card
 ## 9. Verification contract
 
 - `pnpm build` clean (HR-1/HR-12/icon-text audits pass).
-- `tests/e2e/analytics-allergen-intro.spec.ts` — 8 cases: empty→all-ready, almond→tree-nut tolerated, peanut→watching, reaction surfacing, mixed render + notable tier + progress bar, exposure-count roll-up (alias-correct), actionability ordering, tap-through to the R3 floor.
+- `tests/e2e/analytics-allergen-intro.spec.ts` — **11 cases**: empty→all-ready, almond→tree-nut tolerated, peanut→watching, reaction surfacing, **reaction excluded from `introduced` (V-V-1)**, **future-date guard (V-V-2)**, **egg safe-form floor fallback (M-1)**, mixed render + notable tier + progress bar, exposure-count roll-up (`FOOD_EFFECTS`-alias-correct), actionability ordering, tap-through to the R3 floor.
 - **Routing for the canon-cc-008 chain:** `intelligence-cards.js` edited → **Vela** (render). The compute *reads* `feedingData` + `extractDayFoods` (Maren's diet region) without editing them → `pnpm qa-route` ripple widens the summon-set to **Maren** (cross-Province read). No `styles.css`/`template.html` → not triple-Gov. Lyra synthesizes; **Cipher** runs the Edict V final-pass.
 
 ---

--- a/index.html
+++ b/index.html
@@ -69498,22 +69498,37 @@ var AI_ALLERGEN_SET = [
   { key: 'wheat',    label: 'Wheat' }
 ];
 
-// Earliest tried `foods` entry mapping to this allergen. Prefer the shared
-// resolver (alias-correct: almond/cashew → the tree-nut record); fall back to a
-// base-name match for allergens with no FOOD_EFFECTS record (egg/soy/wheat).
-function _aiFoodRecordFor(canonEff, key) {
+// The SINGLE resolution spine both food-readers (`_aiFoodRecordFor` tried-state
+// and `_aiExposureDays` meal-log) run every token through — so the two sources
+// can never disagree about what counts as "tree nut" (Kael B-1). Resolution
+// order: (1) FOOD_EFFECTS identity on the raw token, (2) FOOD_EFFECTS identity
+// on the base name (catches form-prefixed tokens like "raw peanut"), (3) base-
+// name string match for allergens with NO FOOD_EFFECTS record (egg/soy/wheat/
+// sesame).
+//   `=== canonEff` is load-bearing and correct ONLY because `_lookupByFoodName`
+//   returns FOOD_EFFECTS records by reference (module-level singletons) — every
+//   getFoodEffect("almond")/("tree nut") yields the identical object. A future
+//   refactor that clones records would silently break this; keep it by-ref.
+//   LIMITATION (spec §6/§9): culinary synonyms with no alias table — "tofu"→soy,
+//   "roti"→wheat, "scrambled egg"→egg — do not resolve on EITHER reader (the app
+//   has no such alias data anywhere). Both readers agree on the miss, so the card
+//   stays internally consistent; closing the gap is a data.js alias-table task.
+function _aiFoodMatches(foodName, canonEff, base) {
+  if (!foodName) return false;
+  var fn = String(foodName).toLowerCase().trim();
+  if (canonEff && typeof getFoodEffect === 'function') {
+    if (getFoodEffect(fn) === canonEff) return true;
+    if (typeof _baseFoodName === 'function' && getFoodEffect(_baseFoodName(fn)) === canonEff) return true;
+  }
+  return (typeof _baseFoodName === 'function') && _baseFoodName(fn) === base;
+}
+
+// Earliest tried `foods` entry mapping to this allergen, via the shared matcher.
+function _aiFoodRecordFor(canonEff, base) {
   if (typeof foods === 'undefined' || !Array.isArray(foods)) return null;
-  var base = (typeof _baseFoodName === 'function')
-    ? _baseFoodName(String(key).toLowerCase().trim()) : String(key).toLowerCase().trim();
   var match = null;
   foods.forEach(function(f) {
-    if (!f || !f.name) return;
-    var hit = false;
-    if (canonEff && typeof getFoodEffect === 'function') hit = (getFoodEffect(f.name) === canonEff);
-    if (!hit && typeof _baseFoodName === 'function') {
-      hit = (_baseFoodName(String(f.name).toLowerCase().trim()) === base);
-    }
-    if (!hit) return;
+    if (!f || !f.name || !_aiFoodMatches(f.name, canonEff, base)) return;
     if (!match) match = f;
     else if (f.date && (!match.date || f.date < match.date)) match = f; // earliest intro
   });
@@ -69529,10 +69544,7 @@ function _aiExposureDays(canonEff, base) {
   if (typeof feedingData === 'undefined' || !feedingData || typeof extractDayFoods !== 'function') return 0;
   var n = 0;
   Object.keys(feedingData).forEach(function(ds) {
-    var hit = extractDayFoods(ds).some(function(fn) {
-      if (canonEff && typeof getFoodEffect === 'function' && getFoodEffect(fn) === canonEff) return true;
-      return (typeof _baseFoodName === 'function') && _baseFoodName(fn) === base;
-    });
+    var hit = extractDayFoods(ds).some(function(fn) { return _aiFoodMatches(fn, canonEff, base); });
     if (hit) n++;
   });
   return n;
@@ -69547,7 +69559,7 @@ function _aiComputeAllergenIntro() {
       ? _lookupByFoodName(AGE_RULES, a.key) : null;
     var introMonth = (ageRule && ageRule.minMonth) ? ageRule.minMonth : 6;
     var base = (typeof _baseFoodName === 'function') ? _baseFoodName(String(a.key).toLowerCase().trim()) : String(a.key);
-    var rec = _aiFoodRecordFor(eff, a.key);
+    var rec = _aiFoodRecordFor(eff, base);
     var exposureDays = _aiExposureDays(eff, base);
     var ageReady = ageMonths >= introMonth;
     var state, daysSince = null;
@@ -69555,7 +69567,10 @@ function _aiComputeAllergenIntro() {
       if (rec.reaction === 'watch') {
         state = 'reaction';
       } else if (rec.date && tdy) {
-        daysSince = daysBetween(rec.date, tdy);
+        // Guard a future-dated entry (data error / TZ edge): the watch window
+        // hasn't started, so clamp to day 0 rather than abs()-counting it as
+        // a window already underway (Vela V-V-2 / Kael).
+        daysSince = (rec.date <= tdy) ? daysBetween(rec.date, tdy) : 0;
         state = (daysSince >= 3) ? 'tolerated' : 'watching';
       } else {
         state = 'introduced';
@@ -69563,15 +69578,25 @@ function _aiComputeAllergenIntro() {
     } else {
       state = ageReady ? 'ready' : 'waiting';
     }
+    // safe-form note: FOOD_EFFECTS note (peanut/tree-nut) preferred; else the
+    // allergen's own AGE_RULES `reason` (egg's "cook well, yolk first" floor) —
+    // never the generic "in a safe form" where a real per-food floor exists (Maren M-1).
+    var safeForm = (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note
+                 : (ageRule && ageRule.reason) ? ageRule.reason : null;
     return { key: a.key, label: a.label, introMonth: introMonth, ageReady: ageReady,
              tried: !!rec, date: (rec && rec.date) || null, daysSince: daysSince,
-             exposureDays: exposureDays,
-             state: state, safeForm: (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : null };
+             exposureDays: exposureDays, state: state, safeForm: safeForm };
   });
+  // "introduced" must mean a SETTLED introduction — a flagged reaction is open
+  // work, never a win. Excluding it keeps the summary + progress bar honest and
+  // stops the rollup re-merging what the state machine separated (Vela V-V-1,
+  // converging with Maren's reaction-never-suppressed invariant).
+  var settled = items.filter(function(i){ return i.tried && i.state !== 'reaction'; }).length;
   return {
     items: items,
     total: items.length,
-    introduced: items.filter(function(i){ return i.tried; }).length,
+    introduced: settled,
+    reactions: items.filter(function(i){ return i.state === 'reaction'; }).length,
     ready: items.filter(function(i){ return i.state === 'ready'; }).length,
     watching: items.filter(function(i){ return i.state === 'watching'; }).length,
     ageMonths: ageMonths
@@ -69588,7 +69613,8 @@ function renderInfoAllergenIntro() {
   // Summary line + a glanceable sage progress bar (introduced / total).
   var sum = '<div class="t-sm"><strong>' + data.introduced + '</strong> of <strong>' + data.total + '</strong> introduced';
   if (data.ready > 0) sum += ' · <strong>' + data.ready + '</strong> ready to try';
-  if (data.watching > 0) sum += ' · ' + data.watching + ' watching';
+  if (data.watching > 0) sum += ' · <strong>' + data.watching + '</strong> watching';
+  if (data.reactions > 0) sum += ' · <strong>' + data.reactions + '</strong> flagged';
   sum += '</div>';
   sum += _cdBarHtml('Progress', data.introduced, data.total, ' / ' + data.total, 'var(--tc-sage)');
   sumEl.innerHTML = sum;
@@ -69615,9 +69641,9 @@ function renderInfoAllergenIntro() {
       var offered = i.exposureDays > 0 ? ('offered ' + i.exposureDays + (i.exposureDays === 1 ? ' day' : ' days')) : '';
       var meta;
       if (i.state === 'tolerated') meta = (offered ? offered + ' · ' : '') + 'keep it in rotation';
-      else if (i.state === 'watching') meta = 'Day ' + (i.daysSince + 1) + ' of 3 — watch for reactions';
+      else if (i.state === 'watching') meta = 'Day ' + (i.daysSince + 1) + ' of 3 — watch, tap for signs';
       else if (i.state === 'introduced') meta = 'Keep offering to hold tolerance';
-      else if (i.state === 'reaction') meta = 'Reaction flagged' + (i.date ? ' ' + formatDate(i.date) : '') + ' — tap to review';
+      else if (i.state === 'reaction') meta = 'Reaction flagged — tap to review';
       else if (i.state === 'ready') meta = i.safeForm ? i.safeForm : 'Good to introduce now, in a safe form';
       else meta = 'From ' + i.introMonth + ' months';
       // Row taps through to the food's detail sheet — the R3 floor + safe-form

--- a/index.html
+++ b/index.html
@@ -69589,7 +69589,9 @@ function renderInfoAllergenIntro() {
       else if (i.state === 'reaction') meta = 'Flagged for watch' + (i.date ? ' on ' + formatDate(i.date) : '') + ' — open the food for details';
       else if (i.state === 'ready') meta = i.safeForm ? i.safeForm : 'Good to introduce now, in a safe form';
       else meta = 'Fine to wait — around ' + i.introMonth + ' months';
-      rows += '<div class="cd-food-item">' +
+      // Row taps through to the food's detail sheet — the R3 floor + safe-form
+      // for the same resolved food (foodLibDetail → renderFoodDetailSheet).
+      rows += '<div class="cd-food-item tappable" role="button" tabindex="0" data-action="foodLibDetail" data-arg="' + escHtml(i.key) + '">' +
         '<div class="cd-food-name">' + escHtml(i.label) + '</div>' +
         '<div class="cd-pill ' + s.pill + '">' + escHtml(s.text) + '</div>' +
         '<div class="cd-food-meta">' + escHtml(meta) + '</div>' +

--- a/index.html
+++ b/index.html
@@ -69520,6 +69520,24 @@ function _aiFoodRecordFor(canonEff, key) {
   return match;
 }
 
+// "Offered on N days" — the repeated-exposure / keep-offering signal, counted
+// from the meal log (feedingData via extractDayFoods). Distinct from the
+// `foods` tried-state above: that gives the intro date + watch window; this
+// counts the days the allergen actually appeared at a meal. Same resolver
+// spine, so "almond" days count toward Tree nuts.
+function _aiExposureDays(canonEff, base) {
+  if (typeof feedingData === 'undefined' || !feedingData || typeof extractDayFoods !== 'function') return 0;
+  var n = 0;
+  Object.keys(feedingData).forEach(function(ds) {
+    var hit = extractDayFoods(ds).some(function(fn) {
+      if (canonEff && typeof getFoodEffect === 'function' && getFoodEffect(fn) === canonEff) return true;
+      return (typeof _baseFoodName === 'function') && _baseFoodName(fn) === base;
+    });
+    if (hit) n++;
+  });
+  return n;
+}
+
 function _aiComputeAllergenIntro() {
   var ageMonths = (typeof getAgeInMonths === 'function') ? getAgeInMonths() : 0;
   var tdy = (typeof today === 'function') ? today() : null;
@@ -69528,7 +69546,9 @@ function _aiComputeAllergenIntro() {
     var ageRule = (typeof _lookupByFoodName === 'function' && typeof AGE_RULES !== 'undefined')
       ? _lookupByFoodName(AGE_RULES, a.key) : null;
     var introMonth = (ageRule && ageRule.minMonth) ? ageRule.minMonth : 6;
+    var base = (typeof _baseFoodName === 'function') ? _baseFoodName(String(a.key).toLowerCase().trim()) : String(a.key);
     var rec = _aiFoodRecordFor(eff, a.key);
+    var exposureDays = _aiExposureDays(eff, base);
     var ageReady = ageMonths >= introMonth;
     var state, daysSince = null;
     if (rec) {
@@ -69545,6 +69565,7 @@ function _aiComputeAllergenIntro() {
     }
     return { key: a.key, label: a.label, introMonth: introMonth, ageReady: ageReady,
              tried: !!rec, date: (rec && rec.date) || null, daysSince: daysSince,
+             exposureDays: exposureDays,
              state: state, safeForm: (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : null };
   });
   return {
@@ -69564,10 +69585,12 @@ function renderInfoAllergenIntro() {
   var insEl = document.getElementById('infoAllergenIntroInsights');
   var data = _aiComputeAllergenIntro();
 
+  // Summary line + a glanceable sage progress bar (introduced / total).
   var sum = '<div class="t-sm"><strong>' + data.introduced + '</strong> of <strong>' + data.total + '</strong> introduced';
   if (data.ready > 0) sum += ' · <strong>' + data.ready + '</strong> ready to try';
-  if (data.watching > 0) sum += ' · ' + data.watching + ' in the 3-day watch';
+  if (data.watching > 0) sum += ' · ' + data.watching + ' watching';
   sum += '</div>';
+  sum += _cdBarHtml('Progress', data.introduced, data.total, ' / ' + data.total, 'var(--tc-sage)');
   sumEl.innerHTML = sum;
 
   var STATE = {
@@ -69579,16 +69602,24 @@ function renderInfoAllergenIntro() {
     reaction:   { pill: 'cd-pill-neg',     text: 'Reaction noted' }
   };
   if (listEl) {
+    // Order by actionability so what to act on floats up: ready → watching →
+    // reaction → introduced/tolerated → not-yet. Stable sort preserves set order
+    // within a tier.
+    var RANK = { ready: 0, watching: 1, reaction: 2, introduced: 3, tolerated: 3, waiting: 4 };
+    var ordered = data.items.slice().sort(function(a, b) {
+      return (RANK[a.state] != null ? RANK[a.state] : 9) - (RANK[b.state] != null ? RANK[b.state] : 9);
+    });
     var rows = '<div class="cd-section-label">High-priority allergens</div>';
-    data.items.forEach(function(i) {
+    ordered.forEach(function(i) {
       var s = STATE[i.state] || STATE.waiting;
+      var offered = i.exposureDays > 0 ? ('offered ' + i.exposureDays + (i.exposureDays === 1 ? ' day' : ' days')) : '';
       var meta;
-      if (i.state === 'tolerated') meta = 'Introduced ' + (i.date ? formatDate(i.date) : '') + ' · 3-day watch cleared';
-      else if (i.state === 'watching') meta = 'Day ' + (i.daysSince + 1) + ' of 3 — keep watching';
-      else if (i.state === 'introduced') meta = 'Introduced';
-      else if (i.state === 'reaction') meta = 'Flagged for watch' + (i.date ? ' on ' + formatDate(i.date) : '') + ' — open the food for details';
+      if (i.state === 'tolerated') meta = (offered ? offered + ' · ' : '') + 'keep it in rotation';
+      else if (i.state === 'watching') meta = 'Day ' + (i.daysSince + 1) + ' of 3 — watch for reactions';
+      else if (i.state === 'introduced') meta = 'Keep offering to hold tolerance';
+      else if (i.state === 'reaction') meta = 'Reaction flagged' + (i.date ? ' ' + formatDate(i.date) : '') + ' — tap to review';
       else if (i.state === 'ready') meta = i.safeForm ? i.safeForm : 'Good to introduce now, in a safe form';
-      else meta = 'Fine to wait — around ' + i.introMonth + ' months';
+      else meta = 'From ' + i.introMonth + ' months';
       // Row taps through to the food's detail sheet — the R3 floor + safe-form
       // for the same resolved food (foodLibDetail → renderFoodDetailSheet).
       rows += '<div class="cd-food-item tappable" role="button" tabindex="0" data-action="foodLibDetail" data-arg="' + escHtml(i.key) + '">' +
@@ -69603,14 +69634,14 @@ function renderInfoAllergenIntro() {
   if (insEl) {
     var ins;
     if (data.introduced >= data.total) {
-      ins = 'All ' + data.total + ' high-priority allergens introduced — early, regular exposure is what helps build tolerance. Keep them in rotation.';
+      ins = 'All ' + data.total + ' introduced. Keep offering each a few times a week — repeated exposure is what holds the protection.';
     } else if (data.ready > 0) {
       var readyLabels = data.items.filter(function(i){ return i.state === 'ready'; }).map(function(i){ return i.label; });
-      ins = 'Introducing allergens early, in a safe form, is protective. Good to start now: ' + readyLabels.join(', ') + '. Offer one new allergen at a time and watch for 3 days.';
+      ins = 'Early introduction in a safe form is protective. Good to start now: ' + readyLabels.join(', ') + '. One at a time, then watch 3 days.';
     } else if (data.watching > 0) {
-      ins = 'Watching a newly-introduced allergen. A mild rash alone: note it and carry on. Any trouble breathing or swelling of the face or lips: seek care right away.';
+      ins = 'Watching a new allergen. A mild rash alone: note it and carry on. Trouble breathing or swelling of the face or lips: get help right away.';
     } else {
-      ins = 'Allergens are usually introduced from around 6 months, one at a time, in a safe (smooth or thinned) form.';
+      ins = 'Allergens go in from around 6 months — one at a time, in a smooth or thinned form.';
     }
     insEl.innerHTML = '<div class="cd-section-label">What this means</div><div class="t-sm">' + escHtml(ins) + '</div>';
   }

--- a/index.html
+++ b/index.html
@@ -13072,6 +13072,19 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
       <div class="home-section-label sec-t3 col-full">Cross-Domain Intelligence</div>
 
       <!-- Card 1: Food → Poop Pipeline -->
+      <!-- Allergen Introduction (analysis prototype — guided-introduction journey) -->
+      <div class="card card-daily col-full" id="infoAllergenIntroCard">
+        <div class="card-header" data-collapse-target="infoAllergenIntroBody" data-collapse-chevron="infoAllergenIntroChevron">
+          <div class="card-title"><div class="icon icon-sage"><svg class="zi"><use href="#zi-sprout"/></svg></div> Allergen Introduction</div>
+          <span class="collapse-chevron" id="infoAllergenIntroChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
+        </div>
+        <div id="infoAllergenIntroSummary" class="mt-4"></div>
+        <div id="infoAllergenIntroBody" class="collapse-body fx-col g8" style="display:none;">
+          <div id="infoAllergenIntroList" class="mt-4"></div>
+          <div id="infoAllergenIntroInsights" class="mt-8"></div>
+        </div>
+      </div>
+
       <div class="card card-daily col-full" id="infoFoodPoopPipelineCard">
         <div class="card-header" data-collapse-target="infoFoodPoopPipelineBody" data-collapse-chevron="infoFoodPoopPipelineChevron">
           <div class="card-title"><div class="icon icon-peach"><svg class="zi"><use href="#zi-link"/></svg></div> Food → Poop Pipeline</div>
@@ -69463,6 +69476,150 @@ function _cdBarHtml(label, value, maxVal, suffix, color, rawLabel) {
 }
 
 // ════════════════════════════════════════
+// Allergen Introduction (analysis prototype)
+// ════════════════════════════════════════
+// The analysis layer ON TOP of the food-effects-v2 resolver spine: tracks the
+// high-priority "introduce-early" allergens and where Ziva is with each —
+// ready to try / watching the 3-day window / tolerated / reaction noted —
+// sourced from the SAME getFoodEffect + _lookupByFoodName resolver the
+// consequence surfaces use (so a logged "almond"/"cashew" correctly counts as
+// tree-nut introduced), the tried-state in `foods`, and AGE_RULES. Encourage
+// polarity — this is the guided-introduction journey, not an alarm. No
+// hardcoded safety claim: every per-food fact resolves from the data tables;
+// where a food has no FOOD_EFFECTS/AGE_RULES record we fall back to the general
+// ~6-month solids/allergen window rather than inventing a per-food rule.
+
+var AI_ALLERGEN_SET = [
+  { key: 'peanut',   label: 'Peanut' },
+  { key: 'tree nut', label: 'Tree nuts' },
+  { key: 'egg',      label: 'Egg' },
+  { key: 'sesame',   label: 'Sesame' },
+  { key: 'soy',      label: 'Soy' },
+  { key: 'wheat',    label: 'Wheat' }
+];
+
+// Earliest tried `foods` entry mapping to this allergen. Prefer the shared
+// resolver (alias-correct: almond/cashew → the tree-nut record); fall back to a
+// base-name match for allergens with no FOOD_EFFECTS record (egg/soy/wheat).
+function _aiFoodRecordFor(canonEff, key) {
+  if (typeof foods === 'undefined' || !Array.isArray(foods)) return null;
+  var base = (typeof _baseFoodName === 'function')
+    ? _baseFoodName(String(key).toLowerCase().trim()) : String(key).toLowerCase().trim();
+  var match = null;
+  foods.forEach(function(f) {
+    if (!f || !f.name) return;
+    var hit = false;
+    if (canonEff && typeof getFoodEffect === 'function') hit = (getFoodEffect(f.name) === canonEff);
+    if (!hit && typeof _baseFoodName === 'function') {
+      hit = (_baseFoodName(String(f.name).toLowerCase().trim()) === base);
+    }
+    if (!hit) return;
+    if (!match) match = f;
+    else if (f.date && (!match.date || f.date < match.date)) match = f; // earliest intro
+  });
+  return match;
+}
+
+function _aiComputeAllergenIntro() {
+  var ageMonths = (typeof getAgeInMonths === 'function') ? getAgeInMonths() : 0;
+  var tdy = (typeof today === 'function') ? today() : null;
+  var items = AI_ALLERGEN_SET.map(function(a) {
+    var eff = (typeof getFoodEffect === 'function') ? getFoodEffect(a.key) : null;
+    var ageRule = (typeof _lookupByFoodName === 'function' && typeof AGE_RULES !== 'undefined')
+      ? _lookupByFoodName(AGE_RULES, a.key) : null;
+    var introMonth = (ageRule && ageRule.minMonth) ? ageRule.minMonth : 6;
+    var rec = _aiFoodRecordFor(eff, a.key);
+    var ageReady = ageMonths >= introMonth;
+    var state, daysSince = null;
+    if (rec) {
+      if (rec.reaction === 'watch') {
+        state = 'reaction';
+      } else if (rec.date && tdy) {
+        daysSince = daysBetween(rec.date, tdy);
+        state = (daysSince >= 3) ? 'tolerated' : 'watching';
+      } else {
+        state = 'introduced';
+      }
+    } else {
+      state = ageReady ? 'ready' : 'waiting';
+    }
+    return { key: a.key, label: a.label, introMonth: introMonth, ageReady: ageReady,
+             tried: !!rec, date: (rec && rec.date) || null, daysSince: daysSince,
+             state: state, safeForm: (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : null };
+  });
+  return {
+    items: items,
+    total: items.length,
+    introduced: items.filter(function(i){ return i.tried; }).length,
+    ready: items.filter(function(i){ return i.state === 'ready'; }).length,
+    watching: items.filter(function(i){ return i.state === 'watching'; }).length,
+    ageMonths: ageMonths
+  };
+}
+
+function renderInfoAllergenIntro() {
+  var sumEl = document.getElementById('infoAllergenIntroSummary');
+  if (!sumEl) return;
+  var listEl = document.getElementById('infoAllergenIntroList');
+  var insEl = document.getElementById('infoAllergenIntroInsights');
+  var data = _aiComputeAllergenIntro();
+
+  var sum = '<div class="t-sm"><strong>' + data.introduced + '</strong> of <strong>' + data.total + '</strong> introduced';
+  if (data.ready > 0) sum += ' · <strong>' + data.ready + '</strong> ready to try';
+  if (data.watching > 0) sum += ' · ' + data.watching + ' in the 3-day watch';
+  sum += '</div>';
+  sumEl.innerHTML = sum;
+
+  var STATE = {
+    tolerated:  { pill: 'cd-pill-pos',     text: 'Tolerated' },
+    introduced: { pill: 'cd-pill-pos',     text: 'Introduced' },
+    watching:   { pill: 'cd-pill-neutral', text: 'Watching' },
+    ready:      { pill: 'cd-pill-pos',     text: 'Ready to try' },
+    waiting:    { pill: 'cd-pill-neutral', text: 'Not yet' },
+    reaction:   { pill: 'cd-pill-neg',     text: 'Reaction noted' }
+  };
+  if (listEl) {
+    var rows = '<div class="cd-section-label">High-priority allergens</div>';
+    data.items.forEach(function(i) {
+      var s = STATE[i.state] || STATE.waiting;
+      var meta;
+      if (i.state === 'tolerated') meta = 'Introduced ' + (i.date ? formatDate(i.date) : '') + ' · 3-day watch cleared';
+      else if (i.state === 'watching') meta = 'Day ' + (i.daysSince + 1) + ' of 3 — keep watching';
+      else if (i.state === 'introduced') meta = 'Introduced';
+      else if (i.state === 'reaction') meta = 'Flagged for watch' + (i.date ? ' on ' + formatDate(i.date) : '') + ' — open the food for details';
+      else if (i.state === 'ready') meta = i.safeForm ? i.safeForm : 'Good to introduce now, in a safe form';
+      else meta = 'Fine to wait — around ' + i.introMonth + ' months';
+      rows += '<div class="cd-food-item">' +
+        '<div class="cd-food-name">' + escHtml(i.label) + '</div>' +
+        '<div class="cd-pill ' + s.pill + '">' + escHtml(s.text) + '</div>' +
+        '<div class="cd-food-meta">' + escHtml(meta) + '</div>' +
+        '</div>';
+    });
+    listEl.innerHTML = rows;
+  }
+
+  if (insEl) {
+    var ins;
+    if (data.introduced >= data.total) {
+      ins = 'All ' + data.total + ' high-priority allergens introduced — early, regular exposure is what helps build tolerance. Keep them in rotation.';
+    } else if (data.ready > 0) {
+      var readyLabels = data.items.filter(function(i){ return i.state === 'ready'; }).map(function(i){ return i.label; });
+      ins = 'Introducing allergens early, in a safe form, is protective. Good to start now: ' + readyLabels.join(', ') + '. Offer one new allergen at a time and watch for 3 days.';
+    } else if (data.watching > 0) {
+      ins = 'Watching a newly-introduced allergen. A mild rash alone: note it and carry on. Any trouble breathing or swelling of the face or lips: seek care right away.';
+    } else {
+      ins = 'Allergens are usually introduced from around 6 months, one at a time, in a safe (smooth or thinned) form.';
+    }
+    insEl.innerHTML = '<div class="cd-section-label">What this means</div><div class="t-sm">' + escHtml(ins) + '</div>';
+  }
+
+  // Composite card — never urgent (spec v3-6). Actionable (ready/watching) → notable; else ambient.
+  if (typeof _setCardPriority === 'function') {
+    _setCardPriority('infoAllergenIntroCard', (data.ready > 0 || data.watching > 0) ? 'notable' : 'ambient');
+  }
+}
+
+// ════════════════════════════════════════
 // Card 1: Food → Poop Pipeline
 // ════════════════════════════════════════
 
@@ -70482,6 +70639,7 @@ function renderInfo() {
   renderInfoSupplementAdherence();
   renderInfoVaccRecovery();
   renderInfoGrowthVelocity();
+  renderInfoAllergenIntro();
   renderInfoFoodPoopPipeline();
   renderInfoSleepFeeding();
   renderInfoActivitySleepDeep();

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.01-4",
+  "version": "2026.06.01-5",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.01-5",
+  "version": "2026.06.01-6",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.01-2",
+  "version": "2026.06.01-3",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.01-3",
+  "version": "2026.06.01-4",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.05.31-40",
+  "version": "2026.06.01-2",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/intelligence-cards.js
+++ b/split/intelligence-cards.js
@@ -275,22 +275,37 @@ var AI_ALLERGEN_SET = [
   { key: 'wheat',    label: 'Wheat' }
 ];
 
-// Earliest tried `foods` entry mapping to this allergen. Prefer the shared
-// resolver (alias-correct: almond/cashew → the tree-nut record); fall back to a
-// base-name match for allergens with no FOOD_EFFECTS record (egg/soy/wheat).
-function _aiFoodRecordFor(canonEff, key) {
+// The SINGLE resolution spine both food-readers (`_aiFoodRecordFor` tried-state
+// and `_aiExposureDays` meal-log) run every token through — so the two sources
+// can never disagree about what counts as "tree nut" (Kael B-1). Resolution
+// order: (1) FOOD_EFFECTS identity on the raw token, (2) FOOD_EFFECTS identity
+// on the base name (catches form-prefixed tokens like "raw peanut"), (3) base-
+// name string match for allergens with NO FOOD_EFFECTS record (egg/soy/wheat/
+// sesame).
+//   `=== canonEff` is load-bearing and correct ONLY because `_lookupByFoodName`
+//   returns FOOD_EFFECTS records by reference (module-level singletons) — every
+//   getFoodEffect("almond")/("tree nut") yields the identical object. A future
+//   refactor that clones records would silently break this; keep it by-ref.
+//   LIMITATION (spec §6/§9): culinary synonyms with no alias table — "tofu"→soy,
+//   "roti"→wheat, "scrambled egg"→egg — do not resolve on EITHER reader (the app
+//   has no such alias data anywhere). Both readers agree on the miss, so the card
+//   stays internally consistent; closing the gap is a data.js alias-table task.
+function _aiFoodMatches(foodName, canonEff, base) {
+  if (!foodName) return false;
+  var fn = String(foodName).toLowerCase().trim();
+  if (canonEff && typeof getFoodEffect === 'function') {
+    if (getFoodEffect(fn) === canonEff) return true;
+    if (typeof _baseFoodName === 'function' && getFoodEffect(_baseFoodName(fn)) === canonEff) return true;
+  }
+  return (typeof _baseFoodName === 'function') && _baseFoodName(fn) === base;
+}
+
+// Earliest tried `foods` entry mapping to this allergen, via the shared matcher.
+function _aiFoodRecordFor(canonEff, base) {
   if (typeof foods === 'undefined' || !Array.isArray(foods)) return null;
-  var base = (typeof _baseFoodName === 'function')
-    ? _baseFoodName(String(key).toLowerCase().trim()) : String(key).toLowerCase().trim();
   var match = null;
   foods.forEach(function(f) {
-    if (!f || !f.name) return;
-    var hit = false;
-    if (canonEff && typeof getFoodEffect === 'function') hit = (getFoodEffect(f.name) === canonEff);
-    if (!hit && typeof _baseFoodName === 'function') {
-      hit = (_baseFoodName(String(f.name).toLowerCase().trim()) === base);
-    }
-    if (!hit) return;
+    if (!f || !f.name || !_aiFoodMatches(f.name, canonEff, base)) return;
     if (!match) match = f;
     else if (f.date && (!match.date || f.date < match.date)) match = f; // earliest intro
   });
@@ -306,10 +321,7 @@ function _aiExposureDays(canonEff, base) {
   if (typeof feedingData === 'undefined' || !feedingData || typeof extractDayFoods !== 'function') return 0;
   var n = 0;
   Object.keys(feedingData).forEach(function(ds) {
-    var hit = extractDayFoods(ds).some(function(fn) {
-      if (canonEff && typeof getFoodEffect === 'function' && getFoodEffect(fn) === canonEff) return true;
-      return (typeof _baseFoodName === 'function') && _baseFoodName(fn) === base;
-    });
+    var hit = extractDayFoods(ds).some(function(fn) { return _aiFoodMatches(fn, canonEff, base); });
     if (hit) n++;
   });
   return n;
@@ -324,7 +336,7 @@ function _aiComputeAllergenIntro() {
       ? _lookupByFoodName(AGE_RULES, a.key) : null;
     var introMonth = (ageRule && ageRule.minMonth) ? ageRule.minMonth : 6;
     var base = (typeof _baseFoodName === 'function') ? _baseFoodName(String(a.key).toLowerCase().trim()) : String(a.key);
-    var rec = _aiFoodRecordFor(eff, a.key);
+    var rec = _aiFoodRecordFor(eff, base);
     var exposureDays = _aiExposureDays(eff, base);
     var ageReady = ageMonths >= introMonth;
     var state, daysSince = null;
@@ -332,7 +344,10 @@ function _aiComputeAllergenIntro() {
       if (rec.reaction === 'watch') {
         state = 'reaction';
       } else if (rec.date && tdy) {
-        daysSince = daysBetween(rec.date, tdy);
+        // Guard a future-dated entry (data error / TZ edge): the watch window
+        // hasn't started, so clamp to day 0 rather than abs()-counting it as
+        // a window already underway (Vela V-V-2 / Kael).
+        daysSince = (rec.date <= tdy) ? daysBetween(rec.date, tdy) : 0;
         state = (daysSince >= 3) ? 'tolerated' : 'watching';
       } else {
         state = 'introduced';
@@ -340,15 +355,25 @@ function _aiComputeAllergenIntro() {
     } else {
       state = ageReady ? 'ready' : 'waiting';
     }
+    // safe-form note: FOOD_EFFECTS note (peanut/tree-nut) preferred; else the
+    // allergen's own AGE_RULES `reason` (egg's "cook well, yolk first" floor) —
+    // never the generic "in a safe form" where a real per-food floor exists (Maren M-1).
+    var safeForm = (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note
+                 : (ageRule && ageRule.reason) ? ageRule.reason : null;
     return { key: a.key, label: a.label, introMonth: introMonth, ageReady: ageReady,
              tried: !!rec, date: (rec && rec.date) || null, daysSince: daysSince,
-             exposureDays: exposureDays,
-             state: state, safeForm: (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : null };
+             exposureDays: exposureDays, state: state, safeForm: safeForm };
   });
+  // "introduced" must mean a SETTLED introduction — a flagged reaction is open
+  // work, never a win. Excluding it keeps the summary + progress bar honest and
+  // stops the rollup re-merging what the state machine separated (Vela V-V-1,
+  // converging with Maren's reaction-never-suppressed invariant).
+  var settled = items.filter(function(i){ return i.tried && i.state !== 'reaction'; }).length;
   return {
     items: items,
     total: items.length,
-    introduced: items.filter(function(i){ return i.tried; }).length,
+    introduced: settled,
+    reactions: items.filter(function(i){ return i.state === 'reaction'; }).length,
     ready: items.filter(function(i){ return i.state === 'ready'; }).length,
     watching: items.filter(function(i){ return i.state === 'watching'; }).length,
     ageMonths: ageMonths
@@ -365,7 +390,8 @@ function renderInfoAllergenIntro() {
   // Summary line + a glanceable sage progress bar (introduced / total).
   var sum = '<div class="t-sm"><strong>' + data.introduced + '</strong> of <strong>' + data.total + '</strong> introduced';
   if (data.ready > 0) sum += ' · <strong>' + data.ready + '</strong> ready to try';
-  if (data.watching > 0) sum += ' · ' + data.watching + ' watching';
+  if (data.watching > 0) sum += ' · <strong>' + data.watching + '</strong> watching';
+  if (data.reactions > 0) sum += ' · <strong>' + data.reactions + '</strong> flagged';
   sum += '</div>';
   sum += _cdBarHtml('Progress', data.introduced, data.total, ' / ' + data.total, 'var(--tc-sage)');
   sumEl.innerHTML = sum;
@@ -392,9 +418,9 @@ function renderInfoAllergenIntro() {
       var offered = i.exposureDays > 0 ? ('offered ' + i.exposureDays + (i.exposureDays === 1 ? ' day' : ' days')) : '';
       var meta;
       if (i.state === 'tolerated') meta = (offered ? offered + ' · ' : '') + 'keep it in rotation';
-      else if (i.state === 'watching') meta = 'Day ' + (i.daysSince + 1) + ' of 3 — watch for reactions';
+      else if (i.state === 'watching') meta = 'Day ' + (i.daysSince + 1) + ' of 3 — watch, tap for signs';
       else if (i.state === 'introduced') meta = 'Keep offering to hold tolerance';
-      else if (i.state === 'reaction') meta = 'Reaction flagged' + (i.date ? ' ' + formatDate(i.date) : '') + ' — tap to review';
+      else if (i.state === 'reaction') meta = 'Reaction flagged — tap to review';
       else if (i.state === 'ready') meta = i.safeForm ? i.safeForm : 'Good to introduce now, in a safe form';
       else meta = 'From ' + i.introMonth + ' months';
       // Row taps through to the food's detail sheet — the R3 floor + safe-form

--- a/split/intelligence-cards.js
+++ b/split/intelligence-cards.js
@@ -366,7 +366,9 @@ function renderInfoAllergenIntro() {
       else if (i.state === 'reaction') meta = 'Flagged for watch' + (i.date ? ' on ' + formatDate(i.date) : '') + ' — open the food for details';
       else if (i.state === 'ready') meta = i.safeForm ? i.safeForm : 'Good to introduce now, in a safe form';
       else meta = 'Fine to wait — around ' + i.introMonth + ' months';
-      rows += '<div class="cd-food-item">' +
+      // Row taps through to the food's detail sheet — the R3 floor + safe-form
+      // for the same resolved food (foodLibDetail → renderFoodDetailSheet).
+      rows += '<div class="cd-food-item tappable" role="button" tabindex="0" data-action="foodLibDetail" data-arg="' + escHtml(i.key) + '">' +
         '<div class="cd-food-name">' + escHtml(i.label) + '</div>' +
         '<div class="cd-pill ' + s.pill + '">' + escHtml(s.text) + '</div>' +
         '<div class="cd-food-meta">' + escHtml(meta) + '</div>' +

--- a/split/intelligence-cards.js
+++ b/split/intelligence-cards.js
@@ -297,6 +297,24 @@ function _aiFoodRecordFor(canonEff, key) {
   return match;
 }
 
+// "Offered on N days" — the repeated-exposure / keep-offering signal, counted
+// from the meal log (feedingData via extractDayFoods). Distinct from the
+// `foods` tried-state above: that gives the intro date + watch window; this
+// counts the days the allergen actually appeared at a meal. Same resolver
+// spine, so "almond" days count toward Tree nuts.
+function _aiExposureDays(canonEff, base) {
+  if (typeof feedingData === 'undefined' || !feedingData || typeof extractDayFoods !== 'function') return 0;
+  var n = 0;
+  Object.keys(feedingData).forEach(function(ds) {
+    var hit = extractDayFoods(ds).some(function(fn) {
+      if (canonEff && typeof getFoodEffect === 'function' && getFoodEffect(fn) === canonEff) return true;
+      return (typeof _baseFoodName === 'function') && _baseFoodName(fn) === base;
+    });
+    if (hit) n++;
+  });
+  return n;
+}
+
 function _aiComputeAllergenIntro() {
   var ageMonths = (typeof getAgeInMonths === 'function') ? getAgeInMonths() : 0;
   var tdy = (typeof today === 'function') ? today() : null;
@@ -305,7 +323,9 @@ function _aiComputeAllergenIntro() {
     var ageRule = (typeof _lookupByFoodName === 'function' && typeof AGE_RULES !== 'undefined')
       ? _lookupByFoodName(AGE_RULES, a.key) : null;
     var introMonth = (ageRule && ageRule.minMonth) ? ageRule.minMonth : 6;
+    var base = (typeof _baseFoodName === 'function') ? _baseFoodName(String(a.key).toLowerCase().trim()) : String(a.key);
     var rec = _aiFoodRecordFor(eff, a.key);
+    var exposureDays = _aiExposureDays(eff, base);
     var ageReady = ageMonths >= introMonth;
     var state, daysSince = null;
     if (rec) {
@@ -322,6 +342,7 @@ function _aiComputeAllergenIntro() {
     }
     return { key: a.key, label: a.label, introMonth: introMonth, ageReady: ageReady,
              tried: !!rec, date: (rec && rec.date) || null, daysSince: daysSince,
+             exposureDays: exposureDays,
              state: state, safeForm: (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : null };
   });
   return {
@@ -341,10 +362,12 @@ function renderInfoAllergenIntro() {
   var insEl = document.getElementById('infoAllergenIntroInsights');
   var data = _aiComputeAllergenIntro();
 
+  // Summary line + a glanceable sage progress bar (introduced / total).
   var sum = '<div class="t-sm"><strong>' + data.introduced + '</strong> of <strong>' + data.total + '</strong> introduced';
   if (data.ready > 0) sum += ' · <strong>' + data.ready + '</strong> ready to try';
-  if (data.watching > 0) sum += ' · ' + data.watching + ' in the 3-day watch';
+  if (data.watching > 0) sum += ' · ' + data.watching + ' watching';
   sum += '</div>';
+  sum += _cdBarHtml('Progress', data.introduced, data.total, ' / ' + data.total, 'var(--tc-sage)');
   sumEl.innerHTML = sum;
 
   var STATE = {
@@ -356,16 +379,24 @@ function renderInfoAllergenIntro() {
     reaction:   { pill: 'cd-pill-neg',     text: 'Reaction noted' }
   };
   if (listEl) {
+    // Order by actionability so what to act on floats up: ready → watching →
+    // reaction → introduced/tolerated → not-yet. Stable sort preserves set order
+    // within a tier.
+    var RANK = { ready: 0, watching: 1, reaction: 2, introduced: 3, tolerated: 3, waiting: 4 };
+    var ordered = data.items.slice().sort(function(a, b) {
+      return (RANK[a.state] != null ? RANK[a.state] : 9) - (RANK[b.state] != null ? RANK[b.state] : 9);
+    });
     var rows = '<div class="cd-section-label">High-priority allergens</div>';
-    data.items.forEach(function(i) {
+    ordered.forEach(function(i) {
       var s = STATE[i.state] || STATE.waiting;
+      var offered = i.exposureDays > 0 ? ('offered ' + i.exposureDays + (i.exposureDays === 1 ? ' day' : ' days')) : '';
       var meta;
-      if (i.state === 'tolerated') meta = 'Introduced ' + (i.date ? formatDate(i.date) : '') + ' · 3-day watch cleared';
-      else if (i.state === 'watching') meta = 'Day ' + (i.daysSince + 1) + ' of 3 — keep watching';
-      else if (i.state === 'introduced') meta = 'Introduced';
-      else if (i.state === 'reaction') meta = 'Flagged for watch' + (i.date ? ' on ' + formatDate(i.date) : '') + ' — open the food for details';
+      if (i.state === 'tolerated') meta = (offered ? offered + ' · ' : '') + 'keep it in rotation';
+      else if (i.state === 'watching') meta = 'Day ' + (i.daysSince + 1) + ' of 3 — watch for reactions';
+      else if (i.state === 'introduced') meta = 'Keep offering to hold tolerance';
+      else if (i.state === 'reaction') meta = 'Reaction flagged' + (i.date ? ' ' + formatDate(i.date) : '') + ' — tap to review';
       else if (i.state === 'ready') meta = i.safeForm ? i.safeForm : 'Good to introduce now, in a safe form';
-      else meta = 'Fine to wait — around ' + i.introMonth + ' months';
+      else meta = 'From ' + i.introMonth + ' months';
       // Row taps through to the food's detail sheet — the R3 floor + safe-form
       // for the same resolved food (foodLibDetail → renderFoodDetailSheet).
       rows += '<div class="cd-food-item tappable" role="button" tabindex="0" data-action="foodLibDetail" data-arg="' + escHtml(i.key) + '">' +
@@ -380,14 +411,14 @@ function renderInfoAllergenIntro() {
   if (insEl) {
     var ins;
     if (data.introduced >= data.total) {
-      ins = 'All ' + data.total + ' high-priority allergens introduced — early, regular exposure is what helps build tolerance. Keep them in rotation.';
+      ins = 'All ' + data.total + ' introduced. Keep offering each a few times a week — repeated exposure is what holds the protection.';
     } else if (data.ready > 0) {
       var readyLabels = data.items.filter(function(i){ return i.state === 'ready'; }).map(function(i){ return i.label; });
-      ins = 'Introducing allergens early, in a safe form, is protective. Good to start now: ' + readyLabels.join(', ') + '. Offer one new allergen at a time and watch for 3 days.';
+      ins = 'Early introduction in a safe form is protective. Good to start now: ' + readyLabels.join(', ') + '. One at a time, then watch 3 days.';
     } else if (data.watching > 0) {
-      ins = 'Watching a newly-introduced allergen. A mild rash alone: note it and carry on. Any trouble breathing or swelling of the face or lips: seek care right away.';
+      ins = 'Watching a new allergen. A mild rash alone: note it and carry on. Trouble breathing or swelling of the face or lips: get help right away.';
     } else {
-      ins = 'Allergens are usually introduced from around 6 months, one at a time, in a safe (smooth or thinned) form.';
+      ins = 'Allergens go in from around 6 months — one at a time, in a smooth or thinned form.';
     }
     insEl.innerHTML = '<div class="cd-section-label">What this means</div><div class="t-sm">' + escHtml(ins) + '</div>';
   }

--- a/split/intelligence-cards.js
+++ b/split/intelligence-cards.js
@@ -253,6 +253,150 @@ function _cdBarHtml(label, value, maxVal, suffix, color, rawLabel) {
 }
 
 // ════════════════════════════════════════
+// Allergen Introduction (analysis prototype)
+// ════════════════════════════════════════
+// The analysis layer ON TOP of the food-effects-v2 resolver spine: tracks the
+// high-priority "introduce-early" allergens and where Ziva is with each —
+// ready to try / watching the 3-day window / tolerated / reaction noted —
+// sourced from the SAME getFoodEffect + _lookupByFoodName resolver the
+// consequence surfaces use (so a logged "almond"/"cashew" correctly counts as
+// tree-nut introduced), the tried-state in `foods`, and AGE_RULES. Encourage
+// polarity — this is the guided-introduction journey, not an alarm. No
+// hardcoded safety claim: every per-food fact resolves from the data tables;
+// where a food has no FOOD_EFFECTS/AGE_RULES record we fall back to the general
+// ~6-month solids/allergen window rather than inventing a per-food rule.
+
+var AI_ALLERGEN_SET = [
+  { key: 'peanut',   label: 'Peanut' },
+  { key: 'tree nut', label: 'Tree nuts' },
+  { key: 'egg',      label: 'Egg' },
+  { key: 'sesame',   label: 'Sesame' },
+  { key: 'soy',      label: 'Soy' },
+  { key: 'wheat',    label: 'Wheat' }
+];
+
+// Earliest tried `foods` entry mapping to this allergen. Prefer the shared
+// resolver (alias-correct: almond/cashew → the tree-nut record); fall back to a
+// base-name match for allergens with no FOOD_EFFECTS record (egg/soy/wheat).
+function _aiFoodRecordFor(canonEff, key) {
+  if (typeof foods === 'undefined' || !Array.isArray(foods)) return null;
+  var base = (typeof _baseFoodName === 'function')
+    ? _baseFoodName(String(key).toLowerCase().trim()) : String(key).toLowerCase().trim();
+  var match = null;
+  foods.forEach(function(f) {
+    if (!f || !f.name) return;
+    var hit = false;
+    if (canonEff && typeof getFoodEffect === 'function') hit = (getFoodEffect(f.name) === canonEff);
+    if (!hit && typeof _baseFoodName === 'function') {
+      hit = (_baseFoodName(String(f.name).toLowerCase().trim()) === base);
+    }
+    if (!hit) return;
+    if (!match) match = f;
+    else if (f.date && (!match.date || f.date < match.date)) match = f; // earliest intro
+  });
+  return match;
+}
+
+function _aiComputeAllergenIntro() {
+  var ageMonths = (typeof getAgeInMonths === 'function') ? getAgeInMonths() : 0;
+  var tdy = (typeof today === 'function') ? today() : null;
+  var items = AI_ALLERGEN_SET.map(function(a) {
+    var eff = (typeof getFoodEffect === 'function') ? getFoodEffect(a.key) : null;
+    var ageRule = (typeof _lookupByFoodName === 'function' && typeof AGE_RULES !== 'undefined')
+      ? _lookupByFoodName(AGE_RULES, a.key) : null;
+    var introMonth = (ageRule && ageRule.minMonth) ? ageRule.minMonth : 6;
+    var rec = _aiFoodRecordFor(eff, a.key);
+    var ageReady = ageMonths >= introMonth;
+    var state, daysSince = null;
+    if (rec) {
+      if (rec.reaction === 'watch') {
+        state = 'reaction';
+      } else if (rec.date && tdy) {
+        daysSince = daysBetween(rec.date, tdy);
+        state = (daysSince >= 3) ? 'tolerated' : 'watching';
+      } else {
+        state = 'introduced';
+      }
+    } else {
+      state = ageReady ? 'ready' : 'waiting';
+    }
+    return { key: a.key, label: a.label, introMonth: introMonth, ageReady: ageReady,
+             tried: !!rec, date: (rec && rec.date) || null, daysSince: daysSince,
+             state: state, safeForm: (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : null };
+  });
+  return {
+    items: items,
+    total: items.length,
+    introduced: items.filter(function(i){ return i.tried; }).length,
+    ready: items.filter(function(i){ return i.state === 'ready'; }).length,
+    watching: items.filter(function(i){ return i.state === 'watching'; }).length,
+    ageMonths: ageMonths
+  };
+}
+
+function renderInfoAllergenIntro() {
+  var sumEl = document.getElementById('infoAllergenIntroSummary');
+  if (!sumEl) return;
+  var listEl = document.getElementById('infoAllergenIntroList');
+  var insEl = document.getElementById('infoAllergenIntroInsights');
+  var data = _aiComputeAllergenIntro();
+
+  var sum = '<div class="t-sm"><strong>' + data.introduced + '</strong> of <strong>' + data.total + '</strong> introduced';
+  if (data.ready > 0) sum += ' · <strong>' + data.ready + '</strong> ready to try';
+  if (data.watching > 0) sum += ' · ' + data.watching + ' in the 3-day watch';
+  sum += '</div>';
+  sumEl.innerHTML = sum;
+
+  var STATE = {
+    tolerated:  { pill: 'cd-pill-pos',     text: 'Tolerated' },
+    introduced: { pill: 'cd-pill-pos',     text: 'Introduced' },
+    watching:   { pill: 'cd-pill-neutral', text: 'Watching' },
+    ready:      { pill: 'cd-pill-pos',     text: 'Ready to try' },
+    waiting:    { pill: 'cd-pill-neutral', text: 'Not yet' },
+    reaction:   { pill: 'cd-pill-neg',     text: 'Reaction noted' }
+  };
+  if (listEl) {
+    var rows = '<div class="cd-section-label">High-priority allergens</div>';
+    data.items.forEach(function(i) {
+      var s = STATE[i.state] || STATE.waiting;
+      var meta;
+      if (i.state === 'tolerated') meta = 'Introduced ' + (i.date ? formatDate(i.date) : '') + ' · 3-day watch cleared';
+      else if (i.state === 'watching') meta = 'Day ' + (i.daysSince + 1) + ' of 3 — keep watching';
+      else if (i.state === 'introduced') meta = 'Introduced';
+      else if (i.state === 'reaction') meta = 'Flagged for watch' + (i.date ? ' on ' + formatDate(i.date) : '') + ' — open the food for details';
+      else if (i.state === 'ready') meta = i.safeForm ? i.safeForm : 'Good to introduce now, in a safe form';
+      else meta = 'Fine to wait — around ' + i.introMonth + ' months';
+      rows += '<div class="cd-food-item">' +
+        '<div class="cd-food-name">' + escHtml(i.label) + '</div>' +
+        '<div class="cd-pill ' + s.pill + '">' + escHtml(s.text) + '</div>' +
+        '<div class="cd-food-meta">' + escHtml(meta) + '</div>' +
+        '</div>';
+    });
+    listEl.innerHTML = rows;
+  }
+
+  if (insEl) {
+    var ins;
+    if (data.introduced >= data.total) {
+      ins = 'All ' + data.total + ' high-priority allergens introduced — early, regular exposure is what helps build tolerance. Keep them in rotation.';
+    } else if (data.ready > 0) {
+      var readyLabels = data.items.filter(function(i){ return i.state === 'ready'; }).map(function(i){ return i.label; });
+      ins = 'Introducing allergens early, in a safe form, is protective. Good to start now: ' + readyLabels.join(', ') + '. Offer one new allergen at a time and watch for 3 days.';
+    } else if (data.watching > 0) {
+      ins = 'Watching a newly-introduced allergen. A mild rash alone: note it and carry on. Any trouble breathing or swelling of the face or lips: seek care right away.';
+    } else {
+      ins = 'Allergens are usually introduced from around 6 months, one at a time, in a safe (smooth or thinned) form.';
+    }
+    insEl.innerHTML = '<div class="cd-section-label">What this means</div><div class="t-sm">' + escHtml(ins) + '</div>';
+  }
+
+  // Composite card — never urgent (spec v3-6). Actionable (ready/watching) → notable; else ambient.
+  if (typeof _setCardPriority === 'function') {
+    _setCardPriority('infoAllergenIntroCard', (data.ready > 0 || data.watching > 0) ? 'notable' : 'ambient');
+  }
+}
+
+// ════════════════════════════════════════
 // Card 1: Food → Poop Pipeline
 // ════════════════════════════════════════
 
@@ -1272,6 +1416,7 @@ function renderInfo() {
   renderInfoSupplementAdherence();
   renderInfoVaccRecovery();
   renderInfoGrowthVelocity();
+  renderInfoAllergenIntro();
   renderInfoFoodPoopPipeline();
   renderInfoSleepFeeding();
   renderInfoActivitySleepDeep();

--- a/split/template.html
+++ b/split/template.html
@@ -2269,6 +2269,19 @@
       <div class="home-section-label sec-t3 col-full">Cross-Domain Intelligence</div>
 
       <!-- Card 1: Food → Poop Pipeline -->
+      <!-- Allergen Introduction (analysis prototype — guided-introduction journey) -->
+      <div class="card card-daily col-full" id="infoAllergenIntroCard">
+        <div class="card-header" data-collapse-target="infoAllergenIntroBody" data-collapse-chevron="infoAllergenIntroChevron">
+          <div class="card-title"><div class="icon icon-sage"><svg class="zi"><use href="#zi-sprout"/></svg></div> Allergen Introduction</div>
+          <span class="collapse-chevron" id="infoAllergenIntroChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
+        </div>
+        <div id="infoAllergenIntroSummary" class="mt-4"></div>
+        <div id="infoAllergenIntroBody" class="collapse-body fx-col g8" style="display:none;">
+          <div id="infoAllergenIntroList" class="mt-4"></div>
+          <div id="infoAllergenIntroInsights" class="mt-8"></div>
+        </div>
+      </div>
+
       <div class="card card-daily col-full" id="infoFoodPoopPipelineCard">
         <div class="card-header" data-collapse-target="infoFoodPoopPipelineBody" data-collapse-chevron="infoFoodPoopPipelineChevron">
           <div class="card-title"><div class="icon icon-peach"><svg class="zi"><use href="#zi-link"/></svg></div> Food → Poop Pipeline</div>

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -69498,22 +69498,37 @@ var AI_ALLERGEN_SET = [
   { key: 'wheat',    label: 'Wheat' }
 ];
 
-// Earliest tried `foods` entry mapping to this allergen. Prefer the shared
-// resolver (alias-correct: almond/cashew → the tree-nut record); fall back to a
-// base-name match for allergens with no FOOD_EFFECTS record (egg/soy/wheat).
-function _aiFoodRecordFor(canonEff, key) {
+// The SINGLE resolution spine both food-readers (`_aiFoodRecordFor` tried-state
+// and `_aiExposureDays` meal-log) run every token through — so the two sources
+// can never disagree about what counts as "tree nut" (Kael B-1). Resolution
+// order: (1) FOOD_EFFECTS identity on the raw token, (2) FOOD_EFFECTS identity
+// on the base name (catches form-prefixed tokens like "raw peanut"), (3) base-
+// name string match for allergens with NO FOOD_EFFECTS record (egg/soy/wheat/
+// sesame).
+//   `=== canonEff` is load-bearing and correct ONLY because `_lookupByFoodName`
+//   returns FOOD_EFFECTS records by reference (module-level singletons) — every
+//   getFoodEffect("almond")/("tree nut") yields the identical object. A future
+//   refactor that clones records would silently break this; keep it by-ref.
+//   LIMITATION (spec §6/§9): culinary synonyms with no alias table — "tofu"→soy,
+//   "roti"→wheat, "scrambled egg"→egg — do not resolve on EITHER reader (the app
+//   has no such alias data anywhere). Both readers agree on the miss, so the card
+//   stays internally consistent; closing the gap is a data.js alias-table task.
+function _aiFoodMatches(foodName, canonEff, base) {
+  if (!foodName) return false;
+  var fn = String(foodName).toLowerCase().trim();
+  if (canonEff && typeof getFoodEffect === 'function') {
+    if (getFoodEffect(fn) === canonEff) return true;
+    if (typeof _baseFoodName === 'function' && getFoodEffect(_baseFoodName(fn)) === canonEff) return true;
+  }
+  return (typeof _baseFoodName === 'function') && _baseFoodName(fn) === base;
+}
+
+// Earliest tried `foods` entry mapping to this allergen, via the shared matcher.
+function _aiFoodRecordFor(canonEff, base) {
   if (typeof foods === 'undefined' || !Array.isArray(foods)) return null;
-  var base = (typeof _baseFoodName === 'function')
-    ? _baseFoodName(String(key).toLowerCase().trim()) : String(key).toLowerCase().trim();
   var match = null;
   foods.forEach(function(f) {
-    if (!f || !f.name) return;
-    var hit = false;
-    if (canonEff && typeof getFoodEffect === 'function') hit = (getFoodEffect(f.name) === canonEff);
-    if (!hit && typeof _baseFoodName === 'function') {
-      hit = (_baseFoodName(String(f.name).toLowerCase().trim()) === base);
-    }
-    if (!hit) return;
+    if (!f || !f.name || !_aiFoodMatches(f.name, canonEff, base)) return;
     if (!match) match = f;
     else if (f.date && (!match.date || f.date < match.date)) match = f; // earliest intro
   });
@@ -69529,10 +69544,7 @@ function _aiExposureDays(canonEff, base) {
   if (typeof feedingData === 'undefined' || !feedingData || typeof extractDayFoods !== 'function') return 0;
   var n = 0;
   Object.keys(feedingData).forEach(function(ds) {
-    var hit = extractDayFoods(ds).some(function(fn) {
-      if (canonEff && typeof getFoodEffect === 'function' && getFoodEffect(fn) === canonEff) return true;
-      return (typeof _baseFoodName === 'function') && _baseFoodName(fn) === base;
-    });
+    var hit = extractDayFoods(ds).some(function(fn) { return _aiFoodMatches(fn, canonEff, base); });
     if (hit) n++;
   });
   return n;
@@ -69547,7 +69559,7 @@ function _aiComputeAllergenIntro() {
       ? _lookupByFoodName(AGE_RULES, a.key) : null;
     var introMonth = (ageRule && ageRule.minMonth) ? ageRule.minMonth : 6;
     var base = (typeof _baseFoodName === 'function') ? _baseFoodName(String(a.key).toLowerCase().trim()) : String(a.key);
-    var rec = _aiFoodRecordFor(eff, a.key);
+    var rec = _aiFoodRecordFor(eff, base);
     var exposureDays = _aiExposureDays(eff, base);
     var ageReady = ageMonths >= introMonth;
     var state, daysSince = null;
@@ -69555,7 +69567,10 @@ function _aiComputeAllergenIntro() {
       if (rec.reaction === 'watch') {
         state = 'reaction';
       } else if (rec.date && tdy) {
-        daysSince = daysBetween(rec.date, tdy);
+        // Guard a future-dated entry (data error / TZ edge): the watch window
+        // hasn't started, so clamp to day 0 rather than abs()-counting it as
+        // a window already underway (Vela V-V-2 / Kael).
+        daysSince = (rec.date <= tdy) ? daysBetween(rec.date, tdy) : 0;
         state = (daysSince >= 3) ? 'tolerated' : 'watching';
       } else {
         state = 'introduced';
@@ -69563,15 +69578,25 @@ function _aiComputeAllergenIntro() {
     } else {
       state = ageReady ? 'ready' : 'waiting';
     }
+    // safe-form note: FOOD_EFFECTS note (peanut/tree-nut) preferred; else the
+    // allergen's own AGE_RULES `reason` (egg's "cook well, yolk first" floor) —
+    // never the generic "in a safe form" where a real per-food floor exists (Maren M-1).
+    var safeForm = (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note
+                 : (ageRule && ageRule.reason) ? ageRule.reason : null;
     return { key: a.key, label: a.label, introMonth: introMonth, ageReady: ageReady,
              tried: !!rec, date: (rec && rec.date) || null, daysSince: daysSince,
-             exposureDays: exposureDays,
-             state: state, safeForm: (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : null };
+             exposureDays: exposureDays, state: state, safeForm: safeForm };
   });
+  // "introduced" must mean a SETTLED introduction — a flagged reaction is open
+  // work, never a win. Excluding it keeps the summary + progress bar honest and
+  // stops the rollup re-merging what the state machine separated (Vela V-V-1,
+  // converging with Maren's reaction-never-suppressed invariant).
+  var settled = items.filter(function(i){ return i.tried && i.state !== 'reaction'; }).length;
   return {
     items: items,
     total: items.length,
-    introduced: items.filter(function(i){ return i.tried; }).length,
+    introduced: settled,
+    reactions: items.filter(function(i){ return i.state === 'reaction'; }).length,
     ready: items.filter(function(i){ return i.state === 'ready'; }).length,
     watching: items.filter(function(i){ return i.state === 'watching'; }).length,
     ageMonths: ageMonths
@@ -69588,7 +69613,8 @@ function renderInfoAllergenIntro() {
   // Summary line + a glanceable sage progress bar (introduced / total).
   var sum = '<div class="t-sm"><strong>' + data.introduced + '</strong> of <strong>' + data.total + '</strong> introduced';
   if (data.ready > 0) sum += ' · <strong>' + data.ready + '</strong> ready to try';
-  if (data.watching > 0) sum += ' · ' + data.watching + ' watching';
+  if (data.watching > 0) sum += ' · <strong>' + data.watching + '</strong> watching';
+  if (data.reactions > 0) sum += ' · <strong>' + data.reactions + '</strong> flagged';
   sum += '</div>';
   sum += _cdBarHtml('Progress', data.introduced, data.total, ' / ' + data.total, 'var(--tc-sage)');
   sumEl.innerHTML = sum;
@@ -69615,9 +69641,9 @@ function renderInfoAllergenIntro() {
       var offered = i.exposureDays > 0 ? ('offered ' + i.exposureDays + (i.exposureDays === 1 ? ' day' : ' days')) : '';
       var meta;
       if (i.state === 'tolerated') meta = (offered ? offered + ' · ' : '') + 'keep it in rotation';
-      else if (i.state === 'watching') meta = 'Day ' + (i.daysSince + 1) + ' of 3 — watch for reactions';
+      else if (i.state === 'watching') meta = 'Day ' + (i.daysSince + 1) + ' of 3 — watch, tap for signs';
       else if (i.state === 'introduced') meta = 'Keep offering to hold tolerance';
-      else if (i.state === 'reaction') meta = 'Reaction flagged' + (i.date ? ' ' + formatDate(i.date) : '') + ' — tap to review';
+      else if (i.state === 'reaction') meta = 'Reaction flagged — tap to review';
       else if (i.state === 'ready') meta = i.safeForm ? i.safeForm : 'Good to introduce now, in a safe form';
       else meta = 'From ' + i.introMonth + ' months';
       // Row taps through to the food's detail sheet — the R3 floor + safe-form

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -69589,7 +69589,9 @@ function renderInfoAllergenIntro() {
       else if (i.state === 'reaction') meta = 'Flagged for watch' + (i.date ? ' on ' + formatDate(i.date) : '') + ' — open the food for details';
       else if (i.state === 'ready') meta = i.safeForm ? i.safeForm : 'Good to introduce now, in a safe form';
       else meta = 'Fine to wait — around ' + i.introMonth + ' months';
-      rows += '<div class="cd-food-item">' +
+      // Row taps through to the food's detail sheet — the R3 floor + safe-form
+      // for the same resolved food (foodLibDetail → renderFoodDetailSheet).
+      rows += '<div class="cd-food-item tappable" role="button" tabindex="0" data-action="foodLibDetail" data-arg="' + escHtml(i.key) + '">' +
         '<div class="cd-food-name">' + escHtml(i.label) + '</div>' +
         '<div class="cd-pill ' + s.pill + '">' + escHtml(s.text) + '</div>' +
         '<div class="cd-food-meta">' + escHtml(meta) + '</div>' +

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -69520,6 +69520,24 @@ function _aiFoodRecordFor(canonEff, key) {
   return match;
 }
 
+// "Offered on N days" — the repeated-exposure / keep-offering signal, counted
+// from the meal log (feedingData via extractDayFoods). Distinct from the
+// `foods` tried-state above: that gives the intro date + watch window; this
+// counts the days the allergen actually appeared at a meal. Same resolver
+// spine, so "almond" days count toward Tree nuts.
+function _aiExposureDays(canonEff, base) {
+  if (typeof feedingData === 'undefined' || !feedingData || typeof extractDayFoods !== 'function') return 0;
+  var n = 0;
+  Object.keys(feedingData).forEach(function(ds) {
+    var hit = extractDayFoods(ds).some(function(fn) {
+      if (canonEff && typeof getFoodEffect === 'function' && getFoodEffect(fn) === canonEff) return true;
+      return (typeof _baseFoodName === 'function') && _baseFoodName(fn) === base;
+    });
+    if (hit) n++;
+  });
+  return n;
+}
+
 function _aiComputeAllergenIntro() {
   var ageMonths = (typeof getAgeInMonths === 'function') ? getAgeInMonths() : 0;
   var tdy = (typeof today === 'function') ? today() : null;
@@ -69528,7 +69546,9 @@ function _aiComputeAllergenIntro() {
     var ageRule = (typeof _lookupByFoodName === 'function' && typeof AGE_RULES !== 'undefined')
       ? _lookupByFoodName(AGE_RULES, a.key) : null;
     var introMonth = (ageRule && ageRule.minMonth) ? ageRule.minMonth : 6;
+    var base = (typeof _baseFoodName === 'function') ? _baseFoodName(String(a.key).toLowerCase().trim()) : String(a.key);
     var rec = _aiFoodRecordFor(eff, a.key);
+    var exposureDays = _aiExposureDays(eff, base);
     var ageReady = ageMonths >= introMonth;
     var state, daysSince = null;
     if (rec) {
@@ -69545,6 +69565,7 @@ function _aiComputeAllergenIntro() {
     }
     return { key: a.key, label: a.label, introMonth: introMonth, ageReady: ageReady,
              tried: !!rec, date: (rec && rec.date) || null, daysSince: daysSince,
+             exposureDays: exposureDays,
              state: state, safeForm: (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : null };
   });
   return {
@@ -69564,10 +69585,12 @@ function renderInfoAllergenIntro() {
   var insEl = document.getElementById('infoAllergenIntroInsights');
   var data = _aiComputeAllergenIntro();
 
+  // Summary line + a glanceable sage progress bar (introduced / total).
   var sum = '<div class="t-sm"><strong>' + data.introduced + '</strong> of <strong>' + data.total + '</strong> introduced';
   if (data.ready > 0) sum += ' · <strong>' + data.ready + '</strong> ready to try';
-  if (data.watching > 0) sum += ' · ' + data.watching + ' in the 3-day watch';
+  if (data.watching > 0) sum += ' · ' + data.watching + ' watching';
   sum += '</div>';
+  sum += _cdBarHtml('Progress', data.introduced, data.total, ' / ' + data.total, 'var(--tc-sage)');
   sumEl.innerHTML = sum;
 
   var STATE = {
@@ -69579,16 +69602,24 @@ function renderInfoAllergenIntro() {
     reaction:   { pill: 'cd-pill-neg',     text: 'Reaction noted' }
   };
   if (listEl) {
+    // Order by actionability so what to act on floats up: ready → watching →
+    // reaction → introduced/tolerated → not-yet. Stable sort preserves set order
+    // within a tier.
+    var RANK = { ready: 0, watching: 1, reaction: 2, introduced: 3, tolerated: 3, waiting: 4 };
+    var ordered = data.items.slice().sort(function(a, b) {
+      return (RANK[a.state] != null ? RANK[a.state] : 9) - (RANK[b.state] != null ? RANK[b.state] : 9);
+    });
     var rows = '<div class="cd-section-label">High-priority allergens</div>';
-    data.items.forEach(function(i) {
+    ordered.forEach(function(i) {
       var s = STATE[i.state] || STATE.waiting;
+      var offered = i.exposureDays > 0 ? ('offered ' + i.exposureDays + (i.exposureDays === 1 ? ' day' : ' days')) : '';
       var meta;
-      if (i.state === 'tolerated') meta = 'Introduced ' + (i.date ? formatDate(i.date) : '') + ' · 3-day watch cleared';
-      else if (i.state === 'watching') meta = 'Day ' + (i.daysSince + 1) + ' of 3 — keep watching';
-      else if (i.state === 'introduced') meta = 'Introduced';
-      else if (i.state === 'reaction') meta = 'Flagged for watch' + (i.date ? ' on ' + formatDate(i.date) : '') + ' — open the food for details';
+      if (i.state === 'tolerated') meta = (offered ? offered + ' · ' : '') + 'keep it in rotation';
+      else if (i.state === 'watching') meta = 'Day ' + (i.daysSince + 1) + ' of 3 — watch for reactions';
+      else if (i.state === 'introduced') meta = 'Keep offering to hold tolerance';
+      else if (i.state === 'reaction') meta = 'Reaction flagged' + (i.date ? ' ' + formatDate(i.date) : '') + ' — tap to review';
       else if (i.state === 'ready') meta = i.safeForm ? i.safeForm : 'Good to introduce now, in a safe form';
-      else meta = 'Fine to wait — around ' + i.introMonth + ' months';
+      else meta = 'From ' + i.introMonth + ' months';
       // Row taps through to the food's detail sheet — the R3 floor + safe-form
       // for the same resolved food (foodLibDetail → renderFoodDetailSheet).
       rows += '<div class="cd-food-item tappable" role="button" tabindex="0" data-action="foodLibDetail" data-arg="' + escHtml(i.key) + '">' +
@@ -69603,14 +69634,14 @@ function renderInfoAllergenIntro() {
   if (insEl) {
     var ins;
     if (data.introduced >= data.total) {
-      ins = 'All ' + data.total + ' high-priority allergens introduced — early, regular exposure is what helps build tolerance. Keep them in rotation.';
+      ins = 'All ' + data.total + ' introduced. Keep offering each a few times a week — repeated exposure is what holds the protection.';
     } else if (data.ready > 0) {
       var readyLabels = data.items.filter(function(i){ return i.state === 'ready'; }).map(function(i){ return i.label; });
-      ins = 'Introducing allergens early, in a safe form, is protective. Good to start now: ' + readyLabels.join(', ') + '. Offer one new allergen at a time and watch for 3 days.';
+      ins = 'Early introduction in a safe form is protective. Good to start now: ' + readyLabels.join(', ') + '. One at a time, then watch 3 days.';
     } else if (data.watching > 0) {
-      ins = 'Watching a newly-introduced allergen. A mild rash alone: note it and carry on. Any trouble breathing or swelling of the face or lips: seek care right away.';
+      ins = 'Watching a new allergen. A mild rash alone: note it and carry on. Trouble breathing or swelling of the face or lips: get help right away.';
     } else {
-      ins = 'Allergens are usually introduced from around 6 months, one at a time, in a safe (smooth or thinned) form.';
+      ins = 'Allergens go in from around 6 months — one at a time, in a smooth or thinned form.';
     }
     insEl.innerHTML = '<div class="cd-section-label">What this means</div><div class="t-sm">' + escHtml(ins) + '</div>';
   }

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -13072,6 +13072,19 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
       <div class="home-section-label sec-t3 col-full">Cross-Domain Intelligence</div>
 
       <!-- Card 1: Food → Poop Pipeline -->
+      <!-- Allergen Introduction (analysis prototype — guided-introduction journey) -->
+      <div class="card card-daily col-full" id="infoAllergenIntroCard">
+        <div class="card-header" data-collapse-target="infoAllergenIntroBody" data-collapse-chevron="infoAllergenIntroChevron">
+          <div class="card-title"><div class="icon icon-sage"><svg class="zi"><use href="#zi-sprout"/></svg></div> Allergen Introduction</div>
+          <span class="collapse-chevron" id="infoAllergenIntroChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
+        </div>
+        <div id="infoAllergenIntroSummary" class="mt-4"></div>
+        <div id="infoAllergenIntroBody" class="collapse-body fx-col g8" style="display:none;">
+          <div id="infoAllergenIntroList" class="mt-4"></div>
+          <div id="infoAllergenIntroInsights" class="mt-8"></div>
+        </div>
+      </div>
+
       <div class="card card-daily col-full" id="infoFoodPoopPipelineCard">
         <div class="card-header" data-collapse-target="infoFoodPoopPipelineBody" data-collapse-chevron="infoFoodPoopPipelineChevron">
           <div class="card-title"><div class="icon icon-peach"><svg class="zi"><use href="#zi-link"/></svg></div> Food → Poop Pipeline</div>
@@ -69463,6 +69476,150 @@ function _cdBarHtml(label, value, maxVal, suffix, color, rawLabel) {
 }
 
 // ════════════════════════════════════════
+// Allergen Introduction (analysis prototype)
+// ════════════════════════════════════════
+// The analysis layer ON TOP of the food-effects-v2 resolver spine: tracks the
+// high-priority "introduce-early" allergens and where Ziva is with each —
+// ready to try / watching the 3-day window / tolerated / reaction noted —
+// sourced from the SAME getFoodEffect + _lookupByFoodName resolver the
+// consequence surfaces use (so a logged "almond"/"cashew" correctly counts as
+// tree-nut introduced), the tried-state in `foods`, and AGE_RULES. Encourage
+// polarity — this is the guided-introduction journey, not an alarm. No
+// hardcoded safety claim: every per-food fact resolves from the data tables;
+// where a food has no FOOD_EFFECTS/AGE_RULES record we fall back to the general
+// ~6-month solids/allergen window rather than inventing a per-food rule.
+
+var AI_ALLERGEN_SET = [
+  { key: 'peanut',   label: 'Peanut' },
+  { key: 'tree nut', label: 'Tree nuts' },
+  { key: 'egg',      label: 'Egg' },
+  { key: 'sesame',   label: 'Sesame' },
+  { key: 'soy',      label: 'Soy' },
+  { key: 'wheat',    label: 'Wheat' }
+];
+
+// Earliest tried `foods` entry mapping to this allergen. Prefer the shared
+// resolver (alias-correct: almond/cashew → the tree-nut record); fall back to a
+// base-name match for allergens with no FOOD_EFFECTS record (egg/soy/wheat).
+function _aiFoodRecordFor(canonEff, key) {
+  if (typeof foods === 'undefined' || !Array.isArray(foods)) return null;
+  var base = (typeof _baseFoodName === 'function')
+    ? _baseFoodName(String(key).toLowerCase().trim()) : String(key).toLowerCase().trim();
+  var match = null;
+  foods.forEach(function(f) {
+    if (!f || !f.name) return;
+    var hit = false;
+    if (canonEff && typeof getFoodEffect === 'function') hit = (getFoodEffect(f.name) === canonEff);
+    if (!hit && typeof _baseFoodName === 'function') {
+      hit = (_baseFoodName(String(f.name).toLowerCase().trim()) === base);
+    }
+    if (!hit) return;
+    if (!match) match = f;
+    else if (f.date && (!match.date || f.date < match.date)) match = f; // earliest intro
+  });
+  return match;
+}
+
+function _aiComputeAllergenIntro() {
+  var ageMonths = (typeof getAgeInMonths === 'function') ? getAgeInMonths() : 0;
+  var tdy = (typeof today === 'function') ? today() : null;
+  var items = AI_ALLERGEN_SET.map(function(a) {
+    var eff = (typeof getFoodEffect === 'function') ? getFoodEffect(a.key) : null;
+    var ageRule = (typeof _lookupByFoodName === 'function' && typeof AGE_RULES !== 'undefined')
+      ? _lookupByFoodName(AGE_RULES, a.key) : null;
+    var introMonth = (ageRule && ageRule.minMonth) ? ageRule.minMonth : 6;
+    var rec = _aiFoodRecordFor(eff, a.key);
+    var ageReady = ageMonths >= introMonth;
+    var state, daysSince = null;
+    if (rec) {
+      if (rec.reaction === 'watch') {
+        state = 'reaction';
+      } else if (rec.date && tdy) {
+        daysSince = daysBetween(rec.date, tdy);
+        state = (daysSince >= 3) ? 'tolerated' : 'watching';
+      } else {
+        state = 'introduced';
+      }
+    } else {
+      state = ageReady ? 'ready' : 'waiting';
+    }
+    return { key: a.key, label: a.label, introMonth: introMonth, ageReady: ageReady,
+             tried: !!rec, date: (rec && rec.date) || null, daysSince: daysSince,
+             state: state, safeForm: (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : null };
+  });
+  return {
+    items: items,
+    total: items.length,
+    introduced: items.filter(function(i){ return i.tried; }).length,
+    ready: items.filter(function(i){ return i.state === 'ready'; }).length,
+    watching: items.filter(function(i){ return i.state === 'watching'; }).length,
+    ageMonths: ageMonths
+  };
+}
+
+function renderInfoAllergenIntro() {
+  var sumEl = document.getElementById('infoAllergenIntroSummary');
+  if (!sumEl) return;
+  var listEl = document.getElementById('infoAllergenIntroList');
+  var insEl = document.getElementById('infoAllergenIntroInsights');
+  var data = _aiComputeAllergenIntro();
+
+  var sum = '<div class="t-sm"><strong>' + data.introduced + '</strong> of <strong>' + data.total + '</strong> introduced';
+  if (data.ready > 0) sum += ' · <strong>' + data.ready + '</strong> ready to try';
+  if (data.watching > 0) sum += ' · ' + data.watching + ' in the 3-day watch';
+  sum += '</div>';
+  sumEl.innerHTML = sum;
+
+  var STATE = {
+    tolerated:  { pill: 'cd-pill-pos',     text: 'Tolerated' },
+    introduced: { pill: 'cd-pill-pos',     text: 'Introduced' },
+    watching:   { pill: 'cd-pill-neutral', text: 'Watching' },
+    ready:      { pill: 'cd-pill-pos',     text: 'Ready to try' },
+    waiting:    { pill: 'cd-pill-neutral', text: 'Not yet' },
+    reaction:   { pill: 'cd-pill-neg',     text: 'Reaction noted' }
+  };
+  if (listEl) {
+    var rows = '<div class="cd-section-label">High-priority allergens</div>';
+    data.items.forEach(function(i) {
+      var s = STATE[i.state] || STATE.waiting;
+      var meta;
+      if (i.state === 'tolerated') meta = 'Introduced ' + (i.date ? formatDate(i.date) : '') + ' · 3-day watch cleared';
+      else if (i.state === 'watching') meta = 'Day ' + (i.daysSince + 1) + ' of 3 — keep watching';
+      else if (i.state === 'introduced') meta = 'Introduced';
+      else if (i.state === 'reaction') meta = 'Flagged for watch' + (i.date ? ' on ' + formatDate(i.date) : '') + ' — open the food for details';
+      else if (i.state === 'ready') meta = i.safeForm ? i.safeForm : 'Good to introduce now, in a safe form';
+      else meta = 'Fine to wait — around ' + i.introMonth + ' months';
+      rows += '<div class="cd-food-item">' +
+        '<div class="cd-food-name">' + escHtml(i.label) + '</div>' +
+        '<div class="cd-pill ' + s.pill + '">' + escHtml(s.text) + '</div>' +
+        '<div class="cd-food-meta">' + escHtml(meta) + '</div>' +
+        '</div>';
+    });
+    listEl.innerHTML = rows;
+  }
+
+  if (insEl) {
+    var ins;
+    if (data.introduced >= data.total) {
+      ins = 'All ' + data.total + ' high-priority allergens introduced — early, regular exposure is what helps build tolerance. Keep them in rotation.';
+    } else if (data.ready > 0) {
+      var readyLabels = data.items.filter(function(i){ return i.state === 'ready'; }).map(function(i){ return i.label; });
+      ins = 'Introducing allergens early, in a safe form, is protective. Good to start now: ' + readyLabels.join(', ') + '. Offer one new allergen at a time and watch for 3 days.';
+    } else if (data.watching > 0) {
+      ins = 'Watching a newly-introduced allergen. A mild rash alone: note it and carry on. Any trouble breathing or swelling of the face or lips: seek care right away.';
+    } else {
+      ins = 'Allergens are usually introduced from around 6 months, one at a time, in a safe (smooth or thinned) form.';
+    }
+    insEl.innerHTML = '<div class="cd-section-label">What this means</div><div class="t-sm">' + escHtml(ins) + '</div>';
+  }
+
+  // Composite card — never urgent (spec v3-6). Actionable (ready/watching) → notable; else ambient.
+  if (typeof _setCardPriority === 'function') {
+    _setCardPriority('infoAllergenIntroCard', (data.ready > 0 || data.watching > 0) ? 'notable' : 'ambient');
+  }
+}
+
+// ════════════════════════════════════════
 // Card 1: Food → Poop Pipeline
 // ════════════════════════════════════════
 
@@ -70482,6 +70639,7 @@ function renderInfo() {
   renderInfoSupplementAdherence();
   renderInfoVaccRecovery();
   renderInfoGrowthVelocity();
+  renderInfoAllergenIntro();
   renderInfoFoodPoopPipeline();
   renderInfoSleepFeeding();
   renderInfoActivitySleepDeep();

--- a/tests/e2e/analytics-allergen-intro.spec.ts
+++ b/tests/e2e/analytics-allergen-intro.spec.ts
@@ -82,4 +82,20 @@ test.describe('analytics prototype — Allergen Introduction card', () => {
     // ready (4 untried) + watching (1) are actionable → notable, not ambient
     expect(dom.tier).toBe('notable');
   });
+
+  test('a row taps through to the food detail sheet (the R3 floor for peanut)', async ({ page }) => {
+    await page.evaluate(() => { foods.length = 0; renderInfoAllergenIntro(); });
+    const row = page.locator('#infoAllergenIntroList .cd-food-item[data-arg="peanut"]');
+    await expect(row, 'each allergen row is wired to foodLibDetail').toHaveAttribute('data-action', 'foodLibDetail');
+    // tapping opens the detail sheet for the resolved food, carrying the floor
+    await row.evaluate((el: HTMLElement) => el.click());
+    const detail = await page.evaluate(() => {
+      const sheet = document.getElementById('foodDetailSheet');
+      const body = document.getElementById('foodDetailBody');
+      const open = !!sheet && getComputedStyle(sheet).display !== 'none';
+      return { open, severe: body ? body.querySelectorAll('.cons-severe').length : 0 };
+    });
+    expect(detail.open, 'foodDetailSheet modal opened').toBe(true);
+    expect(detail.severe, 'peanut detail carries the anaphylaxis floor (R3 continuity)').toBeGreaterThan(0);
+  });
 });

--- a/tests/e2e/analytics-allergen-intro.spec.ts
+++ b/tests/e2e/analytics-allergen-intro.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+
+// Analytics prototype — Allergen Introduction card (Info tab).
+// The analysis layer on top of the food-effects-v2 resolver: it tracks the
+// high-priority introduce-early allergens and resolves the parent's tried foods
+// through the SAME getFoodEffect spine the consequence surfaces use — so a
+// logged "almond" counts as Tree nuts introduced, and the 3-day watch /
+// tolerated / reaction states are derived, never hardcoded.
+declare const foods: any[];
+declare const today: () => string;
+declare const _offsetDateStr: (base: string, off: number) => string;
+declare const _aiComputeAllergenIntro: () => any;
+declare const renderInfoAllergenIntro: () => void;
+
+async function seedAndCompute(page: any, seed: Array<{ name: string; reaction: string; offset: number }>) {
+  return page.evaluate((rows: Array<{ name: string; reaction: string; offset: number }>) => {
+    foods.length = 0;
+    rows.forEach((r) => foods.push({ name: r.name, reaction: r.reaction, date: _offsetDateStr(today(), r.offset) }));
+    return _aiComputeAllergenIntro();
+  }, seed);
+}
+const byKey = (d: any, key: string) => d.items.find((i: any) => i.key === key);
+
+test.describe('analytics prototype — Allergen Introduction card', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/index.html?nosync');
+    await page.waitForFunction(() =>
+      typeof _aiComputeAllergenIntro === 'function'
+      && typeof renderInfoAllergenIntro === 'function'
+      && typeof foods !== 'undefined'
+      && !!document.getElementById('infoAllergenIntroCard'), null, { timeout: 10_000 });
+  });
+
+  test('empty log, age ≥ 6mo → every allergen reads "ready to try"', async ({ page }) => {
+    const d = await seedAndCompute(page, []);
+    expect(d.total).toBe(6);
+    expect(d.introduced).toBe(0);
+    expect(d.ready).toBe(6);
+    expect(d.items.every((i: any) => i.state === 'ready')).toBe(true);
+  });
+
+  test('alias resolution: logging "almond" marks Tree nuts introduced (not raw-name match)', async ({ page }) => {
+    const d = await seedAndCompute(page, [{ name: 'almond', reaction: 'ok', offset: -10 }]);
+    const tn = byKey(d, 'tree nut');
+    expect(tn.tried, 'almond resolved to the tree-nut record').toBe(true);
+    expect(tn.state, '10 days clear of the 3-day watch → tolerated').toBe('tolerated');
+    expect(d.introduced).toBe(1);
+  });
+
+  test('the 3-day watch window: just-introduced → watching, not yet tolerated', async ({ page }) => {
+    const d = await seedAndCompute(page, [{ name: 'peanut butter', reaction: 'ok', offset: -1 }]);
+    const pn = byKey(d, 'peanut');
+    expect(pn.tried, 'peanut butter → peanut record').toBe(true);
+    expect(pn.state, '1 day in → still watching').toBe('watching');
+    expect(d.watching).toBe(1);
+  });
+
+  test('a flagged reaction surfaces as "reaction", never silently tolerated', async ({ page }) => {
+    const d = await seedAndCompute(page, [{ name: 'egg', reaction: 'watch', offset: -9 }]);
+    const egg = byKey(d, 'egg');
+    expect(egg.state, "reaction:'watch' → reaction state even though 9 days passed").toBe('reaction');
+  });
+
+  test('mixed log renders 6 rows with the right pills + an actionable (notable) tier', async ({ page }) => {
+    const dom = await page.evaluate(() => {
+      foods.length = 0;
+      foods.push({ name: 'cashew', reaction: 'ok', date: _offsetDateStr(today(), -20) }); // tree nut tolerated
+      foods.push({ name: 'peanut', reaction: 'ok', date: _offsetDateStr(today(), -1) });  // watching
+      renderInfoAllergenIntro();
+      const card = document.getElementById('infoAllergenIntroCard')!;
+      return {
+        rows: card.querySelectorAll('.cd-food-item').length,
+        summary: document.getElementById('infoAllergenIntroSummary')!.textContent || '',
+        pos: card.querySelectorAll('.cd-pill-pos').length,
+        neutral: card.querySelectorAll('.cd-pill-neutral').length,
+        tier: card.getAttribute('data-card-priority') || '',
+      };
+    });
+    expect(dom.rows, 'one row per allergen in the set').toBe(6);
+    expect(dom.summary).toMatch(/2 of 6 introduced|introduced/);
+    expect(dom.pos, 'tolerated + ready items carry the positive pill').toBeGreaterThan(0);
+    // ready (4 untried) + watching (1) are actionable → notable, not ambient
+    expect(dom.tier).toBe('notable');
+  });
+});

--- a/tests/e2e/analytics-allergen-intro.spec.ts
+++ b/tests/e2e/analytics-allergen-intro.spec.ts
@@ -62,6 +62,32 @@ test.describe('analytics prototype — Allergen Introduction card', () => {
     expect(egg.state, "reaction:'watch' → reaction state even though 9 days passed").toBe('reaction');
   });
 
+  test('a flagged reaction is NOT counted as introduced — open work, not a win (V-V-1)', async ({ page }) => {
+    const d = await seedAndCompute(page, [
+      { name: 'almond', reaction: 'ok', offset: -20 }, // tree nut tolerated → a real introduction
+      { name: 'egg', reaction: 'watch', offset: -9 },  // reaction → must NOT inflate the count
+    ]);
+    expect(byKey(d, 'egg').state).toBe('reaction');
+    expect(d.introduced, 'reaction excluded from the introduced rollup (bar + summary stay honest)').toBe(1);
+    expect(d.reactions, 'surfaced as its own flagged count instead').toBe(1);
+  });
+
+  test('a future-dated entry does not render a watch window that has not started (V-V-2)', async ({ page }) => {
+    const d = await seedAndCompute(page, [{ name: 'peanut', reaction: 'ok', offset: 2 }]);
+    const pn = byKey(d, 'peanut');
+    expect(pn.state, 'future date clamps to day 0 → watching, not abs()-counted tolerated').toBe('watching');
+    expect(pn.daysSince, 'clamped to 0 (renders "Day 1 of 3"), not abs(2)').toBe(0);
+  });
+
+  test('egg "ready" surfaces its own AGE_RULES floor, not the generic safe-form line (M-1)', async ({ page }) => {
+    const egg = byKey(await seedAndCompute(page, []), 'egg');
+    // egg has no FOOD_EFFECTS record; safeForm must fall back to the AGE_RULES
+    // reason (its cook-well / yolk-first floor), never null → generic copy.
+    if (egg.state === 'ready') {
+      expect(egg.safeForm, 'egg carries its own cook-well floor').toMatch(/cook/i);
+    }
+  });
+
   test('mixed log renders 6 rows with the right pills + an actionable (notable) tier', async ({ page }) => {
     const dom = await page.evaluate(() => {
       foods.length = 0;

--- a/tests/e2e/analytics-allergen-intro.spec.ts
+++ b/tests/e2e/analytics-allergen-intro.spec.ts
@@ -7,6 +7,7 @@ import { test, expect } from '@playwright/test';
 // logged "almond" counts as Tree nuts introduced, and the 3-day watch /
 // tolerated / reaction states are derived, never hardcoded.
 declare const foods: any[];
+declare const feedingData: Record<string, any>;
 declare const today: () => string;
 declare const _offsetDateStr: (base: string, off: number) => string;
 declare const _aiComputeAllergenIntro: () => any;
@@ -74,13 +75,44 @@ test.describe('analytics prototype — Allergen Introduction card', () => {
         pos: card.querySelectorAll('.cd-pill-pos').length,
         neutral: card.querySelectorAll('.cd-pill-neutral').length,
         tier: card.getAttribute('data-card-priority') || '',
+        bar: card.querySelectorAll('#infoAllergenIntroSummary .cd-bar-fill').length,
       };
     });
     expect(dom.rows, 'one row per allergen in the set').toBe(6);
     expect(dom.summary).toMatch(/2 of 6 introduced|introduced/);
     expect(dom.pos, 'tolerated + ready items carry the positive pill').toBeGreaterThan(0);
+    expect(dom.bar, 'summary carries the glanceable progress bar').toBe(1);
     // ready (4 untried) + watching (1) are actionable → notable, not ambient
     expect(dom.tier).toBe('notable');
+  });
+
+  test('exposure count: meal-log days roll up to the allergen (alias-correct)', async ({ page }) => {
+    const d = await page.evaluate(() => {
+      foods.length = 0;
+      Object.keys(feedingData).forEach((k) => delete feedingData[k]); // clear seeded defaults
+      foods.push({ name: 'cashew', reaction: 'ok', date: _offsetDateStr(today(), -10) });
+      // tree-nut foods logged at meals on 3 distinct days (cashew, almond ×2)
+      feedingData[_offsetDateStr(today(), -10)] = { breakfast: 'cashew' };
+      feedingData[_offsetDateStr(today(), -7)] = { lunch: 'almond' };
+      feedingData[_offsetDateStr(today(), -3)] = { snack: 'almond + banana' };
+      return _aiComputeAllergenIntro();
+    });
+    const tn = byKey(d, 'tree nut');
+    expect(tn.exposureDays, '3 distinct meal-log days with a tree nut, via the resolver').toBe(3);
+    expect(byKey(d, 'peanut').exposureDays, 'no peanut at any meal').toBe(0);
+  });
+
+  test('rows ordered by actionability — ready/watching float above tolerated', async ({ page }) => {
+    const order = await page.evaluate(() => {
+      foods.length = 0;
+      foods.push({ name: 'cashew', reaction: 'ok', date: _offsetDateStr(today(), -20) }); // tree nut tolerated
+      foods.push({ name: 'peanut', reaction: 'ok', date: _offsetDateStr(today(), -1) });  // peanut watching
+      renderInfoAllergenIntro();
+      return Array.from(document.querySelectorAll('#infoAllergenIntroList .cd-food-item'))
+        .map((el) => el.getAttribute('data-arg'));
+    });
+    expect(order.indexOf('peanut'), 'watching above tolerated').toBeLessThan(order.indexOf('tree nut'));
+    expect(order.indexOf('egg'), 'ready above tolerated').toBeLessThan(order.indexOf('tree nut'));
   });
 
   test('a row taps through to the food detail sheet (the R3 floor for peanut)', async ({ page }) => {


### PR DESCRIPTION
## Analytics — Allergen Introduction card (Info-tab analysis layer, card #1)

> **🔒 LOCKED REFERENCE + ✅ canon-cc-008 chain cleared.** The prototype was frozen as the design reference (commit `2ce5584`), then taken through the full QA chain. **Spec:** `docs/specs/info-tab-analysis-layer-v1.md`.

First card of the **Info-tab analysis layer** (prototype → spec → chain). Answers a journey question no existing surface does: *"where am I in the high-allergen-introduction sequence, and what should I offer next?"* — distinct from `renderInfoFoodIntro` (variety/pace) and the cross-domain correlation cards.

### What it does
Tracks the introduce-early allergens (peanut, tree nuts, egg, sesame, soy, wheat). State is **derived per allergen, never hardcoded**, resolved through the shared `FOOD_EFFECTS` spine (logging *almond* → Tree nuts). Two sources, kept honest: `foods` (tried-state → intro date + reaction flag + 3-day watch) and `feedingData`/`extractDayFoods` (the "offered N days" keep-offering signal). Ordered by actionability; sage encourage-polarity; **never urgent** (notable when actionable, else ambient).

### canon-cc-008 QA chain — cleared
- **Routing oracle** (`pnpm qa-route`): `intelligence-cards.js` (Vela) + `template.html` shared → **triple-Gov**.
- **Governor audit (parallel, all `amended`):**
  - **Vela V-V-1** *(blocking, folded)* — `introduced` rollup counted the `reaction` state as a win; now `introduced` = settled (tried & not reaction), with a `reactions` rollup surfacing "N flagged."
  - **Maren M-1** *(blocking, folded)* — egg "Ready to try" fell to the generic safe-form line (no `FOOD_EFFECTS` record); `safeForm` now falls back to the allergen's own `AGE_RULES.reason` (egg's cook-well/yolk-first floor). No `data.js` edit.
  - **Kael B-1** *(blocking → adjudicated)* — empirical ground-truth eval **falsified** the two-source-disagreement headline (almond→tree-nut is alias-correct on both readers). Folded the verifiable part: both readers now share one `_aiFoodMatches` matcher (cannot drift). The culinary-synonym gap (tofu→soy) is a documented `data.js` follow-up, out of the read-only fence.
  - Sharpenings folded: future-date guard (V-V-2), date dropped from the reaction row (V-V-3), watching count bolded (V-V-4), watching "tap for signs" cue (M-3).
- **Lyra** synthesized; **Cipher** Edict V final-pass: **`LGTM`** — no new cross-jurisdiction seams, HR-clean, the B-1 downgrade sound and honestly recorded, HR-12 guard timezone-safe.

### Verification
`pnpm build` clean (HR-1/HR-12/icon-text audits pass). `tests/e2e/analytics-allergen-intro.spec.ts` — **11/11** (incl. V-V-1 reaction-exclusion, V-V-2 future-date guard, M-1 egg-floor fallback, dual-reader alias agreement).

### Scope
`intelligence-cards.js` (Vela) + a 13-line `infoAllergenIntroCard` container in `template.html` (shared). Styles-free (reuses `cd-*`/`cd-pill-*`/`cd-bar-*`). No engine/data edit.

### Open for the Architect (spec §10)
- **Exposure window** — "offered N days" counts lifetime history; window it to ~30 days so "keep it in rotation" reflects *recent* offering? (v1 ships lifetime.)
- **Card #2** — queue the next analysis-layer card now, or treat this as a reusable one-off?

**Chain discharged — gate permits leaving draft. Held draft pending Architect ratification of §10.**

https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK)_