### PR TITLE
Fix A: allergen card ready-row meta wraps on a phone

### DIFF
--- a/index.html
+++ b/index.html
@@ -69581,8 +69581,12 @@ function _aiComputeAllergenIntro() {
     // safe-form note: FOOD_EFFECTS note (peanut/tree-nut) preferred; else the
     // allergen's own AGE_RULES `reason` (egg's "cook well, yolk first" floor) —
     // never the generic "in a safe form" where a real per-food floor exists (Maren M-1).
-    var safeForm = (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note
-                 : (ageRule && ageRule.reason) ? ageRule.reason : null;
+    // The `reason` is a full age-gate sentence-pair; surface only its first
+    // sentence on the one-line glance so it doesn't wrap (the full floor rides
+    // the tap-through detail sheet). Phase δ will replace this with a crisp
+    // FOOD_EFFECTS `safeForm.note` authored for the row.
+    var reasonShort = (ageRule && ageRule.reason) ? String(ageRule.reason).split('. ')[0] : null;
+    var safeForm = (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : reasonShort;
     return { key: a.key, label: a.label, introMonth: introMonth, ageReady: ageReady,
              tried: !!rec, date: (rec && rec.date) || null, daysSince: daysSince,
              exposureDays: exposureDays, state: state, safeForm: safeForm };
@@ -69644,7 +69648,16 @@ function renderInfoAllergenIntro() {
       else if (i.state === 'watching') meta = 'Day ' + (i.daysSince + 1) + ' of 3 — watch, tap for signs';
       else if (i.state === 'introduced') meta = 'Keep offering to hold tolerance';
       else if (i.state === 'reaction') meta = 'Reaction flagged — tap to review';
-      else if (i.state === 'ready') meta = i.safeForm ? i.safeForm : 'Good to introduce now, in a safe form';
+      else if (i.state === 'ready') {
+        // The glance stays one line (V-V-3): surface the food's own safe-form
+        // cue only when it fits; otherwise point to the tap-through, which
+        // already carries the full floor (peanut/tree-nut's note is ~150 chars
+        // and wraps to 3 lines on a phone). Egg's trimmed floor (~40) fits and
+        // stays visible, honouring Maren M-1. Phase δ replaces this length-gate
+        // with crisp authored safeForm copy per allergen.
+        meta = !i.safeForm ? 'Good to introduce now, in a safe form'
+             : (i.safeForm.length <= 44 ? i.safeForm : 'In a safe form — tap for how');
+      }
       else meta = 'From ' + i.introMonth + ' months';
       // Row taps through to the food's detail sheet — the R3 floor + safe-form
       // for the same resolved food (foodLibDetail → renderFoodDetailSheet).

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.01-6",
+  "version": "2026.06.01-8",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/intelligence-cards.js
+++ b/split/intelligence-cards.js
@@ -358,8 +358,12 @@ function _aiComputeAllergenIntro() {
     // safe-form note: FOOD_EFFECTS note (peanut/tree-nut) preferred; else the
     // allergen's own AGE_RULES `reason` (egg's "cook well, yolk first" floor) —
     // never the generic "in a safe form" where a real per-food floor exists (Maren M-1).
-    var safeForm = (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note
-                 : (ageRule && ageRule.reason) ? ageRule.reason : null;
+    // The `reason` is a full age-gate sentence-pair; surface only its first
+    // sentence on the one-line glance so it doesn't wrap (the full floor rides
+    // the tap-through detail sheet). Phase δ will replace this with a crisp
+    // FOOD_EFFECTS `safeForm.note` authored for the row.
+    var reasonShort = (ageRule && ageRule.reason) ? String(ageRule.reason).split('. ')[0] : null;
+    var safeForm = (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : reasonShort;
     return { key: a.key, label: a.label, introMonth: introMonth, ageReady: ageReady,
              tried: !!rec, date: (rec && rec.date) || null, daysSince: daysSince,
              exposureDays: exposureDays, state: state, safeForm: safeForm };
@@ -421,7 +425,16 @@ function renderInfoAllergenIntro() {
       else if (i.state === 'watching') meta = 'Day ' + (i.daysSince + 1) + ' of 3 — watch, tap for signs';
       else if (i.state === 'introduced') meta = 'Keep offering to hold tolerance';
       else if (i.state === 'reaction') meta = 'Reaction flagged — tap to review';
-      else if (i.state === 'ready') meta = i.safeForm ? i.safeForm : 'Good to introduce now, in a safe form';
+      else if (i.state === 'ready') {
+        // The glance stays one line (V-V-3): surface the food's own safe-form
+        // cue only when it fits; otherwise point to the tap-through, which
+        // already carries the full floor (peanut/tree-nut's note is ~150 chars
+        // and wraps to 3 lines on a phone). Egg's trimmed floor (~40) fits and
+        // stays visible, honouring Maren M-1. Phase δ replaces this length-gate
+        // with crisp authored safeForm copy per allergen.
+        meta = !i.safeForm ? 'Good to introduce now, in a safe form'
+             : (i.safeForm.length <= 44 ? i.safeForm : 'In a safe form — tap for how');
+      }
       else meta = 'From ' + i.introMonth + ' months';
       // Row taps through to the food's detail sheet — the R3 floor + safe-form
       // for the same resolved food (foodLibDetail → renderFoodDetailSheet).

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -69581,8 +69581,12 @@ function _aiComputeAllergenIntro() {
     // safe-form note: FOOD_EFFECTS note (peanut/tree-nut) preferred; else the
     // allergen's own AGE_RULES `reason` (egg's "cook well, yolk first" floor) —
     // never the generic "in a safe form" where a real per-food floor exists (Maren M-1).
-    var safeForm = (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note
-                 : (ageRule && ageRule.reason) ? ageRule.reason : null;
+    // The `reason` is a full age-gate sentence-pair; surface only its first
+    // sentence on the one-line glance so it doesn't wrap (the full floor rides
+    // the tap-through detail sheet). Phase δ will replace this with a crisp
+    // FOOD_EFFECTS `safeForm.note` authored for the row.
+    var reasonShort = (ageRule && ageRule.reason) ? String(ageRule.reason).split('. ')[0] : null;
+    var safeForm = (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : reasonShort;
     return { key: a.key, label: a.label, introMonth: introMonth, ageReady: ageReady,
              tried: !!rec, date: (rec && rec.date) || null, daysSince: daysSince,
              exposureDays: exposureDays, state: state, safeForm: safeForm };
@@ -69644,7 +69648,16 @@ function renderInfoAllergenIntro() {
       else if (i.state === 'watching') meta = 'Day ' + (i.daysSince + 1) + ' of 3 — watch, tap for signs';
       else if (i.state === 'introduced') meta = 'Keep offering to hold tolerance';
       else if (i.state === 'reaction') meta = 'Reaction flagged — tap to review';
-      else if (i.state === 'ready') meta = i.safeForm ? i.safeForm : 'Good to introduce now, in a safe form';
+      else if (i.state === 'ready') {
+        // The glance stays one line (V-V-3): surface the food's own safe-form
+        // cue only when it fits; otherwise point to the tap-through, which
+        // already carries the full floor (peanut/tree-nut's note is ~150 chars
+        // and wraps to 3 lines on a phone). Egg's trimmed floor (~40) fits and
+        // stays visible, honouring Maren M-1. Phase δ replaces this length-gate
+        // with crisp authored safeForm copy per allergen.
+        meta = !i.safeForm ? 'Good to introduce now, in a safe form'
+             : (i.safeForm.length <= 44 ? i.safeForm : 'In a safe form — tap for how');
+      }
       else meta = 'From ' + i.introMonth + ' months';
       // Row taps through to the food's detail sheet — the R3 floor + safe-form
       // for the same resolved food (foodLibDetail → renderFoodDetailSheet).

--- a/tests/e2e/analytics-allergen-intro.spec.ts
+++ b/tests/e2e/analytics-allergen-intro.spec.ts
@@ -85,7 +85,27 @@ test.describe('analytics prototype — Allergen Introduction card', () => {
     // reason (its cook-well / yolk-first floor), never null → generic copy.
     if (egg.state === 'ready') {
       expect(egg.safeForm, 'egg carries its own cook-well floor').toMatch(/cook/i);
+      expect(egg.safeForm.length, 'and it is short enough to render on one line').toBeLessThanOrEqual(44);
     }
+  });
+
+  test('ready-row meta stays one line: long safe-forms point to tap-through, short ones show (Fix A)', async ({ page }) => {
+    const metas = await page.evaluate(() => {
+      foods.length = 0; // all untried → ready
+      renderInfoAllergenIntro();
+      const out: Record<string, string> = {};
+      document.querySelectorAll('#infoAllergenIntroList .cd-food-item').forEach((el) => {
+        out[el.getAttribute('data-arg') || ''] = el.querySelector('.cd-food-meta')?.textContent || '';
+      });
+      return out;
+    });
+    // peanut/tree-nut carry a ~150-char FOOD_EFFECTS note → must NOT dump it on the glance
+    expect(metas['peanut'], 'long note points to tap-through, not wrapped inline').toBe('In a safe form — tap for how');
+    expect(metas['tree nut']).toBe('In a safe form — tap for how');
+    // egg's trimmed floor fits → stays visible (M-1)
+    expect(metas['egg'], 'egg short floor stays on the glance').toMatch(/well-cooked yolk/i);
+    // no ready meta should exceed the one-line budget
+    Object.values(metas).forEach((m) => expect(m.length).toBeLessThanOrEqual(44));
   });
 
   test('mixed log renders 6 rows with the right pills + an actionable (notable) tier', async ({ page }) => {


### PR DESCRIPTION
## Fix A — Allergen Introduction card: ready-row meta wraps on a phone

Reported by the Architect with phone screenshots: the **Egg** "Ready to try" row wrapped to multiple lines and crowded the label. Investigation showed the issue is **broader than egg** — **Peanut and Tree nuts** wrap *worse* (3 lines) in the ready state, hidden in the original report only because they were *Tolerated* there.

### Root cause
The ready meta rendered the full safe-form text in a one-line slot. Peanut/tree-nut carry a ~150-char `FOOD_EFFECTS.safeForm.note`; egg, after this session's M-1 fix, fell back to its full two-sentence `AGE_RULES.reason`.

### Fix (render-only, no unsafe truncation)
- **Egg** — `AGE_RULES.reason` fallback trimmed to its **first sentence** (*"Start with well-cooked yolk at 7+ months"*, ~40 chars). Fits one line; egg's specific floor stays visible (**Maren M-1 preserved**). Full floor remains in the tap-through.
- **Length-gate** on the ready meta: a cue ≤44 chars renders inline (egg); anything longer points to *"In a safe form — tap for how"* (peanut/tree-nut), whose full floor already lives in the detail sheet. **No mid-sentence truncation of safety copy** — that would be unsafe (cutting peanut's *"it does not remove the allergy risk"* mid-way inverts the meaning).

This is the phone-evidence resolution of the **M-1 (surface egg's floor) vs V-V-3 (keep metas short)** tension from this session's audit. **Phase δ** replaces the length-gate with crisp authored `safeForm` copy per allergen.

### Verification
`pnpm build` clean. e2e **11 → 12** (adds the one-line-meta gate case: peanut points, egg shows, no meta > 44 chars). **Verified at 390px phone width — all 6 rows single-line.**

### canon-cc-008 status
`intelligence-cards.js` (Vela) only — render/copy fix that *implements Vela's own V-V-3 one-line principle* and *preserves Maren's M-1* (egg's floor still shown; only peanut/tree-nut, which M-1 never demanded on the glance, now point to tap-through). **DRAFT pending the gate decision** — a quick Vela pass, or an Architect waiver given the size and that it realizes a finding the chain already ratified.

https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK)_