### PR TITLE
Phase δ research: egg, soy, wheat, sesame infant-safety briefs + manifest

### DIFF
--- a/docs/research/egg-infant-safety.md
+++ b/docs/research/egg-infant-safety.md
@@ -1,0 +1,109 @@
+# Egg — Infant Safety & Introduction Research Brief
+
+> **Purpose.** Evidence base for SproutLab's Care layer, feeding the *guided-introduction* food-effects model. Built to decide what to surface when a parent introduces **egg** to an under-1 — covering BOTH why to introduce early (allergy-prevention, RCT-backed) AND the two hazards (allergic reaction; the runny-egg salmonella + allergenicity trap). Egg is a **TIER-1 "prevention-proven" allergen** — like peanut, it earns the confident *"introducing early reduces allergy risk"* claim, backed by randomised controlled trials (PETIT, EAT). The food is not gated by choking-form (egg is soft); it is gated by **cooked-state**.
+> **Scope.** Hen's egg (white + yolk). Infants ~6–12 months, in a family context that is **Indian** — egg is a common, affordable, culturally accepted complementary food, but there is **no British-Lion-style salmonella-control mark** on Indian eggs, which changes the safe-form rule.
+> **Reviewer.** Research scout pass (for Maren, Governor of Care).
+> **Date.** 2026-06-01. **Status.** Research complete — *not yet wired into the app.*
+> **Method.** Multi-angle web fan-out → source fetch → adversarial cross-check → synthesis. Authorities: AAP/HealthyChildren, UK NHS, ASCIA (Australasia), US NIAID, IAP (India); pivotal trials **PETIT (Natsume et al., Lancet 2017)** and **EAT (Perkin/Lack, NEJM 2016)**. **Trial figures verified against the primary literature via PubMed** (PETIT: PMID 27939035; EAT: PMID 26943128). A few preparation specifics rest on reputable secondary sources (flagged inline) rather than a top-tier body's verbatim words.
+
+---
+
+## TL;DR (the parent-facing truth)
+
+- **The advice REVERSED.** The old "delay egg to prevent allergy" guidance is gone. Current consensus (AAP, NHS, ASCIA, NIAID-aligned): introduce egg **early** — around 6 months, alongside other solids, **not before 4 months** — and keep it in the diet regularly. Delaying does not prevent allergy and may *increase* it. *(AAP; NHS; ASCIA 2026; NIAID 2017.)*
+- **Early introduction PREVENTS egg allergy — RCT-proven.** The **PETIT trial** (high-risk eczematous Japanese infants) cut egg allergy at 12 months to **8% (egg group) vs 38% (placebo), P=0.0001** — using **heated egg powder** with **aggressive eczema treatment**. *(Natsume et al., Lancet 2017.)* The **EAT trial** showed a per-protocol reduction (**1.4% vs 5.5%, P=0.009**) but **no significant intention-to-treat effect** — the benefit depends on sustaining regular intake. *(Perkin/Lack, NEJM 2016.)*
+- **The crux is COOKED-STATE, not the food.** The safe form is **fully-cooked egg** — mashed hard-boiled, scrambled until firm, or baked into food. **Runny/soft egg is not safe for an Indian infant**: India has no British-Lion-mark equivalent, so the salmonella safeguard the NHS relies on does not apply, and well-cooking also reduces allergenicity. Start with about **a third of a well-cooked egg**. *(NHS; AAP; PETIT used heated egg.)*
+- **Two distinct hazards, two distinct mitigations.** (1) *Allergy* — mitigated by early, sustained introduction + a watchful first exposure. (2) *Salmonella + raw-egg allergenicity* — mitigated by **fully cooking**. The model must hold both at once. Egg has **no choking-form gate** (it is soft) — this is what distinguishes it from peanut/tree-nut.
+- **Reassuring outlook: most children OUTGROW egg allergy.** Egg is among the most common infant allergens, but unlike peanut it is **commonly outgrown** — a majority of children by school age. The tone should be calm, not alarmed. *(FARE; FAACT.)*
+- **First exposure = small amount, fully cooked, at home, daytime, watch.** Know the difference between a mild reaction (hives/swelling/GI) and anaphylaxis (breathing trouble, tongue/throat swelling, hoarse voice, pale-and-floppy) — the latter is an emergency-call event (**112 / 108** in India). *(ASCIA first aid.)*
+
+---
+
+## Axis 1 — The benefit: early introduction reduces egg allergy *(confidence: HIGH)*
+
+- **The paradigm flipped.** Until ~2008–2015, guidance advised *delaying* allergenic foods (incl. egg) to prevent allergy. That advice is reversed: AAP/HealthyChildren now states there is no evidence that delaying allergenic foods like egg prevents allergies once a baby is ready, typically around 6 months. *(AAP/HealthyChildren.)*
+- **PETIT trial (the pivotal RCT for egg).** High-risk Japanese infants **with eczema**, randomised to a **stepwise heated whole-egg powder** regimen — **50 mg/day from 6–9 months, then 250 mg/day from 9–12 months** — **alongside aggressive eczema treatment**, vs placebo. Egg allergy at 12 months:
+  - **8% (egg group) vs 38% (placebo)** — **P=0.0001.** *(Natsume et al., Lancet 2017; verified from PubMed PMID 27939035.)*
+  - **Two integral conditions of this result:** (a) the studied form was **HEATED/cooked egg** (not raw), and (b) **eczema was actively controlled** as part of the protocol. The trial does not license giving raw egg, nor giving egg to an uncontrolled-eczema infant without care.
+  > ⚑ *The high-risk-eczema pathway warrants clinician input.* PETIT studied infants **with eczema** under **medical eczema management**. For an infant with significant eczema or a sibling/family history of food allergy, early egg is still the goal — but it is prudent to involve a paediatrician on timing and on getting eczema under control first, rather than reading PETIT as "give any eczematous baby egg at home unsupervised."
+- **EAT trial (the nuance — adherence matters).** General-population, exclusively-breastfed infants randomised to early introduction of allergens (incl. egg) vs standard introduction. For egg:
+  - **Per-protocol** (those who actually achieved the regular dose): **1.4% vs 5.5%, P=0.009** — a real, significant reduction.
+  - **Intention-to-treat: NOT significant** — overall **7.1% vs 5.6%, P=0.32.** *(Perkin/Lack, NEJM 2016; verified from PubMed PMID 26943128.)*
+  > ⚑ *The EAT lesson is dose + adherence:* the benefit is real but depends on getting enough egg in, **regularly**. Early introduction is easy to *attempt* and hard to *sustain*. The model should frame egg as "introduce **and keep offering**," not a one-time tick.
+- **Timing consensus:** introduce egg **around 6 months**, once the baby is developmentally ready for solids and a few first foods are tolerated — **not before 4 months**. *(NHS; AAP; ASCIA; NIAID-aligned.)*
+
+## Axis 2 — Safe FORM: fully-cooked egg *(confidence: HIGH)*
+
+- **The safe form is FULLY-COOKED egg.** Mashed/grated **hard-boiled** egg, **scrambled until firm and no longer runny**, or **baked into** another food (pancake, omelette set firm, egg stirred into porridge/khichdi and cooked through). Start with about **one-third of a well-cooked egg**. *(AAP/HealthyChildren; NHS.)*
+- **Why not runny egg — the India-specific divergence.** NHS permits **runny or lightly-cooked egg for infants only if the eggs carry the British Lion mark** (a UK salmonella-control assurance scheme); **otherwise the egg must be cooked until both white and yolk are solid.** *(NHS — foods to avoid / food allergies.)*
+  > ⚑ **India has no British-Lion-mark equivalent.** Therefore the NHS "runny is fine if Lion-marked" exception **does not apply to an Indian family** — the default must be **fully-cooked egg (solid white + solid yolk)**. Two reasons compound: **(1) salmonella** — without a control-scheme assurance, raw/undercooked egg carries an infection risk that is far more serious in an infant; **(2) allergenicity** — well-cooking (heating) reduces egg's allergenic potency, which is precisely why PETIT used **heated** egg powder rather than raw.
+- **Egg has no choking-form gate.** Unlike whole peanuts/tree nuts, cooked egg is soft and does not need grinding/thinning for airway safety. The gate egg passes through is **cooked-state**, not particle-size. (Standard general choking caution — soft, age-appropriate textures — still applies, but egg is not a choking-hazard food in the nut sense.)
+
+## Axis 3 — Allergic-reaction watch-fors & the emergency floor *(confidence: HIGH)*
+
+- **Egg is among the most common infant food allergens** — but, reassuringly, it is **commonly outgrown**: a **majority of egg-allergic children outgrow it by school age**, unlike peanut/tree-nut which tend to be lifelong. The tone here should be **calm and reassuring**, not alarmist. *(FARE — egg; FAACT — egg.)*
+- **Mild–moderate reaction (one body system):** itchy **hives/welts**, redness or **rash**, **swelling** (esp. around the mouth/eyes), **vomiting**, loose stool or other **GI upset**, sudden fussiness. *(FARE; FAACT.)*
+- **Severe / anaphylaxis — act immediately (red flags):**
+  - **Difficulty/noisy breathing**, wheeze, persistent cough.
+  - **Swelling of the tongue or throat**, tightness in the throat.
+  - **Hoarse voice or cry.**
+  - **Pale and floppy** (in a baby, sudden limpness / can't hold head up is a recognised severe sign), collapse.
+  - **→ This is an emergency. Lay the child flat (do not stand them up); use an adrenaline auto-injector immediately if one has been prescribed; call emergency services — 112 (all-India) or 108 (ambulance).** *(ASCIA — First Aid for Anaphylaxis.)*
+- **What to do for a mild, single-system reaction:** stop the food, monitor closely, contact your doctor; an antihistamine may be advised by a clinician. **Any breathing difficulty, tongue/throat swelling, hoarse voice, floppiness, or two body systems involved → treat as anaphylaxis (adrenaline + 112/108).** *(ASCIA.)*
+- **First-exposure practice:** offer a **small amount** of fully-cooked egg, **at home**, in the **morning or midday** (not at dinner) so you can observe through the day, and **watch** afterward — most reactions appear within a couple of hours. If tolerated, **keep offering regularly** (the EAT lesson).
+
+## Axis 4 — Culinary aliases & hidden sources *(confidence: HIGH for the alias list; MODERATE on "lecithin is egg")*
+
+- **Egg goes by many names on labels.** Watch for: **albumin / albumen, ovalbumin, ovomucoid, ovomucin, ovo-** (any "ovo-" prefix), **ovovitellin / vitellin, livetin, lysozyme** (often in cheese/wine as a preservative), **globulin, conalbumin**, "egg solids," "dried/powdered egg," "egg white/egg yolk." *(FARE — egg; FAACT — egg.)*
+- **Lecithin may be egg-derived.** Lecithin (an emulsifier, E322) is **usually soy- or sunflower-derived but can be egg-derived** — for an egg-allergic child, lecithin of unspecified origin is worth checking. *(FARE; FAACT — flagged as "may contain," not "always egg.")*
+- **Hidden-egg foods (common in an Indian household):**
+  - **Baked goods** — many cakes, biscuits, breads, and **egg-glazed / egg-washed buns and pastries** (the shiny glaze on bakery buns is frequently an egg wash).
+  - **Mayonnaise**, salad dressings, **custard and custard puddings**, ice cream, some **kheer/pudding** mixes.
+  - **Egg noodles / hakka noodles / egg-containing chow mein.**
+  - Batters, some "instant" pancake/cake mixes, marshmallow, meringue, certain breaded/fried coatings.
+- **Why this matters for the model:** once a parent is avoiding egg (suspected or confirmed allergy), the failure mode is **accidental exposure via an unlabelled or aliased source** — Indian bakery items and egg-glazed buns are a particularly easy miss. Surfacing the alias list and the bakery-glaze/noodle/custard examples is the highest-value safety content here.
+
+## Axis 5 — Indian & cultural context *(confidence: HIGH for staple status + cooked-default; MODERATE→LOW for India-specific official guidance)*
+
+- **Egg is a common, affordable, accepted complementary food in India.** It appears in the **IAP (Indian Academy of Pediatrics) complementary-feeding food groups** as a protein-rich option for infants. *(IAP Complementary Feeding parental guideline, Ch-040.)*
+  > ⚑ **Read the IAP citation correctly — nutrition framing, NOT an allergy-prevention directive.** IAP listing egg among complementary-feeding **food groups** is a **nutrition** statement (egg is a good infant protein/iron/choline source). It is **not** an IAP statement that "introduce egg early to *prevent allergy*." Do not launder the international early-introduction-for-prevention claim onto IAP's name — see the gap note below (the honey lesson).
+- **The cooked-default fits Indian practice.** Indian egg preparations for infants — well-mashed boiled egg, firm scrambled egg (egg bhurji cooked through, not runny), egg stirred into khichdi/porridge and cooked — are **already fully-cooked forms**, which is exactly the safe default. This is a cultural asset the model can affirm. The thing to **correct** is any practice of giving **half-boiled / soft-yolk / runny egg** to a baby (no Lion-mark safeguard in India).
+- **Vegetarian note:** in a vegetarian or egg-avoiding household, egg is simply not introduced; this is a dietary choice, not a safety failure. The brief should not push egg on a family that doesn't eat it — the prevention benefit is one input, not an obligation.
+
+## Axis 6 — Myths to correct *(confidence: HIGH)*
+
+- **Myth: "Delay egg to prevent allergy."** **Reversed.** Delaying does not prevent egg allergy and likely increases risk; early, sustained introduction around 6 months (not before 4) is now recommended, and is **RCT-backed for egg specifically** (PETIT, EAT per-protocol). *(AAP; NHS; ASCIA; PETIT; EAT.)* This is the highest-value myth to surface — many grandparents/relatives still believe the old rule.
+- **Myth: "Egg allergy is forever."** **Mostly false for egg.** Unlike peanut/tree-nut, **most children outgrow egg allergy** — a majority by school age. A diagnosis is not a life sentence; re-evaluation over time (by a clinician) is standard. *(FARE; FAACT.)*
+- **Myth: "Runny / half-boiled egg is fine for babies."** **No — fully cook it.** In India there is no British-Lion-mark salmonella safeguard, so runny egg carries an infection risk; and well-cooking also lowers allergenicity. Cook until **both white and yolk are solid.** *(NHS; PETIT used heated egg.)*
+- **Myth: "If a baby reacts once, never give egg again in any form."** **Nuanced — a clinician's call.** Many egg-allergic children tolerate **baked/well-heated egg** even when reacting to lightly-cooked egg, and most outgrow over time; what to reintroduce and when is an **allergist's decision**, not a permanent self-imposed total ban. *(FARE; FAACT — flagged as practice-level; do not act without clinical input.)*
+
+---
+
+## Source list
+
+| # | Authority | URL |
+|---|-----------|-----|
+| 1 | NEJM — Perkin/Lack et al., EAT trial (2016) | https://www.nejm.org/doi/full/10.1056/NEJMoa1514210 |
+| 2 | PubMed — EAT trial (PMID 26943128) | https://pubmed.ncbi.nlm.nih.gov/26943128/ |
+| 3 | The Lancet — Natsume et al., PETIT trial (2017) | https://www.thelancet.com/journals/lancet/article/PIIS0140-6736(16)31418-0/abstract |
+| 4 | PubMed — PETIT trial (PMID 27939035) | https://pubmed.ncbi.nlm.nih.gov/27939035/ |
+| 5 | NIAID — Addendum Guidelines (allergen prevention; ~6 mo / not-before-4 framing) | https://www.niaid.nih.gov/sites/default/files/addendum-peanut-allergy-prevention-guidelines.pdf |
+| 6 | AAP / HealthyChildren — When to introduce egg, peanut butter & other allergens | https://www.healthychildren.org/English/healthy-living/nutrition/Pages/when-to-introduce-egg-peanut-butter-and-other-common-food-allergens-to-your-baby-food-allergy-prevention-tips.aspx |
+| 7 | UK NHS — Food allergies in babies & young children | https://www.nhs.uk/baby/weaning-and-feeding/food-allergies-in-babies-and-young-children/ |
+| 8 | UK NHS — Foods to avoid giving babies (runny egg / British Lion mark) | https://www.nhs.uk/baby/weaning-and-feeding/foods-to-avoid-giving-babies-and-young-children/ |
+| 9 | ASCIA — Infant Feeding for Food Allergy Prevention | https://www.allergy.org.au/hp/papers/infant-feeding-and-allergy-prevention |
+| 10 | ASCIA — Updated infant-feeding guideline (published Jan 2026) | https://www.allergy.org.au/about-ascia/info-updates/updated-ascia-guideline-infant-feeding-for-food-allergy-prevention-published-january-2026 |
+| 11 | ASCIA — First Aid for Anaphylaxis | https://www.allergy.org.au/hp/anaphylaxis/first-aid-for-anaphylaxis |
+| 12 | FARE — Egg allergy (common allergens) | https://www.foodallergy.org/living-food-allergy/food-allergy-essentials/common-allergens/egg |
+| 13 | FAACT — Egg allergen | https://www.foodallergyawareness.org/food-allergy-and-anaphylaxis/food-allergens/egg/ |
+| 14 | IAP — Complementary Feeding parental guideline (Ch-040; egg in food groups) | https://iapindia.org/pdf/Ch-040-IAP-Parental-Guideline-Complementary-Feeding.pdf |
+
+### Verification status & gaps
+1. ✅ **PETIT figures** — verified from the primary literature via PubMed (PMID 27939035): high-risk eczematous infants; stepwise **heated** egg powder (50 mg/day 6–9 mo → 250 mg/day 9–12 mo) **with aggressive eczema treatment**; egg allergy at 12 mo **8% vs 38%, P=0.0001**. The **heated form** and **integral eczema control** are not incidental — they are conditions of the result.
+2. ✅ **EAT figures** — verified from the primary literature via PubMed (PMID 26943128): per-protocol **1.4% vs 5.5%, P=0.009**; intention-to-treat **NOT** significant (**7.1% vs 5.6%, P=0.32**). The headline lesson is **adherence/dose**, not a simple "early egg works regardless."
+3. ✅ **Timing reversal** — corroborated independently by AAP, NHS, ASCIA, NIAID-aligned framing (~6 mo, not before 4).
+4. ✅ **Fully-cooked default for India** — derived correctly: NHS permits runny egg *only* with the **British Lion mark**; India has **no equivalent scheme**, so the exception does not transfer → fully-cooked (solid white + yolk) is the default. Salmonella + reduced-allergenicity rationale is sound and aligns with PETIT's use of **heated** egg.
+5. ✅ **Commonly-outgrown reassurance** — egg allergy is typically outgrown (majority by school age), per FARE/FAACT. *(These are advocacy/patient-education bodies — see note 7 — but the "egg is commonly outgrown" claim is uncontroversial and consistent across mainstream paediatric allergy sources.)*
+6. ⚑ **India early-egg-for-prevention directive — HONEST GAP, none exists.** No India-specific (**IAP / MoHFW / NHM / FSSAI**) directive recommending **early egg introduction to *prevent* allergy** was located. IAP's Ch-040 lists egg among complementary-feeding **food groups** — a **nutrition** framing, **not** an allergy-prevention recommendation. The early-introduction-prevents-allergy evidence base is **international** (NHS / ASCIA / NIAID / PETIT / EAT). Treat the prevention claim as well-sourced internationally and culturally compatible with Indian practice, but **do not attribute an early-egg-for-prevention recommendation to IAP or any Indian body.** *(The honey-brief lesson: never launder international guidance onto an Indian body's name.)*
+7. ⚑ **Source-tier flag.** **FARE** and **FAACT** are **advocacy / patient-education organisations**, not government regulators or primary trials — cited here for the **alias list, hidden-egg sources, mild-vs-severe symptom descriptions, and the commonly-outgrown framing**, all of which are mainstream and corroborated, but they should be labelled as advocacy-tier, not regulator-verbatim. Trial claims rest on PETIT/EAT (primary, PubMed-verified); cooked-state and timing rest on NHS/AAP/ASCIA (official bodies).
+8. ⚑ **Emergency numbers** — **112** is India's unified emergency number; **108** is the widely-used ambulance number across most Indian states. Both are practice-level/operational facts, not allergy-guideline-issued; ASCIA's first-aid *content* (lay flat, adrenaline first, then call) is the cited clinical procedure.

--- a/docs/research/food-effects.manifest.js
+++ b/docs/research/food-effects.manifest.js
@@ -121,7 +121,157 @@ window.FOOD_EFFECTS_MANIFEST = [
     lastReviewed:  '2026-05-30',
   },
 
-  // ── append the next food here (egg / cow's milk / sesame / salt …) ──
+  // ── food-effects Phase δ: egg, soy, wheat, sesame (the four remaining big-9 allergens) ──
+  // TWO-TIER evidence discipline (verified 2026-06-01): EGG is prevention-PROVEN
+  // (PETIT RCT + EAT) and may make peanut-style confident claims. SOY / WHEAT /
+  // SESAME are introduce-early-and-SAFE but prevention is NOT RCT-proven — EAT
+  // (NEJM 2016) found "no significant effects with respect to milk, sesame, fish,
+  // or wheat" (soy untested in EAT). Their earlyIntroBenefit is framed honestly:
+  // "don't delay, it's safe" — never "early intro prevents this allergy."
+  // All four are foodClass:'allergen-introduce-early' (sage/encourage, NOT honey's
+  // rose acute-toxin) — the evidence base for the polarity-aware banner (Phase δ).
+  // `aliases` are deliberately culinary-rich so wiring into FOOD_EFFECTS closes the
+  // Kael B-1 resolution gap (tofu→soy, roti→wheat, til→sesame, anda→egg).
+  // minMonth:6 follows AAP/NHS/ASCIA (~6mo, not before 4); NOTE for wiring — the
+  // app's AGE_RULES carries egg-yolk:7 / whole-egg:8, to be reconciled with Maren.
+  {
+    food:          'egg',
+    aliases:       ['eggs','anda','egg yolk','whole egg','boiled egg','hard-boiled egg','scrambled egg','omelette','omelet'],
+    foodClass:     'allergen-introduce-early',
+    severity:      'caution',
+    category:      'egg',
+    effect:        'food allergy',
+    minMonth:      6,                      // AAP/NHS ~6mo (not before 4); reconcile with AGE_RULES egg-yolk:7 at wiring
+    thresholdBasis:'developmental-readiness',
+    allergen:      true,
+    reactionType:  ['allergy'],
+    headline:      'Introduce early (~6 months), well-cooked — early egg lowers allergy risk.',
+    whyGood:       'Complete protein, choline, iron, vitamin D — and early, regular well-cooked egg helps prevent egg allergy.',
+    earlyIntroBenefit: { claim:'Early, regular well-cooked egg helps prevent egg allergy.',
+                         evidence:'PETIT (Lancet 2017): heated egg + eczema care cut egg allergy 38%→8% at 12mo (P=0.0001). EAT (NEJM 2016): per-protocol 5.5%→1.4% (P=0.009).',
+                         paradigm:'Reverses old "delay egg to prevent allergy" advice.' },
+    safeForm:      { ok:['well-cooked egg — mashed hard-boiled, scrambled, or baked into soft food','start with cooked yolk; offer whole egg once yolk is tolerated'],
+                     never:['raw or runny egg','lightly-cooked egg (no British-Lion-mark assurance exists in India)'],
+                     note:'Cook until BOTH white and yolk are solid — this is the studied safe form and removes the salmonella risk.' },
+    myth:          { claim:'Delay egg to prevent allergy.',
+                     truth:'Reversed — early, regular well-cooked egg helps prevent egg allergy; delaying may increase risk.' },
+    watchFor:      ['hives / rash','swelling (mouth, eyes, lips)','vomiting'],
+    severeSigns:   ['trouble breathing / wheeze','face/lip/tongue swelling','floppy, pale, or very sleepy'],
+    timeCourse:    'minutes to ~2 hours after eating; anaphylaxis often within 5–30 min',
+    seekCare:      'Mild single-system: stop, monitor, call doctor. Any breathing trouble, face/throat swelling, or floppiness: EMERGENCY — call 112, use prescribed adrenaline auto-injector.',
+    breastfeedingSafe: true,
+    culturalNote:  'No British-Lion-mark assured-egg scheme in India — default to fully-cooked egg (solid white and yolk). Egg allergy is common in infancy but usually outgrown by school age.',
+    confidence:    'high',
+    sources:       ['Lancet PETIT 2017','NEJM EAT 2016','AAP','UK NHS','ASCIA 2026','NIAID 2017'],
+    dashboard:     'egg-infant-safety.visual.html',   // render pending (Phase δ render step)
+    brief:         'egg-infant-safety.md',
+    longform:      'egg-infant-safety.html',           // render pending
+    lastReviewed:  '2026-06-01',
+  },
+  {
+    food:          'soy',
+    aliases:       ['soya','soybean','soya bean','tofu','edamame','soya chunks','soya granules','soya nuggets','soy milk','soya milk','tempeh','miso','natto','tamari','tvp','textured vegetable protein'],
+    foodClass:     'allergen-introduce-early',
+    severity:      'caution',
+    category:      'legume',
+    effect:        'food allergy (incl. FPIES)',
+    minMonth:      6,
+    thresholdBasis:'developmental-readiness',
+    allergen:      true,
+    reactionType:  ['allergy','digestive'],   // digestive = FPIES (non-IgE), a classic soy presentation
+    headline:      'Introduce around 6 months — don\'t delay. Soft tofu, not whole edamame.',
+    whyGood:       'Valuable plant protein for a vegetarian diet (tofu, soya chunks) — introduce early alongside other solids.',
+    earlyIntroBenefit: { claim:'Introduce around 6 months; don\'t delay allergens.',
+                         evidence:'AAP/NHS/ASCIA advise early introduction of soy among the major allergens; early intro is SAFE, but no RCT proves early soy prevents soy allergy (soy was not among EAT\'s prevention-positive foods).',
+                         paradigm:'Don\'t delay — but no proven soy-specific prevention claim.' },
+    safeForm:      { ok:['soft / silken tofu, smushable or blended','well-cooked soybeans mashed','soy yoghurt; soya stirred into food'],
+                     never:['whole edamame or whole soybeans (round, firm — a choking risk)','soy milk as a main drink in the first year (not a breastmilk/formula substitute)'],
+                     note:'Shell and mash edamame at 6mo; halve cooked beans at 9mo. Soft tofu needs no choking prep.' },
+    myth:          { claim:'Soy isn\'t recommended for babies.',
+                     truth:'That advice is about soy infant FORMULA for allergy prevention — not soy FOODS like tofu, which are fine to introduce around 6 months.' },
+    watchFor:      ['hives / rash','swelling (mouth, eyes, lips)','vomiting or diarrhoea'],
+    severeSigns:   ['trouble breathing / wheeze','face/lip/tongue swelling','floppy, pale, or very sleepy','repeated forceful vomiting + lethargy hours later (possible FPIES)'],
+    timeCourse:    'IgE: minutes to ~2 hours. FPIES (non-IgE): delayed — profuse repeated vomiting + lethargy/pallor 1–4 hours after eating.',
+    seekCare:      'Mild single-system: stop, monitor, call doctor. Breathing trouble, face/throat swelling, or floppiness: EMERGENCY — call 112. Repeated forceful vomiting with lethargy/pallor hours after a soy feed (possible FPIES): seek urgent care even without a rash.',
+    breastfeedingSafe: true,
+    culturalNote:  'Soya chunks/granules are everyday vegetarian protein in India — a concentrated soy-protein form. Some cow\'s-milk-allergic babies also react to soy; introduce as a minor ingredient first.',
+    confidence:    'high',
+    sources:       ['AAP','UK NHS','ASCIA','NIAID 2017','FARE','CHOP (FPIES)','NEJM EAT 2016'],
+    dashboard:     'soy-infant-safety.visual.html',    // render pending
+    brief:         'soy-infant-safety.md',
+    longform:      'soy-infant-safety.html',           // render pending
+    lastReviewed:  '2026-06-01',
+  },
+  {
+    food:          'wheat',
+    aliases:       ['atta','maida','wheat flour','suji','sooji','rava','semolina','dalia','broken wheat','roti','chapati','phulka','paratha','naan','bread','pasta','sevai','vermicelli','durum','couscous','bulgur','seitan'],
+    foodClass:     'allergen-introduce-early',
+    severity:      'caution',
+    category:      'grain',
+    effect:        'food allergy (distinct from celiac disease)',
+    minMonth:      6,
+    thresholdBasis:'developmental-readiness',
+    allergen:      true,
+    reactionType:  ['allergy'],
+    headline:      'Introduce around 6 months — don\'t delay. Soft cereal or softened roti.',
+    whyGood:       'Staple grain — soft wheat cereal, well-cooked pasta, or softened roti; introduce early alongside other solids.',
+    earlyIntroBenefit: { claim:'Introduce around 6 months; don\'t delay.',
+                         evidence:'AAP/NHS/ASCIA advise early introduction; EAT (NEJM 2016) verified NO significant prevention effect for wheat — early intro is SAFE but does NOT prevent wheat allergy.',
+                         paradigm:'Don\'t delay — but no proven wheat-specific prevention claim.' },
+    safeForm:      { ok:['soft wheat / multigrain cereal or porridge','well-cooked soft pasta','roti / chapati torn small and softened in milk, dal, or sabzi','suji / dalia cooked soft'],
+                     never:['large or doughy bread pieces (fresh soft bread balls up into a sticky clump — toast it or use firm strips)','loose cooked wheat / dalia that scatters in the mouth (mash or bind it)'],
+                     note:'Wheat ALLERGY is separate from celiac disease — see myth.' },
+    myth:          { claim:'Wheat allergy and gluten intolerance / celiac disease are the same.',
+                     truth:'Different conditions — wheat allergy is an immune (IgE) food allergy with rapid reactions; celiac is a separate autoimmune reaction to gluten needing medical diagnosis, not emergency care. This record is about wheat allergy.' },
+    watchFor:      ['hives / rash','swelling (mouth, eyes, lips)','vomiting or diarrhoea','eczema flare'],
+    severeSigns:   ['trouble breathing / wheeze','face/lip/tongue swelling','floppy, pale, or very sleepy'],
+    timeCourse:    'minutes to ~2 hours after eating; anaphylaxis often within 5–30 min',
+    seekCare:      'Mild single-system: stop, monitor, call doctor. Any breathing trouble, face/throat swelling, or floppiness: EMERGENCY — call 112, use prescribed adrenaline auto-injector. (Celiac is NOT an emergency — chronic; needs a doctor\'s diagnosis.)',
+    breastfeedingSafe: true,
+    culturalNote:  'Atta, maida, suji/rava, dalia, sevai are all wheat. Soft cereal and softened roti are ideal early forms. Wheat allergy is commonly outgrown in early childhood.',
+    confidence:    'high',
+    sources:       ['AAP','UK NHS','ASCIA','NIAID 2017','NEJM EAT 2016','ESPGHAN 2016 (celiac/gluten)'],
+    dashboard:     'wheat-infant-safety.visual.html',  // render pending
+    brief:         'wheat-infant-safety.md',
+    longform:      'wheat-infant-safety.html',          // render pending
+    lastReviewed:  '2026-06-01',
+  },
+  {
+    food:          'sesame',
+    aliases:       ['til','tahini','gingelly','gingelly oil','sesame seeds','sesame oil','sim sim','benne','gomashio','hummus','halva','halwa','gajak','til laddoo'],
+    foodClass:     'allergen-introduce-early',
+    severity:      'caution',
+    category:      'seed',
+    effect:        'food allergy (often lifelong)',
+    minMonth:      6,
+    thresholdBasis:'developmental-readiness',
+    allergen:      true,
+    reactionType:  ['allergy'],
+    headline:      'Introduce around 6 months, as thinned tahini — never a thick glob.',
+    whyGood:       'Seed source of calcium, iron and healthy fats; offer as smooth tahini thinned into food.',
+    earlyIntroBenefit: { claim:'Introduce around 6 months; don\'t delay.',
+                         evidence:'AAP/NHS/ASCIA name sesame among allergens to introduce early; EAT (NEJM 2016) verified NO significant prevention effect for sesame — early intro is SAFE but not proven to prevent sesame allergy. (Sesame is the US 9th major allergen, FASTER Act, labeling since Jan 1 2023 — US-only; does not apply to Indian/home foods.)',
+                         paradigm:'Don\'t delay — but no proven sesame-specific prevention claim.' },
+    safeForm:      { ok:['smooth tahini (sesame paste) thinned with water, milk, or puree','finely ground sesame stirred into food'],
+                     never:['a thick glob of tahini (sticky — a choking risk; thin it, like nut butter)','whole sesame seeds in quantity for a young infant'],
+                     note:'Same "thin the sticky glob" rule as peanut butter. Unrefined / cold-pressed gingelly (sesame) oil can still carry allergenic protein.' },
+    myth:          { claim:'Sesame allergy is outgrown like egg or milk.',
+                     truth:'Usually not — sesame allergy tends to be lifelong (~70–80% persist), so first exposures and ongoing care matter more than for commonly-outgrown allergens.' },
+    watchFor:      ['hives / rash','swelling (mouth, eyes, lips)','vomiting'],
+    severeSigns:   ['trouble breathing / wheeze','face/lip/tongue swelling','floppy, pale, or very sleepy'],
+    timeCourse:    'minutes to ~2 hours after eating; anaphylaxis often within 5–30 min',
+    seekCare:      'Mild single-system: stop, monitor, call doctor. Any breathing trouble, face/throat swelling, or floppiness: EMERGENCY — call 112, use prescribed adrenaline auto-injector. Sesame is a leading anaphylaxis trigger — watch closely.',
+    breastfeedingSafe: true,
+    culturalNote:  'Til is deeply embedded — til laddoo, gajak (peak around Makar Sankranti), chutneys, gingelly oil. Thin tahini into dal, khichdi, curd, or fruit puree; avoid loose til seeds from laddoo/gajak for young infants.',
+    confidence:    'high',
+    sources:       ['AAP','UK NHS','ASCIA','FDA FASTER Act 2021','NEJM EAT 2016','J Asthma Allergy (persistence)','JAMA Netw Open 2019'],
+    dashboard:     'sesame-infant-safety.visual.html', // render pending
+    brief:         'sesame-infant-safety.md',
+    longform:      'sesame-infant-safety.html',         // render pending
+    lastReviewed:  '2026-06-01',
+  },
+
+  // ── append the next food here (cow's milk / fish / salt …) ──
 ];
 
 /* Node/CommonJS convenience (so the hub OR a build step can require it). */

--- a/docs/research/sesame-infant-safety.md
+++ b/docs/research/sesame-infant-safety.md
@@ -1,0 +1,106 @@
+# Sesame (Til) — Infant Safety & Introduction Research Brief
+
+> **Purpose.** Evidence base for SproutLab's Care layer, feeding the *guided-introduction* food-effects model. Built to decide what to surface when a parent introduces **sesame (til)** to an under-1 — covering BOTH why to introduce early (don't-delay-allergens guidance) AND the two hazards (allergy reaction; choking-by-form). The food is not banned — the **FORM** is gated. **Tone caveat unique to sesame:** the prevention rationale here is *weaker* than peanut's — see TL;DR — and the persistence profile is *graver*, so the emergency floor is the most serious of the four allergens.
+> **Scope.** Sesame (til): tahini (sesame paste), til laddoo, gajak, chutneys, gingelly/sesame oil, and sesame on breads/buns. Infants ~6–12 months, with the choking note running to ~5 years. Family context: Indian — til is a deeply embedded staple (sweets, oils, chutneys), not a novelty.
+> **Reviewer.** Research scout pass (for Maren, Governor of Care).
+> **Date.** 2026-06-01. **Status.** Research complete — *not yet wired into the app.*
+> **Method.** Multi-angle web fan-out → source fetch → adversarial cross-check → synthesis. Authorities: AAP/HealthyChildren, UK NHS, ASCIA (Australasia), US NIAID; US FDA + FoodSafety.gov (FASTER Act / 9th-allergen labeling); pivotal trial EAT (Perkins/Lack, NEJM 2016); peer-reviewed persistence/prevalence literature (J Asthma Allergy; JAMA Netw Open 2019). **Note:** the **FDA FASTER-Act sesame page and the ASCIA infant-feeding page returned 401/403 to automated fetchers**; those facts are corroborated across FDA indexed text, the FoodSafety.gov government mirror, and independent sources — marked **high-confidence-but-not-direct-fetch** below. The EAT sesame-null result is verified verbatim from PubMed (26943128).
+
+---
+
+## TL;DR (the parent-facing truth)
+
+- **Introduce early — but be honest about *why*.** Current consensus (AAP, NHS, ASCIA, NIAID) is to introduce sesame **early — around 6 months, alongside other solids** — and not to delay. *(AAP/HealthyChildren; NHS; ASCIA.)* This is the right advice. **But unlike peanut, this is NOT RCT-proven prevention for sesame.**
+- **The RCT did NOT find a sesame benefit.** The **EAT trial (NEJM 2016)** tested early introduction of six allergens including sesame and reported, verbatim, **"no significant effects with respect to milk, sesame, fish, or wheat."** *(Perkins/Lack, NEJM 2016; verified PubMed 26943128.)* The peanut+egg benefit does **not** transfer to sesame. The "introduce early" rationale for sesame rests on **general don't-delay-allergens guidance**, not a sesame-specific prevention trial. **Do not claim early sesame prevents sesame allergy.**
+- **Sesame is the 9th major US allergen.** Under the **FASTER Act of 2021**, sesame became the **9th major US food allergen**; mandatory labeling took effect **January 1, 2023** (US packaged foods must declare it, e.g. "tahini (sesame)" or "Contains sesame"). The EU has long required sesame declaration. *(US FDA; FoodSafety.gov — high-confidence; FDA page blocked direct fetch.)* **This labeling does NOT apply to Indian/home foods** — an Indian-bought packet or a homemade laddoo carries no such guarantee.
+- **The crux is FORM, not the food.** A thick glob of tahini is a sticky choking risk, and whole sesame seeds in quantity are a hazard. The safe form is **smooth tahini THINNED with water/milk/puree**, or **finely ground sesame stirred into food** — same "thin the sticky glob" rule as peanut butter. *(Mirrors NHS/AAP peanut-butter form guidance; Solid Starts.)*
+- **Sesame allergy is usually LIFELONG — this is the key tone point.** Unlike egg, milk, soy, and wheat (commonly outgrown), **sesame allergy is rarely outgrown — only ~20–30% achieve tolerance, so ~70–80% persists into adulthood.** It is a leading cause of anaphylaxis. *(J Asthma Allergy; JAMA Netw Open 2019.)* So first exposures and ongoing vigilance matter **more** here than for the commonly-outgrown allergens — the emergency floor should carry the most serious tone of the four.
+
+---
+
+## Axis 1 — Benefit, timing & regulatory status *(confidence: HIGH on timing/don't-delay; HIGH that EAT found no sesame benefit; HIGH-but-not-direct-fetch on FASTER Act)*
+
+- **Introduce around 6 months, don't delay.** General-population timing for sesame is **around 6 months**, once the baby is developmentally ready for solids and a few first foods are tolerated — **not before 4 months**, and don't delay once ready. *(NHS; AAP; ASCIA.)*
+  - **AAP names sesame directly:** *"there is no evidence that delaying introduction of allergenic foods like egg, peanut, dairy and sesame prevents allergies once babies are ready, typically at about 6 months."* *(AAP/HealthyChildren.)*
+  - **NHS** lists sesame among allergenic foods to introduce (not delay), with the form note that **seeds — "particularly sesame" — should be served finely ground**. *(NHS.)*
+  - **ASCIA** (Australasia) recommends introducing common allergens including sesame in the first year, ideally before 12 months. *(ASCIA — high-confidence; page blocked direct fetch, corroborated via independent summaries.)*
+- **The EAT nuance — sesame is null (frame honestly).** EAT (1,303 exclusively breastfed, general-population infants) randomised early introduction of six allergens including sesame vs standard ~6 months. The abstract states, verbatim: **"no significant effects with respect to milk, sesame, fish, or wheat."** *(Perkins/Lack, NEJM 2016, NEJMoa1514210; verified PubMed 26943128.)* The per-protocol benefit EAT *did* find was for **peanut and egg only**.
+  > ⚑ *The honest framing the model must hold:* early sesame is **SAFE** and there's no reason to delay — but **RCT evidence does not show early sesame prevents sesame allergy.** The "introduce early" advice for sesame is the general *don't-delay-allergens* principle (AAP/NHS/ASCIA), **not** a sesame-specific prevention result. Lead with "safe to introduce, no need to delay"; never with "introducing early will prevent the allergy."
+- **Regulatory weight — sesame is now a top-tier labeled allergen.** Under the **FASTER Act of 2021** (Food Allergy Safety, Treatment, Education, and Research Act), sesame became the **9th major US food allergen**; the mandatory labeling requirement took effect **January 1, 2023**. US packaged foods must now declare sesame plainly (e.g. "tahini (sesame)" or a "Contains sesame" statement). The **EU has long required** sesame declaration; the **US only since 2023.** *(US FDA — FASTER Act sesame page; FoodSafety.gov mirror — high-confidence; see Axis below + Verification.)*
+  > ⚑ *Scope limit — flag for the spec:* this labeling law is **US (and analogously EU) packaged-food regulation. It does NOT apply to Indian-bought packets or home foods.** A homemade til laddoo, a loose chutney, or an unlabeled Indian sweet carries no "Contains sesame" guarantee — the parent is the label.
+
+## Axis 2 — Safe FORM: the choking gate *(confidence: HIGH)*
+
+- **Two form hazards with sesame:** (1) a **thick glob of tahini** — sesame paste forms a sticky clump that can lodge in the airway, exactly the peanut-butter problem; (2) **whole sesame seeds given in quantity** — small, hard, easily inhaled. *(NHS "seeds, particularly sesame, served finely ground"; Solid Starts; mirrors NHS/AAP peanut-butter form rule.)*
+- **Safe forms (the gate the food passes through):**
+  1. **Smooth tahini (sesame paste), THINNED** — whisk **~⅛–½ tsp** into breast milk, formula, water, or an already-tolerated puree/yoghurt/dal/khichdi/curd/fruit puree until it's a thin, smooth consistency. *(Mirrors NHS/AAP peanut-butter ~¼ tsp form; Solid Starts.)*
+  2. **Finely ground sesame** stirred into food — ground to a fine meal, never left as whole seeds. *(NHS.)*
+  3. **NEVER** a thick glob/spoonful of paste straight up, and **never whole seeds in quantity** for a young infant.
+- **India-specific form note:** thin tahini into **dal, khichdi, curd, or fruit puree**; **avoid loose til shaken off laddoo/gajak** for a young infant — those carry whole seeds and a hard/sticky matrix that is both a choking risk and an uncontrolled first-exposure dose.
+- **This is the design crux:** the choking hazard is removable by FORM transformation (thin/grind), like peanut — *not* like honey (where cooking does not remove the spore hazard). The **allergy axis is separate and is NOT removed by form** — thinning the tahini makes it safe to swallow, not safe for an allergic child.
+
+## Axis 3 — Allergy watch-fors & what to do (the gravest emergency floor) *(confidence: HIGH)*
+
+- **Sesame is a leading cause of food-allergic anaphylaxis, and the allergy is usually lifelong.** Treat the first exposures and ongoing vigilance with the **most** seriousness of the four allergens — because, unlike egg/milk/soy/wheat, this one is very unlikely to be outgrown (Axis 5). *(J Asthma Allergy; JAMA Netw Open 2019.)*
+- **Mild–moderate reaction (one body system):** itchy **hives/welts**, redness or **rash**, **swelling** (esp. around the mouth/eyes), **vomiting**, sometimes loose stool/GI upset, sudden fussiness. *(Solid Starts.)*
+- **Severe / anaphylaxis (act immediately):** difficulty breathing, **wheeze/persistent cough/noisy breathing**, **swelling of the face/lips/tongue/throat**, hoarse cry or voice, **pale / floppy / lethargic** or unusually sleepy, collapse. In babies, *behaviour change* (suddenly limp, can't hold head up) is a recognised severe sign. *(Solid Starts; general anaphylaxis consensus.)*
+- **What to do:**
+  - **Mild, single-system:** stop the food, monitor closely, contact your doctor; an antihistamine may be advised by a clinician.
+  - **Any breathing difficulty, throat/face/tongue swelling, floppiness, or two body systems involved → emergency. Use an adrenaline auto-injector immediately if one has been prescribed, and call emergency services (112 / 108 in India).** *(Consensus.)*
+  - First exposures matter especially here: the very first taste may sensitise with the reaction on a later one — keep watching across the first several exposures, not just day one. And because sesame allergy is **usually permanent**, this vigilance does not "age out" the way it tends to for milk/egg.
+
+## Axis 4 — Culinary aliases & hidden sources *(confidence: HIGH on aliases; MODERATE on the oil-protein nuance)*
+
+- **Sesame hides under many names — a confirmed-allergic child's caregiver must recognise all of them:**
+  - **tahini** (sesame paste), **hummus** (tahini-based), **halva / halwa** (sesame variety), **til** and **til laddoo**, **gajak** (Indian sesame-jaggery brittle/sweet, peak season around **Makar Sankranti, mid-January**), **benne / benniseed**, **gomashio**, **goma** (Japanese), **sim sim**, and **gingelly oil (= sesame oil on South Asian labels).** *(Tahini/aliases; Solid Starts; culinary sources.)*
+  - **Hidden on/in:** sesame seeds on **breads, buns, crackers, bagels**, sprinkled in **chutneys**, baked into **sweets**, and in many **dressings/spice blends**.
+- **The sesame-oil nuance (do not over-simplify):** **highly refined sesame oil is largely de-proteinized and lower-risk.** **But cold-pressed / unrefined gingelly oil — common in Indian cooking — can retain allergenic protein.** *(Allergen consensus; mark as moderate-confidence.)*
+  > ⚑ *Do NOT assume "it's only oil, so it's safe"* for a confirmed sesame-allergic child. Refined oil ≠ unrefined gingelly oil; the unrefined oil prevalent in Indian kitchens can carry enough protein to react to. For a non-allergic baby this is not a barrier to introduction; for a *known-allergic* child, treat unrefined sesame/gingelly oil as a potential exposure.
+
+## Axis 5 — Persistence: the key tone point *(confidence: HIGH)*
+
+- **Sesame allergy is rarely outgrown.** Peer-reviewed data put resolution at roughly **20–30%** — meaning **~70–80% persists into adulthood.** *(J Asthma Allergy — sesame persistence; JAMA Netw Open 2019 — sesame prevalence/persistence.)*
+- **Contrast that makes the tone:** egg, milk, soy, and wheat allergies are **commonly outgrown** in childhood; **sesame, peanut, and tree nuts tend to be lifelong.** Sesame sits firmly in the *lifelong* camp and is a *leading anaphylaxis trigger.*
+- **Why this drives the model's tone:** for a commonly-outgrown allergen, a parent can reasonably expect the risk to fade. For sesame, the risk does **not** reliably fade — so the model's emergency floor, label-vigilance, and "carry the adrenaline plan" framing should be the **most serious of the four**, and should not soften over the toddler years the way it might for milk/egg.
+
+## Axis 6 — Indian & cultural context *(confidence: HIGH for cultural embedding; MODERATE for India-specific official guidance/prevalence)*
+
+- **Til is deeply embedded in the Indian diet** — **til laddoo, gajak, sesame chutneys, gingelly (sesame) oil** are everyday foods, with sesame sweets peaking around **Makar Sankranti (mid-January)**. Early, regular introduction is therefore culturally natural — the challenge is FORM (thin/grind) and first-exposure discipline, not novelty.
+- **Sesame is reportedly among the more common sensitizing allergens in India** — appears in Indian allergy literature/parenting sources; treat as directional, not a precise figure. *(Secondary / regional literature — flag as not a top-tier verbatim.)*
+- **The cultural double-edge:** because til is *everywhere* (sweets, oils, chutneys) and often **unlabeled** in home/loose form, an Indian family both (a) introduces sesame naturally and early, and (b) faces a harder *avoidance* task if the child turns out allergic — the US "Contains sesame" label does **not** appear on a homemade laddoo or a loose chutney. The parent is the label.
+  > ⚑ *Gap:* **No India-specific (IAP / MoHFW / FSSAI) sesame directive** — on early introduction *or* on labeling — was located. The early-introduction-and-don't-delay guidance is international (AAP/NHS/ASCIA); the 9th-allergen labeling law is **US (FASTER Act) and does not apply in India.** Do not launder either onto an Indian body's name.
+
+## Axis 7 — Myths to correct *(confidence: HIGH)*
+
+- **Myth: "Delay sesame to prevent the allergy."** **Don't delay.** Current guidance is to introduce sesame around 6 months and not hold it back; delaying is not protective. *(AAP names sesame directly; NHS; ASCIA.)* **But the corollary myth is also wrong** — see next — so frame this as "no reason to delay; it's safe," **not** "introduce early to prevent it."
+- **Myth: "Early sesame prevents sesame allergy (like peanut does)."** **Not proven.** The EAT trial found **"no significant effects with respect to milk, sesame, fish, or wheat"** — the prevention benefit was **peanut + egg only.** *(EAT, NEJM 2016; PubMed 26943128.)* Introduce early because it's safe and there's no reason to wait — **not** on a promise of prevention.
+- **Myth: "Sesame allergy is outgrown like egg/milk."** **No — usually lifelong.** Only ~20–30% outgrow it; ~70–80% persists into adulthood, and it's a leading anaphylaxis trigger. *(J Asthma Allergy; JAMA Netw Open 2019.)* This is the highest-value correction for sesame — it changes how seriously a family treats first exposures and ongoing label-reading.
+- **Myth: "Sesame oil is always safe (it's just oil)."** **Nuanced.** Highly refined sesame oil is largely de-proteinized and lower-risk, but **unrefined / cold-pressed gingelly oil — common in Indian cooking — can retain allergenic protein.** Don't assume oil is safe for a *confirmed-allergic* child. *(Allergen consensus.)*
+
+---
+
+## Source list
+
+| # | Authority | Tier | URL |
+|---|-----------|------|-----|
+| 1 | AAP / HealthyChildren — When to introduce egg, peanut butter & other allergens (names sesame; no-delay) | Official | https://www.healthychildren.org/English/healthy-living/nutrition/Pages/when-to-introduce-egg-peanut-butter-and-other-common-food-allergens-to-your-baby-food-allergy-prevention-tips.aspx |
+| 2 | UK NHS — Food allergies in babies & young children (seeds "particularly sesame" finely ground) | Official | https://www.nhs.uk/baby/weaning-and-feeding/food-allergies-in-babies-and-young-children/ |
+| 3 | ASCIA — Infant Feeding & Allergy Prevention *(401/403 to fetcher — corroborated indirectly)* | Official | https://www.allergy.org.au/hp/papers/infant-feeding-and-allergy-prevention |
+| 4 | NIAID — Food allergy guidelines for clinicians & patients | Official | https://www.niaid.nih.gov/diseases-conditions/guidelines-clinicians-and-patients-food-allergy |
+| 5 | US FDA — FASTER Act: sesame the 9th major food allergen *(401 to fetcher — corroborated indirectly)* | Official | https://www.fda.gov/food/food-allergies/faster-act-sesame-ninth-major-food-allergen |
+| 6 | FoodSafety.gov — FASTER Act 2021 (government mirror; corroborates 9th-allergen + Jan 1 2023) | Official | https://www.foodsafety.gov/blog/food-allergy-safety-treatment-education-and-research-act-2021 |
+| 7 | NEJM — Perkins/Lack et al., EAT trial (2016); **sesame-null** | Pivotal trial | (PubMed) https://pubmed.ncbi.nlm.nih.gov/26943128/ |
+| 8 | J Asthma Allergy — sesame allergy persistence (~20–30% resolve) | Peer-reviewed | https://pmc.ncbi.nlm.nih.gov/articles/PMC5414576/ |
+| 9 | JAMA Netw Open 2019 — sesame allergy prevalence/persistence | Peer-reviewed | https://pmc.ncbi.nlm.nih.gov/articles/PMC6681546/ |
+| 10 | Solid Starts — sesame (form, symptoms) | **Secondary (advocacy/commercial)** | https://solidstarts.com/foods/sesame/ |
+| 11 | Wikipedia — Tahini (culinary aliases) | **Secondary (encyclopedia)** | https://en.wikipedia.org/wiki/Tahini |
+
+### Verification status & gaps
+1. ✅ **EAT sesame-null** — **verified verbatim** from the primary trial via PubMed 26943128: *"no significant effects with respect to milk, sesame, fish, or wheat."* The peanut+egg per-protocol benefit does **not** extend to sesame. The strongest discipline in this brief: **do not claim early sesame prevents sesame allergy.**
+2. ✅ **Introduce-early / don't-delay** — corroborated by AAP (names sesame directly), NHS ("seeds, particularly sesame, served finely ground"), and ASCIA. This rests on **general don't-delay-allergens guidance**, not a sesame-specific RCT.
+3. ⚑ **FASTER Act — 9th major US allergen + Jan 1 2023 labeling** — **HIGH-CONFIDENCE-BUT-NOT-DIRECT-FETCH.** The **FDA page (#5) returned 401** to automated fetchers; the fact is corroborated across FDA indexed text, the **FoodSafety.gov government mirror (#6)**, and independent sources. Reliable, but flagged as not a clean primary-page fetch. **Scope:** US (and analogously EU) packaged-food labeling — **does NOT apply to Indian/home foods.**
+4. ⚑ **ASCIA page** — returned 401/403 to the fetcher; the infant-feeding stance (introduce common allergens incl. sesame in the first year) is corroborated via independent summaries, not a direct page read. Re-extract from the primary page before any verbatim ASCIA attribution.
+5. ✅ **Persistence ~20–30% resolve / ~70–80% persist; leading anaphylaxis trigger** — peer-reviewed (J Asthma Allergy; JAMA Netw Open 2019). This is the tone-setting fact: sesame is *lifelong*, unlike commonly-outgrown egg/milk/soy/wheat.
+6. ⚑ **Sesame-oil protein nuance** — refined oil largely de-proteinized vs. unrefined/cold-pressed gingelly oil retaining protein: allergen consensus, **moderate confidence**; not a single top-tier verbatim. Conservative line for a *confirmed-allergic* child: treat unrefined gingelly oil as a potential exposure.
+7. ⚑ **India-specific directive — GAP.** **No IAP / MoHFW / FSSAI sesame directive** (early-introduction or labeling) located. Early-introduction guidance is international; the 9th-allergen labeling law is US-only and **does not apply in India**. Do not attribute either to an Indian body.
+8. ⚑ **Secondary sources flagged explicitly:** Solid Starts (#10, advocacy/commercial) and Wikipedia/Tahini (#11, encyclopedia) are marked secondary — used for form specifics and culinary aliases, consistent with but not a substitute for the official/peer-reviewed tiers. "India among more common sensitizing allergens" is regional/secondary and directional only.

--- a/docs/research/soy-infant-safety.md
+++ b/docs/research/soy-infant-safety.md
@@ -1,0 +1,110 @@
+# Soy (Soya) — Infant Safety & Introduction Research Brief
+
+> **Purpose.** Evidence base for SproutLab's Care layer, feeding the *guided-introduction* food-effects model. Built to decide what to surface when a parent introduces **soy (soya)** to an under-2 — covering why to introduce early (don't delay an allergen), the safe FORM (tofu vs. choking-hazard whole edamame), and the **two distinct emergency branches** (IgE-allergy/anaphylaxis AND the delayed non-IgE **FPIES** reaction for which soy is a classic trigger). The food is not banned — and unlike peanut/egg, early introduction is **NOT proven to prevent** soy allergy. We frame honestly: safe to introduce early, prevention not established.
+> **Scope.** Soy as a food allergen and complementary food: tofu, edamame/soybeans, soy yoghurt, and the soya-protein products central to vegetarian Indian cooking (**soya chunks/granules/nuggets = TVP**). Infants ~6–12 months, choking note running to ~5 years. Family context: Indian, vegetarian — soya chunks and tofu are protein staples, not novelties. **Out of scope:** soy *infant formula* as a feeding choice (touched only to debunk the "soy not recommended" confusion — see Axis 1 & 6).
+> **Reviewer.** Research scout pass (for Maren, Governor of Care).
+> **Date.** 2026-06-01. **Status.** Research complete — *not yet wired into the app.*
+> **Method.** Multi-angle web fan-out → source fetch → adversarial cross-check → synthesis. Authorities: AAP/HealthyChildren, UK NHS, ASCIA (Australasia), US NIAID, WHO complementary-feeding; pivotal trial EAT (Perkins/Lack, NEJM 2016). Disease-specific clinical detail (FPIES, natural history) from CHOP, FARE, and a JACI natural-history paper — **flagged inline as secondary/clinical**. Preparation specifics rest on reputable secondary sources (Solid Starts, flagged inline) rather than a top-tier body's verbatim words.
+
+---
+
+## TL;DR (the parent-facing truth)
+
+- **Introduce early — but DON'T claim it prevents allergy.** Current consensus (AAP, NHS, ASCIA, NIAID): introduce major allergens, soy included, **around 6 months** alongside other solids, and **don't deliberately delay**. Soy is one of the US **"Big 9" major allergens**. *(AAP; NHS; ASCIA; NIAID.)* **BUT** — the headline prevention evidence (LEAP/EAT) is for peanut and egg. The **EAT trial found NO significant prevention effect for soy** (nor for milk, sesame, or fish). *(Perkins/Lack, NEJM 2016.)* So: *safe to introduce early; early introduction is not proven to stop soy allergy.* Do not borrow the peanut prevention claim.
+- **The soy-formula ≠ soy-food trap (read this first).** When you see "soy is **not recommended** for babies," it almost always means **soy infant formula as an allergy-prevention strategy** — NOT soy *foods* like tofu. NIAID/ASCIA do not endorse soy formula to prevent allergy; that has nothing to do with feeding a 7-month-old mashed tofu, which is fine. This is the single most common error in this topic. *(NIAID; ASCIA.)*
+- **There are TWO emergency branches, not one.** (1) **IgE allergy / anaphylaxis** — fast (minutes), hives/swelling/breathing trouble. (2) **FPIES** (Food Protein-Induced Enterocolitis Syndrome) — a **non-IgE** reaction that is **delayed (1–4 hours), with profuse repetitive vomiting + pallor/lethargy/dehydration, often NO hives**, frequently mistaken for a stomach bug; standard allergy tests come back **negative**. **Soy is a classic FPIES trigger.** *(CHOP — clinical secondary.)* The model must hold both branches.
+- **The crux on the food itself is FORM.** **Silken/soft tofu** (smushable) and **well-cooked mashed soybeans** are infant-safe. **Whole edamame and whole soybeans are a choking hazard** — round, firm, slippery: shell + mash at 6 months, halve from ~9 months. **Soy milk is NOT a breast-milk/formula substitute in year one.** *(Solid Starts — secondary; NHS form principles.)*
+- **Indian vegetarian context is central, not peripheral.** **Soya chunks/granules/nuggets (TVP — textured vegetable protein)** are everyday protein in vegetarian households — concentrated soy protein. Introduce soy first as **soft tofu or as a minor ingredient**, then work up; soya chunks are fine once tolerated (soften/mash for the youngest).
+- **Often outgrown.** Soy allergy affects ~**0.4%** of infants and is **commonly outgrown by ~age 3**, the majority by age 10. *(FARE; JACI natural history.)* "Soy allergy is permanent" is a myth.
+- **Watch the cross-reactivity.** Some **cow's-milk-protein-allergic (CMPA)** babies also react to soy — introduce soya as a **minor ingredient first**. Soy is also a **legume**, so there's some cross-sensitisation potential with peanut. *(FARE; clinical consensus.)*
+
+---
+
+## Axis 1 — Benefit & timing: introduce early, but prevention is NOT proven *(confidence: HIGH on "don't delay / safe early"; HIGH that prevention is unproven for soy)*
+
+- **Don't deliberately delay.** Mainstream guidance is that there is no benefit to delaying allergenic foods past ~6 months once the baby is ready, and delay may not help: introduce the common allergens — soy among them — **around 6 months**, alongside other first foods, **not before 4 months**. *(AAP/HealthyChildren; NHS; ASCIA.)*
+- **Soy is a recognised major allergen.** Soy is one of the US FDA **"Big 9"** major food allergens (alongside milk, egg, peanut, tree nuts, wheat, fish, shellfish, sesame), so it warrants the same single-allergen, watchful first-exposure care as the others. *(FARE; US allergen-labelling law.)*
+- **The prevention evidence does NOT cover soy — frame this honestly.** The trials that flipped the "delay" paradigm tested **peanut** (LEAP) and a 6-allergen panel (EAT). In **EAT** (1,303 exclusively breastfed general-population infants, early introduction of 6 allergens from 3 months vs ~6 months): the **per-protocol prevention benefit was significant for peanut and egg only**. **Soy showed no significant prevention effect** — and neither did milk, sesame, or fish. *(Perkins/Lack et al., NEJM 2016, NEJMoa1514210.)*
+  > ⚑ *The honest framing the model MUST use:* introducing soy early is **safe and appropriate**, and there's no reason to delay it — but we **cannot tell a parent that early soy prevents soy allergy**. That claim is true for peanut/egg, false-by-evidence for soy. Tier-2 allergen: *introduce-early because there's no reason not to and the diet benefits, NOT because an RCT proved prevention.* Conflating the two is the kind of over-claim Maren should reject.
+- **Why introduce at all, then?** Dietary value (soy is a complete plant protein — especially valuable in a vegetarian household), normal allergen exposure as part of a varied diet, and avoiding the downsides of unnecessary restriction. The reason is **nutrition + no-reason-to-avoid**, not proven prevention.
+
+## Axis 2 — Safe FORM: tofu vs. the edamame choking gate *(confidence: HIGH on the choking principle; MODERATE on exact age/size specifics — secondary-sourced)*
+
+- **Infant-safe forms (the gate the food passes through):**
+  1. **Silken or soft tofu**, in pieces a baby can mush with gums/fingers, or mashed/blended into other food. Soft tofu is one of the easier first proteins to offer by form. *(Solid Starts — tofu; secondary.)*
+  2. **Well-cooked, mashed soybeans**, or soy stirred into already-tolerated purées/porridge/dal.
+  3. **Soy yoghurt** (unsweetened) as a smooth vehicle.
+  4. **Soya chunks/granules** softened and finely mashed/minced once soy is tolerated (see Axis 5 for the Indian-staple detail).
+- **The choking hazard — whole edamame and whole soybeans.** Whole edamame beans and whole/firm soybeans are **round, firm, and slippery** — a classic choking shape for infants. **Shell and mash at ~6 months; from ~9 months offer halved/quartered** rather than whole, and only move toward whole beans well past toddlerhood when chewing is reliable. Never give a baby a handful of whole edamame. *(Solid Starts — edamame; secondary, consistent with NHS whole-food choking principles.)*
+  > ⚑ *Form removes the choking hazard but NOT the allergy hazard.* Mashing tofu/soybeans genuinely makes the food safe on the **choking** axis; it does nothing for the **allergy** axis (IgE or FPIES), which is managed by introduction + watchfulness. Two axes, held separately — same design crux as the peanut brief.
+- **Soy milk is NOT a milk substitute in year one.** Fortified soy *drink* is not a replacement for breast milk or infant formula as the main milk before 12 months. It can appear as an ingredient in food, but it is not a bottle drink for an infant. *(NHS milk-for-babies principles; ASCIA.)* (Distinct again from *soy infant formula* — see Axis 1 trap.)
+
+## Axis 3 — Emergency floor: the TWO branches *(confidence: HIGH on IgE/anaphylaxis from official bodies; MODERATE-clinical on FPIES, CHOP-sourced)*
+
+This food has **two separate reaction pathways**, and the parent response differs. The model must surface both — FPIES especially, because it presents with **no hives** and is routinely mistaken for gastroenteritis.
+
+**Branch A — IgE allergy (fast, minutes):**
+- **Mild–moderate (one body system):** itchy **hives/welts**, redness/rash, **swelling** (esp. mouth/eyes), **vomiting**, sometimes loose stool, sudden fussiness. In infants, reactions skew toward **skin + GI**, with breathing signs **less** prominent than in older children. *(NHS food allergies; Solid Starts — secondary for the infant-pattern detail.)*
+- **Severe / anaphylaxis (act immediately):** **difficulty breathing / wheeze / noisy breathing / persistent cough**, **swelling of the throat/tongue/lips/face**, **pale or blue** colour, hoarse cry, **floppy/limp/lethargic** or unusually sleepy, collapse. *(NHS anaphylaxis.)*
+  - **Action:** **use an adrenaline auto-injector immediately if prescribed, and call emergency services (112 / 108 in India; 999 UK; 911 US).** Lie the child flat (or sit up if breathing is hard); do not stand them up. *(NHS anaphylaxis.)*
+
+**Branch B — FPIES (delayed, non-IgE — soy is a classic trigger):**
+- **What it is:** Food Protein-Induced Enterocolitis Syndrome — a **non-IgE** food reaction affecting the gut. **Standard allergy tests (skin-prick, sIgE) are typically negative**, which is why it's missed. *(CHOP — clinical secondary.)*
+- **Presentation:** **delayed — typically 1–4 hours after eating** — with **profuse, repetitive (projectile) vomiting**, then **lethargy, pallor**, and risk of **dehydration**; sometimes diarrhoea later. **Often NO hives, NO swelling, NO breathing trouble** — which is exactly what makes it look like a stomach bug. *(CHOP — clinical secondary.)*
+- **Most common triggers:** **cow's milk, soy, rice, oats** are the classic FPIES foods. *(CHOP — clinical secondary.)*
+- **Action:** repetitive vomiting + a pale/floppy/lethargic baby a couple of hours after a soy feed is a reason for **urgent medical care even without any rash** — severe FPIES episodes can cause dehydration/shock and may need IV fluids. Tell the clinician *what was eaten and when*, because the delay is the diagnostic clue. *(CHOP — clinical secondary.)*
+  > ⚑ *Design note for the model:* a hives-centric allergy card will **miss FPIES entirely**. The soy record needs a distinct "delayed vomiting + lethargy, no rash" branch that routes to urgent care, separate from the IgE/anaphylaxis branch. This is the most important soy-specific safety insight in this brief.
+
+## Axis 4 — Culinary aliases & hidden sources *(confidence: HIGH on the alias list; MODERATE on label-exemption specifics)*
+
+Soy hides under many names — vital for a family reading labels and for the model's ingredient resolver:
+
+- **Whole-food / fermented:** tofu (bean curd), **edamame** (immature soybeans), soybeans, **soya chunks / granules / nuggets** = **TVP / textured vegetable protein** (concentrated, defatted soy protein — heavy in Indian veg cooking), **miso**, **natto**, **tempeh**, soy/soya flour.
+- **Liquids & condiments:** **soy milk / soya drink**, **soy sauce**, **tamari** (note: soy sauce/tamari also commonly carry **wheat** — a separate allergen flag).
+- **Additives (usually tolerated, but label-listed):** **soy lecithin** (an emulsifier in chocolate, baked goods — *most soy-allergic individuals tolerate it*, but it is a soy-derived ingredient); soy protein isolate/concentrate.
+- **Label-exemption nuance:** in the US, **highly refined soybean oil** is **exempt** from major-allergen labelling (the refining removes the protein), so it may not be flagged as "soy" on a US label. Cold-pressed/expeller/unrefined soybean oil is **not** exempt. *(US allergen-labelling law via FARE.)*
+  > ⚑ *Flag for the resolver:* "no soy listed" on a US label does **not** guarantee soy-oil-free; and "soy lecithin" present does **not** mean a soy-allergic child will react (usually tolerated). Don't auto-escalate lecithin; do surface TVP/soya chunks as full soy protein.
+
+## Axis 5 — Indian & vegetarian context *(confidence: HIGH for staple status + cultural prep; see Axis 6 GAP for India-specific official guidance)*
+
+- **Soya is a protein backbone of vegetarian Indian households.** **Soya chunks/granules/nuggets (TVP)** — rehydrated into curries, pulao, kheema-style dishes — are an everyday, affordable, concentrated plant protein. **Tofu** and soy milk are increasingly common. In a vegetarian diet (no meat/fish protein), soy is a high-value complete protein, which makes early, regular introduction both natural and nutritionally useful.
+- **Introduce in soft/tofu form first, then build up.** Start soy as **soft/silken tofu** or as a **minor ingredient** mashed into an already-tolerated dish (see the CMPA cross-reactivity note below for *why* minor-ingredient-first), watch the first exposures, then progress to **softened, finely-mashed soya chunks/granules** once tolerated. The youngest infants should get soya chunks softened and mashed/minced, never as firm chewy pieces (texture + the legume's density).
+- **Cross-reactivity to introduce carefully around:**
+  - **Soy ↔ CMPA:** some **cow's-milk-protein-allergic** babies also react to soy protein. If there's known CMPA, introduce soy cautiously as a **minor ingredient first** and consider a paediatrician's input. *(FARE; clinical consensus.)*
+  - **Legume cross-sensitisation:** soy is a **legume**, like peanut — there is some cross-sensitisation potential, though a positive test ≠ clinical allergy. Treat soy as its own allergen, introduced on its own day for attribution. *(FARE; clinical consensus.)*
+
+## Axis 6 — Myths to correct *(confidence: HIGH)*
+
+- **Myth: "Soy is not recommended for babies."** **Conflation.** This refers to **soy infant formula as an allergy-prevention strategy**, which bodies like NIAID/ASCIA do not endorse — **NOT** soy *foods* (tofu, mashed soybeans, soya chunks), which are fine to introduce around 6 months. The model should actively separate "soy formula (a milk choice)" from "soy food (a complementary food)." *(NIAID; ASCIA.)* **Highest-value myth on this topic.**
+- **Myth: "Soy allergy is permanent / lifelong."** **Usually false.** Soy allergy affects ~**0.4%** of infants and is **commonly outgrown — many by ~age 3, the majority by age 10**. It behaves more like milk/egg (often outgrown) than peanut/tree nut (often lifelong). *(FARE; JACI natural-history paper.)*
+- **Myth: "Introduce soy early to prevent soy allergy" (the over-claim in the other direction).** **Not proven.** The prevention evidence is peanut/egg; **EAT found no significant effect for soy**. Introduce early because it's safe and nutritious and there's no reason to delay — **not** on a prevention promise. *(Perkins/Lack, NEJM 2016.)*
+- **Myth: "Soy lecithin will trigger a soy-allergic child."** **Usually not.** Most soy-allergic individuals tolerate soy lecithin (negligible residual protein); it's still label-listed, so don't auto-panic on its presence. *(FARE.)*
+
+---
+
+## Source list
+
+| # | Authority | Type | URL |
+|---|-----------|------|-----|
+| 1 | AAP / HealthyChildren — When to introduce egg, peanut butter & other allergens (don't delay; ~6 mo) | Official | https://www.healthychildren.org/English/healthy-living/nutrition/Pages/when-to-introduce-egg-peanut-butter-and-other-common-food-allergens-to-your-baby-food-allergy-prevention-tips.aspx |
+| 2 | UK NHS — Food allergies in babies & young children (signs; introduction) | Official | https://www.nhs.uk/baby/weaning-and-feeding/food-allergies-in-babies-and-young-children/ |
+| 3 | UK NHS — Anaphylaxis (severe-reaction signs + action) | Official | https://www.nhs.uk/conditions/anaphylaxis/ |
+| 4 | NIAID — Addendum Guidelines for Prevention of Peanut Allergy (2017); soy-formula context | Official | https://www.niaid.nih.gov/sites/default/files/addendum-peanut-allergy-prevention-guidelines.pdf |
+| 5 | ASCIA — Infant Feeding for Food Allergy Prevention | Official | https://www.allergy.org.au/hp/papers/infant-feeding-and-allergy-prevention |
+| 6 | WHO — Complementary feeding of infants & young children 6–23 months (2023) | Official | https://www.ncbi.nlm.nih.gov/books/NBK596423/ |
+| 7 | NEJM — Perkins/Lack et al., EAT trial (2016); soy = no significant prevention effect | Primary trial | https://pubmed.ncbi.nlm.nih.gov/26943128/ |
+| 8 | FARE — Soy allergy (prevalence ~0.4%; outgrown; allergen status; lecithin) | Secondary (advocacy/clinical) | https://www.foodallergy.org/living-food-allergies/food-allergy-essentials/common-allergens/soy |
+| 9 | JACI — Natural history of soy allergy (outgrowth by age 3/10) | Secondary (clinical literature) | https://www.jacionline.org/article/S0091-6749(10)00007-2/fulltext |
+| 10 | CHOP — Food Protein-Induced Enterocolitis Syndrome (FPIES): delayed vomiting, triggers, negative tests | Secondary (clinical) | https://www.chop.edu/conditions-diseases/food-protein-induced-enterocolitis-syndrome-fpies |
+| 11 | Solid Starts — Edamame (choking-by-form; shell + mash) | Secondary (prep) | https://solidstarts.com/foods/edamame/ |
+| 12 | Solid Starts — Tofu (soft/silken first form) | Secondary (prep) | https://solidstarts.com/foods/tofu/ |
+
+### Verification status & gaps
+1. ✅ **"Introduce early / don't delay ~6 mo"** — corroborated across AAP, NHS, ASCIA, NIAID for major allergens generally; soy is a recognised major allergen (FARE / Big 9).
+2. ✅ **EAT null result for soy** — soy (with milk, sesame, fish) showed **no significant prevention effect**; benefit was peanut + egg only. The "early soy prevents soy allergy" claim is **not** supported — flagged so the model never borrows the peanut prevention frame for soy.
+3. ✅ **Soy formula ≠ soy food** — the "soy not recommended" caution is about **soy infant formula as prevention**, not tofu/soy foods. Treated as the headline myth; sourced to NIAID/ASCIA framing.
+4. ⚑ **FPIES detail is clinical-secondary (CHOP)** — the delayed-vomiting / lethargy-pallor / negative-test / cow's-milk-soy-rice-oats-triggers picture is well-established clinically but is **CHOP-sourced, not from a patient-facing top-tier body's verbatim allergen page**. Marked clinical secondary; the *existence* of a delayed non-IgE branch is not in doubt, but verbatim timings (1–4 h) should be re-confirmed against an official allergy body before going to parents as a hard number.
+5. ⚑ **Prevalence ~0.4% & outgrowth ages (3 / 10)** — FARE + JACI natural-history sourced (secondary/clinical), not a regulator figure; directionally robust (soy is commonly outgrown), exact percentages are literature-derived.
+6. ⚑ **Form specifics (shell+mash at 6 mo, halve at 9 mo; silken-tofu-first)** — **Solid Starts** (secondary prep source), consistent with NHS whole-food choking principles but not a top-tier body's verbatim age/size standard. Flagged as practice-level.
+7. ⚑ **US soybean-oil label exemption & lecithin tolerance** — US-labelling-law specific (via FARE); applies to US labels, **not** Indian labelling. Don't present as a universal rule.
+8. ⚑ **No India-specific official soy / allergen-introduction directive (the honest gap).** **No IAP / MoHFW / FSSAI directive on allergen introduction *or* on soy for infants was located.** The **IAP complementary-feeding parental guideline does not mention soy or allergen introduction at all.** The early-introduction guidance here is **entirely international** (AAP/NHS/ASCIA/NIAID); the Indian vegetarian context (soya chunks/tofu as staples) is cultural/nutritional, not government-issued. **Do not manufacture or attribute any Indian official soy/allergen guidance** — there is none to cite, and laundering international guidance onto an Indian body's name would repeat the error the peanut/honey briefs warn against.

--- a/docs/research/wheat-infant-safety.md
+++ b/docs/research/wheat-infant-safety.md
@@ -1,0 +1,122 @@
+# Wheat — Infant Safety & Introduction Research Brief
+
+> **Purpose.** Evidence base for SproutLab's Care layer, feeding the *guided-introduction* food-effects model. Built to decide what to surface when a parent introduces **wheat** to an infant — covering why to introduce early (don't delay), the honest limit on the prevention claim, and the **three-way conceptual split** that wheat uniquely forces: *wheat allergy* (IgE), *celiac disease* (autoimmune), and *gluten-introduction timing* (a celiac-prevention question). Wheat is a TIER-2 allergen: **introduce-early but prevention is NOT RCT-proven.** The food is not gated by form alone; it is gated by *clarity* — keeping three things that look like one thing apart.
+> **Scope.** Wheat as an infant food and allergen. Infant ~6–12 months. Family context: Indian — **wheat/atta/roti/dalia/suji are everyday staples**, not novelties; the household eats wheat at most meals. Celiac and adult WDEIA noted only to keep them *separated* from the infant-allergy question, not as infant management targets.
+> **Reviewer.** Research scout pass (for Maren, Governor of Care).
+> **Date.** 2026-06-01. **Status.** Research complete — *not yet wired into the app.*
+> **Method.** Multi-angle source fetch → adversarial cross-check → synthesis, with the EAT and ESPGHAN primary records as the spine. Authorities: AAP/HealthyChildren, UK NHS, ASCIA (Australasia), US NIAID, WHO; pivotal trial EAT (Perkin/Lack, NEJM 2016, PubMed 26943128); celiac position paper ESPGHAN 2016 (PubMed 26815017). **Note:** the EAT wheat-null result and the ESPGHAN gluten-timing window are verified verbatim from their PubMed abstracts; preparation/form specifics and culinary-alias coverage rest on reputable secondary sources (Solid Starts, CHOP, Mayo, FARE, FAACT), flagged inline. **No India-specific (IAP/MoHFW) early-allergen or wheat directive was located** — see gap.
+
+---
+
+## TL;DR (the parent-facing truth)
+
+- **Introduce wheat early — around 6 months — and don't delay it.** Wheat is one of the common infant allergens, and current consensus is the same as for the other allergens: introduce around 6 months alongside other solids, don't hold it back. Delaying allergens does not prevent allergy. *(AAP; NHS — lists "foods containing gluten (wheat, barley, rye)" among the allergens to introduce; ASCIA; NIAID.)*
+- **BUT — do NOT claim early wheat *prevents* wheat allergy.** This is the honest limit and the reason wheat is TIER-2, not TIER-1. The EAT trial tested early wheat directly and found **"no significant effects… with respect to milk, sesame, fish, or wheat."** The trial's prevention benefit was real **only for peanut and egg.** Early wheat was *safe* and is *fine to give early* — it just was **not shown to prevent wheat allergy.** *(Perkin/Lack, NEJM 2016; PubMed 26943128.)*
+- **Three things wear the word "wheat" — keep them rigorously apart.** (1) **Wheat allergy** = an IgE immune reaction to wheat *proteins* (hives, vomiting, anaphylaxis — fast). (2) **Celiac disease** = a chronic *autoimmune* reaction to *gluten* — NOT an allergy, NOT anaphylactic. (3) **Gluten-introduction timing** = a celiac-prevention question, separate from allergy. Wheat sits in all three conversations because it contains gluten — that overlap is exactly the source of parent confusion this brief exists to defuse.
+- **Celiac is not an emergency and is not "wheat allergy."** It's a chronic, medically-diagnosed condition (poor growth, chronic GI), not a 112-call event. Conflating it with wheat allergy is the central myth.
+- **The Indian context is a gift and a trap.** Wheat is already in the diet daily (roti, dalia, suji, sevai), so introduction is culturally trivial — softened **roti/chapati pieces**, soft cooked suji/dalia, well-cooked pasta are near-ideal forms. The trap is the **alias thicket**: atta, maida, suji/rava, dalia, sevai, seitan, even soy sauce all *are* wheat, and fresh Indian staples carry no allergen label — so caregiver alias-knowledge is the safeguard, not the package.
+- **ESPGHAN reversed the breastfeeding advice.** Neither breastfeeding nor breastfeeding-during-gluten-introduction reduces celiac risk (this reverses 2008 advice). Gluten may be introduced anytime **4–12 months**; timing does not change lifetime celiac incidence, only *when* it presents. Large quantities of gluten should be avoided in the first weeks and during infancy. *(ESPGHAN 2016; PubMed 26815017.)*
+
+---
+
+## Axis 1 — The benefit & timing: introduce ~6 months, don't delay *(confidence: HIGH on "introduce early / don't delay"; the prevention claim is explicitly NOT supported — see the EAT null)*
+
+- **Introduce around 6 months, with other solids, once the baby is developmentally ready.** Wheat is named among the common infant allergens and is handled like the others: offer early, don't delay, keep it in the diet. The NHS explicitly lists **"foods containing gluten, including wheat, barley and rye"** among the allergenic foods to introduce from around 6 months, one at a time. *(NHS; AAP; ASCIA; NIAID 2017 addendum framing for early allergen introduction generally.)*
+- **Delaying does not help.** The general early-introduction consensus — that delaying allergenic foods does not prevent allergy — applies to wheat as a member of the allergen set. There is no benefit to holding wheat back past ~6 months in a baby who is ready for solids. *(AAP; NHS; ASCIA.)*
+- **⚑ The honest limit — EAT found NO wheat benefit.** The EAT trial (Perkin/Lack, NEJM 2016) randomised general-population breastfed infants to early introduction of six allergens (including wheat) vs standard introduction. Its abstract states, verbatim:
+  > *"…there were no significant effects with respect to milk, sesame, fish, or wheat."*
+  The trial's prevention benefit was confined to **peanut and egg** (and only in the per-protocol, dose-achieving analysis). **Early wheat was safe but did not prevent wheat allergy.** *(Verified — PubMed 26943128.)*
+  > ⚑ *Design consequence:* the model must say "introduce wheat early — it's safe, don't delay" **without** saying "early wheat prevents wheat allergy." That second claim is unproven and EAT is the direct evidence against it. This is the TIER-2 distinction: the *introduce-early* posture stands on safety + the don't-delay consensus, **not** on a proven prevention RCT the way peanut stands on LEAP.
+- **No India-specific directive.** No IAP/MoHFW early-introduction or wheat guidance was located; the "introduce ~6mo, don't delay" posture is borrowed from AAP/NHS/ASCIA/NIAID and is culturally compatible with a wheat-staple Indian diet. *(See gap.)*
+
+## Axis 2 — Wheat allergy vs celiac vs gluten-timing: the three-way split *(confidence: HIGH — this is the spine of the brief)*
+
+This is the single most important axis. Wheat is the one infant food where three distinct medical concepts collide under one word, and conflating them produces both needless fear and genuine error. Keep them labelled.
+
+- **(1) Wheat allergy — an IgE food allergy.** An immune (IgE) reaction to wheat *proteins*. Presents like other food allergies: rapid hives, swelling, vomiting, GI upset, eczema flare, and at the severe end anaphylaxis. **This is the "introduce-early" target** and the subject of Axes 1, 3, and 4. Commonly **outgrown** by early childhood. *(AAP; CHOP; Mayo; FARE.)*
+- **(2) Celiac disease — a chronic autoimmune condition.** A chronic *autoimmune* reaction to **gluten** (the protein in wheat, barley, and rye), not an allergy and **not anaphylactic**. Presents chronically — poor growth, chronic diarrhoea/GI symptoms, failure to thrive — and requires **medical diagnosis** (serology + specialist), not an at-home watch-and-wait. **Celiac is NOT an emergency.** It is genuinely a different disease that happens to involve the same grain. *(ESPGHAN 2016; general celiac consensus.)*
+- **(3) Gluten-introduction timing — a celiac-prevention question.** *When* to introduce gluten is debated **in the celiac literature**, separate from the allergy question. The ESPGHAN 2016 position paper (a **celiac** document, not an allergy one) concludes:
+  - **"Gluten may be introduced into the infant's diet anytime between 4 and 12 completed months of age."**
+  - Age of introduction **does not change lifetime celiac incidence** — earlier vs later only shifts **when** celiac presents, not whether it occurs.
+  - **Breastfeeding reversal:** ESPGHAN now states that **neither breastfeeding nor breastfeeding at the time of gluten introduction reduces the risk of celiac disease** — explicitly *reversing* the 2008 advice that recommended introducing gluten while still breastfeeding.
+  - **"Consumption of large quantities of gluten should be avoided during the first weeks after gluten introduction and during infancy."**
+  *(Verified — PubMed 26815017.)*
+- **Why wheat sits in both conversations:** wheat contains gluten, so it is simultaneously an *allergen* (wheat protein → IgE allergy) and the *vehicle for gluten* (→ celiac). A parent hearing "introduce wheat early" and "be careful about gluten timing" is hearing two different bodies answering two different questions. The model's job is to **answer each in its own lane and never let one borrow the other's authority.**
+  > ⚑ *Practical reconciliation for ~6-month introduction:* both lanes agree wheat/gluten can begin around 6 months — the allergy lane says "introduce early, don't delay," and the celiac lane (ESPGHAN) says "anytime 4–12 months, and avoid large quantities early." These are compatible: introduce wheat around 6 months in ordinary food-sized amounts, not in a gluten-loading binge.
+
+## Axis 3 — Safe FORM: texture & choking *(confidence: HIGH on forms; choking-form cautions partly secondary, flagged)*
+
+Unlike whole nuts, wheat is not intrinsically a hard-choke food — but specific wheat *forms* carry texture hazards a caregiver should pre-empt.
+
+- **Good first forms (soft, infant-friendly):**
+  - **Soft wheat / multigrain infant cereal** — smooth, easy to dose, mix to a thin porridge. *(Solid Starts; general consensus.)*
+  - **Well-cooked pasta** — cooked soft (past al dente), large pieces the baby can gum, or small soft pieces. *(Solid Starts.)*
+  - **Softened roti / chapati pieces** — torn small and **soaked in milk, dal, or sabzi** until soft and pliable. This is the culturally native form and a near-ideal one. *(Secondary / culturally derived; consistent with soft-form guidance.)*
+  - **Cream-of-wheat / suji (sooji/rava) / dalia (broken wheat)** — cooked soft to a smooth or well-mashed porridge consistency. *(Secondary; consistent with cereal-form guidance.)*
+- **Choking cautions — two specific wheat traps:**
+  1. **Fresh soft bread balls up into a sticky clump** in a baby's mouth and can lodge — a known hazard. **Mitigation: toast it** (toast or firm bread strips don't gum together the way fresh soft bread does), or offer firm bread strips rather than squishy fresh slices. *(Solid Starts — bread; flagged secondary but well-established.)*
+  2. **Loose cooked wheat / dalia / suji scatters** — dry, loose grains can be inhaled/scatter rather than form a manageable bolus. **Mitigation: cook it soft and mash or bind** it (into porridge, with milk/dal) so it holds together. *(Secondary; consistent with loose-grain caution.)*
+  > ⚑ *Form note vs the nut brief:* with wheat, **form addresses choking, not allergy** — same principle as nuts. Cooking/softening does **not** remove the allergy hazard or the celiac relevance; a baby with wheat-protein allergy will react to soft well-cooked roti just as to bread. Form is the choking lane only.
+
+## Axis 4 — Emergency floor: IgE reaction vs anaphylaxis (and celiac is NOT here) *(confidence: HIGH)*
+
+- **Mild–moderate IgE reaction (single body system):** itchy **hives/welts**, redness or **rash**, **swelling** (especially around the mouth/eyes), **vomiting**, GI upset/loose stool, **eczema flare**, sudden fussiness. *(CHOP; Mayo; FARE; FAACT.)*
+- **Severe / anaphylaxis (act immediately):** **difficulty breathing**, wheeze/persistent cough/noisy breathing, **swelling of the throat/tongue/lips/face**, hoarse cry, **pale / floppy / lethargic** or unusually sleepy, collapse. In a baby, sudden behaviour change (limp, can't hold head up) is a recognised severe sign. **Two or more body systems involved = treat as anaphylaxis.** *(FAACT; FARE; consensus.)*
+- **What to do:**
+  - **Mild, single-system:** stop the food, monitor closely, contact your doctor; a clinician may advise an antihistamine.
+  - **Any breathing difficulty, throat/tongue/face swelling, floppiness, or two body systems → emergency. Use a prescribed adrenaline auto-injector immediately and call emergency services (112 / 108 in India).**
+- **⚑ Celiac is explicitly NOT an emergency.** Celiac disease is **chronic**, not acute — it does not cause anaphylaxis and is **not** a 112/108 event. It presents over weeks/months (poor growth, chronic GI) and needs **medical diagnosis**, not emergency response. The model must not let celiac symptoms ride the allergy-emergency rail, and must not let a parent worried about celiac think they're watching for anaphylaxis. *(ESPGHAN; celiac consensus.)*
+  > ⚑ *Aside — WDEIA (wheat-dependent exercise-induced anaphylaxis)* is an **adult/adolescent** phenomenon (anaphylaxis triggered by wheat + exercise). It is **not relevant to infants** and is mentioned here only so it isn't mistaken for an infant wheat-allergy pattern. Do not surface it in infant-facing copy except to rule it out.
+
+## Axis 5 — Culinary aliases & hidden sources: the alias thicket *(confidence: HIGH on the alias list; label-regime specifics flagged)*
+
+Wheat hides under many names — and in an Indian kitchen, much of it is in **unlabeled fresh-made** food. Caregiver alias-knowledge is the real safeguard.
+
+- **Core flours & forms:** atta (wholewheat), maida (refined wheat flour), **semolina / suji / sooji / rava**, **broken wheat / dalia**, **sevai / vermicelli**, durum, farina, couscous, bulgur, **seitan (= wheat gluten)**, **soy sauce (typically contains wheat)**. *(FARE; FAACT; CHOP.)*
+- **Related wheat grains (often missed):** spelt, kamut, einkorn, emmer, farro, triticale — all contain wheat/gluten and are not "wheat-free." *(FARE; FAACT.)*
+- **Indian staples that ARE wheat:** roti, chapati, paratha, naan, **pav**, upma (suji), halwa (suji/atta), samosa & pakora batter/wrapper, **rusks and biscuits**, sevai/vermicelli dishes. A wheat-allergic or celiac-relevant child encounters wheat across most of a typical Indian menu — alias literacy is essential, not optional.
+- **⚑ Label-regime divergence (flag for the spec):**
+  - **US** declares the allergen as **"wheat"** plainly.
+  - **EU / UK** declare it as **"cereals containing gluten"** (so a label may say "gluten" not "wheat").
+  - **India (FSSAI)** requires a **gluten-cereal declaration on PACKAGED food** — but **fresh, unpackaged Indian staples (roti, dalia from the local chakki, restaurant/street food) carry no allergen label at all.**
+  - **Consequence:** in the Indian context the package label is the *weakest* safeguard because so much wheat intake is fresh and unlabeled. The model should lean on **caregiver alias-knowledge** (knowing suji, maida, dalia, sevai, seitan, soy sauce all = wheat) rather than on label-reading. *(FSSAI labelling regime; FARE/FAACT alias lists — label-regime specifics flagged as needing primary-FSSAI confirmation before any verbatim citation.)*
+
+## Axis 6 — Myths to correct *(confidence: HIGH)*
+
+- **Myth: "Delay wheat to prevent allergy."** **No.** Delaying does not prevent allergy; introduce around 6 months and don't hold it back. *(AAP; NHS; ASCIA.)* (Note the honest companion truth: early wheat also wasn't *shown* to prevent allergy — EAT was null — so the correct line is "introduce early because it's safe and delaying has no benefit," not "introduce early to prevent allergy.")
+- **Myth: "Wheat allergy and gluten intolerance / celiac are the same thing."** **They are NOT.** Wheat allergy is a fast IgE immune reaction to wheat protein; celiac is a chronic autoimmune reaction to gluten, diagnosed medically and never anaphylactic. Treating them as one causes both false alarms (fearing anaphylaxis over a chronic condition) and false reassurance (dismissing chronic poor-growth as "just a mild allergy"). *(ESPGHAN; CHOP; Mayo; AAP.)*
+- **Myth: "You must introduce gluten *while breastfeeding* to prevent celiac."** **Withdrawn.** ESPGHAN's 2016 position paper reversed this: **neither breastfeeding nor breastfeeding at the time of gluten introduction reduces celiac risk.** The old 2008 advice no longer stands. *(ESPGHAN 2016; PubMed 26815017.)*
+  > ⚑ This myth is high-value to surface because it's *stale official advice*, not folklore — a relative or older resource may still cite the 2008 line. Name the reversal explicitly.
+
+---
+
+## Source list
+
+| # | Authority | Type | URL |
+|---|-----------|------|-----|
+| 1 | NEJM / PubMed — Perkin, Lack et al., **EAT trial (2016)** — "no significant effects… with respect to milk, sesame, fish, or wheat" | Primary (RCT) | https://pubmed.ncbi.nlm.nih.gov/26943128/ |
+| 2 | **ESPGHAN 2016** gluten introduction position paper (4–12mo window; breastfeeding reversal; avoid-large-quantities-early) — *a celiac document* | Primary (position paper) | https://pubmed.ncbi.nlm.nih.gov/26815017/ |
+| 3 | AAP / HealthyChildren — When should I introduce wheat into my baby's diet? (wheat allergy commonly outgrown) | Official body | https://www.healthychildren.org/English/tips-tools/ask-the-pediatrician/Pages/When-should-I-introduce-wheat-into-my-babys-diet.aspx |
+| 4 | NIAID (2017) — early allergen introduction addendum framing | Official body | https://pmc.ncbi.nlm.nih.gov/articles/PMC5226648/ |
+| 5 | UK NHS — Food allergies in babies & young children (lists "foods containing gluten — wheat, barley, rye") | Official body | https://www.nhs.uk/conditions/baby/weaning-and-feeding/food-allergies-in-babies-and-young-children/ |
+| 6 | ASCIA — Infant feeding & allergy prevention | Official body | https://www.allergy.org.au/hp/papers/infant-feeding-and-allergy-prevention |
+| 7 | WHO — Complementary feeding of infants & young children 6–23 months | Official body | https://www.ncbi.nlm.nih.gov/books/NBK596423/ |
+| 8 | Solid Starts — Wheat | Secondary | https://solidstarts.com/foods/wheat/ |
+| 9 | Solid Starts — Bread (toast vs soft-bread choking caution) | Secondary | https://solidstarts.com/foods/bread/ |
+| 10 | CHOP — Wheat allergy | Secondary | https://www.chop.edu/conditions-diseases/wheat-allergy |
+| 11 | Mayo Clinic — Wheat allergy (symptoms & causes) | Secondary | https://www.mayoclinic.org/diseases-conditions/wheat-allergy/symptoms-causes/syc-20378897 |
+| 12 | FARE — Wheat (allergen profile; aliases) | Secondary (advocacy) | https://www.foodallergy.org/living-food-allergies/food-allergy-essentials/common-allergens/wheat |
+| 13 | FAACT — Wheat (top allergen; aliases) | Secondary (advocacy) | https://www.foodallergyawareness.org/food-allergy-and-anaphylaxis/food-allergens/wheat/ |
+
+### Verification status & gaps
+
+1. ✅ **EAT wheat-null** — verified verbatim from the PubMed abstract (26943128): *"no significant effects… with respect to milk, sesame, fish, or wheat."* The trial's benefit was peanut + egg only. **Do not attribute wheat-allergy prevention to early introduction.**
+2. ✅ **ESPGHAN 2016 gluten window & reversals** — verified from the PubMed abstract (26815017): 4–12-month window; age of introduction shifts presentation not lifetime incidence; **breastfeeding (and breastfeeding-during-introduction) reversal of 2008 advice**; avoid large gluten quantities in the first weeks and during infancy. This is a **celiac** document — cite it only in the celiac/gluten-timing lane, never as allergy-prevention evidence.
+3. ✅ **NHS allergen listing** — NHS names "foods containing gluten (wheat, barley, rye)" among allergens to introduce around 6 months, one at a time.
+4. ✅ **Wheat allergy commonly outgrown** — AAP-supported; corroborated by CHOP/Mayo/FARE.
+5. ⚑ **Choking-form cautions (soft-bread clump; loose-grain scatter)** — drawn from Solid Starts (secondary). Well-established and consistent with general infant-feeding guidance, but not a top-tier body's verbatim rule. Flagged as secondary.
+6. ⚑ **Softened-roti / suji / dalia forms** — culturally derived and consistent with soft-cereal guidance, but not issued by an official body for the Indian context. Secondary/derived.
+7. ⚑ **FSSAI label-regime claim** — the US "wheat" vs EU/UK "cereals containing gluten" vs India "FSSAI gluten-cereal declaration on packaged food; fresh staples unlabeled" framing should have the FSSAI labelling rule confirmed against the primary FSSAI regulation before any verbatim citation. The *operational* conclusion (caregiver alias-knowledge is the safeguard for unlabeled fresh staples) stands regardless.
+8. ⚑ **No India-specific (IAP / MoHFW) early-allergen or wheat directive located.** Indian practice borrows AAP/ASCIA/NIAID. The "introduce ~6mo, don't delay" posture is well-sourced internationally and culturally compatible with a wheat-staple diet, but is **not** an Indian-government-issued rule. Never launder international guidance onto an Indian body's name.
+9. ⚑ **WDEIA** — adult/adolescent, not infant-relevant; included only to keep it separated from infant wheat allergy. Do not surface in infant copy except to rule out.
+10. 🚫 **Hard line — no overclaim.** The brief must not state, imply, or let the model infer that early wheat introduction *prevents* wheat allergy. The introduce-early posture rests on safety + the don't-delay consensus (TIER-2), not on a prevention RCT (which, for wheat, was null).


### PR DESCRIPTION
## Phase δ research — egg, soy, wheat, sesame infant-safety briefs

Deep-research pass on the four remaining big-9 allergens, the evidence base for "proper B": giving these four the same encourage-paradigm treatment peanut/tree-nut already have, and grounding the polarity-aware banner. Four cited briefs (`docs/research/<food>-infant-safety.md`) + four `food-effects.manifest.js` records.

### The load-bearing finding: a two-tier evidence split

Held rigorously throughout (the same gap-discipline that overturned the laundered honey claims):

| Tier | Allergens | Claim the record may make |
|---|---|---|
| **Prevention proven** | **Egg** | "Early, regular cooked egg helps *prevent* egg allergy" — RCT-backed. **PETIT (Lancet 2017): 38%→8% at 12mo, P=0.0001** (heated egg + eczema care); **EAT: 5.5%→1.4%, P=0.009.** Both verified from primaries. |
| **Introduce-early, prevention *not* RCT-proven** | **Soy, wheat, sesame** | "Introduce ~6mo, don't delay, it's safe — but no proof early intro *prevents* this allergy." EAT verbatim: **"no significant effects with respect to milk, sesame, fish, or wheat."** The briefs *explicitly forbid* the prevention claim. |

A verification-phase catch: EAT's null covers **sesame and wheat** (and milk, fish) — so neither may borrow peanut/egg's confident framing.

### Per-allergen depth
- **Egg** — fully-cooked default (no British-Lion-mark scheme in India → no runny allowance); commonly outgrown (reassuring tone).
- **Soy** — the **FPIES** branch (non-IgE: delayed vomiting + lethargy, not hives) + the **soy-formula ≠ soy-food** trap; heavy Indian-veg relevance (soya chunks = concentrated TVP).
- **Wheat** — keeps **wheat allergy / celiac / gluten-timing** as three separate concepts (ESPGHAN 4–12mo window; breastfeeding-benefit *withdrawn*); softened-roti forms; bread-balls-up choking note.
- **Sesame** — gravest tone (**~70–80% persist, rarely outgrown**); thinned-tahini form (the "thin the glob" rule); FASTER-Act 9th-allergen context (US-only; not Indian/home foods).

### Cross-cutting
- All four are `foodClass:'allergen-introduce-early'` (sage/encourage — **not** honey's rose acute-toxin). This is the evidence base for the polarity-aware banner that fixes the "red = don't give" wrong-message you flagged.
- Manifest **aliases are culinary-rich** (tofu→soy, roti→wheat, til→sesame, anda→egg) so wiring into `FOOD_EFFECTS` will also **close the Kael B-1 resolution gap** from the card session.
- Every record carries the honest universal gap: **no India-specific (IAP/MoHFW/FSSAI) early-introduction directive exists** — basis is AAP/NHS/ASCIA/NIAID.

### Verification
PETIT + EAT figures primary-confirmed (PubMed 27939035, 26943128); FASTER-Act date high-confidence (gov pages block fetchers; multi-source). Manifest validates: **7 records, 0 malformed**. The four scribe-drafted briefs were content-verified against the load-bearing facts (not trusted on report).

### Scope / process
**Docs-only ⇒ canon-cc-008 Governor audit waived** per the test-/docs-only carve-out (research layer, not wired into the app). The gated build phase that follows: `.html`/`.visual.html` renders, wiring the four records into `data.js` `FOOD_EFFECTS`, and the polarity-aware banner in `diet.js` (Maren + Kael + Vela triple-Gov).

https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK)_