### PR TITLE
Phase δ renders: egg/soy/wheat/sesame dashboards + long-forms (animated template)

### DIFF
--- a/docs/research/_TEMPLATE.food-dashboard.html
+++ b/docs/research/_TEMPLATE.food-dashboard.html
@@ -48,6 +48,27 @@
   .tab.on{color:var(--accent);background:var(--card);border-bottom-color:var(--accent)}
   .panel{display:none;animation:f .25s ease}.panel.on{display:block}
   @keyframes f{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:none}}
+  /* ── Entrance animations — re-trigger each time a panel is shown (display:none→block
+     restarts descendant animations). All gated behind prefers-reduced-motion so the
+     dashboard is fully usable (and calm) for anyone who opts out of motion. ── */
+  @media (prefers-reduced-motion: no-preference){
+    /* bars grow from the left — scaleX keeps the inline width:% target intact */
+    .panel.on .bar .fil{transform-origin:left center;animation:grow .7s cubic-bezier(.34,1.1,.4,1) both}
+    @keyframes grow{from{transform:scaleX(0)}to{transform:scaleX(1)}}
+    /* stat tiles + timeline steps + therm cols rise in with a gentle stagger */
+    .panel.on .stat,.panel.on .tl-step,.panel.on .therm .col{animation:rise .45s ease both}
+    .panel.on .stat:nth-child(2),.panel.on .tl-step:nth-child(2),.panel.on .therm .col:nth-child(2){animation-delay:.07s}
+    .panel.on .stat:nth-child(3),.panel.on .tl-step:nth-child(3){animation-delay:.14s}
+    .panel.on .stat:nth-child(4),.panel.on .tl-step:nth-child(4){animation-delay:.21s}
+    .panel.on .tl-step:nth-child(5){animation-delay:.28s}
+    @keyframes rise{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}
+    /* donut sweeps in (the partial-arc value stays exact; only the reveal animates) */
+    .panel.on svg[role="img"]{animation:sweep .8s ease both}
+    @keyframes sweep{from{opacity:0;transform:rotate(-12deg) scale(.9)}to{opacity:1;transform:none}}
+    /* flag callouts slide a touch from the left edge they're anchored to */
+    .panel.on .flag{animation:slidein .5s ease both}
+    @keyframes slidein{from{opacity:0;transform:translateX(-6px)}to{opacity:1;transform:none}}
+  }
   h2{font:600 18px/1.3 Fraunces,Georgia,serif;margin:26px 0 10px}
   h3{font:700 13px/1.3 Nunito;text-transform:uppercase;letter-spacing:.4px;color:var(--mid);margin:18px 0 8px}
   .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:16px 18px;margin:12px 0}

--- a/docs/research/egg-infant-safety.html
+++ b/docs/research/egg-infant-safety.html
@@ -1,0 +1,268 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Egg &amp; Infant Safety — Care Research Brief · SproutLab</title>
+<style>
+  :root{
+    --bg:#faf6f0; --card:#fffdf9; --ink:#2e2a26; --mid:#6b6258; --line:#e8ddcf;
+    --sage:#3a7060; --sage-bg:#e8f5ef; --rose:#b04a5e; --rose-bg:#fbe9ec;
+    --amber:#8a6320; --amber-bg:#fbf0d9; --accent:#9a6a3a;
+    --hi:#2f7d5b; --hi-bg:#e3f3ea; --mod:#9a7320; --mod-bg:#f7eed6; --weak:#9a5a5a; --weak-bg:#f5e6e6;
+  }
+  @media (prefers-color-scheme: dark){
+    :root{ --bg:#1d1a17; --card:#262220; --ink:#ece5db; --mid:#a89c8c; --line:#3a342d;
+      --sage:#7ac0a0; --sage-bg:#1e3028; --rose:#e090a0; --rose-bg:#3a2026;
+      --amber:#e0b060; --amber-bg:#352a16; --accent:#c99a6a;
+      --hi:#7ac0a0; --hi-bg:#1e3028; --mod:#d8b060; --mod-bg:#332a14; --weak:#e09090; --weak-bg:#3a2222; }
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+    font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Nunito,sans-serif;
+    -webkit-font-smoothing:antialiased;padding:0 0 80px}
+  .wrap{max-width:880px;margin:0 auto;padding:0 20px}
+  header{background:linear-gradient(160deg,var(--sage-bg),var(--bg));border-bottom:1px solid var(--line);
+    padding:34px 0 26px;margin-bottom:8px}
+  h1{font:700 27px/1.25 Fraunces,Georgia,serif;margin:0 0 6px}
+  .sub{color:var(--mid);font-size:14.5px;margin:0}
+  .meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
+  .pill{font-size:12px;font-weight:600;padding:4px 10px;border-radius:999px;background:var(--card);
+    border:1px solid var(--line);color:var(--mid)}
+  .pill.good{background:var(--sage-bg);color:var(--sage);border-color:transparent}
+  .pill.warn{background:var(--rose-bg);color:var(--rose);border-color:transparent}
+  h2{font:600 19px/1.3 Fraunces,Georgia,serif;margin:30px 0 12px;padding-top:10px;border-top:1px solid var(--line)}
+  h2 .ax{color:var(--accent);font-weight:700}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:18px 20px;margin:14px 0}
+  .tldr{background:var(--sage-bg);border-color:transparent}
+  .tldr ul{margin:8px 0 0;padding-left:20px}
+  .tldr li{margin:7px 0}
+  ul{margin:6px 0;padding-left:22px}
+  li{margin:6px 0}
+  .badge{display:inline-block;font-size:11px;font-weight:700;letter-spacing:.3px;text-transform:uppercase;
+    padding:3px 9px;border-radius:7px;vertical-align:middle;margin-left:8px}
+  .b-hi{background:var(--hi-bg);color:var(--hi)} .b-mod{background:var(--mod-bg);color:var(--mod)} .b-weak{background:var(--weak-bg);color:var(--weak)}
+  .flag{background:var(--amber-bg);border-left:3px solid var(--amber);border-radius:6px;
+    padding:10px 14px;margin:12px 0;font-size:14px;color:var(--ink)}
+  .flag b{color:var(--amber)}
+  .flag.good{background:var(--sage-bg);border-left-color:var(--sage)}
+  .flag.good b{color:var(--sage)}
+  blockquote{margin:12px 0;padding:8px 0 8px 16px;border-left:3px solid var(--sage);color:var(--mid);font-style:italic}
+  code,pre{font-family:"SF Mono",Menlo,Consolas,monospace}
+  pre{background:#1e1b18;color:#e8e2d6;border-radius:12px;padding:18px;overflow:auto;font-size:12.5px;line-height:1.55}
+  pre .c{color:#8a9a7a} pre .k{color:#d8a0b0} pre .s{color:#cbb080}
+  table{width:100%;border-collapse:collapse;font-size:13.5px;margin:10px 0}
+  th,td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{color:var(--mid);font-weight:700;font-size:12px;text-transform:uppercase;letter-spacing:.3px}
+  td a{color:var(--sage);word-break:break-all;font-size:12px}
+  .quote{background:var(--card);border:1px dashed var(--line);border-radius:10px;padding:6px 14px;margin:8px 0;font-size:14px}
+  .quote b{color:var(--accent)}
+  .foot{color:var(--mid);font-size:13px;margin-top:30px;text-align:center}
+  .gap{background:var(--rose-bg);border-color:transparent}
+</style>
+</head>
+<body>
+<header><div class="wrap">
+  <h1>Egg &amp; Infant Safety</h1>
+  <p class="sub">Care research brief — evidence base for SproutLab's Care layer, feeding the <i>guided-introduction</i> food-effects model. Egg is a <b>tier-1, prevention-proven</b> allergen: like peanut, it earns the confident "introducing early reduces allergy risk" claim, RCT-backed (PETIT, EAT).</p>
+  <div class="meta">
+    <span class="pill">Reviewer · Maren (Care)</span>
+    <span class="pill">2026-06-01</span>
+    <span class="pill">Hen's egg · infants ~6–12mo · India</span>
+    <span class="pill good">PETIT/EAT PubMed-verified</span>
+    <span class="pill warn">Research artifact — NOT yet wired into the app</span>
+  </div>
+</div></header>
+
+<div class="wrap">
+
+  <div class="card">
+    <p style="margin:0"><b>Purpose.</b> Evidence base for SproutLab's Care layer, feeding the <i>guided-introduction</i> food-effects model. Built to decide what to surface when a parent introduces <b>egg</b> to an under-1 — covering BOTH why to introduce early (allergy-prevention, RCT-backed) AND the two hazards (allergic reaction; the runny-egg salmonella + allergenicity trap). Egg is a <b>tier-1 "prevention-proven" allergen</b> — like peanut, it earns the confident <i>"introducing early reduces allergy risk"</i> claim, backed by randomised controlled trials (PETIT, EAT). The food is not gated by choking-form (egg is soft); it is gated by <b>cooked-state</b>.</p>
+    <p style="margin:10px 0 0"><b>Scope.</b> Hen's egg (white + yolk). Infants ~6–12 months, in a family context that is <b>Indian</b> — egg is a common, affordable, culturally accepted complementary food, but there is <b>no British-Lion-style salmonella-control mark</b> on Indian eggs, which changes the safe-form rule.</p>
+    <p style="margin:10px 0 0;font-size:14px;color:var(--mid)"><b>Method.</b> Multi-angle web fan-out → source fetch → adversarial cross-check → synthesis. Authorities: AAP/HealthyChildren, UK NHS, ASCIA (Australasia), US NIAID, IAP (India); pivotal trials <b>PETIT (Natsume et al., Lancet 2017)</b> and <b>EAT (Perkin/Lack, NEJM 2016)</b>. Trial figures verified against the primary literature via PubMed (PETIT: PMID 27939035; EAT: PMID 26943128). A few preparation specifics rest on reputable secondary sources (flagged inline) rather than a top-tier body's verbatim words.</p>
+  </div>
+
+  <div class="card tldr">
+    <strong>TL;DR — the parent-facing truth</strong>
+    <ul>
+      <li><b>The advice REVERSED.</b> The old "delay egg to prevent allergy" guidance is gone. Current consensus (AAP, NHS, ASCIA, NIAID-aligned): introduce egg <b>early</b> — around 6 months, alongside other solids, <b>not before 4 months</b> — and keep it in the diet regularly. Delaying does not prevent allergy and may <i>increase</i> it.</li>
+      <li><b>Early introduction PREVENTS egg allergy — RCT-proven.</b> The <b>PETIT trial</b> (high-risk eczematous Japanese infants) cut egg allergy at 12 months to <b>8% (egg group) vs 38% (placebo), P=0.0001</b> — using <b>heated egg powder</b> with <b>aggressive eczema treatment</b>. The <b>EAT trial</b> showed a per-protocol reduction (<b>1.4% vs 5.5%, P=0.009</b>) but <b>no significant intention-to-treat effect</b> — the benefit depends on sustaining regular intake.</li>
+      <li><b>The crux is COOKED-STATE, not the food.</b> The safe form is <b>fully-cooked egg</b> — mashed hard-boiled, scrambled until firm, or baked into food. <b>Runny/soft egg is not safe for an Indian infant</b>: India has no British-Lion-mark equivalent, so the salmonella safeguard the NHS relies on does not apply, and well-cooking also reduces allergenicity. Start with about <b>a third of a well-cooked egg</b>.</li>
+      <li><b>Two distinct hazards, two distinct mitigations.</b> (1) <i>Allergy</i> — mitigated by early, sustained introduction + a watchful first exposure. (2) <i>Salmonella + raw-egg allergenicity</i> — mitigated by <b>fully cooking</b>. The model must hold both at once. Egg has <b>no choking-form gate</b> (it is soft) — this is what distinguishes it from peanut/tree-nut.</li>
+      <li><b>Reassuring outlook: most children OUTGROW egg allergy.</b> Egg is among the most common infant allergens, but unlike peanut it is <b>commonly outgrown</b> — a majority of children by school age. The tone should be calm, not alarmed.</li>
+      <li><b>First exposure = small amount, fully cooked, at home, daytime, watch.</b> Know the difference between a mild reaction (hives/swelling/GI) and anaphylaxis (breathing trouble, tongue/throat swelling, hoarse voice, pale-and-floppy) — the latter is an emergency-call event (<b>112 / 108</b> in India).</li>
+    </ul>
+  </div>
+
+  <h2><span class="ax">Axis 1</span> · The benefit: early introduction reduces egg allergy <span class="badge b-hi">High</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>The paradigm flipped.</b> Until ~2008–2015, guidance advised <i>delaying</i> allergenic foods (incl. egg) to prevent allergy. That advice is reversed: AAP/HealthyChildren now states there is no evidence that delaying allergenic foods like egg prevents allergies once a baby is ready, typically around 6 months.</li>
+      <li><b>PETIT trial (the pivotal RCT for egg).</b> High-risk Japanese infants <b>with eczema</b>, randomised to a <b>stepwise heated whole-egg powder</b> regimen — <b>50 mg/day from 6–9 months, then 250 mg/day from 9–12 months</b> — <b>alongside aggressive eczema treatment</b>, vs placebo. Egg allergy at 12 months:
+        <ul>
+          <li><b>8% (egg group) vs 38% (placebo)</b> — <b>P=0.0001.</b> <span class="badge b-hi">Lancet 2017 · PMID 27939035</span></li>
+          <li><b>Two integral conditions of this result:</b> (a) the studied form was <b>HEATED/cooked egg</b> (not raw), and (b) <b>eczema was actively controlled</b> as part of the protocol. The trial does not license giving raw egg, nor giving egg to an uncontrolled-eczema infant without care.</li>
+        </ul>
+      </li>
+    </ul>
+    <div class="flag"><b>⚑ The high-risk-eczema pathway warrants clinician input.</b> PETIT studied infants <b>with eczema</b> under <b>medical eczema management</b>. For an infant with significant eczema or a sibling/family history of food allergy, early egg is still the goal — but it is prudent to involve a paediatrician on timing and on getting eczema under control first, rather than reading PETIT as "give any eczematous baby egg at home unsupervised."</div>
+    <ul>
+      <li><b>EAT trial (the nuance — adherence matters).</b> General-population, exclusively-breastfed infants randomised to early introduction of allergens (incl. egg) vs standard introduction. For egg:
+        <ul>
+          <li><b>Per-protocol</b> (those who actually achieved the regular dose): <b>1.4% vs 5.5%, P=0.009</b> — a real, significant reduction.</li>
+          <li><b>Intention-to-treat: NOT significant</b> — overall <b>7.1% vs 5.6%, P=0.32.</b> <span class="badge b-hi">NEJM 2016 · PMID 26943128</span></li>
+        </ul>
+      </li>
+    </ul>
+    <div class="flag"><b>⚑ The EAT lesson is dose + adherence:</b> the benefit is real but depends on getting enough egg in, <b>regularly</b>. Early introduction is easy to <i>attempt</i> and hard to <i>sustain</i>. The model should frame egg as "introduce <b>and keep offering</b>," not a one-time tick.</div>
+    <ul>
+      <li><b>Timing consensus:</b> introduce egg <b>around 6 months</b>, once the baby is developmentally ready for solids and a few first foods are tolerated — <b>not before 4 months</b>. <span class="badge b-hi">NHS · AAP · ASCIA · NIAID-aligned</span></li>
+    </ul>
+  </div>
+
+  <h2><span class="ax">Axis 2</span> · Safe FORM: fully-cooked egg <span class="badge b-hi">High</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>The safe form is FULLY-COOKED egg.</b> Mashed/grated <b>hard-boiled</b> egg, <b>scrambled until firm and no longer runny</b>, or <b>baked into</b> another food (pancake, omelette set firm, egg stirred into porridge/khichdi and cooked through). Start with about <b>one-third of a well-cooked egg</b>. <span class="badge b-hi">AAP · NHS</span></li>
+      <li><b>Why not runny egg — the India-specific divergence.</b> NHS permits <b>runny or lightly-cooked egg for infants only if the eggs carry the British Lion mark</b> (a UK salmonella-control assurance scheme); <b>otherwise the egg must be cooked until both white and yolk are solid.</b></li>
+    </ul>
+    <div class="flag"><b>⚑ India has no British-Lion-mark equivalent.</b> Therefore the NHS "runny is fine if Lion-marked" exception <b>does not apply to an Indian family</b> — the default must be <b>fully-cooked egg (solid white + solid yolk)</b>. Two reasons compound: <b>(1) salmonella</b> — without a control-scheme assurance, raw/undercooked egg carries an infection risk that is far more serious in an infant; <b>(2) allergenicity</b> — well-cooking (heating) reduces egg's allergenic potency, which is precisely why PETIT used <b>heated</b> egg powder rather than raw.</div>
+    <ul>
+      <li><b>Egg has no choking-form gate.</b> Unlike whole peanuts/tree nuts, cooked egg is soft and does not need grinding/thinning for airway safety. The gate egg passes through is <b>cooked-state</b>, not particle-size. (Standard general choking caution — soft, age-appropriate textures — still applies, but egg is not a choking-hazard food in the nut sense.)</li>
+    </ul>
+  </div>
+
+  <h2><span class="ax">Axis 3</span> · Allergic-reaction watch-fors &amp; the emergency floor <span class="badge b-hi">High</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>Egg is among the most common infant food allergens</b> — but, reassuringly, it is <b>commonly outgrown</b>: a <b>majority of egg-allergic children outgrow it by school age</b>, unlike peanut/tree-nut which tend to be lifelong. The tone here should be <b>calm and reassuring</b>, not alarmist. <span class="badge b-mod">FARE · FAACT</span></li>
+      <li><b>Mild–moderate reaction (one body system):</b> itchy <b>hives/welts</b>, redness or <b>rash</b>, <b>swelling</b> (esp. around the mouth/eyes), <b>vomiting</b>, loose stool or other <b>GI upset</b>, sudden fussiness.</li>
+    </ul>
+    <div class="flag" style="border-left-color:var(--rose);background:var(--rose-bg)"><b style="color:var(--rose)">⚑ Severe / anaphylaxis — act immediately (red flags):</b>
+      <ul style="margin:6px 0 0">
+        <li><b>Difficulty/noisy breathing</b>, wheeze, persistent cough.</li>
+        <li><b>Swelling of the tongue or throat</b>, tightness in the throat.</li>
+        <li><b>Hoarse voice or cry.</b></li>
+        <li><b>Pale and floppy</b> (in a baby, sudden limpness / can't hold head up is a recognised severe sign), collapse.</li>
+        <li><b>→ This is an emergency. Lay the child flat (do not stand them up); use an adrenaline auto-injector immediately if one has been prescribed; call emergency services — 112 (all-India) or 108 (ambulance).</b> <span class="badge b-hi">ASCIA First Aid</span></li>
+      </ul>
+    </div>
+    <ul>
+      <li><b>What to do for a mild, single-system reaction:</b> stop the food, monitor closely, contact your doctor; an antihistamine may be advised by a clinician. <b>Any breathing difficulty, tongue/throat swelling, hoarse voice, floppiness, or two body systems involved → treat as anaphylaxis (adrenaline + 112/108).</b></li>
+      <li><b>First-exposure practice:</b> offer a <b>small amount</b> of fully-cooked egg, <b>at home</b>, in the <b>morning or midday</b> (not at dinner) so you can observe through the day, and <b>watch</b> afterward — most reactions appear within a couple of hours. If tolerated, <b>keep offering regularly</b> (the EAT lesson).</li>
+    </ul>
+  </div>
+
+  <h2><span class="ax">Axis 4</span> · Culinary aliases &amp; hidden sources <span class="badge b-hi">High (alias list)</span> <span class="badge b-mod">Moderate ("lecithin is egg")</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>Egg goes by many names on labels.</b> Watch for: <b>albumin / albumen, ovalbumin, ovomucoid, ovomucin, ovo-</b> (any "ovo-" prefix), <b>ovovitellin / vitellin, livetin, lysozyme</b> (often in cheese/wine as a preservative), <b>globulin, conalbumin</b>, "egg solids," "dried/powdered egg," "egg white/egg yolk."</li>
+      <li><b>Lecithin may be egg-derived.</b> Lecithin (an emulsifier, E322) is <b>usually soy- or sunflower-derived but can be egg-derived</b> — for an egg-allergic child, lecithin of unspecified origin is worth checking. <span class="badge b-mod">FARE/FAACT — "may contain," not "always egg"</span></li>
+      <li><b>Hidden-egg foods (common in an Indian household):</b>
+        <ul>
+          <li><b>Baked goods</b> — many cakes, biscuits, breads, and <b>egg-glazed / egg-washed buns and pastries</b> (the shiny glaze on bakery buns is frequently an egg wash).</li>
+          <li><b>Mayonnaise</b>, salad dressings, <b>custard and custard puddings</b>, ice cream, some <b>kheer/pudding</b> mixes.</li>
+          <li><b>Egg noodles / hakka noodles / egg-containing chow mein.</b></li>
+          <li>Batters, some "instant" pancake/cake mixes, marshmallow, meringue, certain breaded/fried coatings.</li>
+        </ul>
+      </li>
+      <li><b>Why this matters for the model:</b> once a parent is avoiding egg (suspected or confirmed allergy), the failure mode is <b>accidental exposure via an unlabelled or aliased source</b> — Indian bakery items and egg-glazed buns are a particularly easy miss. Surfacing the alias list and the bakery-glaze/noodle/custard examples is the highest-value safety content here.</li>
+    </ul>
+  </div>
+
+  <h2><span class="ax">Axis 5</span> · Indian &amp; cultural context <span class="badge b-hi">High (staple + cooked-default)</span> <span class="badge b-weak">Mod→Low (India official guidance)</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>Egg is a common, affordable, accepted complementary food in India.</b> It appears in the <b>IAP (Indian Academy of Pediatrics) complementary-feeding food groups</b> as a protein-rich option for infants. <span class="badge b-mod">IAP Ch-040</span></li>
+    </ul>
+    <div class="flag"><b>⚑ Read the IAP citation correctly — nutrition framing, NOT an allergy-prevention directive.</b> IAP listing egg among complementary-feeding <b>food groups</b> is a <b>nutrition</b> statement (egg is a good infant protein/iron/choline source). It is <b>not</b> an IAP statement that "introduce egg early to <i>prevent allergy</i>." Do not launder the international early-introduction-for-prevention claim onto IAP's name — see the gap note below (the honey lesson).</div>
+    <ul>
+      <li><b>The cooked-default fits Indian practice.</b> Indian egg preparations for infants — well-mashed boiled egg, firm scrambled egg (egg bhurji cooked through, not runny), egg stirred into khichdi/porridge and cooked — are <b>already fully-cooked forms</b>, which is exactly the safe default. This is a cultural asset the model can affirm. The thing to <b>correct</b> is any practice of giving <b>half-boiled / soft-yolk / runny egg</b> to a baby (no Lion-mark safeguard in India).</li>
+      <li><b>Vegetarian note:</b> in a vegetarian or egg-avoiding household, egg is simply not introduced; this is a dietary choice, not a safety failure. The brief should not push egg on a family that doesn't eat it — the prevention benefit is one input, not an obligation.</li>
+    </ul>
+  </div>
+
+  <h2><span class="ax">Axis 6</span> · Myths to correct <span class="badge b-hi">High</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>Myth: "Delay egg to prevent allergy."</b> <b>Reversed.</b> Delaying does not prevent egg allergy and likely increases risk; early, sustained introduction around 6 months (not before 4) is now recommended, and is <b>RCT-backed for egg specifically</b> (PETIT, EAT per-protocol). This is the highest-value myth to surface — many grandparents/relatives still believe the old rule.</li>
+      <li><b>Myth: "Egg allergy is forever."</b> <b>Mostly false for egg.</b> Unlike peanut/tree-nut, <b>most children outgrow egg allergy</b> — a majority by school age. A diagnosis is not a life sentence; re-evaluation over time (by a clinician) is standard.</li>
+      <li><b>Myth: "Runny / half-boiled egg is fine for babies."</b> <b>No — fully cook it.</b> In India there is no British-Lion-mark salmonella safeguard, so runny egg carries an infection risk; and well-cooking also lowers allergenicity. Cook until <b>both white and yolk are solid.</b></li>
+      <li><b>Myth: "If a baby reacts once, never give egg again in any form."</b> <b>Nuanced — a clinician's call.</b> Many egg-allergic children tolerate <b>baked/well-heated egg</b> even when reacting to lightly-cooked egg, and most outgrow over time; what to reintroduce and when is an <b>allergist's decision</b>, not a permanent self-imposed total ban. <span class="badge b-mod">practice-level — do not act without clinical input</span></li>
+    </ul>
+  </div>
+
+  <h2>Proposed data shape · <code>FOOD_EFFECTS['egg']</code></h2>
+  <div class="card">
+    <p style="margin:0 0 10px;font-size:14px;color:var(--mid)">Drop-in record (mirror of egg's entry in <code>food-effects.manifest.js</code>) for a future <code>FOOD_EFFECTS</code> table in <code>data.js</code>, sitting alongside <code>AGE_RULES</code>/<code>ALLERGENS</code>. <code>foodClass:'allergen-introduce-early'</code> drives the sage <i>encourage</i> banner; the gate is <b>cooked-state</b>, not particle-size. <b>Not yet wired.</b></p>
+<pre><span class="c">// guided-introduction record — encourage polarity, tier-1 prevention-proven allergen</span>
+<span class="k">const</span> FOOD_EFFECTS = {
+  <span class="s">'egg'</span>: {
+    foodClass:     <span class="s">'allergen-introduce-early'</span>,
+    severity:      <span class="s">'caution'</span>,            <span class="c">// amber, NOT rose (rose = acute-toxin honey)</span>
+    effect:        <span class="s">'food allergy'</span>,
+    minMonth:      <span class="s">6</span>,                      <span class="c">// AAP/NHS ~6mo (not before 4); reconcile with AGE_RULES egg-yolk:7</span>
+    aliases:       [<span class="s">'eggs'</span>, <span class="s">'anda'</span>, <span class="s">'egg yolk'</span>, <span class="s">'whole egg'</span>, <span class="s">'boiled egg'</span>, <span class="s">'scrambled egg'</span>, <span class="s">'omelette'</span>],
+    headline:      <span class="s">'Introduce early (~6 months), well-cooked — early egg lowers allergy risk.'</span>,
+    whyGood:       <span class="s">'Complete protein, choline, iron, vitamin D — early, regular well-cooked egg helps prevent egg allergy.'</span>,
+    earlyIntroBenefit: { evidence: <span class="s">'PETIT (Lancet 2017): heated egg + eczema care cut egg allergy 38%→8% at 12mo (P=0.0001). EAT (NEJM 2016): per-protocol 5.5%→1.4% (P=0.009).'</span> },
+    safeForm:      { ok:[<span class="s">'well-cooked egg — mashed hard-boiled, scrambled, or baked into soft food'</span>],
+                     never:[<span class="s">'raw or runny egg'</span>, <span class="s">'lightly-cooked egg (no British-Lion-mark in India)'</span>],
+                     note:<span class="s">'Cook until BOTH white and yolk are solid — studied safe form; removes salmonella risk.'</span> },
+    myth:          { claim:<span class="s">'Delay egg to prevent allergy.'</span>,
+                     truth:<span class="s">'Reversed — early, regular well-cooked egg helps prevent egg allergy; delaying may increase risk.'</span> },
+    watchFor:      [<span class="s">'hives / rash'</span>, <span class="s">'swelling (mouth, eyes, lips)'</span>, <span class="s">'vomiting'</span>],
+    severeSigns:   [<span class="s">'trouble breathing / wheeze'</span>, <span class="s">'face/lip/tongue swelling'</span>, <span class="s">'floppy, pale, or very sleepy'</span>],
+    seekCare:      <span class="s">'Mild single-system: stop, monitor, call doctor. Any breathing trouble, face/throat swelling, or floppiness: EMERGENCY — call 112, use prescribed adrenaline.'</span>,
+    culturalNote:  <span class="s">'No British-Lion-mark assured-egg scheme in India — default to fully-cooked egg. Egg allergy common in infancy but usually outgrown by school age.'</span>,
+    confidence:    <span class="s">'high'</span>,
+    lastReviewed:  <span class="s">'2026-06-01'</span>,
+  },
+};</pre>
+  </div>
+
+  <h2>Sources</h2>
+  <div class="card">
+  <table>
+    <tr><th>#</th><th>Authority</th><th>URL</th></tr>
+    <tr><td>1</td><td>NEJM — Perkin/Lack et al., EAT trial (2016)</td><td><a href="https://www.nejm.org/doi/full/10.1056/NEJMoa1514210">nejm.org/…/NEJMoa1514210</a></td></tr>
+    <tr><td>2</td><td>PubMed — EAT trial (PMID 26943128)</td><td><a href="https://pubmed.ncbi.nlm.nih.gov/26943128/">pubmed.ncbi.nlm.nih.gov/26943128</a></td></tr>
+    <tr><td>3</td><td>The Lancet — Natsume et al., PETIT trial (2017)</td><td><a href="https://www.thelancet.com/journals/lancet/article/PIIS0140-6736(16)31418-0/abstract">thelancet.com/…/PETIT</a></td></tr>
+    <tr><td>4</td><td>PubMed — PETIT trial (PMID 27939035)</td><td><a href="https://pubmed.ncbi.nlm.nih.gov/27939035/">pubmed.ncbi.nlm.nih.gov/27939035</a></td></tr>
+    <tr><td>5</td><td>NIAID — Addendum Guidelines (allergen prevention; ~6mo / not-before-4)</td><td><a href="https://www.niaid.nih.gov/sites/default/files/addendum-peanut-allergy-prevention-guidelines.pdf">niaid.nih.gov/…/prevention</a></td></tr>
+    <tr><td>6</td><td>AAP / HealthyChildren — When to introduce egg, peanut butter &amp; other allergens</td><td><a href="https://www.healthychildren.org/English/healthy-living/nutrition/Pages/when-to-introduce-egg-peanut-butter-and-other-common-food-allergens-to-your-baby-food-allergy-prevention-tips.aspx">healthychildren.org/…/allergens</a></td></tr>
+    <tr><td>7</td><td>UK NHS — Food allergies in babies &amp; young children</td><td><a href="https://www.nhs.uk/baby/weaning-and-feeding/food-allergies-in-babies-and-young-children/">nhs.uk/baby/…/food-allergies</a></td></tr>
+    <tr><td>8</td><td>UK NHS — Foods to avoid giving babies (runny egg / British Lion mark)</td><td><a href="https://www.nhs.uk/baby/weaning-and-feeding/foods-to-avoid-giving-babies-and-young-children/">nhs.uk/baby/…/foods-to-avoid</a></td></tr>
+    <tr><td>9</td><td>ASCIA — Infant Feeding for Food Allergy Prevention</td><td><a href="https://www.allergy.org.au/hp/papers/infant-feeding-and-allergy-prevention">allergy.org.au/…/infant-feeding</a></td></tr>
+    <tr><td>10</td><td>ASCIA — Updated infant-feeding guideline (published Jan 2026)</td><td><a href="https://www.allergy.org.au/about-ascia/info-updates/updated-ascia-guideline-infant-feeding-for-food-allergy-prevention-published-january-2026">allergy.org.au/…/2026-update</a></td></tr>
+    <tr><td>11</td><td>ASCIA — First Aid for Anaphylaxis</td><td><a href="https://www.allergy.org.au/hp/anaphylaxis/first-aid-for-anaphylaxis">allergy.org.au/…/first-aid</a></td></tr>
+    <tr><td>12</td><td>FARE — Egg allergy (common allergens)</td><td><a href="https://www.foodallergy.org/living-food-allergy/food-allergy-essentials/common-allergens/egg">foodallergy.org/…/egg</a></td></tr>
+    <tr><td>13</td><td>FAACT — Egg allergen</td><td><a href="https://www.foodallergyawareness.org/food-allergy-and-anaphylaxis/food-allergens/egg/">foodallergyawareness.org/…/egg</a></td></tr>
+    <tr><td>14</td><td>IAP — Complementary Feeding parental guideline (Ch-040; egg in food groups)</td><td><a href="https://iapindia.org/pdf/Ch-040-IAP-Parental-Guideline-Complementary-Feeding.pdf">iapindia.org/…/Ch-040</a></td></tr>
+  </table>
+  </div>
+
+  <div class="card">
+    <strong>Verification status &amp; gaps</strong>
+    <ol style="margin:8px 0 0">
+      <li>✅ <b>PETIT figures</b> — verified from the primary literature via PubMed (PMID 27939035): high-risk eczematous infants; stepwise <b>heated</b> egg powder (50 mg/day 6–9 mo → 250 mg/day 9–12 mo) <b>with aggressive eczema treatment</b>; egg allergy at 12 mo <b>8% vs 38%, P=0.0001</b>. The <b>heated form</b> and <b>integral eczema control</b> are not incidental — they are conditions of the result.</li>
+      <li>✅ <b>EAT figures</b> — verified from the primary literature via PubMed (PMID 26943128): per-protocol <b>1.4% vs 5.5%, P=0.009</b>; intention-to-treat <b>NOT</b> significant (<b>7.1% vs 5.6%, P=0.32</b>). The headline lesson is <b>adherence/dose</b>, not a simple "early egg works regardless."</li>
+      <li>✅ <b>Timing reversal</b> — corroborated independently by AAP, NHS, ASCIA, NIAID-aligned framing (~6 mo, not before 4).</li>
+      <li>✅ <b>Fully-cooked default for India</b> — derived correctly: NHS permits runny egg <i>only</i> with the <b>British Lion mark</b>; India has <b>no equivalent scheme</b>, so the exception does not transfer → fully-cooked (solid white + yolk) is the default. Salmonella + reduced-allergenicity rationale is sound and aligns with PETIT's use of <b>heated</b> egg.</li>
+      <li>✅ <b>Commonly-outgrown reassurance</b> — egg allergy is typically outgrown (majority by school age), per FARE/FAACT. <i>(These are advocacy/patient-education bodies — see note 7 — but the "egg is commonly outgrown" claim is uncontroversial and consistent across mainstream paediatric allergy sources.)</i></li>
+    </ol>
+    <div class="flag"><b>⚑ India early-egg-for-prevention directive — HONEST GAP, none exists.</b> No India-specific (<b>IAP / MoHFW / NHM / FSSAI</b>) directive recommending <b>early egg introduction to <i>prevent</i> allergy</b> was located. IAP's Ch-040 lists egg among complementary-feeding <b>food groups</b> — a <b>nutrition</b> framing, <b>not</b> an allergy-prevention recommendation. The early-introduction-prevents-allergy evidence base is <b>international</b> (NHS / ASCIA / NIAID / PETIT / EAT). Treat the prevention claim as well-sourced internationally and culturally compatible with Indian practice, but <b>do not attribute an early-egg-for-prevention recommendation to IAP or any Indian body.</b> <i>(The honey-brief lesson: never launder international guidance onto an Indian body's name.)</i></div>
+    <div class="flag"><b>⚑ Source-tier flag.</b> <b>FARE</b> and <b>FAACT</b> are <b>advocacy / patient-education organisations</b>, not government regulators or primary trials — cited here for the <b>alias list, hidden-egg sources, mild-vs-severe symptom descriptions, and the commonly-outgrown framing</b>, all of which are mainstream and corroborated, but they should be labelled as advocacy-tier, not regulator-verbatim. Trial claims rest on PETIT/EAT (primary, PubMed-verified); cooked-state and timing rest on NHS/AAP/ASCIA (official bodies).</div>
+    <div class="flag"><b>⚑ Emergency numbers.</b> <b>112</b> is India's unified emergency number; <b>108</b> is the widely-used ambulance number across most Indian states. Both are practice-level/operational facts, not allergy-guideline-issued; ASCIA's first-aid <i>content</i> (lay flat, adrenaline first, then call) is the cited clinical procedure.</div>
+  </div>
+
+  <div class="card tldr">
+    <strong>Surfacing recommendation (Maren) — feeds the guided-introduction model, not yet implemented</strong>
+    <p style="margin:8px 0 0">Egg is a <b>tier-1, prevention-proven</b> allergen — surface it as an <b>encourage</b> card (sage), not honey's <b>warn</b> card (rose). Lead with the RCT-earned benefit (early, regular well-cooked egg lowers allergy risk: PETIT 38%→8%), then the introduce-safely block (<b>fully-cooked</b> form / about ⅓ of a well-cooked egg / watch / keep offering), then a non-collapsible severe-reaction strip. The two highest-value nuggets unique to egg: the <b>fully-cook-it</b> rule (no British-Lion-mark in India → no runny egg) and the reassuring <b>usually-outgrown</b> framing. Hold both hazards at once — allergy (early, sustained intro + watchful first exposure) and salmonella + raw-egg allergenicity (cook through).</p>
+  </div>
+
+  <p class="foot">SproutLab · Care research brief · companion to <code>docs/research/egg-infant-safety.md</code> · generated 2026-06-01<br>
+  Research artifact — informational, not medical advice. Not yet wired into the app.</p>
+</div>
+</body>
+</html>

--- a/docs/research/egg-infant-safety.visual.html
+++ b/docs/research/egg-infant-safety.visual.html
@@ -1,0 +1,374 @@
+<!DOCTYPE html>
+<!-- ═══════════════════════════════════════════════════════════════════════
+  FOOD-DASHBOARD TEMPLATE · SproutLab Care research layer
+  Copy this file to  <food>-infant-safety.visual.html  and fill the {{...}}.
+  Canonical CSS + JS (tab swiping, arrow keys, charts) — DO NOT diverge; if you
+  improve a component, update this template so all dashboards inherit it.
+
+  TABS are generic; relabel per food TYPE:
+    • critical/acute-toxin (honey)  → Summary · The Science · Symptoms & Care · Context · Sources · Data
+    • allergen (egg, nuts, soy)     → Summary · Why/Allergen · Reaction & Introduction · Context · Sources · Data
+    • choking (whole nuts, grapes)  → Summary · The Hazard · Safe Prep · Context · Sources · Data
+    • timing (cow milk, salt, sugar)→ Summary · Why this age · Effects · Context · Sources · Data
+
+  COMPONENT LIBRARY (copy from the commented block at the bottom of <body>):
+    stat tiles · bar chart · donut (SVG) · timeline · thermometer split ·
+    consensus matrix · flag callouts · badges.
+  Every chart value MUST also appear as text (machine-readable for agents).
+  After filling: append a record to food-effects.manifest.js.
+═══════════════════════════════════════════════════════════════════════ -->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Egg &amp; Infant Safety — Visual Dashboard · SproutLab Care</title>
+<style>
+  :root{
+    --bg:#faf6f0; --card:#fffdf9; --ink:#2e2a26; --mid:#6b6258; --line:#e8ddcf; --track:#efe7da;
+    --sage:#3a7060; --sage-bg:#e8f5ef; --rose:#b04a5e; --rose-bg:#fbe9ec;
+    --amber:#9a7320; --amber-bg:#fbf0d9; --accent:#9a6a3a; --honey:#d99a2b; --honey-bg:#fbeccb;
+    --hi:#2f7d5b; --hi-bg:#e3f3ea; --mod:#9a7320; --mod-bg:#f7eed6; --weak:#9a5a5a; --weak-bg:#f5e6e6;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#1d1a17; --card:#262220; --ink:#ece5db; --mid:#a89c8c; --line:#3a342d; --track:#332d26;
+    --sage:#7ac0a0; --sage-bg:#1e3028; --rose:#e090a0; --rose-bg:#3a2026;
+    --amber:#e0b060; --amber-bg:#352a16; --accent:#c99a6a; --honey:#e8b34a; --honey-bg:#3a2c12;
+    --hi:#7ac0a0; --hi-bg:#1e3028; --mod:#d8b060; --mod-bg:#332a14; --weak:#e09090; --weak-bg:#3a2222; }}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Nunito,sans-serif;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:960px;margin:0 auto;padding:0 18px 90px}
+  header{background:linear-gradient(160deg,var(--honey-bg),var(--bg));border-bottom:1px solid var(--line);padding:26px 0 0}
+  h1{font:700 25px/1.2 Fraunces,Georgia,serif;margin:0 0 4px}
+  .sub{color:var(--mid);font-size:14px;margin:0 0 16px;max-width:680px}
+  nav{display:flex;gap:4px;margin-top:6px;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none}
+  nav::-webkit-scrollbar{display:none}
+  .tab{appearance:none;border:0;background:transparent;color:var(--mid);font:600 13.5px/1 Nunito,sans-serif;white-space:nowrap;flex:0 0 auto;
+    padding:11px 14px;border-radius:10px 10px 0 0;cursor:pointer;border-bottom:3px solid transparent}
+  .tab:hover{color:var(--ink);background:var(--card)}
+  .tab.on{color:var(--accent);background:var(--card);border-bottom-color:var(--accent)}
+  .panel{display:none;animation:f .25s ease}.panel.on{display:block}
+  @keyframes f{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:none}}
+  /* ── Entrance animations — re-trigger each time a panel is shown (display:none→block
+     restarts descendant animations). All gated behind prefers-reduced-motion so the
+     dashboard is fully usable (and calm) for anyone who opts out of motion. ── */
+  @media (prefers-reduced-motion: no-preference){
+    /* bars grow from the left — scaleX keeps the inline width:% target intact */
+    .panel.on .bar .fil{transform-origin:left center;animation:grow .7s cubic-bezier(.34,1.1,.4,1) both}
+    @keyframes grow{from{transform:scaleX(0)}to{transform:scaleX(1)}}
+    /* stat tiles + timeline steps + therm cols rise in with a gentle stagger */
+    .panel.on .stat,.panel.on .tl-step,.panel.on .therm .col{animation:rise .45s ease both}
+    .panel.on .stat:nth-child(2),.panel.on .tl-step:nth-child(2),.panel.on .therm .col:nth-child(2){animation-delay:.07s}
+    .panel.on .stat:nth-child(3),.panel.on .tl-step:nth-child(3){animation-delay:.14s}
+    .panel.on .stat:nth-child(4),.panel.on .tl-step:nth-child(4){animation-delay:.21s}
+    .panel.on .tl-step:nth-child(5){animation-delay:.28s}
+    @keyframes rise{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}
+    /* donut sweeps in (the partial-arc value stays exact; only the reveal animates) */
+    .panel.on svg[role="img"]{animation:sweep .8s ease both}
+    @keyframes sweep{from{opacity:0;transform:rotate(-12deg) scale(.9)}to{opacity:1;transform:none}}
+    /* flag callouts slide a touch from the left edge they're anchored to */
+    .panel.on .flag{animation:slidein .5s ease both}
+    @keyframes slidein{from{opacity:0;transform:translateX(-6px)}to{opacity:1;transform:none}}
+  }
+  h2{font:600 18px/1.3 Fraunces,Georgia,serif;margin:26px 0 10px}
+  h3{font:700 13px/1.3 Nunito;text-transform:uppercase;letter-spacing:.4px;color:var(--mid);margin:18px 0 8px}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:16px 18px;margin:12px 0}
+  .grid{display:grid;gap:12px}.g2{grid-template-columns:1fr 1fr}.g3{grid-template-columns:repeat(3,1fr)}.g4{grid-template-columns:repeat(4,1fr)}
+  @media(max-width:680px){.g2,.g3,.g4{grid-template-columns:1fr 1fr}}
+  .stat{text-align:center;padding:16px 10px}
+  .stat .n{font:800 26px/1 Fraunces,Georgia,serif;color:var(--accent)}
+  .stat .l{font-size:12px;color:var(--mid);margin-top:6px;line-height:1.35}
+  .stat.crit .n{color:var(--rose)}.stat.ok .n{color:var(--sage)}
+  .badge{display:inline-block;font:700 10.5px/1 Nunito;text-transform:uppercase;letter-spacing:.3px;padding:4px 8px;border-radius:6px;vertical-align:middle}
+  .b-hi{background:var(--hi-bg);color:var(--hi)}.b-mod{background:var(--mod-bg);color:var(--mod)}.b-weak{background:var(--weak-bg);color:var(--weak)}.b-crit{background:var(--rose-bg);color:var(--rose)}
+  .bar{display:grid;grid-template-columns:130px 1fr 52px;align-items:center;gap:10px;margin:7px 0;font-size:13px}
+  .bar .lab{color:var(--ink);text-align:right;font-weight:600}
+  .bar .trk{display:block;background:var(--track);border:1px solid var(--line);border-radius:7px;height:18px;overflow:hidden}
+  .bar .fil{display:block;height:100%;border-radius:6px;background:var(--sage);min-width:3px}
+  .bar .val{font-weight:700;color:var(--mid);font-size:12.5px}
+  .bar.hl .fil{background:var(--honey)}.bar.hl .lab{color:var(--honey)}.bar.hl .val{color:var(--honey)}
+  .tl{position:relative;margin:14px 0 6px;padding-left:8px}
+  .tl-step{position:relative;padding:0 0 18px 26px;border-left:2px solid var(--line)}
+  .tl-step:last-child{border-left-color:transparent}
+  .tl-dot{position:absolute;left:-8px;top:1px;width:15px;height:15px;border-radius:50%;background:var(--card);border:3px solid var(--accent)}
+  .tl-step.crit .tl-dot{border-color:var(--rose)}.tl-step.first .tl-dot{border-color:var(--honey)}
+  .tl-t{font-weight:700;font-size:13.5px}.tl-d{color:var(--mid);font-size:12.5px}
+  .flag{border-left:3px solid var(--amber);background:var(--amber-bg);border-radius:6px;padding:10px 14px;margin:10px 0;font-size:13px}
+  .flag.good{border-left-color:var(--sage);background:var(--sage-bg)}.flag.bad{border-left-color:var(--rose);background:var(--rose-bg)}
+  table{width:100%;border-collapse:collapse;font-size:13px;margin:8px 0}
+  th,td{padding:8px 9px;border-bottom:1px solid var(--line);text-align:left;vertical-align:top}
+  th{font:700 11px/1.2 Nunito;text-transform:uppercase;letter-spacing:.3px;color:var(--mid)}
+  td.c{text-align:center;font-weight:800}.yes{color:var(--sage)}.no{color:var(--rose)}.dash{color:var(--mid)}
+  td a{color:var(--sage);font-size:12px;word-break:break-all}
+  .pill{display:inline-block;font:600 11px/1 Nunito;padding:5px 10px;border-radius:999px;background:var(--card);border:1px solid var(--line);color:var(--mid);margin:0 4px 4px 0}
+  .pill.warn{background:var(--rose-bg);color:var(--rose);border-color:transparent}
+  .jump{display:inline-block;font-weight:700;color:var(--accent);cursor:pointer;border-bottom:1px dashed var(--accent)}
+  .lead{font-size:16px;line-height:1.5}.lead b{color:var(--accent)}
+  pre{background:#1e1b18;color:#e8e2d6;border-radius:12px;padding:16px;overflow:auto;font:12px/1.5 "SF Mono",Menlo,Consolas,monospace}
+  .therm{display:flex;gap:14px;flex-wrap:wrap}
+  .therm .col{flex:1;min-width:200px;border:1px solid var(--line);border-radius:12px;padding:14px;text-align:center}
+  .therm .big{font:800 19px/1 Fraunces,serif;margin:6px 0}
+  .col.safe{background:var(--sage-bg)}.col.danger{background:var(--rose-bg)}.col.safe .big{color:var(--sage)}.col.danger .big{color:var(--rose)}
+  .foot{color:var(--mid);font-size:12.5px;text-align:center;margin-top:30px}
+</style>
+</head>
+<body>
+<header><div class="wrap">
+  <h1>Egg &amp; Infant Safety — Visual Dashboard</h1>
+  <p class="sub">A <b>tier-1, prevention-proven</b> allergen — like peanut, egg earns the confident <i>"introduce early to lower allergy risk"</i> claim, backed by RCTs (PETIT, EAT). The one gate is <b>cooked-state</b>, not the food. Skim the Summary; drill into a tab for detail.</p>
+  <nav>
+    <button class="tab on" data-p="p-sum">Summary</button>
+    <button class="tab" data-p="p-why">Why / Allergen</button>
+    <button class="tab" data-p="p-sym">Reaction &amp; Introduction</button>
+    <button class="tab" data-p="p-ctx">Context</button>
+    <button class="tab" data-p="p-src">Sources &amp; Confidence</button>
+    <button class="tab" data-p="p-data">Data Stub</button>
+  </nav>
+  <p style="font-size:11.5px;color:var(--mid);margin:6px 0 10px">Swipe ‹ › between tabs · or use ← → arrow keys</p>
+</div></header>
+
+<div class="wrap">
+
+  <!-- ───────── SUMMARY ───────── -->
+  <section class="panel on" id="p-sum">
+    <div class="card" style="background:var(--honey-bg);border-color:transparent;margin-top:18px">
+      <p class="lead" style="margin:0"><b>The one rule: introduce well-cooked egg early — around 6 months — and keep it regular.</b> Early, sustained egg <b>lowers</b> egg-allergy risk, RCT-proven (PETIT: 38%→8%). The only gate is <b>cooked-state</b>: fully-cooked (solid white + yolk), never runny — there is no British-Lion-mark salmonella safeguard in India.</p>
+    </div>
+
+    <div class="grid g4">
+      <!-- stat tiles: .crit (red) / .ok (sage) / default (accent) -->
+      <div class="card stat ok"><div class="n">~6<span style="font-size:14px">mo</span></div><div class="l">introduce well-cooked egg from ~6 months (not before 4) — AAP·NHS·ASCIA</div></div>
+      <div class="card stat ok"><div class="n">38<span style="font-size:14px">%</span>→8<span style="font-size:14px">%</span></div><div class="l">egg allergy at 12mo — heated egg vs placebo (PETIT, P=0.0001)</div></div>
+      <div class="card stat ok"><div class="n">5.5<span style="font-size:14px">%</span>→1.4<span style="font-size:14px">%</span></div><div class="l">EAT per-protocol egg-allergy reduction (P=0.009)</div></div>
+      <div class="card stat"><div class="n">usually<br>outgrown</div><div class="l">most egg-allergic children outgrow it by school age — calm, not alarmed</div></div>
+    </div>
+
+    <h3>The things to know <span class="badge b-hi">all high-confidence</span></h3>
+    <div class="grid g2">
+      <div class="card"><b>1 · The advice reversed.</b> "Delay egg to prevent allergy" is gone — delaying does not prevent allergy and may <i>increase</i> it. Introduce ~6mo and keep offering. → <span class="jump" data-go="p-why">Why / Allergen</span></div>
+      <div class="card"><b>2 · Cooked-state is the gate, not the food.</b> Fully-cooked egg is the safe (and studied) form; runny/raw egg is not safe for an Indian infant — no Lion-mark, plus heating lowers allergenicity. → <span class="jump" data-go="p-why">Why / Allergen</span></div>
+      <div class="card"><b>3 · Watch the first exposure.</b> Small amount, fully cooked, at home, daytime, watch. Know mild (hives/vomiting) vs severe (breathing/floppy → call 112). → <span class="jump" data-go="p-sym">Reaction &amp; Introduction</span></div>
+      <div class="card"><b>4 · An Indian cultural asset.</b> Well-mashed boiled egg, firm bhurji, egg in khichdi — already fully-cooked forms. Just correct any half-boiled / runny-egg practice. → <span class="jump" data-go="p-ctx">Context</span></div>
+    </div>
+
+    <h3>When to surface this</h3>
+    <div class="card flag good" style="margin-top:0"><b>Recommendation (Maren):</b> an <b>encourage-polarity</b> card (sage, not honey's rose warn-card) — benefit first (the early-intro-lowers-allergy claim is RCT-earned here), then the introduce-safely block (<b>fully-cooked</b> form + ~⅓ egg amount + watch + keep offering), then a non-collapsible severe-reaction strip. The two highest-value nuggets unique to egg: the <b>fully-cook-it (no Lion-mark in India)</b> rule and the reassuring <b>usually-outgrown</b> framing.</div>
+    <div style="margin-top:14px">
+      <span class="pill">Reviewer · Maren (Care)</span><span class="pill">2026-06-01</span>
+      <span class="pill warn">Research artifact — not yet wired into the app</span>
+    </div>
+    <p style="font-size:12.5px;color:var(--mid);margin-top:10px">Full prose: <code>egg-infant-safety.md</code> · long-form HTML: <code>egg-infant-safety.html</code>. This dashboard is the skim layer over both.</p>
+  </section>
+
+  <!-- ───────── WHY / ALLERGEN ───────── -->
+  <section class="panel" id="p-why"><h2>Why it matters — early intro PREVENTS egg allergy</h2>
+    <div class="card">
+      <p style="margin:0 0 6px">Until ~2008–2015, guidance advised <b>delaying</b> allergenic foods (incl. egg) to prevent allergy. <b>That advice is reversed.</b> AAP/HealthyChildren now states there is no evidence that delaying allergenic foods like egg prevents allergies once a baby is ready, typically around 6 months. Delaying does not prevent allergy and may <i>increase</i> it. <span class="badge b-hi">consensus</span></p>
+    </div>
+
+    <h3>PETIT &amp; EAT — RCT reductions <span class="badge b-hi">PubMed-verified</span></h3>
+    <div class="card">
+      <div class="bar"><span class="lab">PETIT placebo</span><span class="trk"><span class="fil" style="width:100%;background:var(--rose)"></span></span><span class="val">38%</span></div>
+      <div class="bar hl"><span class="lab">PETIT heated egg</span><span class="trk"><span class="fil" style="width:21%"></span></span><span class="val">8%</span></div>
+      <div class="bar"><span class="lab">EAT per-protocol (std)</span><span class="trk"><span class="fil" style="width:14%;background:var(--rose)"></span></span><span class="val">5.5%</span></div>
+      <div class="bar hl"><span class="lab">EAT per-protocol (egg)</span><span class="trk"><span class="fil" style="width:4%"></span></span><span class="val">1.4%</span></div>
+      <p style="font-size:12px;color:var(--mid);margin:6px 0 0"><b>PETIT (Natsume et al., Lancet 2017; PMID 27939035):</b> high-risk eczematous Japanese infants on stepwise <b>heated</b> whole-egg powder (50 mg/day 6–9mo → 250 mg/day 9–12mo) <b>plus aggressive eczema treatment</b> — egg allergy at 12mo <b>8% vs 38% placebo, P=0.0001.</b> <b>EAT (Perkin/Lack, NEJM 2016; PMID 26943128):</b> per-protocol <b>1.4% vs 5.5%, P=0.009</b>; intention-to-treat <b>NOT</b> significant (7.1% vs 5.6%, P=0.32).</p>
+    </div>
+    <div class="flag"><b>⚑ Two integral conditions of the PETIT result:</b> (a) the studied form was <b>heated/cooked</b> egg, not raw; (b) <b>eczema was actively controlled</b> as part of the protocol. PETIT does not license giving raw egg, nor giving egg to an uncontrolled-eczema infant without care. For significant eczema or a strong family allergy history, early egg is still the goal — but involve a paediatrician on timing and eczema control.</div>
+    <div class="flag"><b>⚑ The EAT lesson is dose + adherence.</b> The benefit is real but depends on getting enough egg in, <b>regularly</b>. Frame egg as "introduce <b>and keep offering</b>," not a one-time tick.</div>
+
+    <h3>The safe form — fully-cooked egg <span class="badge b-hi">High</span></h3>
+    <div class="therm">
+      <div class="col safe">
+        <div style="font-size:12px;color:var(--mid)">Fully-cooked (SAFE)</div>
+        <div class="big">introduce early</div>
+        <div style="font-size:12.5px">mashed <b>hard-boiled</b> egg, <b>scrambled until firm</b>, or <b>baked into</b> food (omelette set firm, egg in khichdi/porridge cooked through). Start with about <b>⅓ of a well-cooked egg</b>.</div>
+      </div>
+      <div class="col danger">
+        <div style="font-size:12px;color:var(--mid)">Runny / raw (AVOID)</div>
+        <div class="big">not safe in India</div>
+        <div style="font-size:12.5px">runny, soft-yolk, half-boiled or lightly-cooked egg. NHS allows runny egg for infants <b>only with the British Lion mark</b> — <b>India has no equivalent scheme</b>, so cook until both white and yolk are solid.</div>
+      </div>
+    </div>
+    <div class="flag good"><b>✓ Why fully-cook.</b> Two reasons compound: <b>(1) salmonella</b> — without a control-scheme assurance, raw/undercooked egg carries an infection risk far more serious in an infant; <b>(2) allergenicity</b> — well-cooking (heating) reduces egg's allergenic potency, which is exactly why PETIT used <b>heated</b> egg powder. Egg has <b>no choking-form gate</b> (it is soft) — the gate it passes through is cooked-state, not particle-size.</div>
+  </section>
+
+  <!-- ───────── REACTION & INTRODUCTION ───────── -->
+  <section class="panel" id="p-sym"><h2>Reaction watch &amp; first introduction</h2>
+    <div class="card">
+      <p style="margin:0;font-size:13px;color:var(--mid)">Egg is among the most common infant food allergens — but, reassuringly, it is <b>commonly outgrown</b>: a <b>majority of egg-allergic children outgrow it by school age</b>, unlike peanut/tree-nut. The tone here is <b>calm and reassuring</b>, not alarmist.</p>
+    </div>
+
+    <h3>From mild to emergency</h3>
+    <div class="card">
+      <div class="tl">
+        <div class="tl-step first"><span class="tl-dot"></span><div class="tl-t">Mild — one body system</div><div class="tl-d">itchy hives/welts, redness or rash, swelling (esp. around mouth/eyes), vomiting, loose stool / GI upset, sudden fussiness.</div></div>
+        <div class="tl-step"><span class="tl-dot"></span><div class="tl-t">What to do for mild</div><div class="tl-d">stop the food, monitor closely, contact your doctor; an antihistamine may be advised by a clinician.</div></div>
+        <div class="tl-step crit"><span class="tl-dot"></span><div class="tl-t">Severe / anaphylaxis — red flags</div><div class="tl-d">difficulty/noisy breathing, wheeze, persistent cough; tongue/throat swelling or throat tightness; hoarse voice or cry; pale and floppy (sudden limpness), collapse. Two body systems involved → treat as anaphylaxis.</div></div>
+        <div class="tl-step crit"><span class="tl-dot"></span><div class="tl-t">Act immediately</div><div class="tl-d">lay the child flat (do not stand them up); use a prescribed adrenaline auto-injector immediately; <b>call emergency services — 112 (all-India) or 108 (ambulance).</b></div></div>
+      </div>
+      <p style="font-size:12px;color:var(--mid);margin:6px 0 0">Most reactions appear within <b>minutes to ~2 hours</b>; anaphylaxis often within <b>5–30 minutes</b>. (ASCIA — First Aid for Anaphylaxis.)</p>
+    </div>
+
+    <h3>First-exposure protocol</h3>
+    <div class="card">
+      <div class="tl">
+        <div class="tl-step first"><span class="tl-dot"></span><div class="tl-t">Small amount, fully cooked</div><div class="tl-d">a small portion of fully-cooked egg (about ⅓ of a well-cooked egg to build toward).</div></div>
+        <div class="tl-step"><span class="tl-dot"></span><div class="tl-t">At home, morning or midday</div><div class="tl-d">not at dinner — so you can observe through the day.</div></div>
+        <div class="tl-step"><span class="tl-dot"></span><div class="tl-t">Watch afterward</div><div class="tl-d">most reactions appear within a couple of hours.</div></div>
+        <div class="tl-step first"><span class="tl-dot"></span><div class="tl-t">If tolerated — keep offering regularly</div><div class="tl-d">the EAT lesson: sustained, regular intake is what carries the benefit.</div></div>
+      </div>
+    </div>
+    <div class="flag good"><b>✓ Reassurance.</b> Most introductions go fine. "Small amount, fully cooked, at home, watch" exists so that, in the rare reaction, you spot it early and act — not a reason to avoid egg.</div>
+  </section>
+
+  <!-- ───────── CONTEXT ───────── -->
+  <section class="panel" id="p-ctx"><h2>Indian &amp; cultural context</h2>
+    <div class="card">
+      <p style="margin:0">Egg is a <b>common, affordable, culturally accepted</b> complementary food in India. It appears in the <b>IAP</b> (Indian Academy of Pediatrics) complementary-feeding food groups as a protein-rich infant option. <span class="badge b-hi">staple status</span></p>
+    </div>
+
+    <h3>Cultural prep is already the safe form</h3>
+    <div class="card">
+      <p style="margin:0">Indian egg preparations for infants — well-mashed boiled egg, firm scrambled egg (egg bhurji cooked through, not runny), egg stirred into khichdi/porridge and cooked — are <b>already fully-cooked forms</b>, which is exactly the safe default. A cultural asset the model can affirm. The thing to <b>correct</b> is any practice of giving <b>half-boiled / soft-yolk / runny egg</b> to a baby (no Lion-mark safeguard in India).</p>
+    </div>
+
+    <h3>Hidden-egg sources (for an avoiding household)</h3>
+    <div class="card">
+      <p style="margin:0 0 6px">Once a parent is avoiding egg, the failure mode is <b>accidental exposure via an aliased or unlabelled source</b>. Watch labels for: <b>albumin/albumen, ovalbumin, ovomucoid, ovomucin, any "ovo-" prefix, ovovitellin/vitellin, livetin, lysozyme, globulin, conalbumin</b>, "egg solids," "dried/powdered egg."</p>
+      <p style="margin:0">Hidden-egg foods common in an Indian household: <b>egg-glazed / egg-washed bakery buns and pastries</b> (the shiny glaze is frequently an egg wash), cakes/biscuits/breads, mayonnaise &amp; salad dressings, custard puddings, ice cream, some kheer mixes, <b>egg noodles / hakka noodles</b>, batters, instant pancake/cake mixes, marshmallow, meringue. Lecithin (E322) is usually soy/sunflower but <b>can be egg-derived</b> — worth checking.</p>
+    </div>
+
+    <div class="flag"><b>⚑ Read the IAP citation correctly.</b> IAP listing egg among complementary-feeding food groups is a <b>nutrition</b> statement (good infant protein/iron/choline source) — <b>NOT</b> an "introduce egg early to prevent allergy" directive. Do not launder the international early-introduction-for-prevention claim onto IAP's name (the honey-brief lesson).</div>
+    <div class="flag good"><b>✓ Vegetarian note.</b> In a vegetarian or egg-avoiding household, egg is simply not introduced — a dietary choice, not a safety failure. The prevention benefit is one input, not an obligation; the brief should not push egg on a family that doesn't eat it.</div>
+  </section>
+
+  <!-- ───────── SOURCES & CONFIDENCE ───────── -->
+  <section class="panel" id="p-src">
+    <h2>Who says what — consensus matrix</h2>
+    <div class="card" style="overflow-x:auto"><table>
+      <tr><th>Authority</th><th class="c">Introduce ~6mo (not before 4)</th><th class="c">Fully-cook / cooked-state</th><th class="c">Early intro reduces allergy</th></tr>
+      <tr><td>AAP / HealthyChildren</td><td class="c yes">✓</td><td class="c yes">✓</td><td class="c yes">✓</td></tr>
+      <tr><td>UK NHS</td><td class="c yes">✓</td><td class="c yes">✓ (runny only if Lion-mark)</td><td class="c yes">✓</td></tr>
+      <tr><td>ASCIA (Australasia, 2026)</td><td class="c yes">✓</td><td class="c yes">✓</td><td class="c yes">✓</td></tr>
+      <tr><td>US NIAID (2017)</td><td class="c yes">✓</td><td class="c dash">—</td><td class="c yes">✓</td></tr>
+      <tr><td>PETIT (Lancet 2017)</td><td class="c yes">✓ (6–12mo)</td><td class="c yes">✓ (heated egg)</td><td class="c yes">✓ 38%→8%</td></tr>
+      <tr><td>EAT (NEJM 2016)</td><td class="c yes">✓</td><td class="c dash">—</td><td class="c yes">✓ per-protocol 5.5%→1.4%</td></tr>
+      <tr><td>IAP (India)</td><td class="c dash">— (nutrition food-group only)</td><td class="c dash">—</td><td class="c no">✗ no prevention directive</td></tr>
+    </table>
+    <p style="font-size:12px;color:var(--mid);margin:6px 0 0">The early-intro-prevents-allergy evidence is <b>international + RCT-backed</b> (AAP/NHS/ASCIA/NIAID/PETIT/EAT). IAP's egg listing is a nutrition framing only — do <b>not</b> attribute a prevention directive to any Indian body.</p>
+    </div>
+
+    <h2>Sources</h2>
+    <div class="card" style="overflow-x:auto"><table>
+      <tr><th>Authority</th><th>Link</th></tr>
+      <tr><td>NEJM — Perkin/Lack, EAT trial (2016)</td><td><a href="https://www.nejm.org/doi/full/10.1056/NEJMoa1514210">nejm.org/…/NEJMoa1514210</a></td></tr>
+      <tr><td>PubMed — EAT trial (PMID 26943128)</td><td><a href="https://pubmed.ncbi.nlm.nih.gov/26943128/">pubmed.ncbi.nlm.nih.gov/26943128</a></td></tr>
+      <tr><td>The Lancet — Natsume et al., PETIT trial (2017)</td><td><a href="https://www.thelancet.com/journals/lancet/article/PIIS0140-6736(16)31418-0/abstract">thelancet.com/…/PETIT</a></td></tr>
+      <tr><td>PubMed — PETIT trial (PMID 27939035)</td><td><a href="https://pubmed.ncbi.nlm.nih.gov/27939035/">pubmed.ncbi.nlm.nih.gov/27939035</a></td></tr>
+      <tr><td>NIAID — Addendum Guidelines (~6mo / not-before-4)</td><td><a href="https://www.niaid.nih.gov/sites/default/files/addendum-peanut-allergy-prevention-guidelines.pdf">niaid.nih.gov/…/prevention</a></td></tr>
+      <tr><td>AAP / HealthyChildren — when to introduce egg &amp; allergens</td><td><a href="https://www.healthychildren.org/English/healthy-living/nutrition/Pages/when-to-introduce-egg-peanut-butter-and-other-common-food-allergens-to-your-baby-food-allergy-prevention-tips.aspx">healthychildren.org/…/allergens</a></td></tr>
+      <tr><td>UK NHS — Food allergies in babies &amp; young children</td><td><a href="https://www.nhs.uk/baby/weaning-and-feeding/food-allergies-in-babies-and-young-children/">nhs.uk/baby/…/food-allergies</a></td></tr>
+      <tr><td>UK NHS — Foods to avoid (runny egg / British Lion mark)</td><td><a href="https://www.nhs.uk/baby/weaning-and-feeding/foods-to-avoid-giving-babies-and-young-children/">nhs.uk/baby/…/foods-to-avoid</a></td></tr>
+      <tr><td>ASCIA — Infant Feeding for Food Allergy Prevention</td><td><a href="https://www.allergy.org.au/hp/papers/infant-feeding-and-allergy-prevention">allergy.org.au/…/infant-feeding</a></td></tr>
+      <tr><td>ASCIA — Updated infant-feeding guideline (Jan 2026)</td><td><a href="https://www.allergy.org.au/about-ascia/info-updates/updated-ascia-guideline-infant-feeding-for-food-allergy-prevention-published-january-2026">allergy.org.au/…/2026-update</a></td></tr>
+      <tr><td>ASCIA — First Aid for Anaphylaxis</td><td><a href="https://www.allergy.org.au/hp/anaphylaxis/first-aid-for-anaphylaxis">allergy.org.au/…/first-aid</a></td></tr>
+      <tr><td>FARE — Egg allergy (common allergens)</td><td><a href="https://www.foodallergy.org/living-food-allergy/food-allergy-essentials/common-allergens/egg">foodallergy.org/…/egg</a></td></tr>
+      <tr><td>FAACT — Egg allergen</td><td><a href="https://www.foodallergyawareness.org/food-allergy-and-anaphylaxis/food-allergens/egg/">foodallergyawareness.org/…/egg</a></td></tr>
+      <tr><td>IAP — Complementary Feeding (Ch-040; egg in food groups)</td><td><a href="https://iapindia.org/pdf/Ch-040-IAP-Parental-Guideline-Complementary-Feeding.pdf">iapindia.org/…/Ch-040</a></td></tr>
+    </table></div>
+    <div class="flag"><b>⚑ Open gaps:</b> <b>(1) No India early-egg-for-prevention directive exists</b> — IAP Ch-040 lists egg as a nutrition food-group, not an allergy-prevention recommendation; the prevention base is international (verified). Do not attribute it to IAP/MoHFW/FSSAI. <b>(2) Source-tier flag</b> — FARE/FAACT are advocacy/patient-education bodies, cited for the alias list, hidden-egg sources, mild-vs-severe symptoms, and the commonly-outgrown framing (all mainstream/corroborated), not regulator-verbatim. Trial claims rest on PETIT/EAT (primary, PubMed-verified); cooked-state &amp; timing on NHS/AAP/ASCIA. <b>(3) 112/108</b> are operational emergency numbers, not allergy-guideline-issued; ASCIA's first-aid content (lay flat, adrenaline first, then call) is the cited clinical procedure.</div>
+  </section>
+
+  <!-- ───────── DATA STUB ───────── -->
+  <section class="panel" id="p-data"><h2>Drop-in record — <code>FOOD_EFFECTS['egg']</code></h2>
+    <p style="font-size:13.5px;color:var(--mid)">Mirror of egg's record in <code>food-effects.manifest.js</code>. Sits alongside <code>AGE_RULES</code>/<code>ALLERGENS</code>. <code>foodClass:'allergen-introduce-early'</code> drives the sage encourage-banner; the form gate is <b>cooked-state</b>, not particle-size. <b>Not yet wired.</b></p>
+<pre>{
+  food:          'egg',
+  aliases:       ['eggs','anda','egg yolk','whole egg','boiled egg','hard-boiled egg','scrambled egg','omelette','omelet'],
+  foodClass:     'allergen-introduce-early',
+  severity:      'caution',
+  category:      'egg',
+  effect:        'food allergy',
+  minMonth:      6,                      // AAP/NHS ~6mo (not before 4); reconcile with AGE_RULES egg-yolk:7 at wiring
+  thresholdBasis:'developmental-readiness',
+  allergen:      true,
+  reactionType:  ['allergy'],
+  headline:      'Introduce early (~6 months), well-cooked — early egg lowers allergy risk.',
+  whyGood:       'Complete protein, choline, iron, vitamin D — and early, regular well-cooked egg helps prevent egg allergy.',
+  earlyIntroBenefit: { claim:'Early, regular well-cooked egg helps prevent egg allergy.',
+                       evidence:'PETIT (Lancet 2017): heated egg + eczema care cut egg allergy 38%→8% at 12mo (P=0.0001). EAT (NEJM 2016): per-protocol 5.5%→1.4% (P=0.009).',
+                       paradigm:'Reverses old "delay egg to prevent allergy" advice.' },
+  safeForm:      { ok:['well-cooked egg — mashed hard-boiled, scrambled, or baked into soft food','start with cooked yolk; offer whole egg once yolk is tolerated'],
+                   never:['raw or runny egg','lightly-cooked egg (no British-Lion-mark assurance exists in India)'],
+                   note:'Cook until BOTH white and yolk are solid — this is the studied safe form and removes the salmonella risk.' },
+  myth:          { claim:'Delay egg to prevent allergy.',
+                   truth:'Reversed — early, regular well-cooked egg helps prevent egg allergy; delaying may increase risk.' },
+  watchFor:      ['hives / rash','swelling (mouth, eyes, lips)','vomiting'],
+  severeSigns:   ['trouble breathing / wheeze','face/lip/tongue swelling','floppy, pale, or very sleepy'],
+  timeCourse:    'minutes to ~2 hours after eating; anaphylaxis often within 5–30 min',
+  seekCare:      'Mild single-system: stop, monitor, call doctor. Any breathing trouble, face/throat swelling, or floppiness: EMERGENCY — call 112, use prescribed adrenaline auto-injector.',
+  breastfeedingSafe: true,
+  culturalNote:  'No British-Lion-mark assured-egg scheme in India — default to fully-cooked egg (solid white and yolk). Egg allergy is common in infancy but usually outgrown by school age.',
+  confidence:    'high',
+  sources:       ['Lancet PETIT 2017','NEJM EAT 2016','AAP','UK NHS','ASCIA 2026','NIAID 2017'],
+  dashboard:     'egg-infant-safety.visual.html',
+  brief:         'egg-infant-safety.md',
+  longform:      'egg-infant-safety.html',
+  lastReviewed:  '2026-06-01',
+}</pre>
+    <div class="flag good"><b>Surfacing hook:</b> an <b>encourage</b> card (sage), not honey's <b>warn</b> card (rose). Benefit banner (the RCT-earned prevention claim) → introduce-safely (<b>fully-cooked</b> form / ~⅓ egg / watch / keep-offering) → the severe-reaction strip (unconditional, never collapsed) → mild watch-fors → the "delay" myth. <code>severity:'caution'</code> drives amber chrome; rose stays reserved for acute-toxin (honey).</div>
+  </section>
+
+  <p class="foot">SproutLab · Care visual dashboard · skim layer over <code>egg-infant-safety.md</code> / <code>.html</code> · 2026-06-01<br>
+  Informational, not medical advice. Not yet wired into the app. All chart values are also in text for machine-reading.</p>
+</div>
+
+<!-- ═══════ COMPONENT LIBRARY — copy a block into a panel and fill it ═══════
+<div class="bar"><span class="lab">Label</span><span class="trk"><span class="fil" style="width:73%"></span></span><span class="val">73%</span></div>
+<div class="bar hl"><span class="lab">Highlight</span><span class="trk"><span class="fil" style="width:12%"></span></span><span class="val">8.9%</span></div>
+  (bar widths are % of the track; scale all rows to the max value; ALWAYS put the real number in .val)
+
+<svg viewBox="0 0 120 120" width="118" height="118" role="img" aria-label="DESCRIBE + give the number">
+  <circle cx="60" cy="60" r="52" fill="none" stroke="var(--track)" stroke-width="15"/>
+  <circle cx="60" cy="60" r="52" fill="none" stroke="var(--honey)" stroke-width="15"
+    stroke-dasharray="PCT_LEN REST" stroke-dashoffset="0" transform="rotate(-90 60 60)" stroke-linecap="round"/>
+  <text x="60" y="58" text-anchor="middle" font-size="20" font-weight="800" fill="var(--honey)" font-family="Fraunces,serif">~20%</text>
+</svg>
+  (circumference for r=52 is 326.7; PCT_LEN = pct*3.267, REST = 326.7 - PCT_LEN)
+
+<div class="tl"><div class="tl-step first"><span class="tl-dot"></span><div class="tl-t">First sign</div><div class="tl-d">detail</div></div>
+  <div class="tl-step crit"><span class="tl-dot"></span><div class="tl-t">Emergency</div><div class="tl-d">detail</div></div></div>
+
+<div class="therm"><div class="col safe"><div style="font-size:12px;color:var(--mid)">A</div><div class="big">safe fact</div><div>detail</div></div>
+  <div class="col danger"><div style="font-size:12px;color:var(--mid)">B</div><div class="big">danger fact</div><div>detail</div></div></div>
+
+<div class="flag good|bad"><b>label</b> text</div>   ·   <span class="badge b-hi|b-mod|b-weak">confidence</span>
+═══════════════════════════════════════════════════════════════════════ -->
+
+<script>
+  var tabs = Array.prototype.slice.call(document.querySelectorAll('.tab'));
+  function activate(t){
+    if(!t) return;
+    tabs.forEach(function(x){x.classList.remove('on');});
+    document.querySelectorAll('.panel').forEach(function(x){x.classList.remove('on');});
+    t.classList.add('on');
+    var el = document.getElementById(t.dataset.p); if(el) el.classList.add('on');
+    t.scrollIntoView({inline:'center', block:'nearest'}); window.scrollTo(0,0);
+  }
+  tabs.forEach(function(t){ t.addEventListener('click', function(){ activate(t); }); });
+  document.querySelectorAll('[data-go]').forEach(function(j){
+    j.addEventListener('click', function(){ activate(document.querySelector('.tab[data-p="'+j.dataset.go+'"]')); });
+  });
+  function step(d){ var c=tabs.findIndex(function(t){return t.classList.contains('on');}); var n=c+d; if(n>=0&&n<tabs.length) activate(tabs[n]); }
+  var sx=0, sy=0, tracking=false;
+  document.addEventListener('touchstart', function(e){ if(e.touches.length>1){tracking=false;return;} sx=e.changedTouches[0].clientX; sy=e.changedTouches[0].clientY; tracking=true; }, {passive:true});
+  document.addEventListener('touchend', function(e){
+    if(!tracking) return; tracking=false;
+    var dx=e.changedTouches[0].clientX-sx, dy=e.changedTouches[0].clientY-sy;
+    if(Math.abs(dx) < 55 || Math.abs(dx) < Math.abs(dy)*1.5) return;
+    step(dx < 0 ? 1 : -1);
+  }, {passive:true});
+  document.addEventListener('keydown', function(e){ if(e.key==='ArrowRight') step(1); else if(e.key==='ArrowLeft') step(-1); });
+</script>
+</body>
+</html>

--- a/docs/research/food-effects.manifest.js
+++ b/docs/research/food-effects.manifest.js
@@ -163,9 +163,9 @@ window.FOOD_EFFECTS_MANIFEST = [
     culturalNote:  'No British-Lion-mark assured-egg scheme in India — default to fully-cooked egg (solid white and yolk). Egg allergy is common in infancy but usually outgrown by school age.',
     confidence:    'high',
     sources:       ['Lancet PETIT 2017','NEJM EAT 2016','AAP','UK NHS','ASCIA 2026','NIAID 2017'],
-    dashboard:     'egg-infant-safety.visual.html',   // render pending (Phase δ render step)
+    dashboard:     'egg-infant-safety.visual.html',
     brief:         'egg-infant-safety.md',
-    longform:      'egg-infant-safety.html',           // render pending
+    longform:      'egg-infant-safety.html',
     lastReviewed:  '2026-06-01',
   },
   {
@@ -197,9 +197,9 @@ window.FOOD_EFFECTS_MANIFEST = [
     culturalNote:  'Soya chunks/granules are everyday vegetarian protein in India — a concentrated soy-protein form. Some cow\'s-milk-allergic babies also react to soy; introduce as a minor ingredient first.',
     confidence:    'high',
     sources:       ['AAP','UK NHS','ASCIA','NIAID 2017','FARE','CHOP (FPIES)','NEJM EAT 2016'],
-    dashboard:     'soy-infant-safety.visual.html',    // render pending
+    dashboard:     'soy-infant-safety.visual.html',
     brief:         'soy-infant-safety.md',
-    longform:      'soy-infant-safety.html',           // render pending
+    longform:      'soy-infant-safety.html',
     lastReviewed:  '2026-06-01',
   },
   {
@@ -231,9 +231,9 @@ window.FOOD_EFFECTS_MANIFEST = [
     culturalNote:  'Atta, maida, suji/rava, dalia, sevai are all wheat. Soft cereal and softened roti are ideal early forms. Wheat allergy is commonly outgrown in early childhood.',
     confidence:    'high',
     sources:       ['AAP','UK NHS','ASCIA','NIAID 2017','NEJM EAT 2016','ESPGHAN 2016 (celiac/gluten)'],
-    dashboard:     'wheat-infant-safety.visual.html',  // render pending
+    dashboard:     'wheat-infant-safety.visual.html',
     brief:         'wheat-infant-safety.md',
-    longform:      'wheat-infant-safety.html',          // render pending
+    longform:      'wheat-infant-safety.html',
     lastReviewed:  '2026-06-01',
   },
   {
@@ -265,9 +265,9 @@ window.FOOD_EFFECTS_MANIFEST = [
     culturalNote:  'Til is deeply embedded — til laddoo, gajak (peak around Makar Sankranti), chutneys, gingelly oil. Thin tahini into dal, khichdi, curd, or fruit puree; avoid loose til seeds from laddoo/gajak for young infants.',
     confidence:    'high',
     sources:       ['AAP','UK NHS','ASCIA','FDA FASTER Act 2021','NEJM EAT 2016','J Asthma Allergy (persistence)','JAMA Netw Open 2019'],
-    dashboard:     'sesame-infant-safety.visual.html', // render pending
+    dashboard:     'sesame-infant-safety.visual.html',
     brief:         'sesame-infant-safety.md',
-    longform:      'sesame-infant-safety.html',         // render pending
+    longform:      'sesame-infant-safety.html',
     lastReviewed:  '2026-06-01',
   },
 

--- a/docs/research/sesame-infant-safety.html
+++ b/docs/research/sesame-infant-safety.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Sesame (Til) &amp; Infant Safety — Care Research Brief · SproutLab</title>
+<style>
+  :root{
+    --bg:#faf6f0; --card:#fffdf9; --ink:#2e2a26; --mid:#6b6258; --line:#e8ddcf;
+    --sage:#3a7060; --sage-bg:#e8f5ef; --rose:#b04a5e; --rose-bg:#fbe9ec;
+    --amber:#8a6320; --amber-bg:#fbf0d9; --accent:#9a6a3a;
+    --hi:#2f7d5b; --hi-bg:#e3f3ea; --mod:#9a7320; --mod-bg:#f7eed6; --weak:#9a5a5a; --weak-bg:#f5e6e6;
+  }
+  @media (prefers-color-scheme: dark){
+    :root{ --bg:#1d1a17; --card:#262220; --ink:#ece5db; --mid:#a89c8c; --line:#3a342d;
+      --sage:#7ac0a0; --sage-bg:#1e3028; --rose:#e090a0; --rose-bg:#3a2026;
+      --amber:#e0b060; --amber-bg:#352a16; --accent:#c99a6a;
+      --hi:#7ac0a0; --hi-bg:#1e3028; --mod:#d8b060; --mod-bg:#332a14; --weak:#e09090; --weak-bg:#3a2222; }
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+    font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Nunito,sans-serif;
+    -webkit-font-smoothing:antialiased;padding:0 0 80px}
+  .wrap{max-width:880px;margin:0 auto;padding:0 20px}
+  header{background:linear-gradient(160deg,var(--amber-bg),var(--bg));border-bottom:1px solid var(--line);
+    padding:34px 0 26px;margin-bottom:8px}
+  h1{font:700 27px/1.25 Fraunces,Georgia,serif;margin:0 0 6px}
+  .sub{color:var(--mid);font-size:14.5px;margin:0}
+  .meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
+  .pill{font-size:12px;font-weight:600;padding:4px 10px;border-radius:999px;background:var(--card);
+    border:1px solid var(--line);color:var(--mid)}
+  .pill.warn{background:var(--rose-bg);color:var(--rose);border-color:transparent}
+  .pill.crit{background:var(--rose-bg);color:var(--rose);border-color:transparent}
+  h2{font:600 19px/1.3 Fraunces,Georgia,serif;margin:30px 0 12px;padding-top:10px;border-top:1px solid var(--line)}
+  h2 .ax{color:var(--accent);font-weight:700}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:18px 20px;margin:14px 0}
+  .tldr{background:var(--sage-bg);border-color:transparent}
+  .tldr ul{margin:8px 0 0;padding-left:20px}
+  .tldr li{margin:7px 0}
+  ul{margin:6px 0;padding-left:22px}
+  li{margin:6px 0}
+  .badge{display:inline-block;font-size:11px;font-weight:700;letter-spacing:.3px;text-transform:uppercase;
+    padding:3px 9px;border-radius:7px;vertical-align:middle;margin-left:8px}
+  .b-hi{background:var(--hi-bg);color:var(--hi)} .b-mod{background:var(--mod-bg);color:var(--mod)} .b-weak{background:var(--weak-bg);color:var(--weak)}
+  .b-crit{background:var(--rose-bg);color:var(--rose)}
+  .flag{background:var(--amber-bg);border-left:3px solid var(--amber);border-radius:6px;
+    padding:10px 14px;margin:12px 0;font-size:14px;color:var(--ink)}
+  .flag b{color:var(--amber)}
+  .flag.crit{background:var(--rose-bg);border-left-color:var(--rose)}
+  .flag.crit b{color:var(--rose)}
+  .flag.good{background:var(--sage-bg);border-left-color:var(--sage)}
+  .flag.good b{color:var(--sage)}
+  blockquote{margin:12px 0;padding:8px 0 8px 16px;border-left:3px solid var(--sage);color:var(--mid);font-style:italic}
+  code,pre{font-family:"SF Mono",Menlo,Consolas,monospace}
+  pre{background:#1e1b18;color:#e8e2d6;border-radius:12px;padding:18px;overflow:auto;font-size:12.5px;line-height:1.55}
+  pre .c{color:#8a9a7a} pre .k{color:#d8a0b0} pre .s{color:#cbb080}
+  table{width:100%;border-collapse:collapse;font-size:13.5px;margin:10px 0}
+  th,td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{color:var(--mid);font-weight:700;font-size:12px;text-transform:uppercase;letter-spacing:.3px}
+  td a{color:var(--sage);word-break:break-all;font-size:12px}
+  .quote{background:var(--card);border:1px dashed var(--line);border-radius:10px;padding:6px 14px;margin:8px 0;font-size:14px}
+  .quote b{color:var(--accent)}
+  .foot{color:var(--mid);font-size:13px;margin-top:30px;text-align:center}
+  .gap{background:var(--rose-bg);border-color:transparent}
+</style>
+</head>
+<body>
+<header><div class="wrap">
+  <h1>Sesame (Til) &amp; Infant Safety</h1>
+  <p class="sub">Care research brief — evidence base for SproutLab's <b>guided-introduction</b> food-effects model. Sesame is the <b>Tier-2</b> case: introduce early because it's safe and don't-delay, but <b>prevention is NOT RCT-proven</b> — and it is the <b>gravest</b> of the four allergens (rarely outgrown).</p>
+  <div class="meta">
+    <span class="pill">Reviewer · Research scout pass (for Maren, Care)</span>
+    <span class="pill">2026-06-01</span>
+    <span class="pill">Sesame / til · infants ~6–12mo (choking note to ~5yr) · India</span>
+    <span class="pill crit">Usually lifelong — ~70–80% persist</span>
+    <span class="pill warn">Research artifact — NOT yet wired into the app</span>
+  </div>
+</div></header>
+
+<div class="wrap">
+
+  <div class="card">
+    <p style="margin:0"><b>Purpose.</b> Evidence base for SproutLab's Care layer, feeding the <i>guided-introduction</i> food-effects model. Built to decide what to surface when a parent introduces <b>sesame (til)</b> to an under-1 — covering BOTH why to introduce early (don't-delay-allergens guidance) AND the two hazards (allergy reaction; choking-by-form). The food is not banned — the <b>FORM</b> is gated. <b>Tone caveat unique to sesame:</b> the prevention rationale here is <i>weaker</i> than peanut's — see TL;DR — and the persistence profile is <i>graver</i>, so the emergency floor is the most serious of the four allergens.</p>
+    <p style="margin:10px 0 0;font-size:14px;color:var(--mid)"><b>Scope.</b> Sesame (til): tahini (sesame paste), til laddoo, gajak, chutneys, gingelly/sesame oil, sesame on breads/buns. Infants ~6–12 months, with the choking note running to ~5 years. Family context: Indian — til is a deeply embedded staple, not a novelty. <b>Method.</b> Multi-angle web fan-out → source fetch → adversarial cross-check → synthesis (AAP/HealthyChildren, NHS, ASCIA, NIAID; FDA + FoodSafety.gov; EAT trial NEJM 2016; J Asthma Allergy; JAMA Netw Open 2019). The <b>FDA FASTER-Act page and the ASCIA page returned 401/403 to automated fetchers</b>; those facts are corroborated across FDA indexed text, the FoodSafety.gov mirror, and independent sources — marked <b>high-confidence-but-not-direct-fetch</b>. The EAT sesame-null result is verified verbatim from PubMed 26943128.</p>
+  </div>
+
+  <div class="card tldr">
+    <strong>TL;DR — the parent-facing truth</strong>
+    <ul>
+      <li><b>Introduce early — but be honest about <i>why</i>.</b> Consensus (AAP, NHS, ASCIA, NIAID) is to introduce sesame <b>early — around 6 months, alongside other solids</b> — and not to delay. This is the right advice. <b>But unlike peanut, this is NOT RCT-proven prevention for sesame.</b></li>
+      <li><b>The RCT did NOT find a sesame benefit.</b> The <b>EAT trial (NEJM 2016)</b> tested early introduction of six allergens including sesame and reported, verbatim, <i>"no significant effects with respect to milk, sesame, fish, or wheat."</i> (Verified PubMed 26943128.) The peanut+egg benefit does <b>not</b> transfer. <b>Do not claim early sesame prevents sesame allergy.</b></li>
+      <li><b>Sesame is the 9th major US allergen.</b> Under the <b>FASTER Act of 2021</b>, sesame became the 9th major US food allergen; mandatory labeling took effect <b>January 1, 2023</b> (e.g. "tahini (sesame)" or "Contains sesame"). The EU has long required sesame declaration. <b>This labeling does NOT apply to Indian/home foods.</b></li>
+      <li><b>The crux is FORM, not the food.</b> A thick glob of tahini is a sticky choking risk, and whole sesame seeds in quantity are a hazard. The safe form is <b>smooth tahini THINNED with water/milk/puree</b>, or <b>finely ground sesame stirred into food</b> — the same "thin the sticky glob" rule as peanut butter.</li>
+      <li><b>Sesame allergy is usually LIFELONG — this is the key tone point.</b> Unlike egg, milk, soy and wheat (commonly outgrown), <b>sesame allergy is rarely outgrown — only ~20–30% achieve tolerance, so ~70–80% persists into adulthood.</b> It is a leading cause of anaphylaxis. So first exposures and ongoing vigilance matter <b>more</b> here — the emergency floor should carry the most serious tone of the four.</li>
+    </ul>
+  </div>
+
+  <h2><span class="ax">Axis 1</span> · Benefit, timing &amp; regulatory status <span class="badge b-hi">High</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>Introduce around 6 months, don't delay.</b> General-population timing for sesame is <b>around 6 months</b>, once the baby is developmentally ready and a few first foods are tolerated — <b>not before 4 months</b>, and don't delay once ready. <span class="badge b-hi">NHS · AAP · ASCIA</span></li>
+      <li><b>AAP names sesame directly:</b><blockquote>"There is no evidence that delaying introduction of allergenic foods like egg, peanut, dairy and sesame prevents allergies once babies are ready, typically at about 6 months." — AAP/HealthyChildren</blockquote></li>
+      <li><b>NHS</b> lists sesame among allergenic foods to introduce (not delay), with the form note that seeds — "particularly sesame" — should be served <b>finely ground</b>.</li>
+      <li><b>ASCIA</b> (Australasia) recommends introducing common allergens including sesame in the first year, ideally before 12 months. <span class="badge b-mod">page blocked direct fetch; corroborated indirectly</span></li>
+    </ul>
+    <p style="margin:10px 0 0"><b>The EAT nuance — sesame is null (frame honestly).</b> EAT (1,303 exclusively breastfed, general-population infants) randomised early introduction of six allergens including sesame vs standard ~6 months. The abstract states, verbatim:</p>
+    <div class="quote"><b>EAT (NEJM 2016):</b> "no significant effects with respect to milk, sesame, fish, or wheat." <span class="badge b-hi">verified PubMed 26943128</span></div>
+    <p style="margin:8px 0 0">The per-protocol benefit EAT <i>did</i> find was for <b>peanut and egg only</b>.</p>
+    <div class="flag good"><b>⚑ The honest framing the model must hold:</b> early sesame is <b>SAFE</b> and there's no reason to delay — but <b>RCT evidence does not show early sesame prevents sesame allergy.</b> The "introduce early" advice for sesame is the general <i>don't-delay-allergens</i> principle (AAP/NHS/ASCIA), <b>not</b> a sesame-specific prevention result. Lead with "safe to introduce, no need to delay"; never with "introducing early will prevent the allergy."</div>
+    <p style="margin:10px 0 0"><b>Regulatory weight — sesame is now a top-tier labeled allergen.</b> Under the <b>FASTER Act of 2021</b> (Food Allergy Safety, Treatment, Education, and Research Act), sesame became the <b>9th major US food allergen</b>; the mandatory labeling requirement took effect <b>January 1, 2023</b>. US packaged foods must now declare sesame plainly (e.g. "tahini (sesame)" or a "Contains sesame" statement). The EU has long required it; the US only since 2023. <span class="badge b-mod">FDA page blocked direct fetch; FoodSafety.gov mirror corroborates</span></p>
+    <div class="flag"><b>⚑ Scope limit — flag for the spec:</b> this labeling law is <b>US (and analogously EU) packaged-food regulation. It does NOT apply to Indian-bought packets or home foods.</b> A homemade til laddoo, a loose chutney, or an unlabeled Indian sweet carries no "Contains sesame" guarantee — the parent is the label.</div>
+  </div>
+
+  <h2><span class="ax">Axis 2</span> · Safe FORM: the choking gate <span class="badge b-hi">High</span></h2>
+  <div class="card">
+    <p style="margin:0 0 6px"><b>Two form hazards with sesame:</b></p>
+    <ul>
+      <li>A <b>thick glob of tahini</b> — sesame paste forms a sticky clump that can lodge in the airway, exactly the peanut-butter problem.</li>
+      <li><b>Whole sesame seeds given in quantity</b> — small, hard, easily inhaled. <span class="badge b-hi">NHS "seeds, particularly sesame, served finely ground"</span></li>
+    </ul>
+    <p style="margin:10px 0 6px"><b>Safe forms (the gate the food passes through):</b></p>
+    <ol>
+      <li><b>Smooth tahini (sesame paste), THINNED</b> — whisk <b>~⅛–½ tsp</b> into breast milk, formula, water, or an already-tolerated puree/yoghurt/dal/khichdi/curd/fruit puree until it's a thin, smooth consistency. (Mirrors NHS/AAP peanut-butter ~¼ tsp form.)</li>
+      <li><b>Finely ground sesame</b> stirred into food — ground to a fine meal, never left as whole seeds.</li>
+      <li><b>NEVER</b> a thick glob/spoonful of paste straight up, and <b>never whole seeds in quantity</b> for a young infant.</li>
+    </ol>
+    <p style="margin:10px 0 0"><b>India-specific form note:</b> thin tahini into <b>dal, khichdi, curd, or fruit puree</b>; <b>avoid loose til shaken off laddoo/gajak</b> for a young infant — those carry whole seeds and a hard/sticky matrix that is both a choking risk and an uncontrolled first-exposure dose.</p>
+    <div class="flag good"><b>✓ This is the design crux:</b> the choking hazard is removable by FORM transformation (thin/grind), like peanut — <i>not</i> like honey (where cooking does not remove the spore hazard). The <b>allergy axis is separate and is NOT removed by form</b> — thinning the tahini makes it safe to swallow, not safe for an allergic child.</div>
+  </div>
+
+  <h2><span class="ax">Axis 3</span> · Allergy watch-fors &amp; what to do — the gravest emergency floor <span class="badge b-hi">High</span></h2>
+  <div class="card">
+    <p style="margin:0 0 8px"><b>Sesame is a leading cause of food-allergic anaphylaxis, and the allergy is usually lifelong.</b> Treat the first exposures and ongoing vigilance with the <b>most</b> seriousness of the four allergens — because, unlike egg/milk/soy/wheat, this one is very unlikely to be outgrown (Axis 5).</p>
+    <p style="margin:0 0 6px"><b>Mild–moderate reaction (one body system):</b> itchy <b>hives/welts</b>, redness or <b>rash</b>, <b>swelling</b> (esp. around the mouth/eyes), <b>vomiting</b>, sometimes loose stool/GI upset, sudden fussiness.</p>
+    <div class="flag crit"><b>Severe / anaphylaxis (act immediately):</b> difficulty breathing, <b>wheeze/persistent cough/noisy breathing</b>, <b>swelling of the face/lips/tongue/throat</b>, hoarse cry or voice, <b>pale / floppy / lethargic</b> or unusually sleepy, collapse. In babies, <i>behaviour change</i> (suddenly limp, can't hold head up) is a recognised severe sign.</div>
+    <p style="margin:10px 0 6px"><b>What to do:</b></p>
+    <ul>
+      <li><b>Mild, single-system:</b> stop the food, monitor closely, contact your doctor; an antihistamine may be advised by a clinician.</li>
+      <li><b>Any breathing difficulty, throat/face/tongue swelling, floppiness, or two body systems involved → emergency. Use an adrenaline auto-injector immediately if one has been prescribed, and call emergency services (112 / 108 in India).</b></li>
+      <li>First exposures matter especially here: the very first taste may sensitise with the reaction on a later one — keep watching across the first several exposures, not just day one. And because sesame allergy is <b>usually permanent</b>, this vigilance does not "age out" the way it tends to for milk/egg.</li>
+    </ul>
+  </div>
+
+  <h2><span class="ax">Axis 4</span> · Culinary aliases &amp; hidden sources <span class="badge b-hi">High (aliases)</span> <span class="badge b-mod">Moderate (oil nuance)</span></h2>
+  <div class="card">
+    <p style="margin:0 0 6px"><b>Sesame hides under many names — a confirmed-allergic child's caregiver must recognise all of them:</b></p>
+    <ul>
+      <li><b>tahini</b> (sesame paste), <b>hummus</b> (tahini-based), <b>halva / halwa</b> (sesame variety), <b>til</b> and <b>til laddoo</b>, <b>gajak</b> (Indian sesame-jaggery brittle/sweet, peak season around <b>Makar Sankranti, mid-January</b>), <b>benne / benniseed</b>, <b>gomashio</b>, <b>goma</b> (Japanese), <b>sim sim</b>, and <b>gingelly oil (= sesame oil on South Asian labels)</b>.</li>
+      <li><b>Hidden on/in:</b> sesame seeds on <b>breads, buns, crackers, bagels</b>, sprinkled in <b>chutneys</b>, baked into <b>sweets</b>, and in many <b>dressings/spice blends</b>.</li>
+    </ul>
+    <p style="margin:10px 0 0"><b>The sesame-oil nuance (do not over-simplify):</b> <b>highly refined sesame oil is largely de-proteinized and lower-risk.</b> <b>But cold-pressed / unrefined gingelly oil — common in Indian cooking — can retain allergenic protein.</b> <span class="badge b-mod">moderate-confidence</span></p>
+    <div class="flag"><b>⚑ Do NOT assume "it's only oil, so it's safe"</b> for a confirmed sesame-allergic child. Refined oil ≠ unrefined gingelly oil; the unrefined oil prevalent in Indian kitchens can carry enough protein to react to. For a non-allergic baby this is not a barrier to introduction; for a <i>known-allergic</i> child, treat unrefined sesame/gingelly oil as a potential exposure.</div>
+  </div>
+
+  <h2><span class="ax">Axis 5</span> · Persistence: the key tone point <span class="badge b-hi">High</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>Sesame allergy is rarely outgrown.</b> Peer-reviewed data put resolution at roughly <b>20–30%</b> — meaning <b>~70–80% persists into adulthood</b>. <span class="badge b-hi">J Asthma Allergy · JAMA Netw Open 2019</span></li>
+      <li><b>Contrast that makes the tone:</b> egg, milk, soy and wheat allergies are <b>commonly outgrown</b> in childhood; <b>sesame, peanut and tree nuts tend to be lifelong</b>. Sesame sits firmly in the <i>lifelong</i> camp and is a <i>leading anaphylaxis trigger</i>.</li>
+    </ul>
+    <div class="flag crit"><b>Why this drives the model's tone:</b> for a commonly-outgrown allergen, a parent can reasonably expect the risk to fade. For sesame, the risk does <b>not</b> reliably fade — so the model's emergency floor, label-vigilance, and "carry the adrenaline plan" framing should be the <b>most serious of the four</b>, and should not soften over the toddler years the way it might for milk/egg.</div>
+  </div>
+
+  <h2><span class="ax">Axis 6</span> · Indian &amp; cultural context <span class="badge b-hi">High (embedding)</span> <span class="badge b-mod">Moderate (India guidance/prevalence)</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>Til is deeply embedded in the Indian diet</b> — <b>til laddoo, gajak, sesame chutneys, gingelly (sesame) oil</b> are everyday foods, with sesame sweets peaking around <b>Makar Sankranti (mid-January)</b>. Early, regular introduction is therefore culturally natural — the challenge is FORM (thin/grind) and first-exposure discipline, not novelty.</li>
+      <li><b>Sesame is reportedly among the more common sensitizing allergens in India</b> — appears in Indian allergy literature/parenting sources; treat as directional, not a precise figure. <span class="badge b-weak">secondary / regional</span></li>
+      <li><b>The cultural double-edge:</b> because til is <i>everywhere</i> (sweets, oils, chutneys) and often <b>unlabeled</b> in home/loose form, an Indian family both (a) introduces sesame naturally and early, and (b) faces a harder <i>avoidance</i> task if the child turns out allergic — the US "Contains sesame" label does <b>not</b> appear on a homemade laddoo or a loose chutney. <b>The parent is the label.</b></li>
+    </ul>
+    <div class="flag"><b>⚑ Gap:</b> <b>No India-specific (IAP / MoHFW / FSSAI) sesame directive</b> — on early introduction <i>or</i> on labeling — was located. The early-introduction-and-don't-delay guidance is international (AAP/NHS/ASCIA); the 9th-allergen labeling law is <b>US (FASTER Act) and does not apply in India</b>. Do not launder either onto an Indian body's name.</div>
+  </div>
+
+  <h2><span class="ax">Axis 7</span> · Myths to correct <span class="badge b-hi">High</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>Myth: "Delay sesame to prevent the allergy."</b> <b>Don't delay.</b> Current guidance is to introduce sesame around 6 months and not hold it back; delaying is not protective. But the corollary myth is also wrong (next) — so frame this as "no reason to delay; it's safe," <b>not</b> "introduce early to prevent it."</li>
+      <li><b>Myth: "Early sesame prevents sesame allergy (like peanut does)."</b> <b>Not proven.</b> The EAT trial found <i>"no significant effects with respect to milk, sesame, fish, or wheat"</i> — the prevention benefit was <b>peanut + egg only</b>. Introduce early because it's safe and there's no reason to wait — <b>not</b> on a promise of prevention.</li>
+      <li><b>Myth: "Sesame allergy is outgrown like egg/milk."</b> <b>No — usually lifelong.</b> Only ~20–30% outgrow it; ~70–80% persists into adulthood, and it's a leading anaphylaxis trigger. This is the highest-value correction for sesame — it changes how seriously a family treats first exposures and ongoing label-reading.</li>
+      <li><b>Myth: "Sesame oil is always safe (it's just oil)."</b> <b>Nuanced.</b> Highly refined sesame oil is largely de-proteinized and lower-risk, but <b>unrefined / cold-pressed gingelly oil — common in Indian cooking — can retain allergenic protein</b>. Don't assume oil is safe for a <i>confirmed-allergic</i> child.</li>
+    </ul>
+  </div>
+
+  <h2>Proposed data shape · <code>FOOD_EFFECTS['sesame']</code></h2>
+  <div class="card">
+    <p style="margin:0 0 10px;font-size:14px;color:var(--mid)">Drop-in record for the <code>FOOD_EFFECTS</code> table, sitting alongside <code>AGE_RULES</code>/<code>ALLERGENS</code>. An <b>encourage</b>-polarity record (introduce early, safe form) carrying the <b>most serious emergency floor of the four</b>. <b>Not yet wired.</b></p>
+<pre><span class="c">// guided-introduction record — Tier-2: introduce early (safe + don't-delay), NOT a prevention promise</span>
+<span class="k">const</span> FOOD_EFFECTS = {
+  <span class="s">'sesame'</span>: {
+    foodClass:     <span class="s">'allergen-introduce-early'</span>,
+    severity:      <span class="s">'caution'</span>,
+    category:      <span class="s">'seed'</span>,
+    effect:        <span class="s">'food allergy (often lifelong)'</span>,
+    minMonth:      <span class="s">6</span>,
+    thresholdBasis:<span class="s">'developmental-readiness'</span>,
+    allergen:      <span class="s">true</span>,
+    headline:      <span class="s">'Introduce around 6 months, as thinned tahini — never a thick glob.'</span>,
+    earlyIntroBenefit: { paradigm:<span class="s">'Don\'t delay — but no proven sesame-specific prevention claim.'</span>,
+                   evidence:<span class="s">'AAP/NHS/ASCIA name sesame; EAT (NEJM 2016) found NO significant prevention effect — early intro is SAFE but not proven to prevent sesame allergy. 9th US major allergen (FASTER Act), labeling since Jan 1 2023 — US-only.'</span> },
+    safeForm:      { ok:[<span class="s">'smooth tahini thinned with water, milk, or puree'</span>, <span class="s">'finely ground sesame stirred into food'</span>],
+                   never:[<span class="s">'a thick glob of tahini (sticky — choking risk; thin it, like nut butter)'</span>, <span class="s">'whole sesame seeds in quantity'</span>] },
+    myth:          { claim:<span class="s">'Sesame allergy is outgrown like egg or milk.'</span>,
+                   truth:<span class="s">'Usually not — tends to be lifelong (~70–80% persist), so first exposures and ongoing care matter more.'</span> },
+    watchFor:      [<span class="s">'hives / rash'</span>, <span class="s">'swelling (mouth, eyes, lips)'</span>, <span class="s">'vomiting'</span>],
+    severeSigns:   [<span class="s">'trouble breathing / wheeze'</span>, <span class="s">'face/lip/tongue swelling'</span>, <span class="s">'floppy, pale, or very sleepy'</span>],
+    seekCare:      <span class="s">'Any breathing trouble, face/throat swelling, or floppiness: EMERGENCY — call 112, use prescribed adrenaline. Leading anaphylaxis trigger — watch closely.'</span>,
+    culturalNote:  <span class="s">'Til laddoo, gajak (Makar Sankranti), chutneys, gingelly oil. Thin tahini into dal/khichdi/curd; avoid loose til seeds for young infants.'</span>,
+    confidence:    <span class="s">'high'</span>,
+    lastReviewed:  <span class="s">'2026-06-01'</span>,
+  },
+};</pre>
+  </div>
+
+  <h2>Source list</h2>
+  <div class="card">
+  <table>
+    <tr><th>#</th><th>Authority</th><th>Tier</th><th>URL</th></tr>
+    <tr><td>1</td><td>AAP / HealthyChildren — allergens (names sesame; no-delay)</td><td>Official</td><td><a href="https://www.healthychildren.org/English/healthy-living/nutrition/Pages/when-to-introduce-egg-peanut-butter-and-other-common-food-allergens-to-your-baby-food-allergy-prevention-tips.aspx">healthychildren.org/…/allergens</a></td></tr>
+    <tr><td>2</td><td>UK NHS — Food allergies in babies (seeds "particularly sesame" finely ground)</td><td>Official</td><td><a href="https://www.nhs.uk/baby/weaning-and-feeding/food-allergies-in-babies-and-young-children/">nhs.uk/baby/…/food-allergies</a></td></tr>
+    <tr><td>3</td><td>ASCIA — Infant Feeding &amp; Allergy Prevention <i>(401/403 to fetcher)</i></td><td>Official</td><td><a href="https://www.allergy.org.au/hp/papers/infant-feeding-and-allergy-prevention">allergy.org.au/…/infant-feeding</a></td></tr>
+    <tr><td>4</td><td>NIAID — Food allergy guidelines for clinicians &amp; patients</td><td>Official</td><td><a href="https://www.niaid.nih.gov/diseases-conditions/guidelines-clinicians-and-patients-food-allergy">niaid.nih.gov/…/food-allergy</a></td></tr>
+    <tr><td>5</td><td>US FDA — FASTER Act: sesame the 9th major food allergen <i>(401 to fetcher)</i></td><td>Official</td><td><a href="https://www.fda.gov/food/food-allergies/faster-act-sesame-ninth-major-food-allergen">fda.gov/…/faster-act-sesame</a></td></tr>
+    <tr><td>6</td><td>FoodSafety.gov — FASTER Act 2021 (govt mirror; corroborates 9th-allergen + Jan 1 2023)</td><td>Official</td><td><a href="https://www.foodsafety.gov/blog/food-allergy-safety-treatment-education-and-research-act-2021">foodsafety.gov/blog/…/faster-act</a></td></tr>
+    <tr><td>7</td><td>NEJM — Perkins/Lack et al., EAT trial (2016); <b>sesame-null</b></td><td>Pivotal trial</td><td><a href="https://pubmed.ncbi.nlm.nih.gov/26943128/">pubmed.ncbi.nlm.nih.gov/26943128</a></td></tr>
+    <tr><td>8</td><td>J Asthma Allergy — sesame allergy persistence (~20–30% resolve)</td><td>Peer-reviewed</td><td><a href="https://pmc.ncbi.nlm.nih.gov/articles/PMC5414576/">pmc.ncbi.nlm.nih.gov/…/PMC5414576</a></td></tr>
+    <tr><td>9</td><td>JAMA Netw Open 2019 — sesame allergy prevalence/persistence</td><td>Peer-reviewed</td><td><a href="https://pmc.ncbi.nlm.nih.gov/articles/PMC6681546/">pmc.ncbi.nlm.nih.gov/…/PMC6681546</a></td></tr>
+    <tr><td>10</td><td>Solid Starts — sesame (form, symptoms)</td><td>Secondary (advocacy/commercial)</td><td><a href="https://solidstarts.com/foods/sesame/">solidstarts.com/foods/sesame</a></td></tr>
+    <tr><td>11</td><td>Wikipedia — Tahini (culinary aliases)</td><td>Secondary (encyclopedia)</td><td><a href="https://en.wikipedia.org/wiki/Tahini">en.wikipedia.org/wiki/Tahini</a></td></tr>
+  </table>
+  </div>
+
+  <div class="card">
+    <strong>Verification status &amp; gaps</strong>
+    <ol style="margin:8px 0 0">
+      <li>✅ <b>EAT sesame-null</b> — verified verbatim via PubMed 26943128: <i>"no significant effects with respect to milk, sesame, fish, or wheat."</i> The peanut+egg per-protocol benefit does <b>not</b> extend to sesame. The strongest discipline in this brief: <b>do not claim early sesame prevents sesame allergy.</b></li>
+      <li>✅ <b>Introduce-early / don't-delay</b> — corroborated by AAP (names sesame directly), NHS ("seeds, particularly sesame, served finely ground"), and ASCIA. Rests on <b>general don't-delay-allergens guidance</b>, not a sesame-specific RCT.</li>
+      <li>⚑ <b>FASTER Act — 9th major US allergen + Jan 1 2023 labeling</b> — <b>HIGH-CONFIDENCE-BUT-NOT-DIRECT-FETCH.</b> The FDA page (#5) returned 401; corroborated across FDA indexed text, the FoodSafety.gov mirror (#6), and independent sources. <b>Scope:</b> US (and analogously EU) packaged-food labeling — <b>does NOT apply to Indian/home foods.</b></li>
+      <li>⚑ <b>ASCIA page</b> — returned 401/403; the infant-feeding stance is corroborated via independent summaries, not a direct page read. Re-extract before any verbatim ASCIA attribution.</li>
+      <li>✅ <b>Persistence ~20–30% resolve / ~70–80% persist; leading anaphylaxis trigger</b> — peer-reviewed (J Asthma Allergy; JAMA Netw Open 2019). The tone-setting fact: sesame is <b>lifelong</b>, unlike commonly-outgrown egg/milk/soy/wheat.</li>
+      <li>⚑ <b>Sesame-oil protein nuance</b> — refined oil largely de-proteinized vs unrefined/cold-pressed gingelly oil retaining protein: allergen consensus, <b>moderate confidence</b>. Conservative line for a <i>confirmed-allergic</i> child: treat unrefined gingelly oil as a potential exposure.</li>
+      <li>⚑ <b>India-specific directive — GAP.</b> No IAP / MoHFW / FSSAI sesame directive located. Early-introduction guidance is international; the 9th-allergen labeling law is US-only and <b>does not apply in India</b>. Do not attribute either to an Indian body.</li>
+      <li>⚑ <b>Secondary sources flagged explicitly:</b> Solid Starts (#10) and Wikipedia/Tahini (#11) are secondary — used for form specifics and culinary aliases, consistent with but not a substitute for the official/peer-reviewed tiers. "India among more common sensitizing allergens" is regional/secondary and directional only.</li>
+    </ol>
+  </div>
+
+  <div class="card tldr">
+    <strong>Surfacing recommendation (for Maren) — feeds the guided-introduction model, not yet implemented</strong>
+    <p style="margin:8px 0 0">Surface an <b>encourage</b> card (introduce early, safe thinned-tahini form) carrying the <b>most serious emergency floor of the four allergens</b>. The two highest-value nuggets unique to sesame: the <b>Tier-2 honesty line</b> — introduce early because it's safe + don't-delay, <b>NOT a prevention promise</b> (EAT null for sesame) — and the <b>usually-lifelong</b> note: ~70–80% persist, so first exposures + ongoing care matter, and vigilance should not age out. Reviewer pills: <b>Maren (Care) · 2026-06-01 · not-yet-wired</b>.</p>
+  </div>
+
+  <p class="foot">SproutLab · Care research brief · companion to <code>docs/research/sesame-infant-safety.md</code> · 2026-06-01<br>
+  Research artifact — informational, not medical advice. Not yet wired into the app.</p>
+</div>
+</body>
+</html>

--- a/docs/research/sesame-infant-safety.visual.html
+++ b/docs/research/sesame-infant-safety.visual.html
@@ -1,0 +1,337 @@
+<!DOCTYPE html>
+<!-- ═══════════════════════════════════════════════════════════════════════
+  FOOD-DASHBOARD TEMPLATE · SproutLab Care research layer
+  Filled for SESAME (til). CSS + JS copied verbatim from _TEMPLATE.food-dashboard.html.
+═══════════════════════════════════════════════════════════════════════ -->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Sesame (Til) &amp; Infant Safety — Visual Dashboard · SproutLab Care</title>
+<style>
+  :root{
+    --bg:#faf6f0; --card:#fffdf9; --ink:#2e2a26; --mid:#6b6258; --line:#e8ddcf; --track:#efe7da;
+    --sage:#3a7060; --sage-bg:#e8f5ef; --rose:#b04a5e; --rose-bg:#fbe9ec;
+    --amber:#9a7320; --amber-bg:#fbf0d9; --accent:#9a6a3a; --honey:#d99a2b; --honey-bg:#fbeccb;
+    --hi:#2f7d5b; --hi-bg:#e3f3ea; --mod:#9a7320; --mod-bg:#f7eed6; --weak:#9a5a5a; --weak-bg:#f5e6e6;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#1d1a17; --card:#262220; --ink:#ece5db; --mid:#a89c8c; --line:#3a342d; --track:#332d26;
+    --sage:#7ac0a0; --sage-bg:#1e3028; --rose:#e090a0; --rose-bg:#3a2026;
+    --amber:#e0b060; --amber-bg:#352a16; --accent:#c99a6a; --honey:#e8b34a; --honey-bg:#3a2c12;
+    --hi:#7ac0a0; --hi-bg:#1e3028; --mod:#d8b060; --mod-bg:#332a14; --weak:#e09090; --weak-bg:#3a2222; }}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Nunito,sans-serif;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:960px;margin:0 auto;padding:0 18px 90px}
+  header{background:linear-gradient(160deg,var(--honey-bg),var(--bg));border-bottom:1px solid var(--line);padding:26px 0 0}
+  h1{font:700 25px/1.2 Fraunces,Georgia,serif;margin:0 0 4px}
+  .sub{color:var(--mid);font-size:14px;margin:0 0 16px;max-width:680px}
+  nav{display:flex;gap:4px;margin-top:6px;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none}
+  nav::-webkit-scrollbar{display:none}
+  .tab{appearance:none;border:0;background:transparent;color:var(--mid);font:600 13.5px/1 Nunito,sans-serif;white-space:nowrap;flex:0 0 auto;
+    padding:11px 14px;border-radius:10px 10px 0 0;cursor:pointer;border-bottom:3px solid transparent}
+  .tab:hover{color:var(--ink);background:var(--card)}
+  .tab.on{color:var(--accent);background:var(--card);border-bottom-color:var(--accent)}
+  .panel{display:none;animation:f .25s ease}.panel.on{display:block}
+  @keyframes f{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:none}}
+  /* ── Entrance animations — re-trigger each time a panel is shown (display:none→block
+     restarts descendant animations). All gated behind prefers-reduced-motion so the
+     dashboard is fully usable (and calm) for anyone who opts out of motion. ── */
+  @media (prefers-reduced-motion: no-preference){
+    /* bars grow from the left — scaleX keeps the inline width:% target intact */
+    .panel.on .bar .fil{transform-origin:left center;animation:grow .7s cubic-bezier(.34,1.1,.4,1) both}
+    @keyframes grow{from{transform:scaleX(0)}to{transform:scaleX(1)}}
+    /* stat tiles + timeline steps + therm cols rise in with a gentle stagger */
+    .panel.on .stat,.panel.on .tl-step,.panel.on .therm .col{animation:rise .45s ease both}
+    .panel.on .stat:nth-child(2),.panel.on .tl-step:nth-child(2),.panel.on .therm .col:nth-child(2){animation-delay:.07s}
+    .panel.on .stat:nth-child(3),.panel.on .tl-step:nth-child(3){animation-delay:.14s}
+    .panel.on .stat:nth-child(4),.panel.on .tl-step:nth-child(4){animation-delay:.21s}
+    .panel.on .tl-step:nth-child(5){animation-delay:.28s}
+    @keyframes rise{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}
+    /* donut sweeps in (the partial-arc value stays exact; only the reveal animates) */
+    .panel.on svg[role="img"]{animation:sweep .8s ease both}
+    @keyframes sweep{from{opacity:0;transform:rotate(-12deg) scale(.9)}to{opacity:1;transform:none}}
+    /* flag callouts slide a touch from the left edge they're anchored to */
+    .panel.on .flag{animation:slidein .5s ease both}
+    @keyframes slidein{from{opacity:0;transform:translateX(-6px)}to{opacity:1;transform:none}}
+  }
+  h2{font:600 18px/1.3 Fraunces,Georgia,serif;margin:26px 0 10px}
+  h3{font:700 13px/1.3 Nunito;text-transform:uppercase;letter-spacing:.4px;color:var(--mid);margin:18px 0 8px}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:16px 18px;margin:12px 0}
+  .grid{display:grid;gap:12px}.g2{grid-template-columns:1fr 1fr}.g3{grid-template-columns:repeat(3,1fr)}.g4{grid-template-columns:repeat(4,1fr)}
+  @media(max-width:680px){.g2,.g3,.g4{grid-template-columns:1fr 1fr}}
+  .stat{text-align:center;padding:16px 10px}
+  .stat .n{font:800 26px/1 Fraunces,Georgia,serif;color:var(--accent)}
+  .stat .l{font-size:12px;color:var(--mid);margin-top:6px;line-height:1.35}
+  .stat.crit .n{color:var(--rose)}.stat.ok .n{color:var(--sage)}
+  .badge{display:inline-block;font:700 10.5px/1 Nunito;text-transform:uppercase;letter-spacing:.3px;padding:4px 8px;border-radius:6px;vertical-align:middle}
+  .b-hi{background:var(--hi-bg);color:var(--hi)}.b-mod{background:var(--mod-bg);color:var(--mod)}.b-weak{background:var(--weak-bg);color:var(--weak)}.b-crit{background:var(--rose-bg);color:var(--rose)}
+  .bar{display:grid;grid-template-columns:130px 1fr 52px;align-items:center;gap:10px;margin:7px 0;font-size:13px}
+  .bar .lab{color:var(--ink);text-align:right;font-weight:600}
+  .bar .trk{display:block;background:var(--track);border:1px solid var(--line);border-radius:7px;height:18px;overflow:hidden}
+  .bar .fil{display:block;height:100%;border-radius:6px;background:var(--sage);min-width:3px}
+  .bar .val{font-weight:700;color:var(--mid);font-size:12.5px}
+  .bar.hl .fil{background:var(--honey)}.bar.hl .lab{color:var(--honey)}.bar.hl .val{color:var(--honey)}
+  .tl{position:relative;margin:14px 0 6px;padding-left:8px}
+  .tl-step{position:relative;padding:0 0 18px 26px;border-left:2px solid var(--line)}
+  .tl-step:last-child{border-left-color:transparent}
+  .tl-dot{position:absolute;left:-8px;top:1px;width:15px;height:15px;border-radius:50%;background:var(--card);border:3px solid var(--accent)}
+  .tl-step.crit .tl-dot{border-color:var(--rose)}.tl-step.first .tl-dot{border-color:var(--honey)}
+  .tl-t{font-weight:700;font-size:13.5px}.tl-d{color:var(--mid);font-size:12.5px}
+  .flag{border-left:3px solid var(--amber);background:var(--amber-bg);border-radius:6px;padding:10px 14px;margin:10px 0;font-size:13px}
+  .flag.good{border-left-color:var(--sage);background:var(--sage-bg)}.flag.bad{border-left-color:var(--rose);background:var(--rose-bg)}
+  table{width:100%;border-collapse:collapse;font-size:13px;margin:8px 0}
+  th,td{padding:8px 9px;border-bottom:1px solid var(--line);text-align:left;vertical-align:top}
+  th{font:700 11px/1.2 Nunito;text-transform:uppercase;letter-spacing:.3px;color:var(--mid)}
+  td.c{text-align:center;font-weight:800}.yes{color:var(--sage)}.no{color:var(--rose)}.dash{color:var(--mid)}
+  td a{color:var(--sage);font-size:12px;word-break:break-all}
+  .pill{display:inline-block;font:600 11px/1 Nunito;padding:5px 10px;border-radius:999px;background:var(--card);border:1px solid var(--line);color:var(--mid);margin:0 4px 4px 0}
+  .pill.warn{background:var(--rose-bg);color:var(--rose);border-color:transparent}
+  .jump{display:inline-block;font-weight:700;color:var(--accent);cursor:pointer;border-bottom:1px dashed var(--accent)}
+  .lead{font-size:16px;line-height:1.5}.lead b{color:var(--accent)}
+  pre{background:#1e1b18;color:#e8e2d6;border-radius:12px;padding:16px;overflow:auto;font:12px/1.5 "SF Mono",Menlo,Consolas,monospace}
+  .therm{display:flex;gap:14px;flex-wrap:wrap}
+  .therm .col{flex:1;min-width:200px;border:1px solid var(--line);border-radius:12px;padding:14px;text-align:center}
+  .therm .big{font:800 19px/1 Fraunces,serif;margin:6px 0}
+  .col.safe{background:var(--sage-bg)}.col.danger{background:var(--rose-bg)}.col.safe .big{color:var(--sage)}.col.danger .big{color:var(--rose)}
+  .foot{color:var(--mid);font-size:12.5px;text-align:center;margin-top:30px}
+</style>
+</head>
+<body>
+<header><div class="wrap">
+  <h1>Sesame (Til) &amp; Infant Safety — Visual Dashboard</h1>
+  <p class="sub">Care dashboard for the <b>guided-introduction</b> layer. Sesame is a <b>Tier-2</b> allergen: introduce early because it's <b>safe</b> and there's no reason to delay — but unlike peanut, prevention is <b>not RCT-proven</b>. The defining note: sesame is the <b>gravest</b> of the four — <b>rarely outgrown</b> and a leading anaphylaxis trigger.</p>
+  <nav>
+    <button class="tab on" data-p="p-sum">Summary</button>
+    <button class="tab" data-p="p-why">Why / Allergen</button>
+    <button class="tab" data-p="p-sym">Reaction &amp; Introduction</button>
+    <button class="tab" data-p="p-ctx">Context</button>
+    <button class="tab" data-p="p-src">Sources &amp; Confidence</button>
+    <button class="tab" data-p="p-data">Data Stub</button>
+  </nav>
+  <p style="font-size:11.5px;color:var(--mid);margin:6px 0 10px">Swipe ‹ › between tabs · or use ← → arrow keys</p>
+</div></header>
+
+<div class="wrap">
+
+  <!-- ───────── SUMMARY ───────── -->
+  <section class="panel on" id="p-sum">
+    <div class="card" style="background:var(--honey-bg);border-color:transparent;margin-top:18px">
+      <p class="lead" style="margin:0">The one rule: <b>introduce sesame around 6 months as smooth tahini THINNED into food — never a thick glob</b> (sticky = choking, just like nut butter). Watch closely, and keep watching: sesame allergy is <b>usually lifelong (~70–80% persist)</b> and a leading anaphylaxis trigger, so first exposures and ongoing care matter more here than for any other allergen.</p>
+    </div>
+    <div class="grid g4">
+      <!-- stat tiles: .crit (red) / .ok (sage) / default (accent) -->
+      <div class="card stat ok"><div class="n">~6<span style="font-size:14px">mo</span></div><div class="l">Introduce from ~6 months (not before 4) — AAP·NHS·ASCIA</div></div>
+      <div class="card stat"><div class="n">9th</div><div class="l">major US food allergen (FASTER Act 2021)</div></div>
+      <div class="card stat crit"><div class="n">~70–80%</div><div class="l">persists into adulthood — rarely outgrown (only ~20–30% achieve tolerance)</div></div>
+      <div class="card stat"><div class="n">Jan 2023</div><div class="l">US sesame labeling in force (US packaged foods only — not Indian/home foods)</div></div>
+    </div>
+    <h3>The things to know <span class="badge b-hi">high-confidence</span></h3>
+    <div class="grid g2">
+      <div class="card"><b>1 · Introduce early — but be honest why.</b> AAP/NHS/ASCIA say don't delay sesame past ~6mo. But the EAT trial found <b>no sesame benefit</b> — early sesame is SAFE, not proven prevention. → <span class="jump" data-go="p-why">Why / Allergen</span></div>
+      <div class="card"><b>2 · Form is the gate.</b> Thinned smooth tahini or finely ground sesame are safe; a thick glob or whole seeds in quantity are choking risks. Thinning fixes choking, <i>not</i> allergy. → <span class="jump" data-go="p-sym">Reaction &amp; Introduction</span></div>
+      <div class="card"><b>3 · Usually LIFELONG — the key tone point.</b> Only ~20–30% outgrow sesame; ~70–80% persists. It is a leading anaphylaxis trigger — the gravest emergency floor of the four. → <span class="jump" data-go="p-why">Why / Allergen</span></div>
+      <div class="card"><b>4 · An Indian staple, often unlabeled.</b> Til laddoo, gajak (Makar Sankranti), gingelly oil — early intro is natural, but a homemade laddoo carries no "Contains sesame" label. The parent is the label. → <span class="jump" data-go="p-ctx">Context</span></div>
+    </div>
+    <h3>When to surface this</h3>
+    <div class="card flag good" style="margin-top:0"><b>Recommendation (Maren):</b> an <b>encourage-polarity</b> card (introduce early, safe form) — but with the <b>most serious emergency floor of the four allergens</b>. Lead "safe to introduce, no need to delay," <b>never</b> "introducing early prevents the allergy" (EAT null for sesame). Carry a non-collapsible severe-reaction strip <b>and</b> the "usually lifelong — vigilance doesn't age out" note. → <span class="jump" data-go="p-data">Data Stub</span></div>
+    <div class="card flag" style="margin-top:0"><b>⚑ Tier-2 honesty:</b> introduce early because it's safe + don't-delay, <b>NOT a prevention promise</b> (EAT null for sesame). And: <b>usually lifelong</b> — first exposures + ongoing care matter.</div>
+    <div style="margin-top:14px">
+      <span class="pill">Reviewer · Maren (Care)</span><span class="pill">2026-06-01</span>
+      <span class="pill warn">Research artifact — not yet wired into the app</span>
+    </div>
+    <p style="font-size:12.5px;color:var(--mid);margin-top:10px">Full prose: <code>sesame-infant-safety.md</code> · long-form HTML: <code>sesame-infant-safety.html</code>. This dashboard is the skim layer over both.</p>
+  </section>
+
+  <!-- ───────── WHY / ALLERGEN ───────── -->
+  <section class="panel" id="p-why"><h2>Why it matters — a Tier-2 allergen that's usually lifelong</h2>
+
+    <div class="card flag" style="margin-top:0"><b>⚑ The honest framing the model must hold:</b> early sesame is <b>SAFE</b> and there's no reason to delay — but <b>RCT evidence does not show early sesame prevents sesame allergy.</b> The EAT trial reported, verbatim: <i>"no significant effects with respect to milk, sesame, fish, or wheat."</i> The peanut+egg benefit does <b>not</b> transfer. <b>Never claim early sesame prevents sesame allergy.</b> <span class="badge b-hi">EAT verified · PubMed 26943128</span></div>
+
+    <h3>Rarely outgrown — the defining fact</h3>
+    <div class="card">
+      <div style="display:flex;align-items:center;gap:18px;flex-wrap:wrap">
+        <svg viewBox="0 0 120 120" width="118" height="118" role="img" aria-label="Sesame allergy persistence: ~70–80% persists into adulthood; only ~20–30% is outgrown">
+          <circle cx="60" cy="60" r="52" fill="none" stroke="var(--track)" stroke-width="15"/>
+          <!-- persists ~75% (rose); circumference r=52 = 326.7; PCT_LEN = 75*3.267 = 245.0, REST = 81.7 -->
+          <circle cx="60" cy="60" r="52" fill="none" stroke="var(--rose)" stroke-width="15"
+            stroke-dasharray="245.0 81.7" stroke-dashoffset="0" transform="rotate(-90 60 60)" stroke-linecap="round"/>
+          <text x="60" y="58" text-anchor="middle" font-size="20" font-weight="800" fill="var(--rose)" font-family="Fraunces,serif">~75%</text>
+        </svg>
+        <div style="font-size:13px;color:var(--mid);min-width:200px;flex:1">
+          <p style="margin:0 0 6px"><b style="color:var(--rose)">~70–80% persists</b> into adulthood — sesame allergy is rarely outgrown.</p>
+          <p style="margin:0 0 6px"><b style="color:var(--sage)">Only ~20–30%</b> achieve tolerance, unlike egg, milk, soy and wheat (commonly outgrown).</p>
+          <p style="margin:0">Sesame sits firmly in the <i>lifelong</i> camp with peanut and tree nuts — and is a <b>leading anaphylaxis trigger</b>. <span class="badge b-hi">J Asthma Allergy · JAMA Netw Open 2019</span></p>
+        </div>
+      </div>
+      <div class="flag bad"><b>⚑ Why this drives the tone:</b> for a commonly-outgrown allergen, the risk fades. For sesame it does <b>not</b> — so the emergency floor, label-vigilance, and "carry the adrenaline plan" framing are the <b>most serious of the four</b>, and should <b>not</b> soften over the toddler years.</div>
+    </div>
+
+    <h3>Introduce early, don't delay <span class="badge b-hi">AAP names sesame directly</span></h3>
+    <div class="card">
+      <p style="margin:0 0 6px">General timing is <b>around 6 months</b>, once ready for solids — <b>not before 4 months</b>, and don't delay once ready.</p>
+      <blockquote style="margin:8px 0;padding:6px 0 6px 14px;border-left:3px solid var(--sage);color:var(--mid);font-style:italic;font-size:13px">"There is no evidence that delaying introduction of allergenic foods like egg, peanut, dairy and sesame prevents allergies once babies are ready, typically at about 6 months." — AAP/HealthyChildren</blockquote>
+      <p style="margin:0;font-size:13px;color:var(--mid)">NHS lists sesame among allergens to introduce, noting seeds — "particularly sesame" — should be finely ground. ASCIA recommends common allergens incl. sesame in the first year.</p>
+    </div>
+
+    <h3>Regulatory weight — the 9th US major allergen</h3>
+    <div class="card">
+      <p style="margin:0 0 6px">Under the <b>FASTER Act of 2021</b>, sesame became the <b>9th major US food allergen</b>; mandatory labeling took effect <b>January 1, 2023</b> (e.g. "tahini (sesame)" or "Contains sesame"). The EU has long required it. <span class="badge b-mod">FDA page blocked direct fetch — corroborated via FoodSafety.gov mirror</span></p>
+      <div class="flag"><b>⚑ Scope limit:</b> this labeling is US (and analogously EU) <b>packaged-food</b> regulation. It does <b>NOT</b> apply to Indian-bought packets or home foods — a homemade til laddoo or loose chutney carries no "Contains sesame" guarantee.</div>
+    </div>
+  </section>
+
+  <!-- ───────── REACTION & INTRODUCTION ───────── -->
+  <section class="panel" id="p-sym"><h2>Reaction &amp; introduction — the gravest emergency floor</h2>
+
+    <h3>Safe form — the choking gate <span class="badge b-hi">High</span></h3>
+    <div class="therm">
+      <div class="col safe">
+        <div style="font-size:12px;color:var(--mid)">Thinned tahini / ground (SAFE)</div>
+        <div class="big">introduce early</div>
+        <div style="font-size:12.5px">smooth tahini <b>thinned</b> (~⅛–½ tsp) into milk, water, puree, yoghurt, dal, khichdi or curd; or finely ground sesame stirred in. Same "thin the sticky glob" rule as peanut butter.</div>
+      </div>
+      <div class="col danger">
+        <div style="font-size:12px;color:var(--mid)">Thick glob / whole seeds (CHOKING)</div>
+        <div class="big">never for a young infant</div>
+        <div style="font-size:12.5px">a thick spoonful of paste (sticky — lodges in the airway) or whole sesame seeds in quantity (small, hard, easily inhaled). Avoid loose til off laddoo/gajak.</div>
+      </div>
+    </div>
+    <div class="flag good"><b>✓ Design crux:</b> thinning/grinding genuinely removes the <b>choking</b> hazard (like peanut — unlike honey, where cooking doesn't remove the spore hazard). The <b>allergy axis is separate and NOT removed by form</b> — thinning makes it safe to swallow, not safe for an allergic child.</div>
+
+    <h3>The reaction watch — most serious of the four</h3>
+    <div class="card">
+      <div class="tl">
+        <div class="tl-step first"><span class="tl-dot"></span><div class="tl-t">First taste — small amount, at home</div><div class="tl-d">~⅛–½ tsp thinned tahini, one allergen at a time, morning/midday so you can observe through the day.</div></div>
+        <div class="tl-step"><span class="tl-dot"></span><div class="tl-t">Mild — one body system (watch closely)</div><div class="tl-d">Itchy hives/welts, redness or rash, swelling (esp. mouth/eyes), vomiting, sometimes loose stool, sudden fussiness. → stop the food, monitor, call your doctor.</div></div>
+        <div class="tl-step crit"><span class="tl-dot"></span><div class="tl-t">Severe / anaphylaxis — act immediately</div><div class="tl-d">Trouble breathing, wheeze/persistent cough, face/lip/tongue/throat swelling, hoarse cry, pale/floppy/lethargic, collapse. In babies, suddenly limp / can't hold head up is a severe sign. → use a prescribed adrenaline auto-injector now, call 112 / 108 (India).</div></div>
+        <div class="tl-step"><span class="tl-dot"></span><div class="tl-t">Keep watching — vigilance does NOT age out</div><div class="tl-d">First taste may sensitise with the reaction on a later one — watch across the first several exposures. Because sesame is usually permanent, this vigilance doesn't fade the way it tends to for milk/egg.</div></div>
+      </div>
+      <div class="flag bad"><b>⚑ Anaphylaxis onset often 5–30 min.</b> Sesame is a leading cause of food-allergic anaphylaxis. Treat first exposures and ongoing care with the <b>most</b> seriousness of the four allergens.</div>
+    </div>
+  </section>
+
+  <!-- ───────── CONTEXT ───────── -->
+  <section class="panel" id="p-ctx"><h2>Context — Indian &amp; cultural</h2>
+    <div class="card">
+      <p style="margin:0"><b>Til is deeply embedded in the Indian diet</b> — <b>til laddoo</b>, <b>gajak</b> (sesame-jaggery brittle, peaking around <b>Makar Sankranti, mid-January</b>), sesame <b>chutneys</b>, and <b>gingelly (sesame) oil</b> are everyday foods. Early, regular introduction is culturally natural — the challenge is FORM (thin/grind) and first-exposure discipline, not novelty. <span class="badge b-hi">cultural embedding</span></p>
+    </div>
+
+    <h3>The cultural double-edge</h3>
+    <div class="card">
+      <p style="margin:0 0 6px">Because til is <i>everywhere</i> and often <b>unlabeled</b> in home/loose form, an Indian family both (a) introduces sesame naturally and early, and (b) faces a harder <i>avoidance</i> task if the child turns out allergic. The US "Contains sesame" label does <b>not</b> appear on a homemade laddoo or a loose chutney. <b>The parent is the label.</b></p>
+      <p style="margin:0;font-size:13px;color:var(--mid)">Form tip: thin tahini into dal, khichdi, curd or fruit puree; avoid loose til seeds shaken off laddoo/gajak for a young infant — those carry whole seeds and an uncontrolled first-exposure dose.</p>
+    </div>
+
+    <h3>Hidden under many names</h3>
+    <div class="card">
+      <p style="margin:0 0 6px">A confirmed-allergic child's caregiver must recognise: <b>tahini</b>, <b>hummus</b>, <b>halva/halwa</b> (sesame variety), <b>til / til laddoo</b>, <b>gajak</b>, <b>benne / benniseed</b>, <b>gomashio</b>, <b>goma</b>, <b>sim sim</b>, and <b>gingelly oil (= sesame oil)</b>. Hidden on breads, buns, crackers, bagels, in chutneys, sweets, dressings and spice blends.</p>
+      <div class="flag"><b>⚑ The sesame-oil nuance:</b> highly refined sesame oil is largely de-proteinized and lower-risk — <b>but cold-pressed / unrefined gingelly oil, common in Indian cooking, can retain allergenic protein.</b> For a non-allergic baby this is no barrier; for a <i>known-allergic</i> child, treat unrefined gingelly oil as a potential exposure. <span class="badge b-mod">Moderate</span></div>
+    </div>
+
+    <div class="card flag" style="margin-top:0"><b>⚑ Gap — no India-specific directive.</b> No IAP / MoHFW / FSSAI sesame directive (early-intro or labeling) was located. The early-introduction guidance is international (AAP/NHS/ASCIA); the 9th-allergen labeling law is US (FASTER Act) and does not apply in India. Do not launder either onto an Indian body. <span class="badge b-mod">India directive absent</span></div>
+  </section>
+
+  <!-- ───────── SOURCES & CONFIDENCE ───────── -->
+  <section class="panel" id="p-src">
+    <h2>Who says what — consensus matrix</h2>
+    <div class="card" style="overflow-x:auto"><table>
+      <tr><th>Authority</th><th class="c">Introduce ~6mo</th><th class="c">Sesame finely ground / thinned</th><th class="c">Proven sesame prevention</th></tr>
+      <tr><td>AAP / HealthyChildren</td><td class="c yes">✓ (names sesame)</td><td class="c yes">✓</td><td class="c no">✗ not claimed</td></tr>
+      <tr><td>UK NHS</td><td class="c yes">✓</td><td class="c yes">✓ "particularly sesame"</td><td class="c no">✗ not claimed</td></tr>
+      <tr><td>ASCIA (Australasia)</td><td class="c yes">✓ in first year</td><td class="c yes">✓</td><td class="c no">✗ not claimed</td></tr>
+      <tr><td>EAT trial (NEJM 2016)</td><td class="c dash">— (tested early intro)</td><td class="c dash">—</td><td class="c no">✗ NULL for sesame</td></tr>
+      <tr><td>FASTER Act (US FDA)</td><td class="c dash">—</td><td class="c dash">—</td><td class="c dash">— (labeling, not intro)</td></tr>
+    </table>
+    <p style="font-size:12px;color:var(--mid);margin:6px 0 0">All authorities agree on <b>introduce early, don't delay</b> and <b>finely ground / thinned form</b> — but <b>none</b> claims early sesame <i>prevents</i> sesame allergy. EAT explicitly found no sesame effect. This is the Tier-2 honesty line.</p>
+    </div>
+
+    <h2>Sources</h2>
+    <div class="card" style="overflow-x:auto"><table>
+      <tr><th>Authority</th><th>Link</th></tr>
+      <tr><td>AAP / HealthyChildren — allergens (names sesame; no-delay)</td><td><a href="https://www.healthychildren.org/English/healthy-living/nutrition/Pages/when-to-introduce-egg-peanut-butter-and-other-common-food-allergens-to-your-baby-food-allergy-prevention-tips.aspx">healthychildren.org/…/allergens</a></td></tr>
+      <tr><td>UK NHS — food allergies in babies (seeds "particularly sesame" finely ground)</td><td><a href="https://www.nhs.uk/baby/weaning-and-feeding/food-allergies-in-babies-and-young-children/">nhs.uk/baby/…/food-allergies</a></td></tr>
+      <tr><td>ASCIA — Infant Feeding &amp; Allergy Prevention <i>(401/403 to fetcher)</i></td><td><a href="https://www.allergy.org.au/hp/papers/infant-feeding-and-allergy-prevention">allergy.org.au/…/infant-feeding</a></td></tr>
+      <tr><td>NIAID — Food allergy guidelines</td><td><a href="https://www.niaid.nih.gov/diseases-conditions/guidelines-clinicians-and-patients-food-allergy">niaid.nih.gov/…/food-allergy</a></td></tr>
+      <tr><td>US FDA — FASTER Act: sesame 9th major allergen <i>(401 to fetcher)</i></td><td><a href="https://www.fda.gov/food/food-allergies/faster-act-sesame-ninth-major-food-allergen">fda.gov/…/faster-act-sesame</a></td></tr>
+      <tr><td>FoodSafety.gov — FASTER Act 2021 (govt mirror)</td><td><a href="https://www.foodsafety.gov/blog/food-allergy-safety-treatment-education-and-research-act-2021">foodsafety.gov/blog/…/faster-act</a></td></tr>
+      <tr><td>NEJM — EAT trial (Perkins/Lack 2016); <b>sesame-null</b></td><td><a href="https://pubmed.ncbi.nlm.nih.gov/26943128/">pubmed.ncbi.nlm.nih.gov/26943128</a></td></tr>
+      <tr><td>J Asthma Allergy — sesame persistence (~20–30% resolve)</td><td><a href="https://pmc.ncbi.nlm.nih.gov/articles/PMC5414576/">pmc.ncbi.nlm.nih.gov/…/PMC5414576</a></td></tr>
+      <tr><td>JAMA Netw Open 2019 — sesame prevalence/persistence</td><td><a href="https://pmc.ncbi.nlm.nih.gov/articles/PMC6681546/">pmc.ncbi.nlm.nih.gov/…/PMC6681546</a></td></tr>
+      <tr><td>Solid Starts — sesame (form, symptoms) <i>(secondary)</i></td><td><a href="https://solidstarts.com/foods/sesame/">solidstarts.com/foods/sesame</a></td></tr>
+      <tr><td>Wikipedia — Tahini (culinary aliases) <i>(secondary)</i></td><td><a href="https://en.wikipedia.org/wiki/Tahini">en.wikipedia.org/wiki/Tahini</a></td></tr>
+    </table></div>
+    <div class="flag"><b>⚑ Open gaps:</b> (1) <b>FASTER Act</b> 9th-allergen + Jan 1 2023 labeling is <b>high-confidence-but-not-direct-fetch</b> — FDA page returned 401; corroborated via FoodSafety.gov mirror + FDA indexed text. (2) <b>ASCIA</b> page returned 401/403 — stance corroborated indirectly; re-extract before any verbatim attribution. (3) <b>Sesame-oil protein nuance</b> — allergen consensus, moderate confidence. (4) <b>No India-specific (IAP/MoHFW/FSSAI) sesame directive</b> located — genuinely absent. EAT sesame-null + persistence figures are verified high-confidence.</div>
+  </section>
+
+  <!-- ───────── DATA STUB ───────── -->
+  <section class="panel" id="p-data"><h2>Drop-in record — <code>FOOD_EFFECTS['sesame']</code></h2>
+    <p style="font-size:13.5px;color:var(--mid)">Mirror of this food's record in <code>food-effects.manifest.js</code>. Sits alongside <code>AGE_RULES</code>/<code>ALLERGENS</code>. <b>Not yet wired.</b></p>
+<pre>{
+  food:          'sesame',
+  aliases:       ['til','tahini','gingelly','gingelly oil','sesame seeds','sesame oil','sim sim','benne','gomashio','hummus','halva','halwa','gajak','til laddoo'],
+  foodClass:     'allergen-introduce-early',
+  severity:      'caution',
+  category:      'seed',
+  effect:        'food allergy (often lifelong)',
+  minMonth:      6,
+  thresholdBasis:'developmental-readiness',
+  allergen:      true,
+  reactionType:  ['allergy'],
+  headline:      'Introduce around 6 months, as thinned tahini — never a thick glob.',
+  whyGood:       'Seed source of calcium, iron and healthy fats; offer as smooth tahini thinned into food.',
+  earlyIntroBenefit: { claim:'Introduce around 6 months; don\'t delay.',
+                       evidence:'AAP/NHS/ASCIA name sesame among allergens to introduce early; EAT (NEJM 2016) verified NO significant prevention effect for sesame — early intro is SAFE but not proven to prevent sesame allergy. (Sesame is the US 9th major allergen, FASTER Act, labeling since Jan 1 2023 — US-only; does not apply to Indian/home foods.)',
+                       paradigm:'Don\'t delay — but no proven sesame-specific prevention claim.' },
+  safeForm:      { ok:['smooth tahini (sesame paste) thinned with water, milk, or puree','finely ground sesame stirred into food'],
+                   never:['a thick glob of tahini (sticky — a choking risk; thin it, like nut butter)','whole sesame seeds in quantity for a young infant'],
+                   note:'Same "thin the sticky glob" rule as peanut butter. Unrefined / cold-pressed gingelly (sesame) oil can still carry allergenic protein.' },
+  myth:          { claim:'Sesame allergy is outgrown like egg or milk.',
+                   truth:'Usually not — sesame allergy tends to be lifelong (~70–80% persist), so first exposures and ongoing care matter more than for commonly-outgrown allergens.' },
+  watchFor:      ['hives / rash','swelling (mouth, eyes, lips)','vomiting'],
+  severeSigns:   ['trouble breathing / wheeze','face/lip/tongue swelling','floppy, pale, or very sleepy'],
+  timeCourse:    'minutes to ~2 hours after eating; anaphylaxis often within 5–30 min',
+  seekCare:      'Mild single-system: stop, monitor, call doctor. Any breathing trouble, face/throat swelling, or floppiness: EMERGENCY — call 112, use prescribed adrenaline auto-injector. Sesame is a leading anaphylaxis trigger — watch closely.',
+  breastfeedingSafe: true,
+  culturalNote:  'Til is deeply embedded — til laddoo, gajak (peak around Makar Sankranti), chutneys, gingelly oil. Thin tahini into dal, khichdi, curd, or fruit puree; avoid loose til seeds from laddoo/gajak for young infants.',
+  confidence:    'high',
+  sources:       ['AAP','UK NHS','ASCIA','FDA FASTER Act 2021','NEJM EAT 2016','J Asthma Allergy (persistence)','JAMA Netw Open 2019'],
+  dashboard:     'sesame-infant-safety.visual.html', // render pending
+  brief:         'sesame-infant-safety.md',
+  longform:      'sesame-infant-safety.html',         // render pending
+  lastReviewed:  '2026-06-01',
+}</pre>
+    <div class="flag good"><b>Surfacing hook:</b> an <b>encourage</b> card (introduce early, safe form) carrying the <b>most serious emergency floor of the four</b>. The two highest-value nuggets unique to sesame: the <b>Tier-2 honesty line</b> ("safe + don't-delay, NOT a prevention promise — EAT null") and the <b>persistence / usually-lifelong</b> note (vigilance doesn't age out).</div>
+  </section>
+
+  <p class="foot">SproutLab · Care visual dashboard · skim layer over <code>sesame-infant-safety.md</code> / <code>.html</code> · 2026-06-01<br>
+  Informational, not medical advice. Not yet wired into the app. All chart values are also in text for machine-reading.</p>
+</div>
+
+<script>
+  var tabs = Array.prototype.slice.call(document.querySelectorAll('.tab'));
+  function activate(t){
+    if(!t) return;
+    tabs.forEach(function(x){x.classList.remove('on');});
+    document.querySelectorAll('.panel').forEach(function(x){x.classList.remove('on');});
+    t.classList.add('on');
+    var el = document.getElementById(t.dataset.p); if(el) el.classList.add('on');
+    t.scrollIntoView({inline:'center', block:'nearest'}); window.scrollTo(0,0);
+  }
+  tabs.forEach(function(t){ t.addEventListener('click', function(){ activate(t); }); });
+  document.querySelectorAll('[data-go]').forEach(function(j){
+    j.addEventListener('click', function(){ activate(document.querySelector('.tab[data-p="'+j.dataset.go+'"]')); });
+  });
+  function step(d){ var c=tabs.findIndex(function(t){return t.classList.contains('on');}); var n=c+d; if(n>=0&&n<tabs.length) activate(tabs[n]); }
+  var sx=0, sy=0, tracking=false;
+  document.addEventListener('touchstart', function(e){ if(e.touches.length>1){tracking=false;return;} sx=e.changedTouches[0].clientX; sy=e.changedTouches[0].clientY; tracking=true; }, {passive:true});
+  document.addEventListener('touchend', function(e){
+    if(!tracking) return; tracking=false;
+    var dx=e.changedTouches[0].clientX-sx, dy=e.changedTouches[0].clientY-sy;
+    if(Math.abs(dx) < 55 || Math.abs(dx) < Math.abs(dy)*1.5) return;
+    step(dx < 0 ? 1 : -1);
+  }, {passive:true});
+  document.addEventListener('keydown', function(e){ if(e.key==='ArrowRight') step(1); else if(e.key==='ArrowLeft') step(-1); });
+</script>
+</body>
+</html>

--- a/docs/research/soy-infant-safety.html
+++ b/docs/research/soy-infant-safety.html
@@ -1,0 +1,273 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Soy (Soya) &amp; Infant Safety — Care Research Brief · SproutLab</title>
+<style>
+  :root{
+    --bg:#faf6f0; --card:#fffdf9; --ink:#2e2a26; --mid:#6b6258; --line:#e8ddcf;
+    --sage:#3a7060; --sage-bg:#e8f5ef; --rose:#b04a5e; --rose-bg:#fbe9ec;
+    --amber:#8a6320; --amber-bg:#fbf0d9; --accent:#9a6a3a;
+    --hi:#2f7d5b; --hi-bg:#e3f3ea; --mod:#9a7320; --mod-bg:#f7eed6; --weak:#9a5a5a; --weak-bg:#f5e6e6;
+  }
+  @media (prefers-color-scheme: dark){
+    :root{ --bg:#1d1a17; --card:#262220; --ink:#ece5db; --mid:#a89c8c; --line:#3a342d;
+      --sage:#7ac0a0; --sage-bg:#1e3028; --rose:#e090a0; --rose-bg:#3a2026;
+      --amber:#e0b060; --amber-bg:#352a16; --accent:#c99a6a;
+      --hi:#7ac0a0; --hi-bg:#1e3028; --mod:#d8b060; --mod-bg:#332a14; --weak:#e09090; --weak-bg:#3a2222; }
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+    font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Nunito,sans-serif;
+    -webkit-font-smoothing:antialiased;padding:0 0 80px}
+  .wrap{max-width:880px;margin:0 auto;padding:0 20px}
+  header{background:linear-gradient(160deg,var(--amber-bg),var(--bg));border-bottom:1px solid var(--line);
+    padding:34px 0 26px;margin-bottom:8px}
+  h1{font:700 27px/1.25 Fraunces,Georgia,serif;margin:0 0 6px}
+  .sub{color:var(--mid);font-size:14.5px;margin:0}
+  .meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
+  .pill{font-size:12px;font-weight:600;padding:4px 10px;border-radius:999px;background:var(--card);
+    border:1px solid var(--line);color:var(--mid)}
+  .pill.warn{background:var(--rose-bg);color:var(--rose);border-color:transparent}
+  h2{font:600 19px/1.3 Fraunces,Georgia,serif;margin:30px 0 12px;padding-top:10px;border-top:1px solid var(--line)}
+  h2 .ax{color:var(--accent);font-weight:700}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:18px 20px;margin:14px 0}
+  .tldr{background:var(--sage-bg);border-color:transparent}
+  .tldr ul{margin:8px 0 0;padding-left:20px}
+  .tldr li{margin:7px 0}
+  ul{margin:6px 0;padding-left:22px}
+  li{margin:6px 0}
+  .badge{display:inline-block;font-size:11px;font-weight:700;letter-spacing:.3px;text-transform:uppercase;
+    padding:3px 9px;border-radius:7px;vertical-align:middle;margin-left:8px}
+  .b-hi{background:var(--hi-bg);color:var(--hi)} .b-mod{background:var(--mod-bg);color:var(--mod)} .b-weak{background:var(--weak-bg);color:var(--weak)}
+  .flag{background:var(--amber-bg);border-left:3px solid var(--amber);border-radius:6px;
+    padding:10px 14px;margin:12px 0;font-size:14px;color:var(--ink)}
+  .flag b{color:var(--amber)}
+  .flag.good{background:var(--sage-bg);border-left-color:var(--sage)}
+  .flag.good b{color:var(--sage)}
+  .flag.bad{background:var(--rose-bg);border-left-color:var(--rose)}
+  .flag.bad b{color:var(--rose)}
+  blockquote{margin:12px 0;padding:8px 0 8px 16px;border-left:3px solid var(--sage);color:var(--mid);font-style:italic}
+  code,pre{font-family:"SF Mono",Menlo,Consolas,monospace}
+  pre{background:#1e1b18;color:#e8e2d6;border-radius:12px;padding:18px;overflow:auto;font-size:12.5px;line-height:1.55}
+  pre .c{color:#8a9a7a} pre .k{color:#d8a0b0} pre .s{color:#cbb080}
+  table{width:100%;border-collapse:collapse;font-size:13.5px;margin:10px 0}
+  th,td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{color:var(--mid);font-weight:700;font-size:12px;text-transform:uppercase;letter-spacing:.3px}
+  td a{color:var(--sage);word-break:break-all;font-size:12px}
+  td.c{text-align:center;font-weight:800}
+  .yes{color:var(--sage)}.no{color:var(--rose)}.dash{color:var(--mid)}
+  .quote{background:var(--card);border:1px dashed var(--line);border-radius:10px;padding:6px 14px;margin:8px 0;font-size:14px}
+  .quote b{color:var(--accent)}
+  .foot{color:var(--mid);font-size:13px;margin-top:30px;text-align:center}
+  .gap{background:var(--rose-bg);border-color:transparent}
+</style>
+</head>
+<body>
+<header><div class="wrap">
+  <h1>Soy (Soya) &amp; Infant Safety</h1>
+  <p class="sub">Care research brief — evidence base for SproutLab's <b>guided-introduction</b> food-effects model. Soy is a <b>Tier-2</b> allergen: introduce early because it's safe and nutritious, <b>not</b> on a prevention promise.</p>
+  <div class="meta">
+    <span class="pill">Reviewer · Maren (Care)</span>
+    <span class="pill">2026-06-01</span>
+    <span class="pill">Soy / soya · infants ~6–12mo · India, vegetarian</span>
+    <span class="pill">Tier-2 — introduce-early-and-SAFE, prevention NOT RCT-proven</span>
+    <span class="pill warn">Research artifact — NOT yet wired into the app</span>
+  </div>
+</div></header>
+
+<div class="wrap">
+
+  <div class="card">
+    <p style="margin:0"><b>Purpose.</b> Evidence base for SproutLab's Care layer, feeding the <i>guided-introduction</i> food-effects model. Built to decide what to surface when a parent introduces <b>soy (soya)</b> to an under-2 — covering why to introduce early (don't delay an allergen), the safe FORM (tofu vs. choking-hazard whole edamame), and the <b>two distinct emergency branches</b> (IgE-allergy/anaphylaxis AND the delayed non-IgE <b>FPIES</b> reaction for which soy is a classic trigger). The food is not banned — and unlike peanut/egg, early introduction is <b>NOT proven to prevent</b> soy allergy. We frame honestly: safe to introduce early, prevention not established.</p>
+    <p style="margin:10px 0 0"><b>Scope.</b> Soy as a food allergen and complementary food: tofu, edamame/soybeans, soy yoghurt, and the soya-protein products central to vegetarian Indian cooking (<b>soya chunks/granules/nuggets = TVP</b>). Infants ~6–12 months, choking note running to ~5 years. Family context: Indian, vegetarian — soya chunks and tofu are protein staples, not novelties. <b>Out of scope:</b> soy <i>infant formula</i> as a feeding choice (touched only to debunk the "soy not recommended" confusion — see Axis 1 &amp; 6).</p>
+    <p style="margin:10px 0 0;font-size:14px;color:var(--mid)"><b>Method.</b> Multi-angle web fan-out → source fetch → adversarial cross-check → synthesis. Authorities: AAP/HealthyChildren, UK NHS, ASCIA (Australasia), US NIAID, WHO complementary-feeding; pivotal trial EAT (Perkins/Lack, NEJM 2016). Disease-specific clinical detail (FPIES, natural history) from CHOP, FARE, and a JACI natural-history paper — <b>flagged inline as secondary/clinical</b>. Preparation specifics rest on reputable secondary sources (Solid Starts, flagged inline) rather than a top-tier body's verbatim words.</p>
+  </div>
+
+  <div class="card tldr">
+    <strong>TL;DR — the parent-facing truth</strong>
+    <ul>
+      <li><b>Introduce early — but DON'T claim it prevents allergy.</b> Consensus (AAP, NHS, ASCIA, NIAID): introduce major allergens, soy included, <b>around 6 months</b> alongside other solids, and <b>don't deliberately delay</b>. Soy is one of the US <b>"Big 9"</b> major allergens. <b>BUT</b> the headline prevention evidence (LEAP/EAT) is for peanut and egg. The <b>EAT trial found NO significant prevention effect for soy</b> (nor for milk, sesame, or fish). So: <i>safe to introduce early; early introduction is not proven to stop soy allergy.</i> Do not borrow the peanut prevention claim.</li>
+      <li><b>The soy-formula ≠ soy-food trap (read this first).</b> When you see "soy is <b>not recommended</b> for babies," it almost always means <b>soy infant formula as an allergy-prevention strategy</b> — NOT soy <i>foods</i> like tofu. NIAID/ASCIA do not endorse soy formula to prevent allergy; that has nothing to do with feeding a 7-month-old mashed tofu, which is fine. This is the single most common error in this topic.</li>
+      <li><b>There are TWO emergency branches, not one.</b> (1) <b>IgE allergy / anaphylaxis</b> — fast (minutes), hives/swelling/breathing trouble. (2) <b>FPIES</b> (Food Protein-Induced Enterocolitis Syndrome) — a <b>non-IgE</b> reaction that is <b>delayed (1–4 hours), with profuse repetitive vomiting + pallor/lethargy/dehydration, often NO hives</b>, frequently mistaken for a stomach bug; standard allergy tests come back <b>negative</b>. <b>Soy is a classic FPIES trigger.</b> The model must hold both branches.</li>
+      <li><b>The crux on the food itself is FORM.</b> <b>Silken/soft tofu</b> (smushable) and <b>well-cooked mashed soybeans</b> are infant-safe. <b>Whole edamame and whole soybeans are a choking hazard</b> — round, firm, slippery: shell + mash at 6 months, halve from ~9 months. <b>Soy milk is NOT a breast-milk/formula substitute in year one.</b></li>
+      <li><b>Indian vegetarian context is central, not peripheral.</b> <b>Soya chunks/granules/nuggets (TVP — textured vegetable protein)</b> are everyday protein in vegetarian households — concentrated soy protein. Introduce soy first as <b>soft tofu or as a minor ingredient</b>, then work up; soya chunks are fine once tolerated (soften/mash for the youngest).</li>
+      <li><b>Often outgrown.</b> Soy allergy affects ~<b>0.4%</b> of infants and is <b>commonly outgrown by ~age 3</b>, the majority by age 10. "Soy allergy is permanent" is a myth.</li>
+      <li><b>Watch the cross-reactivity.</b> Some <b>cow's-milk-protein-allergic (CMPA)</b> babies also react to soy — introduce soya as a <b>minor ingredient first</b>. Soy is also a <b>legume</b>, so there's some cross-sensitisation potential with peanut.</li>
+    </ul>
+  </div>
+
+  <h2><span class="ax">Axis 1</span> · Benefit &amp; timing — introduce early, but prevention is NOT proven <span class="badge b-hi">High (don't-delay / safe-early)</span> <span class="badge b-hi">High (prevention unproven for soy)</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>Don't deliberately delay.</b> Mainstream guidance is that there is no benefit to delaying allergenic foods past ~6 months once the baby is ready, and delay may not help: introduce the common allergens — soy among them — <b>around 6 months</b>, alongside other first foods, <b>not before 4 months</b>. <span class="badge b-hi">AAP · NHS · ASCIA</span></li>
+      <li><b>Soy is a recognised major allergen.</b> Soy is one of the US FDA <b>"Big 9"</b> major food allergens (alongside milk, egg, peanut, tree nuts, wheat, fish, shellfish, sesame), so it warrants the same single-allergen, watchful first-exposure care as the others. <span class="badge b-hi">FARE</span></li>
+      <li><b>The prevention evidence does NOT cover soy — frame this honestly.</b> The trials that flipped the "delay" paradigm tested <b>peanut</b> (LEAP) and a 6-allergen panel (EAT). In <b>EAT</b> (1,303 exclusively breastfed general-population infants, early introduction of 6 allergens from 3 months vs ~6 months): the <b>per-protocol prevention benefit was significant for peanut and egg only</b>. <b>Soy showed no significant prevention effect</b> — and neither did milk, sesame, or fish. <span class="badge b-hi">Perkins/Lack et al., NEJM 2016</span></li>
+    </ul>
+    <div class="flag"><b>⚑ The honest framing the model MUST use:</b> introducing soy early is <b>safe and appropriate</b>, and there's no reason to delay it — but we <b>cannot tell a parent that early soy prevents soy allergy</b>. That claim is true for peanut/egg, false-by-evidence for soy. Tier-2 allergen: <i>introduce-early because there's no reason not to and the diet benefits, NOT because an RCT proved prevention.</i> Conflating the two is the kind of over-claim Maren should reject.</div>
+    <p style="margin:12px 0 0"><b>Why introduce at all, then?</b> Dietary value (soy is a complete plant protein — especially valuable in a vegetarian household), normal allergen exposure as part of a varied diet, and avoiding the downsides of unnecessary restriction. The reason is <b>nutrition + no-reason-to-avoid</b>, not proven prevention.</p>
+  </div>
+
+  <h2><span class="ax">Axis 2</span> · Safe FORM — tofu vs. the edamame choking gate <span class="badge b-hi">High (choking principle)</span> <span class="badge b-mod">Moderate (exact ages/sizes — secondary)</span></h2>
+  <div class="card">
+    <p style="margin:0 0 6px"><b>Infant-safe forms (the gate the food passes through):</b></p>
+    <ol>
+      <li><b>Silken or soft tofu</b>, in pieces a baby can mush with gums/fingers, or mashed/blended into other food. Soft tofu is one of the easier first proteins to offer by form. <span class="badge b-mod">Solid Starts — tofu</span></li>
+      <li><b>Well-cooked, mashed soybeans</b>, or soy stirred into already-tolerated purées/porridge/dal.</li>
+      <li><b>Soy yoghurt</b> (unsweetened) as a smooth vehicle.</li>
+      <li><b>Soya chunks/granules</b> softened and finely mashed/minced once soy is tolerated (see Axis 5 for the Indian-staple detail).</li>
+    </ol>
+    <p style="margin:12px 0 6px"><b>The choking hazard — whole edamame and whole soybeans.</b> Whole edamame beans and whole/firm soybeans are <b>round, firm, and slippery</b> — a classic choking shape for infants. <b>Shell and mash at ~6 months; from ~9 months offer halved/quartered</b> rather than whole, and only move toward whole beans well past toddlerhood when chewing is reliable. Never give a baby a handful of whole edamame. <span class="badge b-mod">Solid Starts — edamame; NHS choking principles</span></p>
+    <div class="flag"><b>⚑ Form removes the choking hazard but NOT the allergy hazard.</b> Mashing tofu/soybeans genuinely makes the food safe on the <b>choking</b> axis; it does nothing for the <b>allergy</b> axis (IgE or FPIES), which is managed by introduction + watchfulness. Two axes, held separately — same design crux as the peanut brief.</div>
+    <p style="margin:12px 0 0"><b>Soy milk is NOT a milk substitute in year one.</b> Fortified soy <i>drink</i> is not a replacement for breast milk or infant formula as the main milk before 12 months. It can appear as an ingredient in food, but it is not a bottle drink for an infant. <span class="badge b-hi">NHS · ASCIA</span> (Distinct again from <i>soy infant formula</i> — see Axis 1 trap.)</p>
+  </div>
+
+  <h2><span class="ax">Axis 3</span> · Emergency floor — the TWO branches <span class="badge b-hi">High (IgE/anaphylaxis)</span> <span class="badge b-mod">Moderate-clinical (FPIES, CHOP)</span></h2>
+  <div class="card">
+    <p style="margin:0 0 8px">This food has <b>two separate reaction pathways</b>, and the parent response differs. The model must surface both — FPIES especially, because it presents with <b>no hives</b> and is routinely mistaken for gastroenteritis.</p>
+
+    <p style="margin:14px 0 4px"><b>Branch A — IgE allergy (fast, minutes):</b></p>
+    <ul>
+      <li><b>Mild–moderate (one body system):</b> itchy <b>hives/welts</b>, redness/rash, <b>swelling</b> (esp. mouth/eyes), <b>vomiting</b>, sometimes loose stool, sudden fussiness. In infants, reactions skew toward <b>skin + GI</b>, with breathing signs <b>less</b> prominent than in older children. <span class="badge b-hi">NHS</span> <span class="badge b-mod">Solid Starts (infant-pattern detail)</span></li>
+      <li><b>Severe / anaphylaxis (act immediately):</b> <b>difficulty breathing / wheeze / noisy breathing / persistent cough</b>, <b>swelling of the throat/tongue/lips/face</b>, <b>pale or blue</b> colour, hoarse cry, <b>floppy/limp/lethargic</b> or unusually sleepy, collapse. <span class="badge b-hi">NHS anaphylaxis</span>
+        <ul><li><b>Action:</b> <b>use an adrenaline auto-injector immediately if prescribed, and call emergency services (112 / 108 in India; 999 UK; 911 US).</b> Lie the child flat (or sit up if breathing is hard); do not stand them up.</li></ul>
+      </li>
+    </ul>
+
+    <p style="margin:14px 0 4px"><b>Branch B — FPIES (delayed, non-IgE — soy is a classic trigger):</b></p>
+    <ul>
+      <li><b>What it is:</b> Food Protein-Induced Enterocolitis Syndrome — a <b>non-IgE</b> food reaction affecting the gut. <b>Standard allergy tests (skin-prick, sIgE) are typically negative</b>, which is why it's missed. <span class="badge b-mod">CHOP — clinical secondary</span></li>
+      <li><b>Presentation:</b> <b>delayed — typically 1–4 hours after eating</b> — with <b>profuse, repetitive (projectile) vomiting</b>, then <b>lethargy, pallor</b>, and risk of <b>dehydration</b>; sometimes diarrhoea later. <b>Often NO hives, NO swelling, NO breathing trouble</b> — which is exactly what makes it look like a stomach bug.</li>
+      <li><b>Most common triggers:</b> <b>cow's milk, soy, rice, oats</b> are the classic FPIES foods.</li>
+      <li><b>Action:</b> repetitive vomiting + a pale/floppy/lethargic baby a couple of hours after a soy feed is a reason for <b>urgent medical care even without any rash</b> — severe FPIES episodes can cause dehydration/shock and may need IV fluids. Tell the clinician <i>what was eaten and when</i>, because the delay is the diagnostic clue.</li>
+    </ul>
+    <div class="flag bad"><b>⚑ Design note for the model:</b> a hives-centric allergy card will <b>miss FPIES entirely</b>. The soy record needs a distinct "delayed vomiting + lethargy, no rash" branch that routes to urgent care, separate from the IgE/anaphylaxis branch. This is the most important soy-specific safety insight in this brief.</div>
+  </div>
+
+  <h2><span class="ax">Axis 4</span> · Culinary aliases &amp; hidden sources <span class="badge b-hi">High (alias list)</span> <span class="badge b-mod">Moderate (label-exemption specifics)</span></h2>
+  <div class="card">
+    <p style="margin:0 0 8px">Soy hides under many names — vital for a family reading labels and for the model's ingredient resolver:</p>
+    <ul>
+      <li><b>Whole-food / fermented:</b> tofu (bean curd), <b>edamame</b> (immature soybeans), soybeans, <b>soya chunks / granules / nuggets</b> = <b>TVP / textured vegetable protein</b> (concentrated, defatted soy protein — heavy in Indian veg cooking), <b>miso</b>, <b>natto</b>, <b>tempeh</b>, soy/soya flour.</li>
+      <li><b>Liquids &amp; condiments:</b> <b>soy milk / soya drink</b>, <b>soy sauce</b>, <b>tamari</b> (note: soy sauce/tamari also commonly carry <b>wheat</b> — a separate allergen flag).</li>
+      <li><b>Additives (usually tolerated, but label-listed):</b> <b>soy lecithin</b> (an emulsifier in chocolate, baked goods — <i>most soy-allergic individuals tolerate it</i>, but it is a soy-derived ingredient); soy protein isolate/concentrate.</li>
+      <li><b>Label-exemption nuance:</b> in the US, <b>highly refined soybean oil</b> is <b>exempt</b> from major-allergen labelling (the refining removes the protein), so it may not be flagged as "soy" on a US label. Cold-pressed/expeller/unrefined soybean oil is <b>not</b> exempt. <span class="badge b-mod">US allergen-labelling law via FARE</span></li>
+    </ul>
+    <div class="flag"><b>⚑ Flag for the resolver:</b> "no soy listed" on a US label does <b>not</b> guarantee soy-oil-free; and "soy lecithin" present does <b>not</b> mean a soy-allergic child will react (usually tolerated). Don't auto-escalate lecithin; do surface TVP/soya chunks as full soy protein.</div>
+  </div>
+
+  <h2><span class="ax">Axis 5</span> · Indian &amp; vegetarian context <span class="badge b-hi">High (staple status + prep)</span> <span class="badge b-weak">See Axis 6 GAP (India official)</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>Soya is a protein backbone of vegetarian Indian households.</b> <b>Soya chunks/granules/nuggets (TVP)</b> — rehydrated into curries, pulao, kheema-style dishes — are an everyday, affordable, concentrated plant protein. <b>Tofu</b> and soy milk are increasingly common. In a vegetarian diet (no meat/fish protein), soy is a high-value complete protein, which makes early, regular introduction both natural and nutritionally useful.</li>
+      <li><b>Introduce in soft/tofu form first, then build up.</b> Start soy as <b>soft/silken tofu</b> or as a <b>minor ingredient</b> mashed into an already-tolerated dish (see the CMPA cross-reactivity note below for <i>why</i> minor-ingredient-first), watch the first exposures, then progress to <b>softened, finely-mashed soya chunks/granules</b> once tolerated. The youngest infants should get soya chunks softened and mashed/minced, never as firm chewy pieces (texture + the legume's density).</li>
+    </ul>
+    <p style="margin:12px 0 6px"><b>Cross-reactivity to introduce carefully around:</b></p>
+    <ul>
+      <li><b>Soy ↔ CMPA:</b> some <b>cow's-milk-protein-allergic</b> babies also react to soy protein. If there's known CMPA, introduce soy cautiously as a <b>minor ingredient first</b> and consider a paediatrician's input. <span class="badge b-mod">FARE</span></li>
+      <li><b>Legume cross-sensitisation:</b> soy is a <b>legume</b>, like peanut — there is some cross-sensitisation potential, though a positive test ≠ clinical allergy. Treat soy as its own allergen, introduced on its own day for attribution. <span class="badge b-mod">FARE</span></li>
+    </ul>
+  </div>
+
+  <h2><span class="ax">Axis 6</span> · Myths to correct <span class="badge b-hi">High</span></h2>
+  <div class="card">
+    <div class="flag good"><b>✓ Myth: "Soy is not recommended for babies."</b> <b>Conflation.</b> This refers to <b>soy infant formula as an allergy-prevention strategy</b>, which bodies like NIAID/ASCIA do not endorse — <b>NOT</b> soy <i>foods</i> (tofu, mashed soybeans, soya chunks), which are fine to introduce around 6 months. The model should actively separate "soy formula (a milk choice)" from "soy food (a complementary food)." <b>Highest-value myth on this topic.</b></div>
+    <div class="flag good"><b>✓ Myth: "Soy allergy is permanent / lifelong."</b> <b>Usually false.</b> Soy allergy affects ~<b>0.4%</b> of infants and is <b>commonly outgrown — many by ~age 3, the majority by age 10</b>. It behaves more like milk/egg (often outgrown) than peanut/tree nut (often lifelong). <span class="badge b-mod">FARE · JACI natural-history</span></div>
+    <div class="flag"><b>⚑ Myth: "Introduce soy early to prevent soy allergy" (the over-claim in the other direction).</b> <b>Not proven.</b> The prevention evidence is peanut/egg; <b>EAT found no significant effect for soy</b>. Introduce early because it's safe and nutritious and there's no reason to delay — <b>not</b> on a prevention promise. <span class="badge b-hi">Perkins/Lack, NEJM 2016</span></div>
+    <div class="flag good"><b>✓ Myth: "Soy lecithin will trigger a soy-allergic child."</b> <b>Usually not.</b> Most soy-allergic individuals tolerate soy lecithin (negligible residual protein); it's still label-listed, so don't auto-panic on its presence. <span class="badge b-mod">FARE</span></div>
+  </div>
+
+  <h2>Who says what — consensus matrix</h2>
+  <div class="card">
+  <table>
+    <tr><th>Authority</th><th class="c">Introduce ~6mo / don't delay</th><th class="c">Early soy PREVENTS soy allergy</th></tr>
+    <tr><td>AAP / HealthyChildren</td><td class="c yes">✓</td><td class="c dash">— (not claimed)</td></tr>
+    <tr><td>UK NHS</td><td class="c yes">✓</td><td class="c dash">— (not claimed)</td></tr>
+    <tr><td>ASCIA (Australasia)</td><td class="c yes">✓</td><td class="c dash">— (not claimed)</td></tr>
+    <tr><td>US NIAID (2017)</td><td class="c yes">✓</td><td class="c dash">— (not claimed)</td></tr>
+    <tr><td>NEJM — EAT trial (2016)</td><td class="c yes">✓ (safe early)</td><td class="c no">✗ no significant effect for soy</td></tr>
+  </table>
+  <p style="font-size:13px;color:var(--mid);margin:6px 0 0">Every body says "introduce early / don't delay"; <b>none</b> claims early soy <i>prevents</i> soy allergy — and EAT actively found no significant prevention effect. The "introduce-early" and "prevents-allergy" columns are NOT the same claim for soy.</p>
+  </div>
+
+  <h2>Proposed data shape · <code>FOOD_EFFECTS['soy']</code></h2>
+  <div class="card">
+    <p style="margin:0 0 10px;font-size:14px;color:var(--mid)">Drop-in record for the <code>FOOD_EFFECTS</code> table in <code>data.js</code>, sitting alongside <code>AGE_RULES</code>/<code>ALLERGENS</code>. The <code>reactionType</code> carries <code>'digestive'</code> for the non-IgE FPIES branch; <code>severeSigns</code> includes the delayed "vomiting + lethargy hours later" FPIES line; <code>earlyIntroBenefit.paradigm</code> is the Tier-2 honesty guardrail (no proven prevention). <b>Not yet wired.</b></p>
+<pre><span class="c">// guided-introduction record — Tier-2 allergen (encourage polarity, no prevention claim)</span>
+<span class="k">const</span> FOOD_EFFECTS = {
+  <span class="s">'soy'</span>: {
+    foodClass:     <span class="s">'allergen-introduce-early'</span>,
+    severity:      <span class="s">'caution'</span>,            <span class="c">// amber, NOT rose (rose = acute-toxin honey)</span>
+    category:      <span class="s">'legume'</span>,
+    effect:        <span class="s">'food allergy (incl. FPIES)'</span>,
+    minMonth:      <span class="s">6</span>,
+    thresholdBasis:<span class="s">'developmental-readiness'</span>,
+    allergen:      <span class="k">true</span>,
+    reactionType:  [<span class="s">'allergy'</span>, <span class="s">'digestive'</span>],   <span class="c">// digestive = FPIES (non-IgE), a classic soy presentation</span>
+    headline:      <span class="s">'Introduce around 6 months — don\'t delay. Soft tofu, not whole edamame.'</span>,
+    whyGood:       <span class="s">'Valuable plant protein for a vegetarian diet (tofu, soya chunks) — introduce early.'</span>,
+    earlyIntroBenefit: { claim:<span class="s">'Introduce around 6 months; don\'t delay allergens.'</span>,
+                         evidence:<span class="s">'AAP/NHS/ASCIA advise early introduction; SAFE, but no RCT proves early soy prevents soy allergy (soy not among EAT\'s prevention-positive foods).'</span>,
+                         paradigm:<span class="s">'Don\'t delay — but no proven soy-specific prevention claim.'</span> },
+    safeForm:      { ok:[<span class="s">'soft / silken tofu, smushable or blended'</span>, <span class="s">'well-cooked soybeans mashed'</span>, <span class="s">'soy yoghurt; soya stirred into food'</span>],
+                     never:[<span class="s">'whole edamame or whole soybeans (round, firm — a choking risk)'</span>, <span class="s">'soy milk as a main drink in the first year'</span>],
+                     note:<span class="s">'Shell and mash edamame at 6mo; halve cooked beans at 9mo. Soft tofu needs no choking prep.'</span> },
+    myth:          { claim:<span class="s">'Soy isn\'t recommended for babies.'</span>,
+                     truth:<span class="s">'That advice is about soy infant FORMULA for allergy prevention — not soy FOODS like tofu, fine ~6 months.'</span> },
+    watchFor:      [<span class="s">'hives / rash'</span>, <span class="s">'swelling (mouth, eyes, lips)'</span>, <span class="s">'vomiting or diarrhoea'</span>],
+    severeSigns:   [<span class="s">'trouble breathing / wheeze'</span>, <span class="s">'face/lip/tongue swelling'</span>, <span class="s">'floppy, pale, or very sleepy'</span>,
+                    <span class="s">'repeated forceful vomiting + lethargy hours later (possible FPIES)'</span>],
+    timeCourse:    <span class="s">'IgE: minutes to ~2 hours. FPIES (non-IgE): delayed — profuse repeated vomiting + lethargy/pallor 1–4 hours after eating.'</span>,
+    seekCare:      <span class="s">'Mild single-system: stop, monitor, call doctor. Breathing trouble, face/throat swelling, or floppiness: EMERGENCY — call 112. Repeated forceful vomiting + lethargy/pallor hours after a soy feed (possible FPIES): urgent care even without a rash.'</span>,
+    breastfeedingSafe: <span class="k">true</span>,
+    culturalNote:  <span class="s">'Soya chunks/granules are everyday vegetarian protein in India. Some cow\'s-milk-allergic babies also react to soy; introduce as a minor ingredient first.'</span>,
+    confidence:    <span class="s">'high'</span>,
+    lastReviewed:  <span class="s">'2026-06-01'</span>,
+  },
+};</pre>
+  </div>
+
+  <h2>Source list</h2>
+  <div class="card">
+  <table>
+    <tr><th>#</th><th>Authority</th><th>Type</th><th>URL</th></tr>
+    <tr><td>1</td><td>AAP / HealthyChildren — when to introduce egg, peanut butter &amp; other allergens (don't delay; ~6 mo)</td><td>Official</td><td><a href="https://www.healthychildren.org/English/healthy-living/nutrition/Pages/when-to-introduce-egg-peanut-butter-and-other-common-food-allergens-to-your-baby-food-allergy-prevention-tips.aspx">healthychildren.org/…/allergens</a></td></tr>
+    <tr><td>2</td><td>UK NHS — Food allergies in babies &amp; young children (signs; introduction)</td><td>Official</td><td><a href="https://www.nhs.uk/baby/weaning-and-feeding/food-allergies-in-babies-and-young-children/">nhs.uk/baby/…/food-allergies</a></td></tr>
+    <tr><td>3</td><td>UK NHS — Anaphylaxis (severe-reaction signs + action)</td><td>Official</td><td><a href="https://www.nhs.uk/conditions/anaphylaxis/">nhs.uk/conditions/anaphylaxis</a></td></tr>
+    <tr><td>4</td><td>NIAID — Addendum Guidelines for Prevention of Peanut Allergy (2017); soy-formula context</td><td>Official</td><td><a href="https://www.niaid.nih.gov/sites/default/files/addendum-peanut-allergy-prevention-guidelines.pdf">niaid.nih.gov/…/addendum</a></td></tr>
+    <tr><td>5</td><td>ASCIA — Infant Feeding for Food Allergy Prevention</td><td>Official</td><td><a href="https://www.allergy.org.au/hp/papers/infant-feeding-and-allergy-prevention">allergy.org.au/…/infant-feeding</a></td></tr>
+    <tr><td>6</td><td>WHO — Complementary feeding of infants &amp; young children 6–23 months (2023)</td><td>Official</td><td><a href="https://www.ncbi.nlm.nih.gov/books/NBK596423/">ncbi.nlm.nih.gov/books/NBK596423</a></td></tr>
+    <tr><td>7</td><td>NEJM — Perkins/Lack et al., EAT trial (2016); soy = no significant prevention effect</td><td>Primary trial</td><td><a href="https://pubmed.ncbi.nlm.nih.gov/26943128/">pubmed.ncbi.nlm.nih.gov/26943128</a></td></tr>
+    <tr><td>8</td><td>FARE — Soy allergy (prevalence ~0.4%; outgrown; allergen status; lecithin)</td><td>Secondary (advocacy/clinical)</td><td><a href="https://www.foodallergy.org/living-food-allergies/food-allergy-essentials/common-allergens/soy">foodallergy.org/…/soy</a></td></tr>
+    <tr><td>9</td><td>JACI — Natural history of soy allergy (outgrowth by age 3/10)</td><td>Secondary (clinical literature)</td><td><a href="https://www.jacionline.org/article/S0091-6749(10)00007-2/fulltext">jacionline.org/…/soy-natural-history</a></td></tr>
+    <tr><td>10</td><td>CHOP — Food Protein-Induced Enterocolitis Syndrome (FPIES): delayed vomiting, triggers, negative tests</td><td>Secondary (clinical)</td><td><a href="https://www.chop.edu/conditions-diseases/food-protein-induced-enterocolitis-syndrome-fpies">chop.edu/…/fpies</a></td></tr>
+    <tr><td>11</td><td>Solid Starts — Edamame (choking-by-form; shell + mash)</td><td>Secondary (prep)</td><td><a href="https://solidstarts.com/foods/edamame/">solidstarts.com/foods/edamame</a></td></tr>
+    <tr><td>12</td><td>Solid Starts — Tofu (soft/silken first form)</td><td>Secondary (prep)</td><td><a href="https://solidstarts.com/foods/tofu/">solidstarts.com/foods/tofu</a></td></tr>
+  </table>
+  </div>
+
+  <div class="card">
+    <strong>Verification status &amp; gaps</strong>
+    <ol style="margin:8px 0 0">
+      <li>✅ <b>"Introduce early / don't delay ~6 mo"</b> — corroborated across AAP, NHS, ASCIA, NIAID for major allergens generally; soy is a recognised major allergen (FARE / Big 9).</li>
+      <li>✅ <b>EAT null result for soy</b> — soy (with milk, sesame, fish) showed <b>no significant prevention effect</b>; benefit was peanut + egg only. The "early soy prevents soy allergy" claim is <b>not</b> supported — flagged so the model never borrows the peanut prevention frame for soy.</li>
+      <li>✅ <b>Soy formula ≠ soy food</b> — the "soy not recommended" caution is about <b>soy infant formula as prevention</b>, not tofu/soy foods. Treated as the headline myth; sourced to NIAID/ASCIA framing.</li>
+      <li>⚑ <b>FPIES detail is clinical-secondary (CHOP)</b> — the delayed-vomiting / lethargy-pallor / negative-test / cow's-milk-soy-rice-oats-triggers picture is well-established clinically but is <b>CHOP-sourced, not from a patient-facing top-tier body's verbatim allergen page</b>. Marked clinical secondary; the <i>existence</i> of a delayed non-IgE branch is not in doubt, but verbatim timings (1–4 h) should be re-confirmed against an official allergy body before going to parents as a hard number.</li>
+      <li>⚑ <b>Prevalence ~0.4% &amp; outgrowth ages (3 / 10)</b> — FARE + JACI natural-history sourced (secondary/clinical), not a regulator figure; directionally robust (soy is commonly outgrown), exact percentages are literature-derived.</li>
+      <li>⚑ <b>Form specifics (shell+mash at 6 mo, halve at 9 mo; silken-tofu-first)</b> — <b>Solid Starts</b> (secondary prep source), consistent with NHS whole-food choking principles but not a top-tier body's verbatim age/size standard. Flagged as practice-level.</li>
+      <li>⚑ <b>US soybean-oil label exemption &amp; lecithin tolerance</b> — US-labelling-law specific (via FARE); applies to US labels, <b>not</b> Indian labelling. Don't present as a universal rule.</li>
+      <li>⚑ <b>No India-specific official soy / allergen-introduction directive (the honest gap).</b> <b>No IAP / MoHFW / FSSAI directive on allergen introduction <i>or</i> on soy for infants was located.</b> The <b>IAP complementary-feeding parental guideline does not mention soy or allergen introduction at all.</b> The early-introduction guidance here is <b>entirely international</b> (AAP/NHS/ASCIA/NIAID); the Indian vegetarian context (soya chunks/tofu as staples) is cultural/nutritional, not government-issued. <b>Do not manufacture or attribute any Indian official soy/allergen guidance</b> — there is none to cite, and laundering international guidance onto an Indian body's name would repeat the error the peanut/honey briefs warn against.</li>
+    </ol>
+  </div>
+
+  <div class="card tldr">
+    <strong>Surfacing recommendation (Maren) — feeds the food-effects-v2 model, not yet implemented</strong>
+    <p style="margin:8px 0 0">Surface soy as an <b>encourage-polarity</b> card (sage chrome, <code>severity:'caution'</code> → amber, not honey's rose) — benefit and "introduce ~6mo, don't delay" first, then the form gate (soft tofu vs whole edamame). But the soy card needs <b>two things a generic allergen card lacks</b>: (1) a <b>distinct FPIES branch</b> — delayed vomiting + lethargy/pallor, often no rash, tests negative → urgent care — that a hives-centric layout would miss entirely; and (2) the <b>formula ≠ food</b> myth surfaced up front. The honesty guardrail is non-negotiable: the model must <b>never</b> render "early soy prevents soy allergy" — Tier-2 means introduce-early-because-safe-and-nutritious, not on a prevention promise (EAT was null for soy).</p>
+  </div>
+
+  <p class="foot">SproutLab · Care research brief · companion to <code>docs/research/soy-infant-safety.md</code> · generated 2026-06-01<br>
+  Research artifact — informational, not medical advice. Not yet wired into the app.</p>
+</div>
+</body>
+</html>

--- a/docs/research/soy-infant-safety.visual.html
+++ b/docs/research/soy-infant-safety.visual.html
@@ -1,0 +1,369 @@
+<!DOCTYPE html>
+<!-- ═══════════════════════════════════════════════════════════════════════
+  FOOD-DASHBOARD TEMPLATE · SproutLab Care research layer
+  Copy this file to  <food>-infant-safety.visual.html  and fill the {{...}}.
+  Canonical CSS + JS (tab swiping, arrow keys, charts) — DO NOT diverge; if you
+  improve a component, update this template so all dashboards inherit it.
+
+  TABS are generic; relabel per food TYPE:
+    • critical/acute-toxin (honey)  → Summary · The Science · Symptoms & Care · Context · Sources · Data
+    • allergen (egg, nuts, soy)     → Summary · Why/Allergen · Reaction & Introduction · Context · Sources · Data
+    • choking (whole nuts, grapes)  → Summary · The Hazard · Safe Prep · Context · Sources · Data
+    • timing (cow milk, salt, sugar)→ Summary · Why this age · Effects · Context · Sources · Data
+
+  COMPONENT LIBRARY (copy from the commented block at the bottom of <body>):
+    stat tiles · bar chart · donut (SVG) · timeline · thermometer split ·
+    consensus matrix · flag callouts · badges.
+  Every chart value MUST also appear as text (machine-readable for agents).
+  After filling: append a record to food-effects.manifest.js.
+═══════════════════════════════════════════════════════════════════════ -->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Soy (Soya) &amp; Infant Safety — Visual Dashboard · SproutLab Care</title>
+<style>
+  :root{
+    --bg:#faf6f0; --card:#fffdf9; --ink:#2e2a26; --mid:#6b6258; --line:#e8ddcf; --track:#efe7da;
+    --sage:#3a7060; --sage-bg:#e8f5ef; --rose:#b04a5e; --rose-bg:#fbe9ec;
+    --amber:#9a7320; --amber-bg:#fbf0d9; --accent:#9a6a3a; --honey:#d99a2b; --honey-bg:#fbeccb;
+    --hi:#2f7d5b; --hi-bg:#e3f3ea; --mod:#9a7320; --mod-bg:#f7eed6; --weak:#9a5a5a; --weak-bg:#f5e6e6;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#1d1a17; --card:#262220; --ink:#ece5db; --mid:#a89c8c; --line:#3a342d; --track:#332d26;
+    --sage:#7ac0a0; --sage-bg:#1e3028; --rose:#e090a0; --rose-bg:#3a2026;
+    --amber:#e0b060; --amber-bg:#352a16; --accent:#c99a6a; --honey:#e8b34a; --honey-bg:#3a2c12;
+    --hi:#7ac0a0; --hi-bg:#1e3028; --mod:#d8b060; --mod-bg:#332a14; --weak:#e09090; --weak-bg:#3a2222; }}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Nunito,sans-serif;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:960px;margin:0 auto;padding:0 18px 90px}
+  header{background:linear-gradient(160deg,var(--honey-bg),var(--bg));border-bottom:1px solid var(--line);padding:26px 0 0}
+  h1{font:700 25px/1.2 Fraunces,Georgia,serif;margin:0 0 4px}
+  .sub{color:var(--mid);font-size:14px;margin:0 0 16px;max-width:680px}
+  nav{display:flex;gap:4px;margin-top:6px;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none}
+  nav::-webkit-scrollbar{display:none}
+  .tab{appearance:none;border:0;background:transparent;color:var(--mid);font:600 13.5px/1 Nunito,sans-serif;white-space:nowrap;flex:0 0 auto;
+    padding:11px 14px;border-radius:10px 10px 0 0;cursor:pointer;border-bottom:3px solid transparent}
+  .tab:hover{color:var(--ink);background:var(--card)}
+  .tab.on{color:var(--accent);background:var(--card);border-bottom-color:var(--accent)}
+  .panel{display:none;animation:f .25s ease}.panel.on{display:block}
+  @keyframes f{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:none}}
+  /* ── Entrance animations — re-trigger each time a panel is shown (display:none→block
+     restarts descendant animations). All gated behind prefers-reduced-motion so the
+     dashboard is fully usable (and calm) for anyone who opts out of motion. ── */
+  @media (prefers-reduced-motion: no-preference){
+    /* bars grow from the left — scaleX keeps the inline width:% target intact */
+    .panel.on .bar .fil{transform-origin:left center;animation:grow .7s cubic-bezier(.34,1.1,.4,1) both}
+    @keyframes grow{from{transform:scaleX(0)}to{transform:scaleX(1)}}
+    /* stat tiles + timeline steps + therm cols rise in with a gentle stagger */
+    .panel.on .stat,.panel.on .tl-step,.panel.on .therm .col{animation:rise .45s ease both}
+    .panel.on .stat:nth-child(2),.panel.on .tl-step:nth-child(2),.panel.on .therm .col:nth-child(2){animation-delay:.07s}
+    .panel.on .stat:nth-child(3),.panel.on .tl-step:nth-child(3){animation-delay:.14s}
+    .panel.on .stat:nth-child(4),.panel.on .tl-step:nth-child(4){animation-delay:.21s}
+    .panel.on .tl-step:nth-child(5){animation-delay:.28s}
+    @keyframes rise{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}
+    /* donut sweeps in (the partial-arc value stays exact; only the reveal animates) */
+    .panel.on svg[role="img"]{animation:sweep .8s ease both}
+    @keyframes sweep{from{opacity:0;transform:rotate(-12deg) scale(.9)}to{opacity:1;transform:none}}
+    /* flag callouts slide a touch from the left edge they're anchored to */
+    .panel.on .flag{animation:slidein .5s ease both}
+    @keyframes slidein{from{opacity:0;transform:translateX(-6px)}to{opacity:1;transform:none}}
+  }
+  h2{font:600 18px/1.3 Fraunces,Georgia,serif;margin:26px 0 10px}
+  h3{font:700 13px/1.3 Nunito;text-transform:uppercase;letter-spacing:.4px;color:var(--mid);margin:18px 0 8px}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:16px 18px;margin:12px 0}
+  .grid{display:grid;gap:12px}.g2{grid-template-columns:1fr 1fr}.g3{grid-template-columns:repeat(3,1fr)}.g4{grid-template-columns:repeat(4,1fr)}
+  @media(max-width:680px){.g2,.g3,.g4{grid-template-columns:1fr 1fr}}
+  .stat{text-align:center;padding:16px 10px}
+  .stat .n{font:800 26px/1 Fraunces,Georgia,serif;color:var(--accent)}
+  .stat .l{font-size:12px;color:var(--mid);margin-top:6px;line-height:1.35}
+  .stat.crit .n{color:var(--rose)}.stat.ok .n{color:var(--sage)}
+  .badge{display:inline-block;font:700 10.5px/1 Nunito;text-transform:uppercase;letter-spacing:.3px;padding:4px 8px;border-radius:6px;vertical-align:middle}
+  .b-hi{background:var(--hi-bg);color:var(--hi)}.b-mod{background:var(--mod-bg);color:var(--mod)}.b-weak{background:var(--weak-bg);color:var(--weak)}.b-crit{background:var(--rose-bg);color:var(--rose)}
+  .bar{display:grid;grid-template-columns:130px 1fr 52px;align-items:center;gap:10px;margin:7px 0;font-size:13px}
+  .bar .lab{color:var(--ink);text-align:right;font-weight:600}
+  .bar .trk{display:block;background:var(--track);border:1px solid var(--line);border-radius:7px;height:18px;overflow:hidden}
+  .bar .fil{display:block;height:100%;border-radius:6px;background:var(--sage);min-width:3px}
+  .bar .val{font-weight:700;color:var(--mid);font-size:12.5px}
+  .bar.hl .fil{background:var(--honey)}.bar.hl .lab{color:var(--honey)}.bar.hl .val{color:var(--honey)}
+  .tl{position:relative;margin:14px 0 6px;padding-left:8px}
+  .tl-step{position:relative;padding:0 0 18px 26px;border-left:2px solid var(--line)}
+  .tl-step:last-child{border-left-color:transparent}
+  .tl-dot{position:absolute;left:-8px;top:1px;width:15px;height:15px;border-radius:50%;background:var(--card);border:3px solid var(--accent)}
+  .tl-step.crit .tl-dot{border-color:var(--rose)}.tl-step.first .tl-dot{border-color:var(--honey)}
+  .tl-t{font-weight:700;font-size:13.5px}.tl-d{color:var(--mid);font-size:12.5px}
+  .flag{border-left:3px solid var(--amber);background:var(--amber-bg);border-radius:6px;padding:10px 14px;margin:10px 0;font-size:13px}
+  .flag.good{border-left-color:var(--sage);background:var(--sage-bg)}.flag.bad{border-left-color:var(--rose);background:var(--rose-bg)}
+  table{width:100%;border-collapse:collapse;font-size:13px;margin:8px 0}
+  th,td{padding:8px 9px;border-bottom:1px solid var(--line);text-align:left;vertical-align:top}
+  th{font:700 11px/1.2 Nunito;text-transform:uppercase;letter-spacing:.3px;color:var(--mid)}
+  td.c{text-align:center;font-weight:800}.yes{color:var(--sage)}.no{color:var(--rose)}.dash{color:var(--mid)}
+  td a{color:var(--sage);font-size:12px;word-break:break-all}
+  .pill{display:inline-block;font:600 11px/1 Nunito;padding:5px 10px;border-radius:999px;background:var(--card);border:1px solid var(--line);color:var(--mid);margin:0 4px 4px 0}
+  .pill.warn{background:var(--rose-bg);color:var(--rose);border-color:transparent}
+  .jump{display:inline-block;font-weight:700;color:var(--accent);cursor:pointer;border-bottom:1px dashed var(--accent)}
+  .lead{font-size:16px;line-height:1.5}.lead b{color:var(--accent)}
+  pre{background:#1e1b18;color:#e8e2d6;border-radius:12px;padding:16px;overflow:auto;font:12px/1.5 "SF Mono",Menlo,Consolas,monospace}
+  .therm{display:flex;gap:14px;flex-wrap:wrap}
+  .therm .col{flex:1;min-width:200px;border:1px solid var(--line);border-radius:12px;padding:14px;text-align:center}
+  .therm .big{font:800 19px/1 Fraunces,serif;margin:6px 0}
+  .col.safe{background:var(--sage-bg)}.col.danger{background:var(--rose-bg)}.col.safe .big{color:var(--sage)}.col.danger .big{color:var(--rose)}
+  .foot{color:var(--mid);font-size:12.5px;text-align:center;margin-top:30px}
+</style>
+</head>
+<body>
+<header><div class="wrap">
+  <h1>Soy (Soya) &amp; Infant Safety — Visual Dashboard</h1>
+  <p class="sub">Care dashboard for the <b>guided-introduction</b> layer. Soy is a <b>Tier-2</b> allergen: introduce early because it's <b>safe and nutritious</b> — <b>not</b> on a prevention promise. Two reaction branches (IgE + the delayed non-IgE <b>FPIES</b>), and one form gate. Skim the Summary; drill into a tab.</p>
+  <nav>
+    <button class="tab on" data-p="p-sum">Summary</button>
+    <button class="tab" data-p="p-why">Why / Allergen</button>
+    <button class="tab" data-p="p-sym">Reaction &amp; Introduction</button>
+    <button class="tab" data-p="p-ctx">Context</button>
+    <button class="tab" data-p="p-src">Sources &amp; Confidence</button>
+    <button class="tab" data-p="p-data">Data Stub</button>
+  </nav>
+  <p style="font-size:11.5px;color:var(--mid);margin:6px 0 10px">Swipe ‹ › between tabs · or use ← → arrow keys</p>
+</div></header>
+
+<div class="wrap">
+
+  <!-- ───────── SUMMARY ───────── -->
+  <section class="panel on" id="p-sum">
+    <div class="card" style="background:var(--honey-bg);border-color:transparent;margin-top:18px">
+      <p class="lead" style="margin:0">The one rule: <b>introduce soy around 6 months — don't delay — as soft tofu, not whole edamame.</b> But hold the honesty line: early soy is <b>safe and nutritious</b>, and there's no reason to delay — yet <b>no RCT proves early soy prevents soy allergy</b> (EAT was null for soy). Two emergency branches, not one: fast <b>IgE allergy</b> AND the delayed, hives-less <b>FPIES</b> — for which soy is a classic trigger.</p>
+    </div>
+    <div class="grid g4">
+      <!-- stat tiles: .crit (red) / .ok (sage) / default (accent) -->
+      <div class="card stat ok"><div class="n">~6<span style="font-size:14px">mo</span></div><div class="l">introduce from ~6 months (not before 4) — AAP·NHS·ASCIA</div></div>
+      <div class="card stat"><div class="n">~0.4%</div><div class="l">of infants have soy allergy — uncommon (FARE)</div></div>
+      <div class="card stat ok"><div class="n">by age 3</div><div class="l">commonly outgrown; majority by age 10 (FARE·JACI)</div></div>
+      <div class="card stat crit"><div class="n">1–4<span style="font-size:14px">h</span></div><div class="l">FPIES delayed onset — vomiting + lethargy, often no rash (CHOP)</div></div>
+    </div>
+    <h3>The four things to know <span class="badge b-hi">high-confidence</span></h3>
+    <div class="grid g2">
+      <div class="card"><b>1 · Introduce early — but DON'T claim prevention.</b> Consensus is "don't delay" soy past ~6mo; but EAT found <i>no</i> prevention effect for soy. Safe early, not a prevention promise. → <span class="jump" data-go="p-why">Why / Allergen</span></div>
+      <div class="card"><b>2 · Two emergency branches.</b> Fast IgE allergy (minutes, hives/swelling/breathing) AND delayed FPIES (1–4h, profuse vomiting + lethargy, no hives, tests negative). → <span class="jump" data-go="p-sym">Reaction &amp; Introduction</span></div>
+      <div class="card"><b>3 · The crux is FORM.</b> Soft/silken tofu and mashed soybeans are infant-safe; whole edamame and whole soybeans are a choking hazard. Mashing fixes choking, not allergy. → <span class="jump" data-go="p-sym">Reaction &amp; Introduction</span></div>
+      <div class="card"><b>4 · The formula≠food trap.</b> "Soy isn't recommended for babies" means soy <i>infant formula</i> as prevention — NOT tofu and soy foods, which are fine. → <span class="jump" data-go="p-ctx">Context</span></div>
+    </div>
+    <h3>When to surface this</h3>
+    <div class="card flag good" style="margin-top:0"><b>Recommendation (Maren):</b> an <b>encourage-polarity</b> card (sage, not honey's rose) — but with a <b>distinct FPIES branch</b> a hives-centric card would miss (delayed vomiting + lethargy, no rash → urgent care), and the <b>formula≠food</b> myth surfaced up front. Highest-value soy nuggets: the FPIES branch and the formula-confusion trap. Ready-to-wire shape → <span class="jump" data-go="p-data">Data Stub</span>.</div>
+    <div class="card flag" style="margin-top:0"><b>⚑ Tier-2 — honest framing:</b> introduce early because it's <b>safe + nutritious</b>, <b>NOT</b> on a prevention promise (EAT was null for soy). Never tell a parent "early soy prevents soy allergy" — that claim is true for peanut/egg, false-by-evidence for soy.</div>
+    <div style="margin-top:14px">
+      <span class="pill">Reviewer · Maren (Care)</span><span class="pill">2026-06-01</span>
+      <span class="pill warn">Research artifact — not yet wired into the app</span>
+    </div>
+    <p style="font-size:12.5px;color:var(--mid);margin-top:10px">Full prose: <code>soy-infant-safety.md</code> · long-form HTML: <code>soy-infant-safety.html</code>. This dashboard is the skim layer over both.</p>
+  </section>
+
+  <!-- ───────── WHY / ALLERGEN ───────── -->
+  <section class="panel" id="p-why"><h2>Introduce early — but prevention is NOT proven for soy</h2>
+    <div class="card">
+      <p style="margin:0 0 6px">Mainstream guidance (AAP, NHS, ASCIA, NIAID): introduce the major allergens — soy among them — <b>around 6 months</b> alongside other solids, <b>not before 4 months</b>, and <b>don't deliberately delay</b>. Soy is one of the US <b>"Big 9"</b> major allergens. <span class="badge b-hi">consensus</span></p>
+      <p style="margin:6px 0 0">But the prevention evidence (LEAP/EAT) is for <b>peanut and egg</b>. In <b>EAT</b> (1,303 exclusively breastfed infants, 6 allergens from 3mo vs ~6mo), the per-protocol benefit was significant for <b>peanut and egg only</b>. <b>Soy showed no significant prevention effect</b> — nor did milk, sesame, or fish. <span class="badge b-hi">NEJM 2016</span></p>
+    </div>
+    <div class="flag"><b>⚑ The honest framing the model MUST use:</b> introducing soy early is <b>safe and appropriate</b>, and there's no reason to delay it — but we <b>cannot tell a parent that early soy prevents soy allergy</b>. That claim is true for peanut/egg, false-by-evidence for soy. <b>Tier-2 allergen:</b> introduce-early because there's no reason not to and the diet benefits, <b>NOT</b> because an RCT proved prevention.</div>
+
+    <h3>Why introduce at all, then?</h3>
+    <div class="card">
+      <p style="margin:0"><b>Nutrition + no-reason-to-avoid</b>, not proven prevention. Soy is a <b>complete plant protein</b> — especially valuable in a vegetarian household — and normal allergen exposure as part of a varied diet beats the downsides of unnecessary restriction.</p>
+    </div>
+
+    <h3>Often outgrown — soy is not a lifelong sentence <span class="badge b-mod">FARE · JACI (clinical)</span></h3>
+    <div class="card">
+      <div class="bar"><span class="lab">Infant prevalence</span><span class="trk"><span class="fil" style="width:6%"></span></span><span class="val">~0.4%</span></div>
+      <p style="margin:8px 0 0;font-size:12.5px;color:var(--mid)">Soy allergy affects ~<b>0.4%</b> of infants and is <b>commonly outgrown — many by ~age 3, the majority by age 10</b>. It behaves more like milk/egg (often outgrown) than peanut/tree-nut (often lifelong). "Soy allergy is permanent" is a myth.</p>
+    </div>
+  </section>
+
+  <!-- ───────── REACTION & INTRODUCTION ───────── -->
+  <section class="panel" id="p-sym"><h2>Two reaction branches — and the form gate</h2>
+
+    <h3>The form gate — tofu vs the edamame choking hazard</h3>
+    <div class="therm">
+      <div class="col safe">
+        <div style="font-size:12px;color:var(--mid)">Soft tofu / mashed soybeans (SAFE)</div>
+        <div class="big">introduce early</div>
+        <div style="font-size:12.5px">silken/soft tofu (smushable or blended), well-cooked mashed soybeans, soy yoghurt, softened-mashed soya chunks once tolerated.</div>
+      </div>
+      <div class="col danger">
+        <div style="font-size:12px;color:var(--mid)">Whole edamame / whole soybeans (CHOKING)</div>
+        <div class="big">round · firm · slippery</div>
+        <div style="font-size:12.5px">shell + mash at ~6mo; halve/quarter from ~9mo; whole beans only well past toddlerhood. Soy milk is NOT a milk substitute in year one.</div>
+      </div>
+    </div>
+    <div class="flag good"><b>✓ The design crux.</b> Mashing tofu/soybeans genuinely makes the food safe on the <b>choking</b> axis — but it does <b>nothing</b> for the <b>allergy</b> axis (IgE or FPIES), which is managed by introduction + watchfulness. Two axes, held separately.</div>
+
+    <h3>The TWO emergency branches — a hives-centric card misses FPIES</h3>
+    <div class="card">
+      <div class="tl">
+        <div class="tl-step first"><span class="tl-dot"></span><div class="tl-t">Branch A — IgE allergy · FAST (minutes–~2h)</div><div class="tl-d">Mild (one body system): itchy hives/welts, redness, swelling (mouth/eyes), vomiting, sometimes loose stool, sudden fussiness. In infants reactions skew to skin + GI.</div></div>
+        <div class="tl-step crit"><span class="tl-dot"></span><div class="tl-t">Branch A — anaphylaxis · act immediately</div><div class="tl-d">Trouble breathing / wheeze / persistent cough, throat/tongue/lip/face swelling, pale or blue, floppy/limp/lethargic, collapse. → adrenaline auto-injector if prescribed + call 112 (108 India; 999 UK; 911 US). Lie flat, or sit up if breathing is hard.</div></div>
+        <div class="tl-step first"><span class="tl-dot"></span><div class="tl-t">Branch B — FPIES · DELAYED (1–4h after eating)</div><div class="tl-d">Non-IgE reaction. Profuse, repetitive (projectile) vomiting, then lethargy, pallor, risk of dehydration; sometimes diarrhoea later. <b>Often NO hives, NO swelling, NO breathing trouble</b> — looks like a stomach bug. Standard allergy tests (skin-prick, sIgE) come back <b>negative</b>. Soy is a classic trigger.</div></div>
+        <div class="tl-step crit"><span class="tl-dot"></span><div class="tl-t">Branch B — FPIES · urgent care even with no rash</div><div class="tl-d">Repetitive vomiting + a pale/floppy/lethargic baby a couple of hours after a soy feed → urgent medical care even without any rash; severe episodes can cause dehydration/shock and may need IV fluids. Tell the clinician <i>what was eaten and when</i> — the delay is the diagnostic clue.</div></div>
+      </div>
+      <div class="flag bad"><b>⚑ The most important soy-specific safety insight.</b> A hives-centric allergy card will <b>miss FPIES entirely</b>. The soy record needs a distinct "delayed vomiting + lethargy, no rash" branch that routes to urgent care, separate from the IgE/anaphylaxis branch. Classic FPIES triggers: <b>cow's milk, soy, rice, oats</b>. <span class="badge b-mod">CHOP — clinical secondary</span></div>
+    </div>
+
+    <h3>First-exposure approach</h3>
+    <div class="card">
+      <p style="margin:0;font-size:13px;color:var(--mid)">Start soy as <b>soft/silken tofu</b> or as a <b>minor ingredient</b> mashed into an already-tolerated dish (minor-ingredient-first matters for the CMPA cross-reactivity below), watch the first exposures, then progress to softened, finely-mashed soya chunks once tolerated. Introduce soy on its own day for attribution.</p>
+    </div>
+  </section>
+
+  <!-- ───────── CONTEXT ───────── -->
+  <section class="panel" id="p-ctx"><h2>Context — the formula≠food trap, India, and the myths</h2>
+
+    <div class="card flag bad" style="margin-top:0"><b>⚑ The soy-formula ≠ soy-food trap (read this first).</b> When you see "soy is <b>not recommended</b> for babies," it almost always means <b>soy infant formula as an allergy-prevention strategy</b> — NOT soy <i>foods</i> like tofu. NIAID/ASCIA don't endorse soy formula to prevent allergy; that has nothing to do with feeding a 7-month-old mashed tofu, which is fine. This is the single most common error on this topic. <span class="badge b-hi">NIAID · ASCIA</span></div>
+
+    <h3>Indian &amp; vegetarian context — central, not peripheral</h3>
+    <div class="card">
+      <p style="margin:0"><b>Soya chunks/granules/nuggets (TVP — textured vegetable protein)</b> are everyday, affordable, concentrated plant protein in vegetarian Indian households; tofu and soy milk are increasingly common. In a vegetarian diet, soy is a high-value complete protein — making early, regular introduction both natural and nutritionally useful. Introduce as <b>soft tofu or a minor ingredient first</b>, then work up to softened/mashed soya chunks. <span class="badge b-hi">staple status</span></p>
+    </div>
+
+    <h3>Cross-reactivity to introduce carefully around</h3>
+    <div class="grid g2">
+      <div class="card"><b>Soy ↔ CMPA.</b> Some <b>cow's-milk-protein-allergic</b> babies also react to soy protein. If there's known CMPA, introduce soy cautiously as a <b>minor ingredient first</b> and consider a paediatrician's input. <span class="badge b-mod">FARE</span></div>
+      <div class="card"><b>Legume cross-sensitisation.</b> Soy is a <b>legume</b>, like peanut — some cross-sensitisation potential, though a positive test ≠ clinical allergy. Treat soy as its own allergen, on its own day. <span class="badge b-mod">FARE</span></div>
+    </div>
+
+    <h3>Myths to correct</h3>
+    <div class="card flag good" style="margin-top:0"><b>✓ "Soy is not recommended for babies."</b> Conflation — it's about soy <i>formula</i> as prevention, not tofu/soy foods (fine around 6mo). Highest-value myth on this topic.</div>
+    <div class="card flag good" style="margin-top:0"><b>✓ "Soy allergy is permanent."</b> Usually false — ~0.4% of infants, commonly outgrown by ~age 3, the majority by age 10.</div>
+    <div class="card flag" style="margin-top:0"><b>⚑ "Introduce soy early to prevent soy allergy."</b> The over-claim in the other direction — <b>not proven.</b> EAT found no significant effect for soy. Introduce early because it's safe and nutritious, NOT on a prevention promise.</div>
+    <div class="card flag" style="margin-top:0"><b>⚑ "Soy lecithin will trigger a soy-allergic child."</b> Usually not — most soy-allergic individuals tolerate soy lecithin (negligible residual protein); still label-listed, so don't auto-panic on its presence.</div>
+
+    <h3>Aliases &amp; hidden sources (for the resolver)</h3>
+    <div class="card">
+      <p style="margin:0;font-size:13px"><b>Whole-food / fermented:</b> tofu (bean curd), edamame, soybeans, <b>soya chunks/granules/nuggets = TVP</b>, miso, natto, tempeh, soy/soya flour. <b>Liquids &amp; condiments:</b> soy milk/soya drink, soy sauce, tamari (often carry <b>wheat</b> too). <b>Additives:</b> soy lecithin (usually tolerated), soy protein isolate/concentrate.</p>
+      <div class="flag" style="margin-top:8px"><b>⚑ Label nuance (US-specific).</b> Highly refined <b>soybean oil is exempt</b> from US major-allergen labelling (protein removed); cold-pressed/unrefined is not. So "no soy listed" on a US label doesn't guarantee soy-oil-free — and "soy lecithin" present doesn't mean a child will react. Applies to US labels, not Indian labelling. Surface TVP/soya chunks as full soy protein; don't auto-escalate lecithin.</div>
+    </div>
+  </section>
+
+  <!-- ───────── SOURCES & CONFIDENCE ───────── -->
+  <section class="panel" id="p-src">
+    <h2>Who says what — consensus matrix</h2>
+    <div class="card" style="overflow-x:auto"><table>
+      <tr><th>Authority</th><th class="c">Introduce ~6mo / don't delay</th><th class="c">Early soy PREVENTS soy allergy</th></tr>
+      <tr><td>AAP / HealthyChildren</td><td class="c yes">✓</td><td class="c dash">— (not claimed)</td></tr>
+      <tr><td>UK NHS</td><td class="c yes">✓</td><td class="c dash">— (not claimed)</td></tr>
+      <tr><td>ASCIA (Australasia)</td><td class="c yes">✓</td><td class="c dash">— (not claimed)</td></tr>
+      <tr><td>US NIAID (2017)</td><td class="c yes">✓</td><td class="c dash">— (not claimed)</td></tr>
+      <tr><td>NEJM — EAT trial (2016)</td><td class="c yes">✓ (safe early)</td><td class="c no">✗ no significant effect for soy</td></tr>
+    </table>
+    <p style="font-size:12px;color:var(--mid);margin:6px 0 0">Every body says "introduce early / don't delay"; <b>none</b> claims early soy <i>prevents</i> soy allergy — and EAT actively found no significant prevention effect. The "introduce-early" and "prevents-allergy" columns are NOT the same claim for soy.</p>
+    </div>
+
+    <h2>Sources</h2>
+    <div class="card" style="overflow-x:auto"><table>
+      <tr><th>Authority</th><th>Type</th><th>Link</th></tr>
+      <tr><td>AAP / HealthyChildren — when to introduce allergens</td><td>Official</td><td><a href="https://www.healthychildren.org/English/healthy-living/nutrition/Pages/when-to-introduce-egg-peanut-butter-and-other-common-food-allergens-to-your-baby-food-allergy-prevention-tips.aspx">healthychildren.org/…/allergens</a></td></tr>
+      <tr><td>UK NHS — food allergies in babies</td><td>Official</td><td><a href="https://www.nhs.uk/baby/weaning-and-feeding/food-allergies-in-babies-and-young-children/">nhs.uk/baby/…/food-allergies</a></td></tr>
+      <tr><td>UK NHS — Anaphylaxis</td><td>Official</td><td><a href="https://www.nhs.uk/conditions/anaphylaxis/">nhs.uk/conditions/anaphylaxis</a></td></tr>
+      <tr><td>NIAID — Peanut Allergy Prevention Addendum (2017); soy-formula context</td><td>Official</td><td><a href="https://www.niaid.nih.gov/sites/default/files/addendum-peanut-allergy-prevention-guidelines.pdf">niaid.nih.gov/…/addendum</a></td></tr>
+      <tr><td>ASCIA — Infant Feeding for Food Allergy Prevention</td><td>Official</td><td><a href="https://www.allergy.org.au/hp/papers/infant-feeding-and-allergy-prevention">allergy.org.au/…/infant-feeding</a></td></tr>
+      <tr><td>WHO — Complementary feeding 6–23mo (2023)</td><td>Official</td><td><a href="https://www.ncbi.nlm.nih.gov/books/NBK596423/">ncbi.nlm.nih.gov/books/NBK596423</a></td></tr>
+      <tr><td>NEJM — Perkins/Lack et al., EAT trial (2016); soy = no significant prevention effect</td><td>Primary trial</td><td><a href="https://pubmed.ncbi.nlm.nih.gov/26943128/">pubmed.ncbi.nlm.nih.gov/26943128</a></td></tr>
+      <tr><td>FARE — Soy allergy (prevalence ~0.4%; outgrown; lecithin)</td><td>Secondary (advocacy/clinical)</td><td><a href="https://www.foodallergy.org/living-food-allergies/food-allergy-essentials/common-allergens/soy">foodallergy.org/…/soy</a></td></tr>
+      <tr><td>JACI — Natural history of soy allergy (outgrowth by 3/10)</td><td>Secondary (clinical)</td><td><a href="https://www.jacionline.org/article/S0091-6749(10)00007-2/fulltext">jacionline.org/…/soy-natural-history</a></td></tr>
+      <tr><td>CHOP — FPIES (delayed vomiting, triggers, negative tests)</td><td>Secondary (clinical)</td><td><a href="https://www.chop.edu/conditions-diseases/food-protein-induced-enterocolitis-syndrome-fpies">chop.edu/…/fpies</a></td></tr>
+      <tr><td>Solid Starts — Edamame (choking-by-form; shell + mash)</td><td>Secondary (prep)</td><td><a href="https://solidstarts.com/foods/edamame/">solidstarts.com/foods/edamame</a></td></tr>
+      <tr><td>Solid Starts — Tofu (soft/silken first form)</td><td>Secondary (prep)</td><td><a href="https://solidstarts.com/foods/tofu/">solidstarts.com/foods/tofu</a></td></tr>
+    </table></div>
+    <div class="flag"><b>⚑ Open gaps:</b> (1) <b>FPIES detail is clinical-secondary (CHOP)</b> — the delayed-vomiting / lethargy-pallor / negative-test picture is clinically well-established, but the verbatim 1–4h timing should be re-confirmed against an official allergy body before going to parents as a hard number. (2) <b>Prevalence ~0.4% &amp; outgrowth ages (3/10)</b> are FARE + JACI (secondary/clinical), directionally robust but literature-derived, not regulator figures. (3) <b>Form specifics</b> (shell+mash at 6mo, halve at 9mo; silken-tofu-first) are Solid Starts (secondary prep), consistent with NHS choking principles. (4) <b>US soybean-oil exemption &amp; lecithin tolerance</b> are US-labelling-specific, not universal. (5) <b>No India-specific official soy/allergen directive exists</b> — no IAP/MoHFW/FSSAI guidance on allergen introduction or soy for infants was located; the early-intro guidance is entirely international, the Indian vegetarian context is cultural/nutritional. <b>Do not manufacture or attribute any Indian official soy/allergen guidance.</b></div>
+  </section>
+
+  <!-- ───────── DATA STUB ───────── -->
+  <section class="panel" id="p-data"><h2>Drop-in record — <code>FOOD_EFFECTS['soy']</code></h2>
+    <p style="font-size:13.5px;color:var(--mid)">Mirror of this food's record in <code>food-effects.manifest.js</code>. Sits alongside <code>AGE_RULES</code>/<code>ALLERGENS</code>. The <code>reactionType</code> carries <code>'digestive'</code> for the non-IgE FPIES branch; <code>severeSigns</code> includes the delayed "vomiting + lethargy hours later" FPIES line; <code>earlyIntroBenefit.paradigm</code> holds the Tier-2 honesty line (no proven prevention). <b>Not yet wired.</b></p>
+<pre>{
+  food:          'soy',
+  aliases:       ['soya','soybean','soya bean','tofu','edamame','soya chunks','soya granules','soya nuggets','soy milk','soya milk','tempeh','miso','natto','tamari','tvp','textured vegetable protein'],
+  foodClass:     'allergen-introduce-early',
+  severity:      'caution',
+  category:      'legume',
+  effect:        'food allergy (incl. FPIES)',
+  minMonth:      6,
+  thresholdBasis:'developmental-readiness',
+  allergen:      true,
+  reactionType:  ['allergy','digestive'],   // digestive = FPIES (non-IgE), a classic soy presentation
+  headline:      'Introduce around 6 months — don\'t delay. Soft tofu, not whole edamame.',
+  whyGood:       'Valuable plant protein for a vegetarian diet (tofu, soya chunks) — introduce early alongside other solids.',
+  earlyIntroBenefit: { claim:'Introduce around 6 months; don\'t delay allergens.',
+                       evidence:'AAP/NHS/ASCIA advise early introduction of soy among the major allergens; early intro is SAFE, but no RCT proves early soy prevents soy allergy (soy was not among EAT\'s prevention-positive foods).',
+                       paradigm:'Don\'t delay — but no proven soy-specific prevention claim.' },
+  safeForm:      { ok:['soft / silken tofu, smushable or blended','well-cooked soybeans mashed','soy yoghurt; soya stirred into food'],
+                   never:['whole edamame or whole soybeans (round, firm — a choking risk)','soy milk as a main drink in the first year (not a breastmilk/formula substitute)'],
+                   note:'Shell and mash edamame at 6mo; halve cooked beans at 9mo. Soft tofu needs no choking prep.' },
+  myth:          { claim:'Soy isn\'t recommended for babies.',
+                   truth:'That advice is about soy infant FORMULA for allergy prevention — not soy FOODS like tofu, which are fine to introduce around 6 months.' },
+  watchFor:      ['hives / rash','swelling (mouth, eyes, lips)','vomiting or diarrhoea'],
+  severeSigns:   ['trouble breathing / wheeze','face/lip/tongue swelling','floppy, pale, or very sleepy','repeated forceful vomiting + lethargy hours later (possible FPIES)'],
+  timeCourse:    'IgE: minutes to ~2 hours. FPIES (non-IgE): delayed — profuse repeated vomiting + lethargy/pallor 1–4 hours after eating.',
+  seekCare:      'Mild single-system: stop, monitor, call doctor. Breathing trouble, face/throat swelling, or floppiness: EMERGENCY — call 112. Repeated forceful vomiting with lethargy/pallor hours after a soy feed (possible FPIES): seek urgent care even without a rash.',
+  breastfeedingSafe: true,
+  culturalNote:  'Soya chunks/granules are everyday vegetarian protein in India — a concentrated soy-protein form. Some cow\'s-milk-allergic babies also react to soy; introduce as a minor ingredient first.',
+  confidence:    'high',
+  sources:       ['AAP','UK NHS','ASCIA','NIAID 2017','FARE','CHOP (FPIES)','NEJM EAT 2016'],
+  dashboard:     'soy-infant-safety.visual.html',    // render pending
+  brief:         'soy-infant-safety.md',
+  longform:      'soy-infant-safety.html',           // render pending
+  lastReviewed:  '2026-06-01',
+}</pre>
+    <div class="flag good"><b>Surfacing hook:</b> an <b>encourage</b> card (sage), not honey's <b>warn</b> card (rose) — <code>severity:'caution'</code> drives amber chrome. But the soy card must carry a <b>distinct FPIES branch</b> (delayed vomiting + lethargy, no rash → urgent care) that a hives-centric layout would miss, and surface the <b>formula≠food</b> myth. Honesty constraint: never render "early soy prevents soy allergy" — <code>earlyIntroBenefit.paradigm</code> is the guardrail.</div>
+  </section>
+
+  <p class="foot">SproutLab · Care visual dashboard · skim layer over <code>soy-infant-safety.md</code> / <code>.html</code> · 2026-06-01<br>
+  Informational, not medical advice. Not yet wired into the app. All chart values are also in text for machine-reading.</p>
+</div>
+
+<!-- ═══════ COMPONENT LIBRARY — copy a block into a panel and fill it ═══════
+<div class="bar"><span class="lab">Label</span><span class="trk"><span class="fil" style="width:73%"></span></span><span class="val">73%</span></div>
+<div class="bar hl"><span class="lab">Highlight</span><span class="trk"><span class="fil" style="width:12%"></span></span><span class="val">8.9%</span></div>
+  (bar widths are % of the track; scale all rows to the max value; ALWAYS put the real number in .val)
+
+<svg viewBox="0 0 120 120" width="118" height="118" role="img" aria-label="DESCRIBE + give the number">
+  <circle cx="60" cy="60" r="52" fill="none" stroke="var(--track)" stroke-width="15"/>
+  <circle cx="60" cy="60" r="52" fill="none" stroke="var(--honey)" stroke-width="15"
+    stroke-dasharray="PCT_LEN REST" stroke-dashoffset="0" transform="rotate(-90 60 60)" stroke-linecap="round"/>
+  <text x="60" y="58" text-anchor="middle" font-size="20" font-weight="800" fill="var(--honey)" font-family="Fraunces,serif">~20%</text>
+</svg>
+  (circumference for r=52 is 326.7; PCT_LEN = pct*3.267, REST = 326.7 - PCT_LEN)
+
+<div class="tl"><div class="tl-step first"><span class="tl-dot"></span><div class="tl-t">First sign</div><div class="tl-d">detail</div></div>
+  <div class="tl-step crit"><span class="tl-dot"></span><div class="tl-t">Emergency</div><div class="tl-d">detail</div></div></div>
+
+<div class="therm"><div class="col safe"><div style="font-size:12px;color:var(--mid)">A</div><div class="big">safe fact</div><div>detail</div></div>
+  <div class="col danger"><div style="font-size:12px;color:var(--mid)">B</div><div class="big">danger fact</div><div>detail</div></div></div>
+
+<div class="flag good|bad"><b>label</b> text</div>   ·   <span class="badge b-hi|b-mod|b-weak">confidence</span>
+═══════════════════════════════════════════════════════════════════════ -->
+
+<script>
+  var tabs = Array.prototype.slice.call(document.querySelectorAll('.tab'));
+  function activate(t){
+    if(!t) return;
+    tabs.forEach(function(x){x.classList.remove('on');});
+    document.querySelectorAll('.panel').forEach(function(x){x.classList.remove('on');});
+    t.classList.add('on');
+    var el = document.getElementById(t.dataset.p); if(el) el.classList.add('on');
+    t.scrollIntoView({inline:'center', block:'nearest'}); window.scrollTo(0,0);
+  }
+  tabs.forEach(function(t){ t.addEventListener('click', function(){ activate(t); }); });
+  document.querySelectorAll('[data-go]').forEach(function(j){
+    j.addEventListener('click', function(){ activate(document.querySelector('.tab[data-p="'+j.dataset.go+'"]')); });
+  });
+  function step(d){ var c=tabs.findIndex(function(t){return t.classList.contains('on');}); var n=c+d; if(n>=0&&n<tabs.length) activate(tabs[n]); }
+  var sx=0, sy=0, tracking=false;
+  document.addEventListener('touchstart', function(e){ if(e.touches.length>1){tracking=false;return;} sx=e.changedTouches[0].clientX; sy=e.changedTouches[0].clientY; tracking=true; }, {passive:true});
+  document.addEventListener('touchend', function(e){
+    if(!tracking) return; tracking=false;
+    var dx=e.changedTouches[0].clientX-sx, dy=e.changedTouches[0].clientY-sy;
+    if(Math.abs(dx) < 55 || Math.abs(dx) < Math.abs(dy)*1.5) return;
+    step(dx < 0 ? 1 : -1);
+  }, {passive:true});
+  document.addEventListener('keydown', function(e){ if(e.key==='ArrowRight') step(1); else if(e.key==='ArrowLeft') step(-1); });
+</script>
+</body>
+</html>

--- a/docs/research/wheat-infant-safety.html
+++ b/docs/research/wheat-infant-safety.html
@@ -1,0 +1,326 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Wheat &amp; Infant Safety — Care Research Brief · SproutLab</title>
+<style>
+  :root{
+    --bg:#faf6f0; --card:#fffdf9; --ink:#2e2a26; --mid:#6b6258; --line:#e8ddcf;
+    --sage:#3a7060; --sage-bg:#e8f5ef; --rose:#b04a5e; --rose-bg:#fbe9ec;
+    --amber:#8a6320; --amber-bg:#fbf0d9; --accent:#9a6a3a;
+    --hi:#2f7d5b; --hi-bg:#e3f3ea; --mod:#9a7320; --mod-bg:#f7eed6; --weak:#9a5a5a; --weak-bg:#f5e6e6;
+  }
+  @media (prefers-color-scheme: dark){
+    :root{ --bg:#1d1a17; --card:#262220; --ink:#ece5db; --mid:#a89c8c; --line:#3a342d;
+      --sage:#7ac0a0; --sage-bg:#1e3028; --rose:#e090a0; --rose-bg:#3a2026;
+      --amber:#e0b060; --amber-bg:#352a16; --accent:#c99a6a;
+      --hi:#7ac0a0; --hi-bg:#1e3028; --mod:#d8b060; --mod-bg:#332a14; --weak:#e09090; --weak-bg:#3a2222; }
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+    font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Nunito,sans-serif;
+    -webkit-font-smoothing:antialiased;padding:0 0 80px}
+  .wrap{max-width:880px;margin:0 auto;padding:0 20px}
+  header{background:linear-gradient(160deg,var(--amber-bg),var(--bg));border-bottom:1px solid var(--line);
+    padding:34px 0 26px;margin-bottom:8px}
+  h1{font:700 27px/1.25 Fraunces,Georgia,serif;margin:0 0 6px}
+  .sub{color:var(--mid);font-size:14.5px;margin:0}
+  .meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
+  .pill{font-size:12px;font-weight:600;padding:4px 10px;border-radius:999px;background:var(--card);
+    border:1px solid var(--line);color:var(--mid)}
+  .pill.warn{background:var(--rose-bg);color:var(--rose);border-color:transparent}
+  h2{font:600 19px/1.3 Fraunces,Georgia,serif;margin:30px 0 12px;padding-top:10px;border-top:1px solid var(--line)}
+  h2 .ax{color:var(--accent);font-weight:700}
+  h3{font:700 13px/1.3 Nunito;text-transform:uppercase;letter-spacing:.4px;color:var(--mid);margin:18px 0 8px}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:18px 20px;margin:14px 0}
+  .tldr{background:var(--sage-bg);border-color:transparent}
+  .tldr ul{margin:8px 0 0;padding-left:20px}
+  .tldr li{margin:7px 0}
+  ul{margin:6px 0;padding-left:22px}
+  li{margin:6px 0}
+  .badge{display:inline-block;font-size:11px;font-weight:700;letter-spacing:.3px;text-transform:uppercase;
+    padding:3px 9px;border-radius:7px;vertical-align:middle;margin-left:8px}
+  .b-hi{background:var(--hi-bg);color:var(--hi)} .b-mod{background:var(--mod-bg);color:var(--mod)} .b-weak{background:var(--weak-bg);color:var(--weak)}
+  .flag{background:var(--amber-bg);border-left:3px solid var(--amber);border-radius:6px;
+    padding:10px 14px;margin:12px 0;font-size:14px;color:var(--ink)}
+  .flag b{color:var(--amber)}
+  .flag.bad{background:var(--rose-bg);border-left-color:var(--rose)}
+  .flag.bad b{color:var(--rose)}
+  .flag.good{background:var(--sage-bg);border-left-color:var(--sage)}
+  .flag.good b{color:var(--sage)}
+  blockquote{margin:12px 0;padding:8px 0 8px 16px;border-left:3px solid var(--sage);color:var(--mid);font-style:italic}
+  code,pre{font-family:"SF Mono",Menlo,Consolas,monospace}
+  pre{background:#1e1b18;color:#e8e2d6;border-radius:12px;padding:18px;overflow:auto;font-size:12.5px;line-height:1.55}
+  pre .c{color:#8a9a7a} pre .k{color:#d8a0b0} pre .s{color:#cbb080}
+  table{width:100%;border-collapse:collapse;font-size:13.5px;margin:10px 0}
+  th,td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{color:var(--mid);font-weight:700;font-size:12px;text-transform:uppercase;letter-spacing:.3px}
+  td a{color:var(--sage);word-break:break-all;font-size:12px}
+  td.c{text-align:center;font-weight:800}
+  .yes{color:var(--sage)}.no{color:var(--rose)}.dash{color:var(--mid)}
+  .quote{background:var(--card);border:1px dashed var(--line);border-radius:10px;padding:6px 14px;margin:8px 0;font-size:14px}
+  .quote b{color:var(--accent)}
+  .three{display:flex;gap:12px;flex-wrap:wrap;margin:12px 0}
+  .three .col{flex:1;min-width:230px;border:1px solid var(--line);border-radius:12px;padding:14px 16px}
+  .three .col h4{font:700 12px/1.3 Nunito;text-transform:uppercase;letter-spacing:.3px;margin:0 0 4px;color:var(--mid)}
+  .three .col .big{font:800 17px/1.15 Fraunces,serif;margin:0 0 8px}
+  .three .allergy{background:var(--sage-bg)}.three .allergy .big{color:var(--sage)}
+  .three .celiac{background:var(--rose-bg)}.three .celiac .big{color:var(--rose)}
+  .three .timing{background:var(--mod-bg)}.three .timing .big{color:var(--mod)}
+  .three .col ul{margin:0;padding-left:18px;font-size:13px}
+  .foot{color:var(--mid);font-size:13px;margin-top:30px;text-align:center}
+  .gap{background:var(--rose-bg);border-color:transparent}
+</style>
+</head>
+<body>
+<header><div class="wrap">
+  <h1>Wheat &amp; Infant Safety</h1>
+  <p class="sub">Care research brief — evidence base for SproutLab's <b>guided-introduction</b> food-effects model. Wheat is a <b>Tier-2 allergen</b>: introduce-early but prevention is NOT RCT-proven. The food is gated not by form alone but by <i>clarity</i> — keeping three things that look like one thing apart.</p>
+  <div class="meta">
+    <span class="pill">Reviewer · Maren (Care)</span>
+    <span class="pill">2026-06-01</span>
+    <span class="pill">Wheat only · infants ~6–12mo · India</span>
+    <span class="pill">Research scout pass</span>
+    <span class="pill warn">Research artifact — NOT yet wired into the app</span>
+  </div>
+</div></header>
+
+<div class="wrap">
+
+  <div class="card">
+    <strong>Purpose.</strong>
+    <p style="margin:8px 0 0">Evidence base for SproutLab's Care layer, feeding the <i>guided-introduction</i> food-effects model. Built to decide what to surface when a parent introduces <b>wheat</b> to an infant — covering why to introduce early (don't delay), the honest limit on the prevention claim, and the <b>three-way conceptual split</b> that wheat uniquely forces: <i>wheat allergy</i> (IgE), <i>celiac disease</i> (autoimmune), and <i>gluten-introduction timing</i> (a celiac-prevention question).</p>
+    <p style="margin:8px 0 0"><strong>Scope.</strong> Wheat as an infant food and allergen. Infant ~6–12 months. Family context: Indian — <b>wheat/atta/roti/dalia/suji are everyday staples</b>, not novelties; the household eats wheat at most meals. Celiac and adult WDEIA are noted only to keep them <i>separated</i> from the infant-allergy question, not as infant management targets.</p>
+    <p style="margin:8px 0 0;font-size:13.5px;color:var(--mid)"><strong>Method.</strong> Multi-angle source fetch → adversarial cross-check → synthesis, with the EAT and ESPGHAN primary records as the spine. Authorities: AAP/HealthyChildren, UK NHS, ASCIA, US NIAID, WHO; pivotal trial EAT (Perkin/Lack, NEJM 2016, PubMed 26943128); celiac position paper ESPGHAN 2016 (PubMed 26815017). The EAT wheat-null result and the ESPGHAN gluten-timing window are verified verbatim from their PubMed abstracts; preparation/form specifics and culinary-alias coverage rest on reputable secondary sources (Solid Starts, CHOP, Mayo, FARE, FAACT), flagged inline. <b>No India-specific (IAP/MoHFW) early-allergen or wheat directive was located</b> — see gap.</p>
+  </div>
+
+  <div class="card tldr">
+    <strong>TL;DR — the parent-facing truth</strong>
+    <ul>
+      <li><b>Introduce wheat early — around 6 months — and don't delay it.</b> Wheat is one of the common infant allergens; current consensus is the same as for the others: introduce around 6 months alongside other solids, don't hold it back. Delaying allergens does not prevent allergy. <i>(AAP; NHS — lists "foods containing gluten (wheat, barley, rye)"; ASCIA; NIAID.)</i></li>
+      <li><b>BUT — do NOT claim early wheat <i>prevents</i> wheat allergy.</b> This is the honest limit and the reason wheat is Tier-2, not Tier-1. The EAT trial tested early wheat directly and found <b>"no significant effects… with respect to milk, sesame, fish, or wheat."</b> Its prevention benefit was real <b>only for peanut and egg.</b> Early wheat was <i>safe</i> and is <i>fine to give early</i> — it just was <b>not shown to prevent wheat allergy.</b> <i>(Perkin/Lack, NEJM 2016; PubMed 26943128.)</i></li>
+      <li><b>Three things wear the word "wheat" — keep them rigorously apart.</b> (1) <b>Wheat allergy</b> = an IgE immune reaction to wheat <i>proteins</i> (hives, vomiting, anaphylaxis — fast). (2) <b>Celiac disease</b> = a chronic <i>autoimmune</i> reaction to <i>gluten</i> — NOT an allergy, NOT anaphylactic. (3) <b>Gluten-introduction timing</b> = a celiac-prevention question, separate from allergy. Wheat sits in all three because it contains gluten — that overlap is exactly the source of parent confusion this brief exists to defuse.</li>
+      <li><b>Celiac is not an emergency and is not "wheat allergy."</b> It's a chronic, medically-diagnosed condition (poor growth, chronic GI), not a 112-call event. Conflating it with wheat allergy is the central myth.</li>
+      <li><b>The Indian context is a gift and a trap.</b> Wheat is already in the diet daily (roti, dalia, suji, sevai), so introduction is culturally trivial — softened <b>roti/chapati pieces</b>, soft cooked suji/dalia, well-cooked pasta are near-ideal forms. The trap is the <b>alias thicket</b>: atta, maida, suji/rava, dalia, sevai, seitan, even soy sauce all <i>are</i> wheat, and fresh Indian staples carry no allergen label — so caregiver alias-knowledge is the safeguard, not the package.</li>
+      <li><b>ESPGHAN reversed the breastfeeding advice.</b> Neither breastfeeding nor breastfeeding-during-gluten-introduction reduces celiac risk (this reverses 2008 advice). Gluten may be introduced anytime <b>4–12 months</b>; timing does not change lifetime celiac incidence, only <i>when</i> it presents. Large quantities of gluten should be avoided in the first weeks and during infancy. <i>(ESPGHAN 2016; PubMed 26815017.)</i></li>
+    </ul>
+  </div>
+
+  <h2><span class="ax">Axis 1</span> · The benefit &amp; timing: introduce ~6 months, don't delay <span class="badge b-hi">High on don't-delay</span> <span class="badge b-weak">prevention NOT supported</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>Introduce around 6 months, with other solids, once the baby is developmentally ready.</b> Wheat is named among the common infant allergens and is handled like the others: offer early, don't delay, keep it in the diet. The NHS explicitly lists <b>"foods containing gluten, including wheat, barley and rye"</b> among the allergenic foods to introduce from around 6 months, one at a time. <i>(NHS; AAP; ASCIA; NIAID 2017 addendum framing for early allergen introduction generally.)</i></li>
+      <li><b>Delaying does not help.</b> The general early-introduction consensus — that delaying allergenic foods does not prevent allergy — applies to wheat as a member of the allergen set. There is no benefit to holding wheat back past ~6 months in a baby who is ready for solids. <i>(AAP; NHS; ASCIA.)</i></li>
+    </ul>
+    <div class="flag"><b>⚑ The honest limit — EAT found NO wheat benefit.</b> The EAT trial (Perkin/Lack, NEJM 2016) randomised general-population breastfed infants to early introduction of six allergens (including wheat) vs standard introduction. Its abstract states, verbatim:
+      <blockquote style="margin:8px 0 0;border-left-color:var(--amber)">"…there were no significant effects with respect to milk, sesame, fish, or wheat."</blockquote>
+      The trial's prevention benefit was confined to <b>peanut and egg</b> (and only in the per-protocol, dose-achieving analysis). <b>Early wheat was safe but did not prevent wheat allergy.</b> <i>(Verified — PubMed 26943128.)</i></div>
+    <div class="flag bad"><b>⚑ Design consequence:</b> the model must say "introduce wheat early — it's safe, don't delay" <b>without</b> saying "early wheat prevents wheat allergy." That second claim is unproven and EAT is the direct evidence against it. This is the Tier-2 distinction: the <i>introduce-early</i> posture stands on safety + the don't-delay consensus, <b>not</b> on a proven prevention RCT the way peanut stands on LEAP.</div>
+    <p style="margin:10px 0 0"><b>No India-specific directive.</b> No IAP/MoHFW early-introduction or wheat guidance was located; the "introduce ~6mo, don't delay" posture is borrowed from AAP/NHS/ASCIA/NIAID and is culturally compatible with a wheat-staple Indian diet. <i>(See gap.)</i></p>
+  </div>
+
+  <h2><span class="ax">Axis 2</span> · Wheat allergy vs celiac vs gluten-timing: the three-way split <span class="badge b-hi">High — the spine</span></h2>
+  <div class="card">
+    <p style="margin:0 0 4px">This is the single most important axis. Wheat is the one infant food where three distinct medical concepts collide under one word, and conflating them produces both needless fear and genuine error. Keep them labelled.</p>
+    <div class="three">
+      <div class="col allergy">
+        <h4>(1) This record</h4>
+        <div class="big">Wheat allergy</div>
+        <ul>
+          <li>An <b>IgE</b> immune reaction to wheat <i>proteins</i></li>
+          <li>Fast: hives, swelling, vomiting, GI upset, eczema flare, at the severe end <b>anaphylaxis</b></li>
+          <li><b>The "introduce-early" target</b> (Axes 1, 3, 4)</li>
+          <li>Commonly <b>outgrown</b> by early childhood</li>
+          <li><i>(AAP; CHOP; Mayo; FARE.)</i></li>
+        </ul>
+      </div>
+      <div class="col celiac">
+        <h4>(2) NOT an allergy</h4>
+        <div class="big">Celiac disease</div>
+        <ul>
+          <li>Chronic <b>autoimmune</b> reaction to <b>gluten</b> (wheat/barley/rye)</li>
+          <li><b>Not</b> an allergy, <b>not</b> anaphylactic</li>
+          <li>Chronic: poor growth, chronic GI, failure to thrive</li>
+          <li>Needs <b>medical diagnosis</b> (serology + specialist), not watch-and-wait</li>
+          <li><b>NOT an emergency</b> <i>(ESPGHAN 2016; celiac consensus.)</i></li>
+        </ul>
+      </div>
+      <div class="col timing">
+        <h4>(3) A celiac-prevention question</h4>
+        <div class="big">Gluten-timing</div>
+        <ul>
+          <li><i>When</i> to introduce gluten — debated in the <b>celiac</b> literature, separate from allergy</li>
+          <li>ESPGHAN 2016 (a <b>celiac</b> document): gluten anytime <b>4–12 months</b></li>
+          <li>Age <b>does not change lifetime celiac incidence</b> — shifts only <i>when</i> it presents</li>
+          <li><b>Breastfeeding reversal</b> of 2008 advice; avoid large gluten quantities early</li>
+          <li><i>(Verified — PubMed 26815017.)</i></li>
+        </ul>
+      </div>
+    </div>
+    <p style="margin:6px 0 0"><b>The ESPGHAN 2016 conclusions, in full:</b></p>
+    <ul>
+      <li><b>"Gluten may be introduced into the infant's diet anytime between 4 and 12 completed months of age."</b></li>
+      <li>Age of introduction <b>does not change lifetime celiac incidence</b> — earlier vs later only shifts <b>when</b> celiac presents, not whether it occurs.</li>
+      <li><b>Breastfeeding reversal:</b> ESPGHAN now states that <b>neither breastfeeding nor breastfeeding at the time of gluten introduction reduces the risk of celiac disease</b> — explicitly <i>reversing</i> the 2008 advice that recommended introducing gluten while still breastfeeding.</li>
+      <li><b>"Consumption of large quantities of gluten should be avoided during the first weeks after gluten introduction and during infancy."</b></li>
+    </ul>
+    <p style="margin:10px 0 0"><b>Why wheat sits in both conversations:</b> wheat contains gluten, so it is simultaneously an <i>allergen</i> (wheat protein → IgE allergy) and the <i>vehicle for gluten</i> (→ celiac). A parent hearing "introduce wheat early" and "be careful about gluten timing" is hearing two different bodies answering two different questions. The model's job is to <b>answer each in its own lane and never let one borrow the other's authority.</b></p>
+    <div class="flag good"><b>⚑ Practical reconciliation for ~6-month introduction:</b> both lanes agree wheat/gluten can begin around 6 months — the allergy lane says "introduce early, don't delay," and the celiac lane (ESPGHAN) says "anytime 4–12 months, and avoid large quantities early." These are compatible: introduce wheat around 6 months in ordinary food-sized amounts, not in a gluten-loading binge.</div>
+  </div>
+
+  <h2><span class="ax">Axis 3</span> · Safe FORM: texture &amp; choking <span class="badge b-hi">High on forms</span> <span class="badge b-mod">choking cautions partly secondary</span></h2>
+  <div class="card">
+    <p style="margin:0 0 4px">Unlike whole nuts, wheat is not intrinsically a hard-choke food — but specific wheat <i>forms</i> carry texture hazards a caregiver should pre-empt.</p>
+    <h3>Good first forms (soft, infant-friendly)</h3>
+    <ul>
+      <li><b>Soft wheat / multigrain infant cereal</b> — smooth, easy to dose, mix to a thin porridge. <i>(Solid Starts; general consensus.)</i></li>
+      <li><b>Well-cooked pasta</b> — cooked soft (past al dente), large pieces the baby can gum, or small soft pieces. <i>(Solid Starts.)</i></li>
+      <li><b>Softened roti / chapati pieces</b> — torn small and <b>soaked in milk, dal, or sabzi</b> until soft and pliable. This is the culturally native form and a near-ideal one. <i>(Secondary / culturally derived; consistent with soft-form guidance.)</i></li>
+      <li><b>Cream-of-wheat / suji (sooji/rava) / dalia (broken wheat)</b> — cooked soft to a smooth or well-mashed porridge consistency. <i>(Secondary; consistent with cereal-form guidance.)</i></li>
+    </ul>
+    <h3>Choking cautions — two specific wheat traps</h3>
+    <ol>
+      <li><b>Fresh soft bread balls up into a sticky clump</b> in a baby's mouth and can lodge — a known hazard. <b>Mitigation: toast it</b> (toast or firm bread strips don't gum together the way fresh soft bread does), or offer firm bread strips rather than squishy fresh slices. <i>(Solid Starts — bread; flagged secondary but well-established.)</i></li>
+      <li><b>Loose cooked wheat / dalia / suji scatters</b> — dry, loose grains can be inhaled/scatter rather than form a manageable bolus. <b>Mitigation: cook it soft and mash or bind</b> it (into porridge, with milk/dal) so it holds together. <i>(Secondary; consistent with loose-grain caution.)</i></li>
+    </ol>
+    <div class="flag"><b>⚑ Form note vs the nut brief:</b> with wheat, <b>form addresses choking, not allergy</b> — same principle as nuts. Cooking/softening does <b>not</b> remove the allergy hazard or the celiac relevance; a baby with wheat-protein allergy will react to soft well-cooked roti just as to bread. Form is the choking lane only.</div>
+  </div>
+
+  <h2><span class="ax">Axis 4</span> · Emergency floor: IgE reaction vs anaphylaxis (and celiac is NOT here) <span class="badge b-hi">High</span></h2>
+  <div class="card">
+    <ul>
+      <li><b>Mild–moderate IgE reaction (single body system):</b> itchy <b>hives/welts</b>, redness or <b>rash</b>, <b>swelling</b> (especially around the mouth/eyes), <b>vomiting</b>, GI upset/loose stool, <b>eczema flare</b>, sudden fussiness. <i>(CHOP; Mayo; FARE; FAACT.)</i></li>
+      <li><b>Severe / anaphylaxis (act immediately):</b> <b>difficulty breathing</b>, wheeze/persistent cough/noisy breathing, <b>swelling of the throat/tongue/lips/face</b>, hoarse cry, <b>pale / floppy / lethargic</b> or unusually sleepy, collapse. In a baby, sudden behaviour change (limp, can't hold head up) is a recognised severe sign. <b>Two or more body systems involved = treat as anaphylaxis.</b> <i>(FAACT; FARE; consensus.)</i></li>
+    </ul>
+    <h3>What to do</h3>
+    <ul>
+      <li><b>Mild, single-system:</b> stop the food, monitor closely, contact your doctor; a clinician may advise an antihistamine.</li>
+      <li><b>Any breathing difficulty, throat/tongue/face swelling, floppiness, or two body systems → emergency. Use a prescribed adrenaline auto-injector immediately and call emergency services (112 / 108 in India).</b></li>
+    </ul>
+    <div class="flag bad"><b>⚑ Celiac is explicitly NOT an emergency.</b> Celiac disease is <b>chronic</b>, not acute — it does not cause anaphylaxis and is <b>not</b> a 112/108 event. It presents over weeks/months (poor growth, chronic GI) and needs <b>medical diagnosis</b>, not emergency response. The model must not let celiac symptoms ride the allergy-emergency rail, and must not let a parent worried about celiac think they're watching for anaphylaxis. <i>(ESPGHAN; celiac consensus.)</i></div>
+    <div class="flag"><b>⚑ Aside — WDEIA (wheat-dependent exercise-induced anaphylaxis)</b> is an <b>adult/adolescent</b> phenomenon (anaphylaxis triggered by wheat + exercise). It is <b>not relevant to infants</b> and is mentioned here only so it isn't mistaken for an infant wheat-allergy pattern. Do not surface it in infant-facing copy except to rule it out.</div>
+  </div>
+
+  <h2><span class="ax">Axis 5</span> · Culinary aliases &amp; hidden sources: the alias thicket <span class="badge b-hi">High on alias list</span> <span class="badge b-mod">label-regime flagged</span></h2>
+  <div class="card">
+    <p style="margin:0 0 4px">Wheat hides under many names — and in an Indian kitchen, much of it is in <b>unlabeled fresh-made</b> food. Caregiver alias-knowledge is the real safeguard.</p>
+    <ul>
+      <li><b>Core flours &amp; forms:</b> atta (wholewheat), maida (refined wheat flour), <b>semolina / suji / sooji / rava</b>, <b>broken wheat / dalia</b>, <b>sevai / vermicelli</b>, durum, farina, couscous, bulgur, <b>seitan (= wheat gluten)</b>, <b>soy sauce (typically contains wheat)</b>. <i>(FARE; FAACT; CHOP.)</i></li>
+      <li><b>Related wheat grains (often missed):</b> spelt, kamut, einkorn, emmer, farro, triticale — all contain wheat/gluten and are not "wheat-free." <i>(FARE; FAACT.)</i></li>
+      <li><b>Indian staples that ARE wheat:</b> roti, chapati, paratha, naan, <b>pav</b>, upma (suji), halwa (suji/atta), samosa &amp; pakora batter/wrapper, <b>rusks and biscuits</b>, sevai/vermicelli dishes. A wheat-allergic or celiac-relevant child encounters wheat across most of a typical Indian menu — alias literacy is essential, not optional.</li>
+    </ul>
+    <h3>Label-regime divergence (flag for the spec)</h3>
+    <table>
+      <tr><th>Region</th><th>How wheat is declared</th></tr>
+      <tr><td><b>US</b></td><td>declares the allergen as <b>"wheat"</b> plainly.</td></tr>
+      <tr><td><b>EU / UK</b></td><td>declare it as <b>"cereals containing gluten"</b> (so a label may say "gluten" not "wheat").</td></tr>
+      <tr><td><b>India (FSSAI)</b></td><td>requires a <b>gluten-cereal declaration on PACKAGED food</b> — but <b>fresh, unpackaged Indian staples (roti, dalia from the local chakki, restaurant/street food) carry no allergen label at all.</b></td></tr>
+    </table>
+    <div class="flag"><b>⚑ Consequence:</b> in the Indian context the package label is the <i>weakest</i> safeguard because so much wheat intake is fresh and unlabeled. The model should lean on <b>caregiver alias-knowledge</b> (knowing suji, maida, dalia, sevai, seitan, soy sauce all = wheat) rather than on label-reading. <i>(FSSAI labelling regime; FARE/FAACT alias lists — label-regime specifics flagged as needing primary-FSSAI confirmation before any verbatim citation.)</i></div>
+  </div>
+
+  <h2><span class="ax">Axis 6</span> · Myths to correct <span class="badge b-hi">High</span></h2>
+  <div class="card">
+    <div class="flag bad"><b>Myth: "Delay wheat to prevent allergy."</b> No. Delaying does not prevent allergy; introduce around 6 months and don't hold it back. <i>(AAP; NHS; ASCIA.)</i> (Note the honest companion truth: early wheat also wasn't <i>shown</i> to prevent allergy — EAT was null — so the correct line is "introduce early because it's safe and delaying has no benefit," not "introduce early to prevent allergy.")</div>
+    <div class="flag bad"><b>Myth: "Wheat allergy and gluten intolerance / celiac are the same thing."</b> They are NOT. Wheat allergy is a fast IgE immune reaction to wheat protein; celiac is a chronic autoimmune reaction to gluten, diagnosed medically and never anaphylactic. Treating them as one causes both false alarms (fearing anaphylaxis over a chronic condition) and false reassurance (dismissing chronic poor-growth as "just a mild allergy"). <i>(ESPGHAN; CHOP; Mayo; AAP.)</i></div>
+    <div class="flag bad"><b>Myth: "You must introduce gluten <i>while breastfeeding</i> to prevent celiac."</b> Withdrawn. ESPGHAN's 2016 position paper reversed this: <b>neither breastfeeding nor breastfeeding at the time of gluten introduction reduces celiac risk.</b> The old 2008 advice no longer stands. <i>(ESPGHAN 2016; PubMed 26815017.)</i> This myth is high-value to surface because it's <i>stale official advice</i>, not folklore — a relative or older resource may still cite the 2008 line. Name the reversal explicitly.</div>
+  </div>
+
+  <h2>Who says what — consensus matrix</h2>
+  <div class="card">
+    <table>
+      <tr><th>Authority</th><th class="c">Introduce ~6mo / don't delay</th><th class="c">Early wheat <i>prevents</i> wheat allergy</th></tr>
+      <tr><td>AAP / HealthyChildren</td><td class="c yes">✓</td><td class="c no">✗ not claimed</td></tr>
+      <tr><td>UK NHS (lists gluten: wheat, barley, rye)</td><td class="c yes">✓</td><td class="c no">✗ not claimed</td></tr>
+      <tr><td>ASCIA (Australasia)</td><td class="c yes">✓</td><td class="c no">✗ not claimed</td></tr>
+      <tr><td>US NIAID (2017)</td><td class="c yes">✓</td><td class="c no">✗ not claimed</td></tr>
+      <tr><td>EAT trial (NEJM 2016)</td><td class="c dash">— (tested it)</td><td class="c no">✗ NULL for wheat</td></tr>
+      <tr><td>ESPGHAN 2016 <i>(celiac/gluten lane)</i></td><td class="c dash">— gluten 4–12mo</td><td class="c dash">— celiac doc, not allergy</td></tr>
+    </table>
+    <p style="margin:8px 0 0;font-size:13.5px;color:var(--mid)">Every body supports introduce-early / don't-delay; <b>no body claims early wheat prevents wheat allergy</b>, and EAT is the direct null evidence. ESPGHAN belongs only in the celiac/gluten-timing lane (4–12-month window), never as allergy-prevention evidence.</p>
+  </div>
+
+  <h2>Proposed data shape · <code>FOOD_EFFECTS['wheat']</code></h2>
+  <div class="card">
+    <p style="margin:0 0 10px;font-size:14px;color:var(--mid)">Drop-in record mirrored from <code>food-effects.manifest.js</code>, sitting alongside <code>AGE_RULES</code>/<code>ALLERGENS</code>. The <code>myth</code> field carries the allergy-vs-celiac clarifier; <code>earlyIntroBenefit</code> is framed honestly (EAT null — no prevention claim). <b>Not yet wired.</b></p>
+<pre><span class="c">// guided-introduction record — Tier-2 allergen: introduce-early, prevention NOT proven</span>
+{
+  food:          <span class="s">'wheat'</span>,
+  aliases:       [<span class="s">'atta'</span>, <span class="s">'maida'</span>, <span class="s">'wheat flour'</span>, <span class="s">'suji'</span>, <span class="s">'sooji'</span>, <span class="s">'rava'</span>, <span class="s">'semolina'</span>, <span class="s">'dalia'</span>, <span class="s">'broken wheat'</span>, <span class="s">'roti'</span>, <span class="s">'chapati'</span>, <span class="s">'phulka'</span>, <span class="s">'paratha'</span>, <span class="s">'naan'</span>, <span class="s">'bread'</span>, <span class="s">'pasta'</span>, <span class="s">'sevai'</span>, <span class="s">'vermicelli'</span>, <span class="s">'durum'</span>, <span class="s">'couscous'</span>, <span class="s">'bulgur'</span>, <span class="s">'seitan'</span>],
+  foodClass:     <span class="s">'allergen-introduce-early'</span>,
+  severity:      <span class="s">'caution'</span>,
+  category:      <span class="s">'grain'</span>,
+  effect:        <span class="s">'food allergy (distinct from celiac disease)'</span>,
+  minMonth:      <span class="s">6</span>,
+  thresholdBasis:<span class="s">'developmental-readiness'</span>,
+  allergen:      <span class="k">true</span>,
+  reactionType:  [<span class="s">'allergy'</span>],
+  headline:      <span class="s">'Introduce around 6 months — don\'t delay. Soft cereal or softened roti.'</span>,
+  whyGood:       <span class="s">'Staple grain — soft wheat cereal, well-cooked pasta, or softened roti; introduce early alongside other solids.'</span>,
+  earlyIntroBenefit: { claim:<span class="s">'Introduce around 6 months; don\'t delay.'</span>,
+                       evidence:<span class="s">'AAP/NHS/ASCIA advise early introduction; EAT (NEJM 2016) verified NO significant prevention effect for wheat — early intro is SAFE but does NOT prevent wheat allergy.'</span>,
+                       paradigm:<span class="s">'Don\'t delay — but no proven wheat-specific prevention claim.'</span> },
+  safeForm:      { ok:[<span class="s">'soft wheat / multigrain cereal or porridge'</span>, <span class="s">'well-cooked soft pasta'</span>, <span class="s">'roti / chapati torn small and softened in milk, dal, or sabzi'</span>, <span class="s">'suji / dalia cooked soft'</span>],
+                   never:[<span class="s">'large or doughy bread pieces (fresh soft bread balls up into a sticky clump — toast it or use firm strips)'</span>, <span class="s">'loose cooked wheat / dalia that scatters in the mouth (mash or bind it)'</span>],
+                   note:<span class="s">'Wheat ALLERGY is separate from celiac disease — see myth.'</span> },
+  myth:          { claim:<span class="s">'Wheat allergy and gluten intolerance / celiac disease are the same.'</span>,
+                   truth:<span class="s">'Different conditions — wheat allergy is an immune (IgE) food allergy with rapid reactions; celiac is a separate autoimmune reaction to gluten needing medical diagnosis, not emergency care. This record is about wheat allergy.'</span> },
+  watchFor:      [<span class="s">'hives / rash'</span>, <span class="s">'swelling (mouth, eyes, lips)'</span>, <span class="s">'vomiting or diarrhoea'</span>, <span class="s">'eczema flare'</span>],
+  severeSigns:   [<span class="s">'trouble breathing / wheeze'</span>, <span class="s">'face/lip/tongue swelling'</span>, <span class="s">'floppy, pale, or very sleepy'</span>],
+  timeCourse:    <span class="s">'minutes to ~2 hours after eating; anaphylaxis often within 5–30 min'</span>,
+  seekCare:      <span class="s">'Mild single-system: stop, monitor, call doctor. Any breathing trouble, face/throat swelling, or floppiness: EMERGENCY — call 112, use prescribed adrenaline auto-injector. (Celiac is NOT an emergency — chronic; needs a doctor\'s diagnosis.)'</span>,
+  breastfeedingSafe: <span class="k">true</span>,
+  culturalNote:  <span class="s">'Atta, maida, suji/rava, dalia, sevai are all wheat. Soft cereal and softened roti are ideal early forms. Wheat allergy is commonly outgrown in early childhood.'</span>,
+  confidence:    <span class="s">'high'</span>,
+  sources:       [<span class="s">'AAP'</span>, <span class="s">'UK NHS'</span>, <span class="s">'ASCIA'</span>, <span class="s">'NIAID 2017'</span>, <span class="s">'NEJM EAT 2016'</span>, <span class="s">'ESPGHAN 2016 (celiac/gluten)'</span>],
+  lastReviewed:  <span class="s">'2026-06-01'</span>,
+}</pre>
+  </div>
+
+  <h2>Source list</h2>
+  <div class="card">
+  <table>
+    <tr><th>#</th><th>Authority</th><th>Type</th><th>URL</th></tr>
+    <tr><td>1</td><td>NEJM / PubMed — Perkin, Lack et al., <b>EAT trial (2016)</b> — "no significant effects… with respect to milk, sesame, fish, or wheat"</td><td>Primary (RCT)</td><td><a href="https://pubmed.ncbi.nlm.nih.gov/26943128/">pubmed.ncbi.nlm.nih.gov/26943128</a></td></tr>
+    <tr><td>2</td><td><b>ESPGHAN 2016</b> gluten introduction position paper (4–12mo window; breastfeeding reversal; avoid-large-quantities-early) — <i>a celiac document</i></td><td>Primary (position paper)</td><td><a href="https://pubmed.ncbi.nlm.nih.gov/26815017/">pubmed.ncbi.nlm.nih.gov/26815017</a></td></tr>
+    <tr><td>3</td><td>AAP / HealthyChildren — When should I introduce wheat into my baby's diet? (wheat allergy commonly outgrown)</td><td>Official body</td><td><a href="https://www.healthychildren.org/English/tips-tools/ask-the-pediatrician/Pages/When-should-I-introduce-wheat-into-my-babys-diet.aspx">healthychildren.org/…/wheat</a></td></tr>
+    <tr><td>4</td><td>NIAID (2017) — early allergen introduction addendum framing</td><td>Official body</td><td><a href="https://pmc.ncbi.nlm.nih.gov/articles/PMC5226648/">pmc.ncbi.nlm.nih.gov/…/PMC5226648</a></td></tr>
+    <tr><td>5</td><td>UK NHS — Food allergies in babies &amp; young children (lists "foods containing gluten — wheat, barley, rye")</td><td>Official body</td><td><a href="https://www.nhs.uk/conditions/baby/weaning-and-feeding/food-allergies-in-babies-and-young-children/">nhs.uk/…/food-allergies</a></td></tr>
+    <tr><td>6</td><td>ASCIA — Infant feeding &amp; allergy prevention</td><td>Official body</td><td><a href="https://www.allergy.org.au/hp/papers/infant-feeding-and-allergy-prevention">allergy.org.au/…/infant-feeding</a></td></tr>
+    <tr><td>7</td><td>WHO — Complementary feeding of infants &amp; young children 6–23 months</td><td>Official body</td><td><a href="https://www.ncbi.nlm.nih.gov/books/NBK596423/">ncbi.nlm.nih.gov/books/NBK596423</a></td></tr>
+    <tr><td>8</td><td>Solid Starts — Wheat</td><td>Secondary</td><td><a href="https://solidstarts.com/foods/wheat/">solidstarts.com/foods/wheat</a></td></tr>
+    <tr><td>9</td><td>Solid Starts — Bread (toast vs soft-bread choking caution)</td><td>Secondary</td><td><a href="https://solidstarts.com/foods/bread/">solidstarts.com/foods/bread</a></td></tr>
+    <tr><td>10</td><td>CHOP — Wheat allergy</td><td>Secondary</td><td><a href="https://www.chop.edu/conditions-diseases/wheat-allergy">chop.edu/…/wheat-allergy</a></td></tr>
+    <tr><td>11</td><td>Mayo Clinic — Wheat allergy (symptoms &amp; causes)</td><td>Secondary</td><td><a href="https://www.mayoclinic.org/diseases-conditions/wheat-allergy/symptoms-causes/syc-20378897">mayoclinic.org/…/wheat-allergy</a></td></tr>
+    <tr><td>12</td><td>FARE — Wheat (allergen profile; aliases)</td><td>Secondary (advocacy)</td><td><a href="https://www.foodallergy.org/living-food-allergies/food-allergy-essentials/common-allergens/wheat">foodallergy.org/…/wheat</a></td></tr>
+    <tr><td>13</td><td>FAACT — Wheat (top allergen; aliases)</td><td>Secondary (advocacy)</td><td><a href="https://www.foodallergyawareness.org/food-allergy-and-anaphylaxis/food-allergens/wheat/">foodallergyawareness.org/…/wheat</a></td></tr>
+  </table>
+  </div>
+
+  <div class="card">
+    <strong>Verification status &amp; gaps</strong>
+    <ol style="margin:8px 0 0">
+      <li>✅ <b>EAT wheat-null</b> — verified verbatim from the PubMed abstract (26943128): <i>"no significant effects… with respect to milk, sesame, fish, or wheat."</i> The trial's benefit was peanut + egg only. <b>Do not attribute wheat-allergy prevention to early introduction.</b></li>
+      <li>✅ <b>ESPGHAN 2016 gluten window &amp; reversals</b> — verified from the PubMed abstract (26815017): 4–12-month window; age of introduction shifts presentation not lifetime incidence; <b>breastfeeding (and breastfeeding-during-introduction) reversal of 2008 advice</b>; avoid large gluten quantities in the first weeks and during infancy. This is a <b>celiac</b> document — cite it only in the celiac/gluten-timing lane, never as allergy-prevention evidence.</li>
+      <li>✅ <b>NHS allergen listing</b> — NHS names "foods containing gluten (wheat, barley, rye)" among allergens to introduce around 6 months, one at a time.</li>
+      <li>✅ <b>Wheat allergy commonly outgrown</b> — AAP-supported; corroborated by CHOP/Mayo/FARE.</li>
+      <li>⚑ <b>Choking-form cautions (soft-bread clump; loose-grain scatter)</b> — drawn from Solid Starts (secondary). Well-established and consistent with general infant-feeding guidance, but not a top-tier body's verbatim rule. Flagged as secondary.</li>
+      <li>⚑ <b>Softened-roti / suji / dalia forms</b> — culturally derived and consistent with soft-cereal guidance, but not issued by an official body for the Indian context. Secondary/derived.</li>
+      <li>⚑ <b>FSSAI label-regime claim</b> — the US "wheat" vs EU/UK "cereals containing gluten" vs India "FSSAI gluten-cereal declaration on packaged food; fresh staples unlabeled" framing should have the FSSAI labelling rule confirmed against the primary FSSAI regulation before any verbatim citation. The <i>operational</i> conclusion (caregiver alias-knowledge is the safeguard for unlabeled fresh staples) stands regardless.</li>
+      <li>⚑ <b>No India-specific (IAP / MoHFW) early-allergen or wheat directive located.</b> Indian practice borrows AAP/ASCIA/NIAID. The "introduce ~6mo, don't delay" posture is well-sourced internationally and culturally compatible with a wheat-staple diet, but is <b>not</b> an Indian-government-issued rule. Never launder international guidance onto an Indian body's name.</li>
+      <li>⚑ <b>WDEIA</b> — adult/adolescent, not infant-relevant; included only to keep it separated from infant wheat allergy. Do not surface in infant copy except to rule out.</li>
+      <li>🚫 <b>Hard line — no overclaim.</b> The brief must not state, imply, or let the model infer that early wheat introduction <i>prevents</i> wheat allergy. The introduce-early posture rests on safety + the don't-delay consensus (Tier-2), not on a prevention RCT (which, for wheat, was null).</li>
+    </ol>
+  </div>
+
+  <div class="card tldr">
+    <strong>Surfacing recommendation (Maren) — feeds the guided-introduction model, not yet implemented</strong>
+    <p style="margin:8px 0 0">An <b>encourage-polarity</b> card (sage, <code>severity:'caution'</code>) — "introduce ~6mo, don't delay" first, then the safe-form block (softened roti/cereal vs the doughy-bread choke), then a non-collapsible severe-reaction strip. The two highest-value nuggets unique to wheat: the <b>"wheat allergy ≠ celiac"</b> clarifier (so a chronic-condition worry never rides the anaphylaxis rail) and the <b>Tier-2 honest-framing flag</b> (early wheat is safe + don't-delay, but EAT was null — <b>no wheat-prevention claim</b>).</p>
+  </div>
+
+  <p class="foot">SproutLab · Care research brief · companion to <code>docs/research/wheat-infant-safety.md</code> · generated 2026-06-01<br>
+  Research artifact — informational, not medical advice. Not yet wired into the app.</p>
+</div>
+</body>
+</html>

--- a/docs/research/wheat-infant-safety.visual.html
+++ b/docs/research/wheat-infant-safety.visual.html
@@ -1,0 +1,372 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Wheat &amp; Infant Safety — Visual Dashboard · SproutLab Care</title>
+<style>
+  :root{
+    --bg:#faf6f0; --card:#fffdf9; --ink:#2e2a26; --mid:#6b6258; --line:#e8ddcf; --track:#efe7da;
+    --sage:#3a7060; --sage-bg:#e8f5ef; --rose:#b04a5e; --rose-bg:#fbe9ec;
+    --amber:#9a7320; --amber-bg:#fbf0d9; --accent:#9a6a3a; --honey:#d99a2b; --honey-bg:#fbeccb;
+    --hi:#2f7d5b; --hi-bg:#e3f3ea; --mod:#9a7320; --mod-bg:#f7eed6; --weak:#9a5a5a; --weak-bg:#f5e6e6;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#1d1a17; --card:#262220; --ink:#ece5db; --mid:#a89c8c; --line:#3a342d; --track:#332d26;
+    --sage:#7ac0a0; --sage-bg:#1e3028; --rose:#e090a0; --rose-bg:#3a2026;
+    --amber:#e0b060; --amber-bg:#352a16; --accent:#c99a6a; --honey:#e8b34a; --honey-bg:#3a2c12;
+    --hi:#7ac0a0; --hi-bg:#1e3028; --mod:#d8b060; --mod-bg:#332a14; --weak:#e09090; --weak-bg:#3a2222; }}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Nunito,sans-serif;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:960px;margin:0 auto;padding:0 18px 90px}
+  header{background:linear-gradient(160deg,var(--honey-bg),var(--bg));border-bottom:1px solid var(--line);padding:26px 0 0}
+  h1{font:700 25px/1.2 Fraunces,Georgia,serif;margin:0 0 4px}
+  .sub{color:var(--mid);font-size:14px;margin:0 0 16px;max-width:680px}
+  nav{display:flex;gap:4px;margin-top:6px;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none}
+  nav::-webkit-scrollbar{display:none}
+  .tab{appearance:none;border:0;background:transparent;color:var(--mid);font:600 13.5px/1 Nunito,sans-serif;white-space:nowrap;flex:0 0 auto;
+    padding:11px 14px;border-radius:10px 10px 0 0;cursor:pointer;border-bottom:3px solid transparent}
+  .tab:hover{color:var(--ink);background:var(--card)}
+  .tab.on{color:var(--accent);background:var(--card);border-bottom-color:var(--accent)}
+  .panel{display:none;animation:f .25s ease}.panel.on{display:block}
+  @keyframes f{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:none}}
+  /* ── Entrance animations — re-trigger each time a panel is shown (display:none→block
+     restarts descendant animations). All gated behind prefers-reduced-motion so the
+     dashboard is fully usable (and calm) for anyone who opts out of motion. ── */
+  @media (prefers-reduced-motion: no-preference){
+    /* bars grow from the left — scaleX keeps the inline width:% target intact */
+    .panel.on .bar .fil{transform-origin:left center;animation:grow .7s cubic-bezier(.34,1.1,.4,1) both}
+    @keyframes grow{from{transform:scaleX(0)}to{transform:scaleX(1)}}
+    /* stat tiles + timeline steps + therm cols rise in with a gentle stagger */
+    .panel.on .stat,.panel.on .tl-step,.panel.on .therm .col{animation:rise .45s ease both}
+    .panel.on .stat:nth-child(2),.panel.on .tl-step:nth-child(2),.panel.on .therm .col:nth-child(2){animation-delay:.07s}
+    .panel.on .stat:nth-child(3),.panel.on .tl-step:nth-child(3){animation-delay:.14s}
+    .panel.on .stat:nth-child(4),.panel.on .tl-step:nth-child(4){animation-delay:.21s}
+    .panel.on .tl-step:nth-child(5){animation-delay:.28s}
+    @keyframes rise{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}
+    /* donut sweeps in (the partial-arc value stays exact; only the reveal animates) */
+    .panel.on svg[role="img"]{animation:sweep .8s ease both}
+    @keyframes sweep{from{opacity:0;transform:rotate(-12deg) scale(.9)}to{opacity:1;transform:none}}
+    /* flag callouts slide a touch from the left edge they're anchored to */
+    .panel.on .flag{animation:slidein .5s ease both}
+    @keyframes slidein{from{opacity:0;transform:translateX(-6px)}to{opacity:1;transform:none}}
+  }
+  h2{font:600 18px/1.3 Fraunces,Georgia,serif;margin:26px 0 10px}
+  h3{font:700 13px/1.3 Nunito;text-transform:uppercase;letter-spacing:.4px;color:var(--mid);margin:18px 0 8px}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:16px 18px;margin:12px 0}
+  .grid{display:grid;gap:12px}.g2{grid-template-columns:1fr 1fr}.g3{grid-template-columns:repeat(3,1fr)}.g4{grid-template-columns:repeat(4,1fr)}
+  @media(max-width:680px){.g2,.g3,.g4{grid-template-columns:1fr 1fr}}
+  .stat{text-align:center;padding:16px 10px}
+  .stat .n{font:800 26px/1 Fraunces,Georgia,serif;color:var(--accent)}
+  .stat .l{font-size:12px;color:var(--mid);margin-top:6px;line-height:1.35}
+  .stat.crit .n{color:var(--rose)}.stat.ok .n{color:var(--sage)}
+  .badge{display:inline-block;font:700 10.5px/1 Nunito;text-transform:uppercase;letter-spacing:.3px;padding:4px 8px;border-radius:6px;vertical-align:middle}
+  .b-hi{background:var(--hi-bg);color:var(--hi)}.b-mod{background:var(--mod-bg);color:var(--mod)}.b-weak{background:var(--weak-bg);color:var(--weak)}.b-crit{background:var(--rose-bg);color:var(--rose)}
+  .bar{display:grid;grid-template-columns:130px 1fr 52px;align-items:center;gap:10px;margin:7px 0;font-size:13px}
+  .bar .lab{color:var(--ink);text-align:right;font-weight:600}
+  .bar .trk{display:block;background:var(--track);border:1px solid var(--line);border-radius:7px;height:18px;overflow:hidden}
+  .bar .fil{display:block;height:100%;border-radius:6px;background:var(--sage);min-width:3px}
+  .bar .val{font-weight:700;color:var(--mid);font-size:12.5px}
+  .bar.hl .fil{background:var(--honey)}.bar.hl .lab{color:var(--honey)}.bar.hl .val{color:var(--honey)}
+  .tl{position:relative;margin:14px 0 6px;padding-left:8px}
+  .tl-step{position:relative;padding:0 0 18px 26px;border-left:2px solid var(--line)}
+  .tl-step:last-child{border-left-color:transparent}
+  .tl-dot{position:absolute;left:-8px;top:1px;width:15px;height:15px;border-radius:50%;background:var(--card);border:3px solid var(--accent)}
+  .tl-step.crit .tl-dot{border-color:var(--rose)}.tl-step.first .tl-dot{border-color:var(--honey)}
+  .tl-t{font-weight:700;font-size:13.5px}.tl-d{color:var(--mid);font-size:12.5px}
+  .flag{border-left:3px solid var(--amber);background:var(--amber-bg);border-radius:6px;padding:10px 14px;margin:10px 0;font-size:13px}
+  .flag.good{border-left-color:var(--sage);background:var(--sage-bg)}.flag.bad{border-left-color:var(--rose);background:var(--rose-bg)}
+  table{width:100%;border-collapse:collapse;font-size:13px;margin:8px 0}
+  th,td{padding:8px 9px;border-bottom:1px solid var(--line);text-align:left;vertical-align:top}
+  th{font:700 11px/1.2 Nunito;text-transform:uppercase;letter-spacing:.3px;color:var(--mid)}
+  td.c{text-align:center;font-weight:800}.yes{color:var(--sage)}.no{color:var(--rose)}.dash{color:var(--mid)}
+  td a{color:var(--sage);font-size:12px;word-break:break-all}
+  .pill{display:inline-block;font:600 11px/1 Nunito;padding:5px 10px;border-radius:999px;background:var(--card);border:1px solid var(--line);color:var(--mid);margin:0 4px 4px 0}
+  .pill.warn{background:var(--rose-bg);color:var(--rose);border-color:transparent}
+  .jump{display:inline-block;font-weight:700;color:var(--accent);cursor:pointer;border-bottom:1px dashed var(--accent)}
+  .lead{font-size:16px;line-height:1.5}.lead b{color:var(--accent)}
+  pre{background:#1e1b18;color:#e8e2d6;border-radius:12px;padding:16px;overflow:auto;font:12px/1.5 "SF Mono",Menlo,Consolas,monospace}
+  .therm{display:flex;gap:14px;flex-wrap:wrap}
+  .therm .col{flex:1;min-width:200px;border:1px solid var(--line);border-radius:12px;padding:14px;text-align:center}
+  .therm .big{font:800 19px/1 Fraunces,serif;margin:6px 0}
+  .col.safe{background:var(--sage-bg)}.col.danger{background:var(--rose-bg)}.col.safe .big{color:var(--sage)}.col.danger .big{color:var(--rose)}
+  .foot{color:var(--mid);font-size:12.5px;text-align:center;margin-top:30px}
+</style>
+</head>
+<body>
+<header><div class="wrap">
+  <h1>Wheat &amp; Infant Safety — Visual Dashboard</h1>
+  <p class="sub">Visual Care dashboard for the <b>guided-introduction</b> layer. Wheat is a <b>Tier-2 allergen</b>: introduce early and it is safe — but the defining job here is keeping <b>three look-alike concepts apart</b>: wheat allergy, celiac disease, and gluten-introduction timing.</p>
+  <nav>
+    <button class="tab on" data-p="p-sum">Summary</button>
+    <button class="tab" data-p="p-why">Why / Allergen</button>
+    <button class="tab" data-p="p-sym">Reaction &amp; Introduction</button>
+    <button class="tab" data-p="p-ctx">Context</button>
+    <button class="tab" data-p="p-src">Sources &amp; Confidence</button>
+    <button class="tab" data-p="p-data">Data Stub</button>
+  </nav>
+  <p style="font-size:11.5px;color:var(--mid);margin:6px 0 10px">Swipe ‹ › between tabs · or use ← → arrow keys</p>
+</div></header>
+
+<div class="wrap">
+
+  <!-- ───────── SUMMARY ───────── -->
+  <section class="panel on" id="p-sum">
+    <div class="card" style="background:var(--honey-bg);border-color:transparent;margin-top:18px">
+      <p class="lead" style="margin:0">The one rule: <b>introduce wheat around 6 months — don't delay it</b> — as soft cereal or softened roti. It's safe to give early. But the honest limit (this is why wheat is <b>Tier-2, not Tier-1</b>): the EAT trial found early wheat did <b>NOT</b> prevent wheat allergy. And the central job — keep <b>wheat allergy ≠ celiac disease ≠ gluten-timing</b> rigorously apart.</p>
+    </div>
+
+    <div class="grid g4">
+      <div class="card stat ok"><div class="n">~6<span style="font-size:14px">mo</span></div><div class="l">Introduce around 6 months, don't delay — AAP·NHS·ASCIA·NIAID</div></div>
+      <div class="card stat"><div class="n">4–12<span style="font-size:14px">mo</span></div><div class="l">ESPGHAN gluten window (a <i>celiac</i> question) — timing doesn't change lifetime celiac incidence</div></div>
+      <div class="card stat ok"><div class="n">outgrown</div><div class="l">wheat allergy is commonly outgrown in early childhood — AAP/CHOP/Mayo/FARE</div></div>
+      <div class="card stat crit"><div class="n">3 ≠</div><div class="l">three distinct concepts under one word: allergy · celiac · gluten-timing — keep apart</div></div>
+    </div>
+
+    <h3>The four things to know <span class="badge b-hi">all high-confidence</span></h3>
+    <div class="grid g2">
+      <div class="card"><b>1 · Introduce early — but no prevention claim.</b> Don't delay wheat; it's safe early. EAT was null for wheat, so we never say "early wheat prevents wheat allergy." → <span class="jump" data-go="p-why">Why / Allergen</span></div>
+      <div class="card"><b>2 · Three things wear the word "wheat."</b> Wheat allergy (IgE, fast) ≠ celiac (chronic autoimmune to gluten) ≠ gluten-introduction timing (a celiac-prevention question). This split is the spine. → <span class="jump" data-go="p-why">Why / Allergen</span></div>
+      <div class="card"><b>3 · Know mild from severe — celiac is NOT here.</b> Hives/vomiting vs breathing/floppiness (call 112/108). Celiac is chronic, not a 112 event. → <span class="jump" data-go="p-sym">Reaction &amp; Introduction</span></div>
+      <div class="card"><b>4 · The Indian alias thicket.</b> Atta, maida, suji/rava, dalia, sevai, seitan, soy sauce all = wheat — and fresh staples carry no label. Caregiver alias-knowledge is the safeguard. → <span class="jump" data-go="p-ctx">Context</span></div>
+    </div>
+
+    <h3>When to surface this (the design hook)</h3>
+    <div class="card flag good" style="margin-top:0">
+      <b>Recommendation (Maren):</b> an <b>encourage-polarity</b> card (sage, not rose) — "introduce ~6mo, don't delay" first, then the safe-form block (softened roti/cereal vs the doughy-bread choke), then a non-collapsible severe-reaction strip. The unique high-value nugget: a <b>"wheat allergy ≠ celiac"</b> clarifier the parent can't skim past, so a chronic-condition worry never rides the anaphylaxis rail. Ready-to-wire shape → <span class="jump" data-go="p-data">Data Stub</span>.
+    </div>
+    <div class="card flag" style="margin-top:0"><b>⚑ Honest-framing flag — Tier-2.</b> Early wheat is safe + don't-delay, but EAT was null: <b>no wheat-prevention claim.</b> The introduce-early posture rests on safety + the don't-delay consensus, not on a prevention RCT (which, for wheat, was null).</div>
+    <div class="card flag bad" style="margin-top:0"><b>✗ Wheat allergy ≠ celiac disease.</b> An IgE food allergy (fast, can be anaphylactic) versus a chronic autoimmune reaction to gluten (medically diagnosed, never anaphylactic). This record is about wheat <i>allergy</i>.</div>
+
+    <div style="margin-top:14px">
+      <span class="pill">Reviewer · Maren (Care)</span>
+      <span class="pill">2026-06-01</span>
+      <span class="pill warn">Research artifact — not yet wired into the app</span>
+    </div>
+    <p style="font-size:12.5px;color:var(--mid);margin-top:10px">Full prose: <code>wheat-infant-safety.md</code> · long-form HTML: <code>wheat-infant-safety.html</code>. This dashboard is the skim layer over both.</p>
+  </section>
+
+  <!-- ───────── WHY / ALLERGEN ───────── -->
+  <section class="panel" id="p-why"><h2>The three-way split — keep them apart</h2>
+    <div class="card" style="background:var(--honey-bg);border-color:transparent">
+      <p style="margin:0">Wheat is the one infant food where <b>three distinct medical concepts collide under one word.</b> Conflating them produces both needless fear and genuine error. Keep them labelled — this is the spine of the whole brief. <span class="badge b-hi">consensus</span></p>
+    </div>
+
+    <h3>Three things wear the word "wheat" <span class="badge b-hi">the centerpiece</span></h3>
+    <div class="therm">
+      <div class="col safe">
+        <div style="font-size:12px;color:var(--mid)">(1) THIS record</div>
+        <div class="big">Wheat allergy</div>
+        <div style="font-size:12.5px"><b>IgE food allergy</b> to wheat <i>proteins</i>. Fast — hives, swelling, vomiting, eczema flare, at the severe end anaphylaxis. <b>The introduce-early target.</b> Commonly <b>outgrown</b> by early childhood.</div>
+      </div>
+      <div class="col danger">
+        <div style="font-size:12px;color:var(--mid)">(2) NOT an allergy</div>
+        <div class="big">Celiac disease</div>
+        <div style="font-size:12.5px">Chronic <b>autoimmune</b> reaction to <i>gluten</i> (wheat/barley/rye). <b>NOT anaphylactic, NOT an emergency.</b> Chronic — poor growth, chronic GI, failure to thrive. Needs <b>medical diagnosis</b> (serology + specialist).</div>
+      </div>
+      <div class="col" style="background:var(--mod-bg)">
+        <div style="font-size:12px;color:var(--mid)">(3) A celiac question</div>
+        <div class="big" style="color:var(--mod)">Gluten-timing</div>
+        <div style="font-size:12.5px"><i>When</i> to introduce gluten — debated in the <b>celiac</b> literature, separate from allergy. ESPGHAN: anytime <b>4–12 months</b>; timing shifts <i>when</i> celiac presents, not <i>whether</i>.</div>
+      </div>
+    </div>
+    <p style="font-size:12px;color:var(--mid);margin:6px 0 0">All chart values in text: (1) wheat allergy = IgE, fast, outgrown, the introduce-early target. (2) celiac = chronic autoimmune to gluten, not anaphylactic, not an emergency, medically diagnosed. (3) gluten-timing = ESPGHAN's 4–12-month celiac-prevention question.</p>
+    <div class="flag"><b>⚑ Why wheat sits in both conversations.</b> Wheat contains gluten, so it's simultaneously an <i>allergen</i> (wheat protein → IgE allergy) and the <i>vehicle for gluten</i> (→ celiac). A parent hearing "introduce wheat early" and "be careful about gluten timing" is hearing two different bodies answering two different questions. <b>Answer each in its own lane; never let one borrow the other's authority.</b></div>
+
+    <h2>Axis 1 — Introduce ~6 months, don't delay</h2>
+    <div class="card">
+      <p style="margin:0 0 6px">Wheat is named among the common infant allergens and handled like the others: offer early, don't delay, keep it in the diet. The NHS explicitly lists <b>"foods containing gluten, including wheat, barley and rye"</b> among the allergenic foods to introduce from around 6 months, one at a time. Delaying allergens does not prevent allergy. <span class="badge b-hi">AAP·NHS·ASCIA·NIAID</span></p>
+    </div>
+
+    <h3>The honest limit — EAT found NO wheat benefit <span class="badge b-hi">NEJM 2016, verified</span></h3>
+    <div class="card">
+      <p style="margin:0 0 8px">The EAT trial (Perkin/Lack, NEJM 2016) randomised general-population breastfed infants to early introduction of six allergens (incl. wheat) vs standard. Its abstract states, verbatim:</p>
+      <div class="flag" style="background:var(--card);border-left-color:var(--honey)"><i>"…there were no significant effects with respect to milk, sesame, fish, or wheat."</i> <span class="badge b-hi">PubMed 26943128</span></div>
+      <p style="margin:8px 0 0">The trial's prevention benefit was confined to <b>peanut and egg</b> (and only in the per-protocol, dose-achieving analysis). <b>Early wheat was safe but did not prevent wheat allergy.</b></p>
+      <div class="flag bad"><b>⚑ Tier-2, not Tier-1.</b> Say "introduce wheat early — it's safe, don't delay" <b>without</b> saying "early wheat prevents wheat allergy." That second claim is unproven and EAT is the direct evidence against it. The introduce-early posture stands on safety + the don't-delay consensus, <b>not</b> on a proven prevention RCT the way peanut stands on LEAP.</div>
+    </div>
+
+    <h3>The gluten-timing lane — ESPGHAN 2016 (a celiac document) <span class="badge b-hi">PubMed 26815017</span></h3>
+    <div class="card">
+      <ul style="margin:0;padding-left:20px">
+        <li><b>"Gluten may be introduced into the infant's diet anytime between 4 and 12 completed months of age."</b></li>
+        <li>Age of introduction <b>does not change lifetime celiac incidence</b> — earlier vs later only shifts <i>when</i> celiac presents, not whether it occurs.</li>
+        <li><b>Breastfeeding reversal:</b> neither breastfeeding nor breastfeeding at the time of gluten introduction reduces celiac risk — explicitly <i>reversing</i> the 2008 advice.</li>
+        <li><b>"Consumption of large quantities of gluten should be avoided during the first weeks after gluten introduction and during infancy."</b></li>
+      </ul>
+      <div class="flag good"><b>✓ Practical reconciliation at ~6 months.</b> Both lanes agree wheat/gluten can begin around 6 months — the allergy lane says "introduce early, don't delay," and the celiac lane (ESPGHAN) says "anytime 4–12 months, avoid large quantities early." Compatible: introduce wheat around 6 months in ordinary food-sized amounts, not in a gluten-loading binge.</div>
+    </div>
+  </section>
+
+  <!-- ───────── REACTION & INTRODUCTION ───────── -->
+  <section class="panel" id="p-sym"><h2>Reaction &amp; introduction — know mild from severe</h2>
+    <div class="grid g2">
+      <div class="card flag" style="margin:0"><b>Mild–moderate IgE reaction (one body system).</b> Itchy hives/welts, redness or rash, swelling (especially mouth/eyes), vomiting, GI upset/loose stool, eczema flare, sudden fussiness. → stop the food, monitor closely, contact your doctor; a clinician may advise an antihistamine.</div>
+      <div class="card flag bad" style="margin:0"><b>Severe / anaphylaxis — act immediately.</b> Difficulty breathing, wheeze/persistent cough/noisy breathing, swelling of throat/tongue/lips/face, hoarse cry, pale/floppy/lethargic or unusually sleepy, collapse. → use a prescribed adrenaline auto-injector and call emergency services (<b>112 / 108</b> in India).</div>
+    </div>
+    <div class="card">
+      <p style="margin:0;font-size:13px;color:var(--mid)">In a baby, sudden behaviour change (limp, can't hold head up) is a recognised severe sign. <b>Two or more body systems involved = treat as anaphylaxis.</b> Reactions appear minutes to ~2 hours after eating; anaphylaxis often within 5–30 min.</p>
+    </div>
+    <div class="card flag bad" style="margin-top:0"><b>⚑ Celiac is explicitly NOT here.</b> Celiac disease is <b>chronic</b>, not acute — it does not cause anaphylaxis and is <b>not</b> a 112/108 event. It presents over weeks/months (poor growth, chronic GI) and needs <b>medical diagnosis</b>, not emergency response. Don't let celiac symptoms ride the allergy-emergency rail, and don't let a parent worried about celiac think they're watching for anaphylaxis.</div>
+    <div class="card flag" style="margin-top:0"><b>⚑ Aside — WDEIA</b> (wheat-dependent exercise-induced anaphylaxis) is an <b>adult/adolescent</b> phenomenon, <b>not relevant to infants</b>. Mentioned only so it isn't mistaken for an infant wheat-allergy pattern. Do not surface in infant copy except to rule out.</div>
+
+    <h2>Safe FORM — softened roti/cereal vs the choke</h2>
+    <div class="therm">
+      <div class="col safe">
+        <div style="font-size:12px;color:var(--mid)">Soft, infant-friendly (SAFE)</div>
+        <div class="big">good first forms</div>
+        <div style="font-size:12.5px">Soft wheat/multigrain cereal (thin porridge); well-cooked soft pasta; <b>softened roti/chapati</b> torn small &amp; soaked in milk/dal/sabzi; suji (sooji/rava) / dalia cooked soft to a smooth mash.</div>
+      </div>
+      <div class="col danger">
+        <div style="font-size:12px;color:var(--mid)">Two wheat choke-traps (CHOKING)</div>
+        <div class="big">toast it / bind it</div>
+        <div style="font-size:12.5px"><b>Fresh soft bread balls up</b> into a sticky clump → <b>toast it</b> or use firm strips. <b>Loose cooked wheat/dalia/suji scatters</b> → cook soft and <b>mash or bind</b> (porridge, with milk/dal) so it holds together.</div>
+      </div>
+    </div>
+    <div class="flag good"><b>✓ Form addresses choking, not allergy.</b> Same principle as nuts — cooking/softening does <b>not</b> remove the allergy hazard or the celiac relevance. A baby with wheat-protein allergy reacts to soft well-cooked roti just as to bread. Form is the choking lane only. <span class="badge b-mod">forms partly secondary, flagged</span></div>
+
+    <h3>First-exposure timeline</h3>
+    <div class="card">
+      <div class="tl">
+        <div class="tl-step first"><span class="tl-dot"></span><div class="tl-t">Offer a soft form, one allergen at a time</div><div class="tl-d">Soft cereal/porridge or softened roti — in ordinary food-sized amounts (not a gluten-loading binge).</div></div>
+        <div class="tl-step"><span class="tl-dot"></span><div class="tl-t">Watch ~2 hours</div><div class="tl-d">Reactions appear minutes to ~2 hours after eating; anaphylaxis often within 5–30 minutes.</div></div>
+        <div class="tl-step crit"><span class="tl-dot"></span><div class="tl-t">If severe signs — emergency</div><div class="tl-d">Breathing trouble, face/throat swelling, floppiness, or two body systems → adrenaline + 112/108.</div></div>
+        <div class="tl-step first"><span class="tl-dot"></span><div class="tl-t">If tolerated — keep wheat in the diet</div><div class="tl-d">Wheat is an everyday Indian staple; ongoing offering is culturally trivial. Allergy commonly outgrown in early childhood.</div></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ───────── CONTEXT ───────── -->
+  <section class="panel" id="p-ctx"><h2>Context — the Indian alias thicket</h2>
+    <div class="card">
+      <p style="margin:0">Wheat is already in the diet daily — roti, dalia, suji, sevai — so introduction is culturally <b>trivial</b>: softened roti/chapati, soft cooked suji/dalia, well-cooked pasta are near-ideal forms. The trap is the <b>alias thicket</b>: many names <i>are</i> wheat, and fresh Indian staples carry <b>no allergen label</b> — so caregiver alias-knowledge is the safeguard, not the package. <span class="badge b-hi">alias list: High</span></p>
+    </div>
+
+    <h3>Wheat hides under many names</h3>
+    <div class="grid g2">
+      <div class="card"><b>Core flours &amp; forms</b><ul style="margin:6px 0;padding-left:20px"><li>atta (wholewheat), maida (refined)</li><li>semolina / suji / sooji / rava</li><li>broken wheat / dalia; sevai / vermicelli</li><li>durum, farina, couscous, bulgur</li><li><b>seitan (= wheat gluten)</b>; <b>soy sauce (typically contains wheat)</b></li></ul></div>
+      <div class="card"><b>Indian staples that ARE wheat</b><ul style="margin:6px 0;padding-left:20px"><li>roti, chapati, paratha, naan, <b>pav</b></li><li>upma (suji), halwa (suji/atta)</li><li>samosa &amp; pakora batter/wrapper</li><li>rusks and biscuits; sevai/vermicelli dishes</li></ul></div>
+    </div>
+    <div class="card"><b>Related wheat grains (often missed):</b> spelt, kamut, einkorn, emmer, farro, triticale — all contain wheat/gluten and are not "wheat-free." <span class="badge b-hi">FARE/FAACT</span></div>
+
+    <h3>Label-regime divergence</h3>
+    <div class="card" style="overflow-x:auto"><table>
+      <tr><th>Region</th><th>How wheat is declared</th></tr>
+      <tr><td>US</td><td>declares the allergen as <b>"wheat"</b> plainly</td></tr>
+      <tr><td>EU / UK</td><td><b>"cereals containing gluten"</b> (a label may say "gluten", not "wheat")</td></tr>
+      <tr><td>India (FSSAI)</td><td>gluten-cereal declaration on <b>packaged</b> food — but <b>fresh, unpackaged staples</b> (roti, chakki dalia, restaurant/street food) carry <b>no allergen label at all</b></td></tr>
+    </table></div>
+    <div class="flag"><b>⚑ Consequence.</b> In the Indian context the package label is the <i>weakest</i> safeguard, because so much wheat intake is fresh and unlabeled. Lean on <b>caregiver alias-knowledge</b> (knowing suji, maida, dalia, sevai, seitan, soy sauce all = wheat) rather than on label-reading. <span class="badge b-mod">FSSAI specifics flagged — needs primary confirmation</span></div>
+
+    <h3>Myths to correct</h3>
+    <div class="card flag bad" style="margin-top:0"><b>Myth: "Delay wheat to prevent allergy."</b> No — delaying does not prevent allergy; introduce around 6 months and don't hold it back. (Honest companion truth: early wheat also wasn't <i>shown</i> to prevent allergy — EAT was null — so the line is "introduce early because it's safe and delaying has no benefit," not "to prevent allergy.")</div>
+    <div class="card flag bad" style="margin-top:0"><b>Myth: "Wheat allergy and gluten intolerance / celiac are the same."</b> They are NOT. Fast IgE reaction to wheat protein vs chronic autoimmune reaction to gluten, diagnosed medically and never anaphylactic. Conflating causes false alarms <i>and</i> false reassurance.</div>
+    <div class="card flag bad" style="margin-top:0"><b>Myth: "You must introduce gluten <i>while breastfeeding</i> to prevent celiac."</b> Withdrawn. ESPGHAN 2016 reversed this; the old 2008 advice no longer stands. High-value to surface because it's <i>stale official advice</i>, not folklore — name the reversal explicitly.</div>
+  </section>
+
+  <!-- ───────── SOURCES & CONFIDENCE ───────── -->
+  <section class="panel" id="p-src">
+    <h2>Who says what — consensus matrix</h2>
+    <div class="card" style="overflow-x:auto"><table>
+      <tr><th>Authority</th><th class="c">Introduce ~6mo / don't delay</th><th class="c">Early wheat <i>prevents</i> wheat allergy</th></tr>
+      <tr><td>AAP / HealthyChildren</td><td class="c yes">✓</td><td class="c no">✗ not claimed</td></tr>
+      <tr><td>UK NHS (lists gluten: wheat, barley, rye)</td><td class="c yes">✓</td><td class="c no">✗ not claimed</td></tr>
+      <tr><td>ASCIA (Australasia)</td><td class="c yes">✓</td><td class="c no">✗ not claimed</td></tr>
+      <tr><td>US NIAID (2017)</td><td class="c yes">✓</td><td class="c no">✗ not claimed</td></tr>
+      <tr><td>EAT trial (NEJM 2016)</td><td class="c dash">— (tested it)</td><td class="c no">✗ NULL for wheat</td></tr>
+      <tr><td>ESPGHAN 2016 <i>(celiac/gluten lane)</i></td><td class="c dash">— gluten 4–12mo</td><td class="c dash">— (celiac doc, not allergy)</td></tr>
+    </table>
+    <p style="font-size:12px;color:var(--mid);margin:6px 0 0">Every body supports introduce-early / don't-delay; <b>no body claims early wheat prevents wheat allergy</b>, and EAT is the direct null evidence. ESPGHAN belongs only in the celiac/gluten-timing lane (4–12-month window), never as allergy-prevention evidence.</p>
+    </div>
+
+    <h2>Sources</h2>
+    <div class="card" style="overflow-x:auto"><table>
+      <tr><th>Authority</th><th>Link</th></tr>
+      <tr><td>NEJM/PubMed — EAT trial (2016) "no significant effects… milk, sesame, fish, or wheat"</td><td><a href="https://pubmed.ncbi.nlm.nih.gov/26943128/">pubmed.ncbi.nlm.nih.gov/26943128</a></td></tr>
+      <tr><td>ESPGHAN 2016 — gluten introduction position paper <i>(celiac document)</i></td><td><a href="https://pubmed.ncbi.nlm.nih.gov/26815017/">pubmed.ncbi.nlm.nih.gov/26815017</a></td></tr>
+      <tr><td>AAP / HealthyChildren — introduce wheat (allergy commonly outgrown)</td><td><a href="https://www.healthychildren.org/English/tips-tools/ask-the-pediatrician/Pages/When-should-I-introduce-wheat-into-my-babys-diet.aspx">healthychildren.org/…/wheat</a></td></tr>
+      <tr><td>NIAID (2017) — early allergen introduction addendum</td><td><a href="https://pmc.ncbi.nlm.nih.gov/articles/PMC5226648/">pmc.ncbi.nlm.nih.gov/…/PMC5226648</a></td></tr>
+      <tr><td>UK NHS — food allergies in babies (lists gluten: wheat, barley, rye)</td><td><a href="https://www.nhs.uk/conditions/baby/weaning-and-feeding/food-allergies-in-babies-and-young-children/">nhs.uk/…/food-allergies</a></td></tr>
+      <tr><td>ASCIA — infant feeding &amp; allergy prevention</td><td><a href="https://www.allergy.org.au/hp/papers/infant-feeding-and-allergy-prevention">allergy.org.au/…/infant-feeding</a></td></tr>
+      <tr><td>WHO — complementary feeding 6–23 months</td><td><a href="https://www.ncbi.nlm.nih.gov/books/NBK596423/">ncbi.nlm.nih.gov/books/NBK596423</a></td></tr>
+      <tr><td>Solid Starts — Wheat</td><td><a href="https://solidstarts.com/foods/wheat/">solidstarts.com/foods/wheat</a></td></tr>
+      <tr><td>Solid Starts — Bread (toast vs soft-bread choking)</td><td><a href="https://solidstarts.com/foods/bread/">solidstarts.com/foods/bread</a></td></tr>
+      <tr><td>CHOP — Wheat allergy</td><td><a href="https://www.chop.edu/conditions-diseases/wheat-allergy">chop.edu/…/wheat-allergy</a></td></tr>
+      <tr><td>Mayo Clinic — Wheat allergy</td><td><a href="https://www.mayoclinic.org/diseases-conditions/wheat-allergy/symptoms-causes/syc-20378897">mayoclinic.org/…/wheat-allergy</a></td></tr>
+      <tr><td>FARE — Wheat (aliases)</td><td><a href="https://www.foodallergy.org/living-food-allergies/food-allergy-essentials/common-allergens/wheat">foodallergy.org/…/wheat</a></td></tr>
+      <tr><td>FAACT — Wheat (aliases)</td><td><a href="https://www.foodallergyawareness.org/food-allergy-and-anaphylaxis/food-allergens/wheat/">foodallergyawareness.org/…/wheat</a></td></tr>
+    </table></div>
+    <div class="flag"><b>⚑ Open gaps:</b> <b>(1)</b> EAT wheat-null and ESPGHAN's gluten window are verified verbatim from PubMed; <b>(2)</b> choking-form cautions (soft-bread clump, loose-grain scatter) and softened-roti/suji/dalia forms rest on secondary sources (Solid Starts, culturally derived), flagged; <b>(3)</b> the FSSAI label-regime claim needs primary-FSSAI confirmation before any verbatim citation; <b>(4)</b> <b>no India-specific (IAP/MoHFW) early-allergen or wheat directive was located</b> — the "introduce ~6mo, don't delay" posture is borrowed from AAP/NHS/ASCIA/NIAID, never to be laundered onto an Indian body; <b>(5)</b> hard line — <b>no overclaim:</b> early wheat must never be said to <i>prevent</i> wheat allergy.</div>
+  </section>
+
+  <!-- ───────── DATA STUB ───────── -->
+  <section class="panel" id="p-data"><h2>Drop-in record — <code>FOOD_EFFECTS['wheat']</code></h2>
+    <p style="font-size:13.5px;color:var(--mid)">Mirror of this food's record in <code>food-effects.manifest.js</code>. Sits alongside <code>AGE_RULES</code>/<code>ALLERGENS</code>. The <code>myth</code> field carries the allergy-vs-celiac clarifier; <code>earlyIntroBenefit</code> is framed honestly (EAT null). <b>Not yet wired.</b></p>
+<pre>{
+  food:          'wheat',
+  aliases:       ['atta','maida','wheat flour','suji','sooji','rava','semolina','dalia','broken wheat','roti','chapati','phulka','paratha','naan','bread','pasta','sevai','vermicelli','durum','couscous','bulgur','seitan'],
+  foodClass:     'allergen-introduce-early',
+  severity:      'caution',
+  category:      'grain',
+  effect:        'food allergy (distinct from celiac disease)',
+  minMonth:      6,
+  thresholdBasis:'developmental-readiness',
+  allergen:      true,
+  reactionType:  ['allergy'],
+  headline:      'Introduce around 6 months — don\'t delay. Soft cereal or softened roti.',
+  whyGood:       'Staple grain — soft wheat cereal, well-cooked pasta, or softened roti; introduce early alongside other solids.',
+  earlyIntroBenefit: { claim:'Introduce around 6 months; don\'t delay.',
+                       evidence:'AAP/NHS/ASCIA advise early introduction; EAT (NEJM 2016) verified NO significant prevention effect for wheat — early intro is SAFE but does NOT prevent wheat allergy.',
+                       paradigm:'Don\'t delay — but no proven wheat-specific prevention claim.' },
+  safeForm:      { ok:['soft wheat / multigrain cereal or porridge','well-cooked soft pasta','roti / chapati torn small and softened in milk, dal, or sabzi','suji / dalia cooked soft'],
+                   never:['large or doughy bread pieces (fresh soft bread balls up into a sticky clump — toast it or use firm strips)','loose cooked wheat / dalia that scatters in the mouth (mash or bind it)'],
+                   note:'Wheat ALLERGY is separate from celiac disease — see myth.' },
+  myth:          { claim:'Wheat allergy and gluten intolerance / celiac disease are the same.',
+                   truth:'Different conditions — wheat allergy is an immune (IgE) food allergy with rapid reactions; celiac is a separate autoimmune reaction to gluten needing medical diagnosis, not emergency care. This record is about wheat allergy.' },
+  watchFor:      ['hives / rash','swelling (mouth, eyes, lips)','vomiting or diarrhoea','eczema flare'],
+  severeSigns:   ['trouble breathing / wheeze','face/lip/tongue swelling','floppy, pale, or very sleepy'],
+  timeCourse:    'minutes to ~2 hours after eating; anaphylaxis often within 5–30 min',
+  seekCare:      'Mild single-system: stop, monitor, call doctor. Any breathing trouble, face/throat swelling, or floppiness: EMERGENCY — call 112, use prescribed adrenaline auto-injector. (Celiac is NOT an emergency — chronic; needs a doctor\'s diagnosis.)',
+  breastfeedingSafe: true,
+  culturalNote:  'Atta, maida, suji/rava, dalia, sevai are all wheat. Soft cereal and softened roti are ideal early forms. Wheat allergy is commonly outgrown in early childhood.',
+  confidence:    'high',
+  sources:       ['AAP','UK NHS','ASCIA','NIAID 2017','NEJM EAT 2016','ESPGHAN 2016 (celiac/gluten)'],
+  dashboard:     'wheat-infant-safety.visual.html',
+  brief:         'wheat-infant-safety.md',
+  longform:      'wheat-infant-safety.html',
+  lastReviewed:  '2026-06-01',
+}</pre>
+    <div class="flag good"><b>Surfacing hook:</b> an <b>encourage</b> card (sage, severity:'caution'), not a rose acute-toxin warn. Introduce-early banner → safe-form (softened roti/cereal vs doughy-bread choke) → the unconditional severe-reaction strip → the <b>myth</b> clarifier (wheat allergy ≠ celiac) so a chronic-condition worry never rides the anaphylaxis rail.</div>
+  </section>
+
+  <p class="foot">SproutLab · Care visual dashboard · skim layer over <code>wheat-infant-safety.md</code> / <code>.html</code> · 2026-06-01<br>
+  Informational, not medical advice. Not yet wired into the app. All chart values are also in text for machine-reading.</p>
+</div>
+
+<script>
+  var tabs = Array.prototype.slice.call(document.querySelectorAll('.tab'));
+  function activate(t){
+    if(!t) return;
+    tabs.forEach(function(x){x.classList.remove('on');});
+    document.querySelectorAll('.panel').forEach(function(x){x.classList.remove('on');});
+    t.classList.add('on');
+    var el = document.getElementById(t.dataset.p); if(el) el.classList.add('on');
+    t.scrollIntoView({inline:'center', block:'nearest'}); window.scrollTo(0,0);
+  }
+  tabs.forEach(function(t){ t.addEventListener('click', function(){ activate(t); }); });
+  document.querySelectorAll('[data-go]').forEach(function(j){
+    j.addEventListener('click', function(){ activate(document.querySelector('.tab[data-p="'+j.dataset.go+'"]')); });
+  });
+  function step(d){ var c=tabs.findIndex(function(t){return t.classList.contains('on');}); var n=c+d; if(n>=0&&n<tabs.length) activate(tabs[n]); }
+  var sx=0, sy=0, tracking=false;
+  document.addEventListener('touchstart', function(e){ if(e.touches.length>1){tracking=false;return;} sx=e.changedTouches[0].clientX; sy=e.changedTouches[0].clientY; tracking=true; }, {passive:true});
+  document.addEventListener('touchend', function(e){
+    if(!tracking) return; tracking=false;
+    var dx=e.changedTouches[0].clientX-sx, dy=e.changedTouches[0].clientY-sy;
+    if(Math.abs(dx) < 55 || Math.abs(dx) < Math.abs(dy)*1.5) return;
+    step(dx < 0 ? 1 : -1);
+  }, {passive:true});
+  document.addEventListener('keydown', function(e){ if(e.key==='ArrowRight') step(1); else if(e.key==='ArrowLeft') step(-1); });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Phase δ renders — egg/soy/wheat/sesame dashboards + long-forms (+ animated template)

Completes the **3-layer set** (`.md` → `.html` → `.visual.html`) for the four Phase-δ allergen briefs, and adds entrance animations to the canonical dashboard template.

### What's here (9 files)
- **Template** — `_TEMPLATE.food-dashboard.html` gains five **CSS-only entrance animations** (bar-grow via scaleX, staggered stat/timeline/therm rise, donut sweep, flag slide), all gated behind `prefers-reduced-motion`, re-triggering on each tab visit. Per the template's own rule (improve a component → update the template), the four dashboards inherit it.
- **4 skim dashboards** (`<food>-infant-safety.visual.html`) — tabs/swipe/charts; each copies the template `<style>`/`<script>` **byte-identical** (verified by diff — no tampering).
- **4 long-forms** (`<food>-infant-safety.html`) — styled prose renders of each `.md`.
- **Manifest** — dropped the now-stale "render pending" notes.

### Per-food centerpieces (figures pulled only from the verified `.md`)
- **Egg** — confident **tier-1** framing: PETIT 38%→8% + EAT bars; "usually outgrown"; fully-cooked / no-Lion-mark-in-India rule.
- **Soy** — twin **IgE / FPIES** timeline (delayed 1–4h branch) + the **soy-formula ≠ soy-food** trap.
- **Wheat** — the **three-concept split** (wheat allergy / celiac / gluten-timing) as the visual centerpiece.
- **Sesame** — **~70–80%-persist donut** + gravest emergency tone; FASTER-Act context.

### Honesty verification
The tier-2 discipline survived rendering: in soy/wheat/sesame dashboards, **every "prevents" string is a negation** ("Never claim early sesame prevents sesame allergy"), and the consensus matrices mark prevention as ✗/not-claimed with EAT as the null row. Verified by context-grep, not trust (the scribe drafts were ground-truth-checked).

### Verification
Scripts diff byte-identical to template across all four dashboards; animation block present in each; manifest validates (7 records, 0 malformed); both sampled dashboards confirmed to render via headless screenshot.

### Scope / process
**Docs-only ⇒ canon-cc-008 Governor audit waived** (research layer, `docs/research/`, not wired into the app). The gated build phase remains: wiring the four `FOOD_EFFECTS` records into `data.js` + the polarity-aware banner in `diet.js` (triple-Gov).

https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK)_