### PR TITLE
food-effects-v2 Phase δ: wire egg/soy/wheat/sesame + polarity-aware banner

### DIFF
--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-06-01 &middot; graph @ <code>40bfe45dcec5</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-01 &middot; graph @ <code>3264fea334b7</code></div>
   <div class="sub" style="margin-top:8px">
     <span class="stat"><b>1,721</b> symbols</span>
     <span class="stat"><b>5,124</b> relations</span>
-    <span class="stat"><b>80,806</b> LOC</span>
+    <span class="stat"><b>80,817</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -65,14 +65,14 @@
       <div class="nums">
         <span><b>11</b> modules</span>
         <span><b>731</b> symbols</span>
-        <span><b>27,290</b> LOC</span>
+        <span><b>27,299</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,290 of 30,000 LOC">
+      <div class="bar" title="27,299 of 30,000 LOC">
         <div class="fill hot" style="width:91%"></div>
         <span class="barlbl">91% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,710 LOC headroom</div>
+      <div class="hd">2,701 LOC headroom</div>
       <div class="mods">core.js, i-illness.js, i-caretickets.js, i-qa-handlers.js, sync.js, data.js, i-qa.js, i-isl.js, config.js, i-correlate.js, start.js</div>
     </div>
     <div class="card" style="border-top:5px solid #b5d5c5">
@@ -99,14 +99,14 @@
       <div class="nums">
         <span><b>2</b> modules</span>
         <span><b>185</b> symbols</span>
-        <span><b>8,645</b> LOC</span>
+        <span><b>8,647</b> LOC</span>
       </div>
       
-      <div class="bar" title="8,645 of 30,000 LOC">
+      <div class="bar" title="8,647 of 30,000 LOC">
         <div class="fill " style="width:29%"></div>
         <span class="barlbl">29% to 30K frontier</span>
       </div>
-      <div class="hd">21,355 LOC headroom</div>
+      <div class="hd">21,353 LOC headroom</div>
       <div class="mods">i-quicklog.js, i-cards.js</div>
     </div>
     <div class="card" style="border-top:5px solid #e8b86d">

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-06-01 &middot; graph @ <code>a6207d0b0e99</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-01 &middot; graph @ <code>40bfe45dcec5</code></div>
   <div class="sub" style="margin-top:8px">
     <span class="stat"><b>1,721</b> symbols</span>
-    <span class="stat"><b>5,123</b> relations</span>
-    <span class="stat"><b>80,641</b> LOC</span>
+    <span class="stat"><b>5,124</b> relations</span>
+    <span class="stat"><b>80,806</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -65,14 +65,14 @@
       <div class="nums">
         <span><b>11</b> modules</span>
         <span><b>731</b> symbols</span>
-        <span><b>27,151</b> LOC</span>
+        <span><b>27,290</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,151 of 30,000 LOC">
+      <div class="bar" title="27,290 of 30,000 LOC">
         <div class="fill hot" style="width:91%"></div>
         <span class="barlbl">91% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,849 LOC headroom</div>
+      <div class="hd">2,710 LOC headroom</div>
       <div class="mods">core.js, i-illness.js, i-caretickets.js, i-qa-handlers.js, sync.js, data.js, i-qa.js, i-isl.js, config.js, i-correlate.js, start.js</div>
     </div>
     <div class="card" style="border-top:5px solid #b5d5c5">
@@ -82,14 +82,14 @@
       <div class="nums">
         <span><b>3</b> modules</span>
         <span><b>668</b> symbols</span>
-        <span><b>27,117</b> LOC</span>
+        <span><b>27,126</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,117 of 30,000 LOC">
+      <div class="bar" title="27,126 of 30,000 LOC">
         <div class="fill hot" style="width:90%"></div>
         <span class="barlbl">90% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,883 LOC headroom</div>
+      <div class="hd">2,874 LOC headroom</div>
       <div class="mods">home.js, medical.js, diet.js</div>
     </div>
     <div class="card" style="border-top:5px solid #c9b8e8">
@@ -99,14 +99,14 @@
       <div class="nums">
         <span><b>2</b> modules</span>
         <span><b>185</b> symbols</span>
-        <span><b>8,632</b> LOC</span>
+        <span><b>8,645</b> LOC</span>
       </div>
       
-      <div class="bar" title="8,632 of 30,000 LOC">
+      <div class="bar" title="8,645 of 30,000 LOC">
         <div class="fill " style="width:29%"></div>
         <span class="barlbl">29% to 30K frontier</span>
       </div>
-      <div class="hd">21,368 LOC headroom</div>
+      <div class="hd">21,355 LOC headroom</div>
       <div class="mods">i-quicklog.js, i-cards.js</div>
     </div>
     <div class="card" style="border-top:5px solid #e8b86d">
@@ -116,7 +116,7 @@
       <div class="nums">
         <span><b>2</b> modules</span>
         <span><b>0</b> symbols</span>
-        <span><b>14,043</b> LOC</span>
+        <span><b>14,047</b> LOC</span>
       </div>
       <div class="note">Unsurveyed &mdash; code-only extraction. Set a backend and rebuild for symbols.</div>
       <div class="mods">styles.css, template.html</div>
@@ -137,7 +137,7 @@
   <h2>Cross-province coupling (highest-traffic calls across jurisdiction borders)</h2>
   <table>
     <thead><tr><th>Module</th><th>Module</th><th class="num">Calls</th><th>Border</th></tr></thead>
-    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">122</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">44</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
+    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">123</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">44</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
   </table>
 
   <h2>Connectivity hubs (highest call-degree symbols per module)</h2>

--- a/index.html
+++ b/index.html
@@ -16611,7 +16611,10 @@ const AGE_RULES = {
                 reason:'Fine from around 6 months — soft tofu or well-mashed soya. Whole edamame is a choking risk; mash it.' },
   'wheat':    { minMonth:6, aliases:['atta','maida','wheat flour','suji','sooji','rava','semolina','dalia','broken wheat','roti','chapati','phulka','paratha','naan','pasta','sevai','vermicelli','durum','couscous','bulgur','seitan'],
                 reason:'Fine from around 6 months — soft cereal or softened roti. Wheat allergy is separate from celiac disease.' },
-  'sesame':   { minMonth:6, aliases:['til','tahini','gingelly','gingelly oil','sesame seeds','sesame oil','sim sim','benne','gomashio','hummus','halva','halwa','gajak','til laddoo'],
+  'sesame':   { minMonth:6, aliases:['til','tahini','gingelly','gingelly oil','sesame seeds','sesame oil','sim sim','benne','gomashio','hummus','gajak','til laddoo'],
+                // 'halva'/'halwa' deliberately NOT aliases — they collide with carrot/banana/
+                // ragi/suji halwa (Kael B-1); til-halwa is covered by 'til'. Suji halwa still
+                // resolves to wheat via 'suji', correctly.
                 reason:'Fine from around 6 months — as smooth tahini thinned into food, not whole seeds.' },
 };
 
@@ -16655,6 +16658,7 @@ const FOOD_EFFECTS = {
       paradigm: 'This reverses the old "delay nuts to avoid allergy" advice.',
     },
     safeForm: {
+      glance:   'Ground or smooth — never whole',   // ≤44-char card-glance cue (Vela V-V-208-3)
       ok:       ['smooth peanut butter thinned with milk, water, or puree', 'finely ground peanut or peanut flour stirred into food'],
       never:    ['whole peanuts', 'chopped peanuts', 'a thick glob of nut butter'],
       chokingUntilYears: 5,
@@ -16687,6 +16691,7 @@ const FOOD_EFFECTS = {
       paradigm: 'This reverses the old "delay nuts to avoid allergy" advice.',
     },
     safeForm: {
+      glance:   'Ground or smooth paste — never whole',
       ok:       ['finely ground nuts or nut powder stirred into food', 'smooth nut butter or paste thinned', 'traditional soaked, peeled, ground almond (badam) paste'],
       never:    ['whole nuts', 'chopped nuts', 'a thick glob of nut butter'],
       chokingUntilYears: 5,
@@ -16728,6 +16733,7 @@ const FOOD_EFFECTS = {
       paradigm: 'This reverses the old "delay egg to avoid allergy" advice.',
     },
     safeForm: {
+      glance:   'Well-cooked; yolk first',
       ok:       ['well-cooked egg — mashed hard-boiled or scrambled', 'cooked yolk first, then whole egg once that is tolerated', 'egg baked into soft food'],
       never:    ['raw or runny egg', 'lightly-cooked egg (no assured-egg scheme exists in India)'],
       note:     'Cook until both white and yolk are solid — this is the studied safe form and avoids the salmonella risk. Raw or runny egg is not safe for a baby.',
@@ -16759,6 +16765,7 @@ const FOOD_EFFECTS = {
       paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
     },
     safeForm: {
+      glance:   'Soft tofu — not whole edamame',
       ok:       ['soft or silken tofu, smushable or blended', 'well-cooked soybeans, mashed', 'soy yoghurt, or soya stirred into food'],
       never:    ['whole edamame or whole soybeans (round and firm — a choking risk)', 'soy milk as a main drink in the first year'],
       note:     'Soft tofu needs no special prep. Shell and mash edamame; soy milk is not a substitute for breastmilk or formula.',
@@ -16770,7 +16777,7 @@ const FOOD_EFFECTS = {
       thenWhat: 'if it goes well, keep offering as part of the normal diet',
       oneAtATime: true,
     },
-    watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting or diarrhoea'],
+    watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting or diarrhoea', 'forceful or repeated vomiting a few hours after eating, not just right away (possible FPIES)'],
     severeSigns:['trouble breathing or wheezing', 'swelling of the face, lips, or tongue', 'going floppy, pale, or very sleepy', 'repeated forceful vomiting with paleness or floppiness a few hours later (possible FPIES)'],
     seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away. Repeated forceful vomiting with paleness or floppiness a few hours after soy (possible FPIES): seek urgent care even without a rash.',
     confidence: 'high',
@@ -16789,6 +16796,7 @@ const FOOD_EFFECTS = {
       paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
     },
     safeForm: {
+      glance:   'Soft cereal or softened roti',
       ok:       ['soft wheat or multigrain cereal or porridge', 'well-cooked soft pasta', 'roti or chapati torn small and softened in milk, dal, or sabzi'],
       never:    ['large or doughy pieces of fresh bread (they ball up into a sticky clump — toast it or use firm strips)', 'loose dry cooked wheat or dalia that scatters in the mouth (mash or bind it)'],
       note:     'Wheat allergy is not the same as celiac disease — this is about the allergy.',
@@ -16808,7 +16816,7 @@ const FOOD_EFFECTS = {
   'sesame': {
     foodClass:  'allergen-introduce-early',
     severity:   'caution',
-    aliases:    ['til', 'tahini', 'gingelly', 'gingelly oil', 'sesame seeds', 'sesame oil', 'sim sim', 'benne', 'gomashio', 'hummus', 'halva', 'halwa', 'gajak', 'til laddoo'],
+    aliases:    ['til', 'tahini', 'gingelly', 'gingelly oil', 'sesame seeds', 'sesame oil', 'sim sim', 'benne', 'gomashio', 'hummus', 'gajak', 'til laddoo'],  // no 'halva'/'halwa' — collides with carrot/banana/ragi halwa (Kael B-1)
     effect:     'food allergy (often lifelong)',
     title:      'Sesame — introduce early, as thinned tahini',
     why:        'Around 6 months, sesame is good to introduce — best as smooth tahini (sesame paste) thinned into food, not whole seeds or a thick glob. There is no reason to delay it. Sesame allergy tends to be lifelong, so watch the first tastes closely and keep an eye out as you continue.',
@@ -16819,6 +16827,7 @@ const FOOD_EFFECTS = {
       paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
     },
     safeForm: {
+      glance:   'Thinned tahini — not whole seeds',
       ok:       ['smooth tahini (sesame paste) thinned with water, milk, or puree', 'finely ground sesame stirred into food'],
       never:    ['a thick glob of tahini (sticky — a choking risk; thin it like nut butter)', 'whole sesame seeds in quantity for a young baby'],
       chokingUntilYears: 4,
@@ -69661,10 +69670,11 @@ var AI_ALLERGEN_SET = [
 //   returns FOOD_EFFECTS records by reference (module-level singletons) — every
 //   getFoodEffect("almond")/("tree nut") yields the identical object. A future
 //   refactor that clones records would silently break this; keep it by-ref.
-//   LIMITATION (spec §6/§9): culinary synonyms with no alias table — "tofu"→soy,
-//   "roti"→wheat, "scrambled egg"→egg — do not resolve on EITHER reader (the app
-//   has no such alias data anywhere). Both readers agree on the miss, so the card
-//   stays internally consistent; closing the gap is a data.js alias-table task.
+//   Culinary synonyms RESOLVE as of food-effects-v2 Phase δ — the egg/soy/wheat/
+//   sesame FOOD_EFFECTS records carry culinary-rich aliases (tofu→soy, roti→wheat,
+//   til→sesame, anda→egg), so getFoodEffect now matches them on both readers.
+//   (Residual: a few unauthored synonyms still miss; both readers agree on any miss,
+//   so the card stays internally consistent.)
 function _aiFoodMatches(foodName, canonEff, base) {
   if (!foodName) return false;
   var fn = String(foodName).toLowerCase().trim();
@@ -69733,12 +69743,13 @@ function _aiComputeAllergenIntro() {
     // safe-form note: FOOD_EFFECTS note (peanut/tree-nut) preferred; else the
     // allergen's own AGE_RULES `reason` (egg's "cook well, yolk first" floor) —
     // never the generic "in a safe form" where a real per-food floor exists (Maren M-1).
-    // The `reason` is a full age-gate sentence-pair; surface only its first
-    // sentence on the one-line glance so it doesn't wrap (the full floor rides
-    // the tap-through detail sheet). Phase δ will replace this with a crisp
-    // FOOD_EFFECTS `safeForm.note` authored for the row.
+    // Prefer the crisp authored `safeForm.glance` (≤44, Phase δ / Vela V-V-208-3) —
+    // the per-food row cue; fall back to the full `note` (the length-gate routes it
+    // to the tap-through), then to the AGE_RULES reason's first sentence.
     var reasonShort = (ageRule && ageRule.reason) ? String(ageRule.reason).split('. ')[0] : null;
-    var safeForm = (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : reasonShort;
+    var safeForm = (eff && eff.safeForm && eff.safeForm.glance) ? eff.safeForm.glance
+                 : (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note
+                 : reasonShort;
     return { key: a.key, label: a.label, introMonth: introMonth, ageReady: ageReady,
              tried: !!rec, date: (rec && rec.date) || null, daysSince: daysSince,
              exposureDays: exposureDays, state: state, safeForm: safeForm };

--- a/index.html
+++ b/index.html
@@ -10773,6 +10773,10 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 .fd-tried-btn { white-space:nowrap; }
 .fd-flag { display:flex; align-items:flex-start; gap:var(--sp-6); padding:var(--sp-8) var(--sp-12); border-radius:var(--r-lg); margin-bottom:var(--sp-8); font-size:var(--fs-sm); line-height:var(--lh-relaxed); }
 .fd-flag-allergen { background:var(--rose-light); color:var(--tc-rose); }
+/* encourage polarity (food-effects-v2): introduce-early allergens read sage/calm,
+   NOT rose/alarm. Rose (.fd-flag-allergen) is reserved for true "avoid". The
+   severe-reaction floor below the banner stays serious regardless. */
+.fd-flag-encourage { background:var(--sage-light); color:var(--tc-sage); }
 .fd-flag-aged { background:var(--peach-light); color:var(--tc-caution); }
 .fd-flag-neutral { background:var(--glass-strong); color:var(--mid); }
 .fd-section { margin-top:var(--sp-12); }
@@ -16601,6 +16605,14 @@ const AGE_RULES = {
   'corn':     { minMonth:8, reason:'Hard to digest whole. After 8 months, use corn flour or well-mashed sweet corn.' },
   'spinach':  { minMonth:7, reason:'Contains oxalates — blanch before use. Fine from 7 months in small amounts.' },
   'bajra':    { minMonth:7, reason:'A warming millet — better after 7 months, avoid in very hot weather.' },
+  // food-effects-v2 Phase δ allergen gates (egg already above). minMonth:6 follows
+  // AAP/NHS/ASCIA (~6mo, don't delay); each backs a FOOD_EFFECTS record below.
+  'soy':      { minMonth:6, aliases:['soya','soybean','soya bean','tofu','edamame','soya chunks','soya granules','soya nuggets','soy milk','soya milk','tempeh','miso','natto','tamari'],
+                reason:'Fine from around 6 months — soft tofu or well-mashed soya. Whole edamame is a choking risk; mash it.' },
+  'wheat':    { minMonth:6, aliases:['atta','maida','wheat flour','suji','sooji','rava','semolina','dalia','broken wheat','roti','chapati','phulka','paratha','naan','pasta','sevai','vermicelli','durum','couscous','bulgur','seitan'],
+                reason:'Fine from around 6 months — soft cereal or softened roti. Wheat allergy is separate from celiac disease.' },
+  'sesame':   { minMonth:6, aliases:['til','tahini','gingelly','gingelly oil','sesame seeds','sesame oil','sim sim','benne','gomashio','hummus','halva','halwa','gajak','til laddoo'],
+                reason:'Fine from around 6 months — as smooth tahini thinned into food, not whole seeds.' },
 };
 
 // ── FOOD EFFECTS (consequence layer — Finding A) ──
@@ -16691,6 +16703,137 @@ const FOOD_EFFECTS = {
     watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting'],
     severeSigns:['trouble breathing or wheezing', 'swelling of the face, lips, or tongue', 'going floppy, pale, or very sleepy'],
     seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away and use a prescribed adrenaline auto-injector if you have one.',
+    confidence: 'high',
+  },
+
+  // ── food-effects-v2 Phase δ: egg, soy, wheat, sesame ──
+  // The four remaining big-9 allergens, reached by `aliases` via _lookupByFoodName
+  // (closes the culinary-synonym gap: tofu→soy, roti→wheat, til→sesame, anda→egg).
+  // All allergen-introduce-early (encourage, sage chrome — NOT honey's rose).
+  // TWO-TIER honesty (docs/research/<food>-infant-safety.md): EGG is prevention-
+  // PROVEN (PETIT/EAT) and claims it; SOY/WHEAT/SESAME are introduce-early-and-safe
+  // but earlyIntroBenefit says so plainly — EAT was null for them, so NO prevention
+  // claim. severity:'caution' (amber/sage), never 'critical' (rose = acute-toxin).
+  'egg': {
+    foodClass:  'allergen-introduce-early',
+    severity:   'caution',
+    aliases:    ['eggs', 'anda', 'egg yolk', 'whole egg', 'boiled egg', 'hard-boiled egg', 'scrambled egg', 'omelette', 'omelet'],
+    effect:     'food allergy',
+    title:      'Egg — good to introduce early, well-cooked',
+    why:        'Around 6–7 months, well-cooked egg is worth introducing — not avoiding. Introducing egg early and keeping it regular lowers the chance of an egg allergy. Give it fully cooked (solid white and yolk), starting with the yolk.',
+    whyGood:    'Complete protein, choline, iron and vitamin D — and early, regular well-cooked egg helps prevent egg allergy.',
+    earlyIntroBenefit: {
+      claim:    'Introducing well-cooked egg early and keeping it in the diet helps prevent egg allergy.',
+      evidence: 'In a randomised trial (PETIT, 2017) of higher-risk babies, heated egg from about 6 months — with eczema kept under control — cut egg allergy at 12 months from 38% to 8%.',
+      paradigm: 'This reverses the old "delay egg to avoid allergy" advice.',
+    },
+    safeForm: {
+      ok:       ['well-cooked egg — mashed hard-boiled or scrambled', 'cooked yolk first, then whole egg once that is tolerated', 'egg baked into soft food'],
+      never:    ['raw or runny egg', 'lightly-cooked egg (no assured-egg scheme exists in India)'],
+      note:     'Cook until both white and yolk are solid — this is the studied safe form and avoids the salmonella risk. Raw or runny egg is not safe for a baby.',
+    },
+    howToIntroduce: {
+      amount:   'start with a little well-cooked yolk',
+      when:     'at home, in the morning or midday',
+      watch:    'watch for about 2 hours after',
+      thenWhat: 'if it goes well, keep offering regularly; move to whole egg once yolk is tolerated',
+      oneAtATime: true,
+      highRiskNote: 'If your baby has severe eczema or a known food allergy, talk to your paediatrician before the first taste.',
+    },
+    watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting'],
+    severeSigns:['trouble breathing or wheezing', 'swelling of the face, lips, or tongue', 'going floppy, pale, or very sleepy'],
+    seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away and use a prescribed adrenaline auto-injector if you have one.',
+    confidence: 'high',
+  },
+  'soy': {
+    foodClass:  'allergen-introduce-early',
+    severity:   'caution',
+    aliases:    ['soya', 'soybean', 'soya bean', 'tofu', 'edamame', 'soya chunks', 'soya granules', 'soya nuggets', 'soy milk', 'soya milk', 'tempeh', 'miso', 'natto', 'tamari'],
+    effect:     'food allergy (including FPIES)',
+    title:      'Soy — fine to introduce early, as soft tofu',
+    why:        'Around 6 months, soy is fine to introduce alongside other foods — there is no reason to delay it. Soft tofu and well-mashed soya are valuable plant protein, especially in a vegetarian diet. Whole edamame beans are a choking risk, so mash them.',
+    whyGood:    'Valuable plant protein for a vegetarian diet — tofu and soya chunks are everyday staples.',
+    earlyIntroBenefit: {
+      claim:    'Introduce soy around 6 months — there is no reason to delay it.',
+      evidence: 'Guidelines (AAP, NHS, ASCIA) advise introducing soy early along with other allergens. Early introduction is safe — but, unlike peanut and egg, there is no trial proof that early soy prevents soy allergy.',
+      paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
+    },
+    safeForm: {
+      ok:       ['soft or silken tofu, smushable or blended', 'well-cooked soybeans, mashed', 'soy yoghurt, or soya stirred into food'],
+      never:    ['whole edamame or whole soybeans (round and firm — a choking risk)', 'soy milk as a main drink in the first year'],
+      note:     'Soft tofu needs no special prep. Shell and mash edamame; soy milk is not a substitute for breastmilk or formula.',
+    },
+    howToIntroduce: {
+      amount:   'start with a small amount of soft tofu',
+      when:     'at home, in the morning or midday',
+      watch:    'watch for about 2 hours after — and note any delayed upset (see below)',
+      thenWhat: 'if it goes well, keep offering as part of the normal diet',
+      oneAtATime: true,
+    },
+    watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting or diarrhoea'],
+    severeSigns:['trouble breathing or wheezing', 'swelling of the face, lips, or tongue', 'going floppy, pale, or very sleepy', 'repeated forceful vomiting with paleness or floppiness a few hours later (possible FPIES)'],
+    seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away. Repeated forceful vomiting with paleness or floppiness a few hours after soy (possible FPIES): seek urgent care even without a rash.',
+    confidence: 'high',
+  },
+  'wheat': {
+    foodClass:  'allergen-introduce-early',
+    severity:   'caution',
+    aliases:    ['atta', 'maida', 'wheat flour', 'suji', 'sooji', 'rava', 'semolina', 'dalia', 'broken wheat', 'roti', 'chapati', 'phulka', 'paratha', 'naan', 'pasta', 'sevai', 'vermicelli', 'durum', 'couscous', 'bulgur', 'seitan'],
+    effect:     'food allergy (different from celiac disease)',
+    title:      'Wheat — fine to introduce early, soft-cooked',
+    why:        'Around 6 months, wheat is fine to introduce — soft wheat cereal, well-cooked pasta, or softened roti. There is no benefit to delaying it. Wheat allergy is a food allergy, and is different from celiac disease — a separate, longer-term gluten condition that needs a doctor\'s diagnosis.',
+    whyGood:    'A staple grain — soft cereal, well-cooked pasta, or softened roti, introduced early alongside other solids.',
+    earlyIntroBenefit: {
+      claim:    'Introduce wheat around 6 months — there is no reason to delay it.',
+      evidence: 'Guidelines (AAP, NHS, ASCIA) advise introducing wheat early. Early introduction is safe — but, unlike peanut and egg, a trial (EAT) did not show early wheat prevents wheat allergy.',
+      paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
+    },
+    safeForm: {
+      ok:       ['soft wheat or multigrain cereal or porridge', 'well-cooked soft pasta', 'roti or chapati torn small and softened in milk, dal, or sabzi'],
+      never:    ['large or doughy pieces of fresh bread (they ball up into a sticky clump — toast it or use firm strips)', 'loose dry cooked wheat or dalia that scatters in the mouth (mash or bind it)'],
+      note:     'Wheat allergy is not the same as celiac disease — this is about the allergy.',
+    },
+    howToIntroduce: {
+      amount:   'start with a little soft wheat cereal or softened roti',
+      when:     'at home, in the morning or midday',
+      watch:    'watch for about 2 hours after',
+      thenWhat: 'if it goes well, keep offering as part of the normal diet',
+      oneAtATime: true,
+    },
+    watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting or diarrhoea'],
+    severeSigns:['trouble breathing or wheezing', 'swelling of the face, lips, or tongue', 'going floppy, pale, or very sleepy'],
+    seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away and use a prescribed adrenaline auto-injector if you have one. Ongoing tummy upset, poor growth, or loose stools over weeks is a different concern (celiac) and needs a doctor, not emergency care.',
+    confidence: 'high',
+  },
+  'sesame': {
+    foodClass:  'allergen-introduce-early',
+    severity:   'caution',
+    aliases:    ['til', 'tahini', 'gingelly', 'gingelly oil', 'sesame seeds', 'sesame oil', 'sim sim', 'benne', 'gomashio', 'hummus', 'halva', 'halwa', 'gajak', 'til laddoo'],
+    effect:     'food allergy (often lifelong)',
+    title:      'Sesame — introduce early, as thinned tahini',
+    why:        'Around 6 months, sesame is good to introduce — best as smooth tahini (sesame paste) thinned into food, not whole seeds or a thick glob. There is no reason to delay it. Sesame allergy tends to be lifelong, so watch the first tastes closely and keep an eye out as you continue.',
+    whyGood:    'A seed source of calcium, iron and healthy fats — offer as smooth tahini thinned into food.',
+    earlyIntroBenefit: {
+      claim:    'Introduce sesame around 6 months — there is no reason to delay it.',
+      evidence: 'Guidelines (AAP, NHS, ASCIA) advise introducing sesame early. Early introduction is safe — but, unlike peanut and egg, a trial (EAT) did not show early sesame prevents sesame allergy.',
+      paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
+    },
+    safeForm: {
+      ok:       ['smooth tahini (sesame paste) thinned with water, milk, or puree', 'finely ground sesame stirred into food'],
+      never:    ['a thick glob of tahini (sticky — a choking risk; thin it like nut butter)', 'whole sesame seeds in quantity for a young baby'],
+      chokingUntilYears: 4,
+      note:     'Thin tahini the same way you would thin nut butter. Unrefined gingelly (sesame) oil can still carry the allergen.',
+    },
+    howToIntroduce: {
+      amount:   'start with a little thinned tahini (about 1/8 to 1/2 tsp) stirred into a familiar food',
+      when:     'at home, in the morning or midday',
+      watch:    'watch for about 2 hours after',
+      thenWhat: 'if it goes well, keep offering regularly — and keep watching, as sesame allergy tends to persist',
+      oneAtATime: true,
+    },
+    watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting'],
+    severeSigns:['trouble breathing or wheezing', 'swelling of the face, lips, or tongue', 'going floppy, pale, or very sleepy'],
+    seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away and use a prescribed adrenaline auto-injector if you have one. Sesame is a common cause of severe reactions — watch closely.',
     confidence: 'high',
   },
 };
@@ -38418,14 +38561,23 @@ function renderFoodDetailSheet(name) {
   // Q-3 call; the severe floor's presence is the non-negotiable, M-S-6.)
   const fdEff = (typeof getFoodEffect === 'function') ? getFoodEffect(lower) : null;
   const fdFloor = (fdEff && typeof _severeFloorHtml === 'function') ? _severeFloorHtml(fdEff) : '';
+  // Polarity (food-effects-v2): an introduce-early allergen reads ENCOURAGE —
+  // sage banner + calm sprout icon ("good to introduce, here's the safe form"),
+  // never rose/siren ("don't give"). Rose is reserved for true avoid (acute-toxin).
+  // The severe-reaction floor (fdFloor) below stays serious regardless.
+  const fdEncourage = (typeof _effHasClass === 'function') && _effHasClass(fdEff, 'allergen-introduce-early');
   if (fdFloor) {
     const head = (fdEff && fdEff.title) ? escHtml(fdEff.title) : 'Allergen';
     const sub = (fdEff && fdEff.safeForm && fdEff.safeForm.note) ? escHtml(fdEff.safeForm.note)
               : (allerg ? escHtml(allerg) : '');
-    html += `<div class="fd-flag fd-flag-allergen">${zi('siren')} <span><strong>${head}</strong>${sub ? ' ' + sub : ''}</span></div>`;
+    const flagCls = fdEncourage ? 'fd-flag-encourage' : 'fd-flag-allergen';
+    const flagIc  = fdEncourage ? zi('sprout') : zi('siren');
+    html += `<div class="fd-flag ${flagCls}">${flagIc} <span><strong>${head}</strong>${sub ? ' ' + sub : ''}</span></div>`;
     html += fdFloor; // .cons-severe / .cons-watch / .cons-seek (shared, already-styled)
   } else if (allerg) {
-    html += `<div class="fd-flag fd-flag-allergen">${zi('siren')} <span><strong>Allergen.</strong> ${escHtml(allerg)}</span></div>`;
+    // A milder allergen with no FOOD_EFFECTS record (kiwi, strawberry, oats …):
+    // informational + calm, never the rose alarm. Introduce carefully, watch.
+    html += `<div class="fd-flag fd-flag-neutral">${zi('note')} <span><strong>Allergen.</strong> ${escHtml(allerg)}</span></div>`;
   }
   if (aged) {
     html += `<div class="fd-flag fd-flag-aged">${zi('warn')} <span><strong>Not before ${ageR.minMonth} months.</strong> ${escHtml(ageR.reason)}</span></div>`;

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.01-8",
+  "version": "2026.06.01-9",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/data.js
+++ b/split/data.js
@@ -2448,7 +2448,10 @@ const AGE_RULES = {
                 reason:'Fine from around 6 months — soft tofu or well-mashed soya. Whole edamame is a choking risk; mash it.' },
   'wheat':    { minMonth:6, aliases:['atta','maida','wheat flour','suji','sooji','rava','semolina','dalia','broken wheat','roti','chapati','phulka','paratha','naan','pasta','sevai','vermicelli','durum','couscous','bulgur','seitan'],
                 reason:'Fine from around 6 months — soft cereal or softened roti. Wheat allergy is separate from celiac disease.' },
-  'sesame':   { minMonth:6, aliases:['til','tahini','gingelly','gingelly oil','sesame seeds','sesame oil','sim sim','benne','gomashio','hummus','halva','halwa','gajak','til laddoo'],
+  'sesame':   { minMonth:6, aliases:['til','tahini','gingelly','gingelly oil','sesame seeds','sesame oil','sim sim','benne','gomashio','hummus','gajak','til laddoo'],
+                // 'halva'/'halwa' deliberately NOT aliases — they collide with carrot/banana/
+                // ragi/suji halwa (Kael B-1); til-halwa is covered by 'til'. Suji halwa still
+                // resolves to wheat via 'suji', correctly.
                 reason:'Fine from around 6 months — as smooth tahini thinned into food, not whole seeds.' },
 };
 
@@ -2492,6 +2495,7 @@ const FOOD_EFFECTS = {
       paradigm: 'This reverses the old "delay nuts to avoid allergy" advice.',
     },
     safeForm: {
+      glance:   'Ground or smooth — never whole',   // ≤44-char card-glance cue (Vela V-V-208-3)
       ok:       ['smooth peanut butter thinned with milk, water, or puree', 'finely ground peanut or peanut flour stirred into food'],
       never:    ['whole peanuts', 'chopped peanuts', 'a thick glob of nut butter'],
       chokingUntilYears: 5,
@@ -2524,6 +2528,7 @@ const FOOD_EFFECTS = {
       paradigm: 'This reverses the old "delay nuts to avoid allergy" advice.',
     },
     safeForm: {
+      glance:   'Ground or smooth paste — never whole',
       ok:       ['finely ground nuts or nut powder stirred into food', 'smooth nut butter or paste thinned', 'traditional soaked, peeled, ground almond (badam) paste'],
       never:    ['whole nuts', 'chopped nuts', 'a thick glob of nut butter'],
       chokingUntilYears: 5,
@@ -2565,6 +2570,7 @@ const FOOD_EFFECTS = {
       paradigm: 'This reverses the old "delay egg to avoid allergy" advice.',
     },
     safeForm: {
+      glance:   'Well-cooked; yolk first',
       ok:       ['well-cooked egg — mashed hard-boiled or scrambled', 'cooked yolk first, then whole egg once that is tolerated', 'egg baked into soft food'],
       never:    ['raw or runny egg', 'lightly-cooked egg (no assured-egg scheme exists in India)'],
       note:     'Cook until both white and yolk are solid — this is the studied safe form and avoids the salmonella risk. Raw or runny egg is not safe for a baby.',
@@ -2596,6 +2602,7 @@ const FOOD_EFFECTS = {
       paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
     },
     safeForm: {
+      glance:   'Soft tofu — not whole edamame',
       ok:       ['soft or silken tofu, smushable or blended', 'well-cooked soybeans, mashed', 'soy yoghurt, or soya stirred into food'],
       never:    ['whole edamame or whole soybeans (round and firm — a choking risk)', 'soy milk as a main drink in the first year'],
       note:     'Soft tofu needs no special prep. Shell and mash edamame; soy milk is not a substitute for breastmilk or formula.',
@@ -2607,7 +2614,7 @@ const FOOD_EFFECTS = {
       thenWhat: 'if it goes well, keep offering as part of the normal diet',
       oneAtATime: true,
     },
-    watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting or diarrhoea'],
+    watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting or diarrhoea', 'forceful or repeated vomiting a few hours after eating, not just right away (possible FPIES)'],
     severeSigns:['trouble breathing or wheezing', 'swelling of the face, lips, or tongue', 'going floppy, pale, or very sleepy', 'repeated forceful vomiting with paleness or floppiness a few hours later (possible FPIES)'],
     seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away. Repeated forceful vomiting with paleness or floppiness a few hours after soy (possible FPIES): seek urgent care even without a rash.',
     confidence: 'high',
@@ -2626,6 +2633,7 @@ const FOOD_EFFECTS = {
       paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
     },
     safeForm: {
+      glance:   'Soft cereal or softened roti',
       ok:       ['soft wheat or multigrain cereal or porridge', 'well-cooked soft pasta', 'roti or chapati torn small and softened in milk, dal, or sabzi'],
       never:    ['large or doughy pieces of fresh bread (they ball up into a sticky clump — toast it or use firm strips)', 'loose dry cooked wheat or dalia that scatters in the mouth (mash or bind it)'],
       note:     'Wheat allergy is not the same as celiac disease — this is about the allergy.',
@@ -2645,7 +2653,7 @@ const FOOD_EFFECTS = {
   'sesame': {
     foodClass:  'allergen-introduce-early',
     severity:   'caution',
-    aliases:    ['til', 'tahini', 'gingelly', 'gingelly oil', 'sesame seeds', 'sesame oil', 'sim sim', 'benne', 'gomashio', 'hummus', 'halva', 'halwa', 'gajak', 'til laddoo'],
+    aliases:    ['til', 'tahini', 'gingelly', 'gingelly oil', 'sesame seeds', 'sesame oil', 'sim sim', 'benne', 'gomashio', 'hummus', 'gajak', 'til laddoo'],  // no 'halva'/'halwa' — collides with carrot/banana/ragi halwa (Kael B-1)
     effect:     'food allergy (often lifelong)',
     title:      'Sesame — introduce early, as thinned tahini',
     why:        'Around 6 months, sesame is good to introduce — best as smooth tahini (sesame paste) thinned into food, not whole seeds or a thick glob. There is no reason to delay it. Sesame allergy tends to be lifelong, so watch the first tastes closely and keep an eye out as you continue.',
@@ -2656,6 +2664,7 @@ const FOOD_EFFECTS = {
       paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
     },
     safeForm: {
+      glance:   'Thinned tahini — not whole seeds',
       ok:       ['smooth tahini (sesame paste) thinned with water, milk, or puree', 'finely ground sesame stirred into food'],
       never:    ['a thick glob of tahini (sticky — a choking risk; thin it like nut butter)', 'whole sesame seeds in quantity for a young baby'],
       chokingUntilYears: 4,

--- a/split/data.js
+++ b/split/data.js
@@ -2442,6 +2442,14 @@ const AGE_RULES = {
   'corn':     { minMonth:8, reason:'Hard to digest whole. After 8 months, use corn flour or well-mashed sweet corn.' },
   'spinach':  { minMonth:7, reason:'Contains oxalates — blanch before use. Fine from 7 months in small amounts.' },
   'bajra':    { minMonth:7, reason:'A warming millet — better after 7 months, avoid in very hot weather.' },
+  // food-effects-v2 Phase δ allergen gates (egg already above). minMonth:6 follows
+  // AAP/NHS/ASCIA (~6mo, don't delay); each backs a FOOD_EFFECTS record below.
+  'soy':      { minMonth:6, aliases:['soya','soybean','soya bean','tofu','edamame','soya chunks','soya granules','soya nuggets','soy milk','soya milk','tempeh','miso','natto','tamari'],
+                reason:'Fine from around 6 months — soft tofu or well-mashed soya. Whole edamame is a choking risk; mash it.' },
+  'wheat':    { minMonth:6, aliases:['atta','maida','wheat flour','suji','sooji','rava','semolina','dalia','broken wheat','roti','chapati','phulka','paratha','naan','pasta','sevai','vermicelli','durum','couscous','bulgur','seitan'],
+                reason:'Fine from around 6 months — soft cereal or softened roti. Wheat allergy is separate from celiac disease.' },
+  'sesame':   { minMonth:6, aliases:['til','tahini','gingelly','gingelly oil','sesame seeds','sesame oil','sim sim','benne','gomashio','hummus','halva','halwa','gajak','til laddoo'],
+                reason:'Fine from around 6 months — as smooth tahini thinned into food, not whole seeds.' },
 };
 
 // ── FOOD EFFECTS (consequence layer — Finding A) ──
@@ -2532,6 +2540,137 @@ const FOOD_EFFECTS = {
     watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting'],
     severeSigns:['trouble breathing or wheezing', 'swelling of the face, lips, or tongue', 'going floppy, pale, or very sleepy'],
     seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away and use a prescribed adrenaline auto-injector if you have one.',
+    confidence: 'high',
+  },
+
+  // ── food-effects-v2 Phase δ: egg, soy, wheat, sesame ──
+  // The four remaining big-9 allergens, reached by `aliases` via _lookupByFoodName
+  // (closes the culinary-synonym gap: tofu→soy, roti→wheat, til→sesame, anda→egg).
+  // All allergen-introduce-early (encourage, sage chrome — NOT honey's rose).
+  // TWO-TIER honesty (docs/research/<food>-infant-safety.md): EGG is prevention-
+  // PROVEN (PETIT/EAT) and claims it; SOY/WHEAT/SESAME are introduce-early-and-safe
+  // but earlyIntroBenefit says so plainly — EAT was null for them, so NO prevention
+  // claim. severity:'caution' (amber/sage), never 'critical' (rose = acute-toxin).
+  'egg': {
+    foodClass:  'allergen-introduce-early',
+    severity:   'caution',
+    aliases:    ['eggs', 'anda', 'egg yolk', 'whole egg', 'boiled egg', 'hard-boiled egg', 'scrambled egg', 'omelette', 'omelet'],
+    effect:     'food allergy',
+    title:      'Egg — good to introduce early, well-cooked',
+    why:        'Around 6–7 months, well-cooked egg is worth introducing — not avoiding. Introducing egg early and keeping it regular lowers the chance of an egg allergy. Give it fully cooked (solid white and yolk), starting with the yolk.',
+    whyGood:    'Complete protein, choline, iron and vitamin D — and early, regular well-cooked egg helps prevent egg allergy.',
+    earlyIntroBenefit: {
+      claim:    'Introducing well-cooked egg early and keeping it in the diet helps prevent egg allergy.',
+      evidence: 'In a randomised trial (PETIT, 2017) of higher-risk babies, heated egg from about 6 months — with eczema kept under control — cut egg allergy at 12 months from 38% to 8%.',
+      paradigm: 'This reverses the old "delay egg to avoid allergy" advice.',
+    },
+    safeForm: {
+      ok:       ['well-cooked egg — mashed hard-boiled or scrambled', 'cooked yolk first, then whole egg once that is tolerated', 'egg baked into soft food'],
+      never:    ['raw or runny egg', 'lightly-cooked egg (no assured-egg scheme exists in India)'],
+      note:     'Cook until both white and yolk are solid — this is the studied safe form and avoids the salmonella risk. Raw or runny egg is not safe for a baby.',
+    },
+    howToIntroduce: {
+      amount:   'start with a little well-cooked yolk',
+      when:     'at home, in the morning or midday',
+      watch:    'watch for about 2 hours after',
+      thenWhat: 'if it goes well, keep offering regularly; move to whole egg once yolk is tolerated',
+      oneAtATime: true,
+      highRiskNote: 'If your baby has severe eczema or a known food allergy, talk to your paediatrician before the first taste.',
+    },
+    watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting'],
+    severeSigns:['trouble breathing or wheezing', 'swelling of the face, lips, or tongue', 'going floppy, pale, or very sleepy'],
+    seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away and use a prescribed adrenaline auto-injector if you have one.',
+    confidence: 'high',
+  },
+  'soy': {
+    foodClass:  'allergen-introduce-early',
+    severity:   'caution',
+    aliases:    ['soya', 'soybean', 'soya bean', 'tofu', 'edamame', 'soya chunks', 'soya granules', 'soya nuggets', 'soy milk', 'soya milk', 'tempeh', 'miso', 'natto', 'tamari'],
+    effect:     'food allergy (including FPIES)',
+    title:      'Soy — fine to introduce early, as soft tofu',
+    why:        'Around 6 months, soy is fine to introduce alongside other foods — there is no reason to delay it. Soft tofu and well-mashed soya are valuable plant protein, especially in a vegetarian diet. Whole edamame beans are a choking risk, so mash them.',
+    whyGood:    'Valuable plant protein for a vegetarian diet — tofu and soya chunks are everyday staples.',
+    earlyIntroBenefit: {
+      claim:    'Introduce soy around 6 months — there is no reason to delay it.',
+      evidence: 'Guidelines (AAP, NHS, ASCIA) advise introducing soy early along with other allergens. Early introduction is safe — but, unlike peanut and egg, there is no trial proof that early soy prevents soy allergy.',
+      paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
+    },
+    safeForm: {
+      ok:       ['soft or silken tofu, smushable or blended', 'well-cooked soybeans, mashed', 'soy yoghurt, or soya stirred into food'],
+      never:    ['whole edamame or whole soybeans (round and firm — a choking risk)', 'soy milk as a main drink in the first year'],
+      note:     'Soft tofu needs no special prep. Shell and mash edamame; soy milk is not a substitute for breastmilk or formula.',
+    },
+    howToIntroduce: {
+      amount:   'start with a small amount of soft tofu',
+      when:     'at home, in the morning or midday',
+      watch:    'watch for about 2 hours after — and note any delayed upset (see below)',
+      thenWhat: 'if it goes well, keep offering as part of the normal diet',
+      oneAtATime: true,
+    },
+    watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting or diarrhoea'],
+    severeSigns:['trouble breathing or wheezing', 'swelling of the face, lips, or tongue', 'going floppy, pale, or very sleepy', 'repeated forceful vomiting with paleness or floppiness a few hours later (possible FPIES)'],
+    seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away. Repeated forceful vomiting with paleness or floppiness a few hours after soy (possible FPIES): seek urgent care even without a rash.',
+    confidence: 'high',
+  },
+  'wheat': {
+    foodClass:  'allergen-introduce-early',
+    severity:   'caution',
+    aliases:    ['atta', 'maida', 'wheat flour', 'suji', 'sooji', 'rava', 'semolina', 'dalia', 'broken wheat', 'roti', 'chapati', 'phulka', 'paratha', 'naan', 'pasta', 'sevai', 'vermicelli', 'durum', 'couscous', 'bulgur', 'seitan'],
+    effect:     'food allergy (different from celiac disease)',
+    title:      'Wheat — fine to introduce early, soft-cooked',
+    why:        'Around 6 months, wheat is fine to introduce — soft wheat cereal, well-cooked pasta, or softened roti. There is no benefit to delaying it. Wheat allergy is a food allergy, and is different from celiac disease — a separate, longer-term gluten condition that needs a doctor\'s diagnosis.',
+    whyGood:    'A staple grain — soft cereal, well-cooked pasta, or softened roti, introduced early alongside other solids.',
+    earlyIntroBenefit: {
+      claim:    'Introduce wheat around 6 months — there is no reason to delay it.',
+      evidence: 'Guidelines (AAP, NHS, ASCIA) advise introducing wheat early. Early introduction is safe — but, unlike peanut and egg, a trial (EAT) did not show early wheat prevents wheat allergy.',
+      paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
+    },
+    safeForm: {
+      ok:       ['soft wheat or multigrain cereal or porridge', 'well-cooked soft pasta', 'roti or chapati torn small and softened in milk, dal, or sabzi'],
+      never:    ['large or doughy pieces of fresh bread (they ball up into a sticky clump — toast it or use firm strips)', 'loose dry cooked wheat or dalia that scatters in the mouth (mash or bind it)'],
+      note:     'Wheat allergy is not the same as celiac disease — this is about the allergy.',
+    },
+    howToIntroduce: {
+      amount:   'start with a little soft wheat cereal or softened roti',
+      when:     'at home, in the morning or midday',
+      watch:    'watch for about 2 hours after',
+      thenWhat: 'if it goes well, keep offering as part of the normal diet',
+      oneAtATime: true,
+    },
+    watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting or diarrhoea'],
+    severeSigns:['trouble breathing or wheezing', 'swelling of the face, lips, or tongue', 'going floppy, pale, or very sleepy'],
+    seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away and use a prescribed adrenaline auto-injector if you have one. Ongoing tummy upset, poor growth, or loose stools over weeks is a different concern (celiac) and needs a doctor, not emergency care.',
+    confidence: 'high',
+  },
+  'sesame': {
+    foodClass:  'allergen-introduce-early',
+    severity:   'caution',
+    aliases:    ['til', 'tahini', 'gingelly', 'gingelly oil', 'sesame seeds', 'sesame oil', 'sim sim', 'benne', 'gomashio', 'hummus', 'halva', 'halwa', 'gajak', 'til laddoo'],
+    effect:     'food allergy (often lifelong)',
+    title:      'Sesame — introduce early, as thinned tahini',
+    why:        'Around 6 months, sesame is good to introduce — best as smooth tahini (sesame paste) thinned into food, not whole seeds or a thick glob. There is no reason to delay it. Sesame allergy tends to be lifelong, so watch the first tastes closely and keep an eye out as you continue.',
+    whyGood:    'A seed source of calcium, iron and healthy fats — offer as smooth tahini thinned into food.',
+    earlyIntroBenefit: {
+      claim:    'Introduce sesame around 6 months — there is no reason to delay it.',
+      evidence: 'Guidelines (AAP, NHS, ASCIA) advise introducing sesame early. Early introduction is safe — but, unlike peanut and egg, a trial (EAT) did not show early sesame prevents sesame allergy.',
+      paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
+    },
+    safeForm: {
+      ok:       ['smooth tahini (sesame paste) thinned with water, milk, or puree', 'finely ground sesame stirred into food'],
+      never:    ['a thick glob of tahini (sticky — a choking risk; thin it like nut butter)', 'whole sesame seeds in quantity for a young baby'],
+      chokingUntilYears: 4,
+      note:     'Thin tahini the same way you would thin nut butter. Unrefined gingelly (sesame) oil can still carry the allergen.',
+    },
+    howToIntroduce: {
+      amount:   'start with a little thinned tahini (about 1/8 to 1/2 tsp) stirred into a familiar food',
+      when:     'at home, in the morning or midday',
+      watch:    'watch for about 2 hours after',
+      thenWhat: 'if it goes well, keep offering regularly — and keep watching, as sesame allergy tends to persist',
+      oneAtATime: true,
+    },
+    watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting'],
+    severeSigns:['trouble breathing or wheezing', 'swelling of the face, lips, or tongue', 'going floppy, pale, or very sleepy'],
+    seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away and use a prescribed adrenaline auto-injector if you have one. Sesame is a common cause of severe reactions — watch closely.',
     confidence: 'high',
   },
 };

--- a/split/diet.js
+++ b/split/diet.js
@@ -631,14 +631,23 @@ function renderFoodDetailSheet(name) {
   // Q-3 call; the severe floor's presence is the non-negotiable, M-S-6.)
   const fdEff = (typeof getFoodEffect === 'function') ? getFoodEffect(lower) : null;
   const fdFloor = (fdEff && typeof _severeFloorHtml === 'function') ? _severeFloorHtml(fdEff) : '';
+  // Polarity (food-effects-v2): an introduce-early allergen reads ENCOURAGE —
+  // sage banner + calm sprout icon ("good to introduce, here's the safe form"),
+  // never rose/siren ("don't give"). Rose is reserved for true avoid (acute-toxin).
+  // The severe-reaction floor (fdFloor) below stays serious regardless.
+  const fdEncourage = (typeof _effHasClass === 'function') && _effHasClass(fdEff, 'allergen-introduce-early');
   if (fdFloor) {
     const head = (fdEff && fdEff.title) ? escHtml(fdEff.title) : 'Allergen';
     const sub = (fdEff && fdEff.safeForm && fdEff.safeForm.note) ? escHtml(fdEff.safeForm.note)
               : (allerg ? escHtml(allerg) : '');
-    html += `<div class="fd-flag fd-flag-allergen">${zi('siren')} <span><strong>${head}</strong>${sub ? ' ' + sub : ''}</span></div>`;
+    const flagCls = fdEncourage ? 'fd-flag-encourage' : 'fd-flag-allergen';
+    const flagIc  = fdEncourage ? zi('sprout') : zi('siren');
+    html += `<div class="fd-flag ${flagCls}">${flagIc} <span><strong>${head}</strong>${sub ? ' ' + sub : ''}</span></div>`;
     html += fdFloor; // .cons-severe / .cons-watch / .cons-seek (shared, already-styled)
   } else if (allerg) {
-    html += `<div class="fd-flag fd-flag-allergen">${zi('siren')} <span><strong>Allergen.</strong> ${escHtml(allerg)}</span></div>`;
+    // A milder allergen with no FOOD_EFFECTS record (kiwi, strawberry, oats …):
+    // informational + calm, never the rose alarm. Introduce carefully, watch.
+    html += `<div class="fd-flag fd-flag-neutral">${zi('note')} <span><strong>Allergen.</strong> ${escHtml(allerg)}</span></div>`;
   }
   if (aged) {
     html += `<div class="fd-flag fd-flag-aged">${zi('warn')} <span><strong>Not before ${ageR.minMonth} months.</strong> ${escHtml(ageR.reason)}</span></div>`;

--- a/split/intelligence-cards.js
+++ b/split/intelligence-cards.js
@@ -286,10 +286,11 @@ var AI_ALLERGEN_SET = [
 //   returns FOOD_EFFECTS records by reference (module-level singletons) — every
 //   getFoodEffect("almond")/("tree nut") yields the identical object. A future
 //   refactor that clones records would silently break this; keep it by-ref.
-//   LIMITATION (spec §6/§9): culinary synonyms with no alias table — "tofu"→soy,
-//   "roti"→wheat, "scrambled egg"→egg — do not resolve on EITHER reader (the app
-//   has no such alias data anywhere). Both readers agree on the miss, so the card
-//   stays internally consistent; closing the gap is a data.js alias-table task.
+//   Culinary synonyms RESOLVE as of food-effects-v2 Phase δ — the egg/soy/wheat/
+//   sesame FOOD_EFFECTS records carry culinary-rich aliases (tofu→soy, roti→wheat,
+//   til→sesame, anda→egg), so getFoodEffect now matches them on both readers.
+//   (Residual: a few unauthored synonyms still miss; both readers agree on any miss,
+//   so the card stays internally consistent.)
 function _aiFoodMatches(foodName, canonEff, base) {
   if (!foodName) return false;
   var fn = String(foodName).toLowerCase().trim();
@@ -358,12 +359,13 @@ function _aiComputeAllergenIntro() {
     // safe-form note: FOOD_EFFECTS note (peanut/tree-nut) preferred; else the
     // allergen's own AGE_RULES `reason` (egg's "cook well, yolk first" floor) —
     // never the generic "in a safe form" where a real per-food floor exists (Maren M-1).
-    // The `reason` is a full age-gate sentence-pair; surface only its first
-    // sentence on the one-line glance so it doesn't wrap (the full floor rides
-    // the tap-through detail sheet). Phase δ will replace this with a crisp
-    // FOOD_EFFECTS `safeForm.note` authored for the row.
+    // Prefer the crisp authored `safeForm.glance` (≤44, Phase δ / Vela V-V-208-3) —
+    // the per-food row cue; fall back to the full `note` (the length-gate routes it
+    // to the tap-through), then to the AGE_RULES reason's first sentence.
     var reasonShort = (ageRule && ageRule.reason) ? String(ageRule.reason).split('. ')[0] : null;
-    var safeForm = (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : reasonShort;
+    var safeForm = (eff && eff.safeForm && eff.safeForm.glance) ? eff.safeForm.glance
+                 : (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note
+                 : reasonShort;
     return { key: a.key, label: a.label, introMonth: introMonth, ageReady: ageReady,
              tried: !!rec, date: (rec && rec.date) || null, daysSince: daysSince,
              exposureDays: exposureDays, state: state, safeForm: safeForm };

--- a/split/styles.css
+++ b/split/styles.css
@@ -10766,6 +10766,10 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 .fd-tried-btn { white-space:nowrap; }
 .fd-flag { display:flex; align-items:flex-start; gap:var(--sp-6); padding:var(--sp-8) var(--sp-12); border-radius:var(--r-lg); margin-bottom:var(--sp-8); font-size:var(--fs-sm); line-height:var(--lh-relaxed); }
 .fd-flag-allergen { background:var(--rose-light); color:var(--tc-rose); }
+/* encourage polarity (food-effects-v2): introduce-early allergens read sage/calm,
+   NOT rose/alarm. Rose (.fd-flag-allergen) is reserved for true "avoid". The
+   severe-reaction floor below the banner stays serious regardless. */
+.fd-flag-encourage { background:var(--sage-light); color:var(--tc-sage); }
 .fd-flag-aged { background:var(--peach-light); color:var(--tc-caution); }
 .fd-flag-neutral { background:var(--glass-strong); color:var(--mid); }
 .fd-section { margin-top:var(--sp-12); }

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -16611,7 +16611,10 @@ const AGE_RULES = {
                 reason:'Fine from around 6 months — soft tofu or well-mashed soya. Whole edamame is a choking risk; mash it.' },
   'wheat':    { minMonth:6, aliases:['atta','maida','wheat flour','suji','sooji','rava','semolina','dalia','broken wheat','roti','chapati','phulka','paratha','naan','pasta','sevai','vermicelli','durum','couscous','bulgur','seitan'],
                 reason:'Fine from around 6 months — soft cereal or softened roti. Wheat allergy is separate from celiac disease.' },
-  'sesame':   { minMonth:6, aliases:['til','tahini','gingelly','gingelly oil','sesame seeds','sesame oil','sim sim','benne','gomashio','hummus','halva','halwa','gajak','til laddoo'],
+  'sesame':   { minMonth:6, aliases:['til','tahini','gingelly','gingelly oil','sesame seeds','sesame oil','sim sim','benne','gomashio','hummus','gajak','til laddoo'],
+                // 'halva'/'halwa' deliberately NOT aliases — they collide with carrot/banana/
+                // ragi/suji halwa (Kael B-1); til-halwa is covered by 'til'. Suji halwa still
+                // resolves to wheat via 'suji', correctly.
                 reason:'Fine from around 6 months — as smooth tahini thinned into food, not whole seeds.' },
 };
 
@@ -16655,6 +16658,7 @@ const FOOD_EFFECTS = {
       paradigm: 'This reverses the old "delay nuts to avoid allergy" advice.',
     },
     safeForm: {
+      glance:   'Ground or smooth — never whole',   // ≤44-char card-glance cue (Vela V-V-208-3)
       ok:       ['smooth peanut butter thinned with milk, water, or puree', 'finely ground peanut or peanut flour stirred into food'],
       never:    ['whole peanuts', 'chopped peanuts', 'a thick glob of nut butter'],
       chokingUntilYears: 5,
@@ -16687,6 +16691,7 @@ const FOOD_EFFECTS = {
       paradigm: 'This reverses the old "delay nuts to avoid allergy" advice.',
     },
     safeForm: {
+      glance:   'Ground or smooth paste — never whole',
       ok:       ['finely ground nuts or nut powder stirred into food', 'smooth nut butter or paste thinned', 'traditional soaked, peeled, ground almond (badam) paste'],
       never:    ['whole nuts', 'chopped nuts', 'a thick glob of nut butter'],
       chokingUntilYears: 5,
@@ -16728,6 +16733,7 @@ const FOOD_EFFECTS = {
       paradigm: 'This reverses the old "delay egg to avoid allergy" advice.',
     },
     safeForm: {
+      glance:   'Well-cooked; yolk first',
       ok:       ['well-cooked egg — mashed hard-boiled or scrambled', 'cooked yolk first, then whole egg once that is tolerated', 'egg baked into soft food'],
       never:    ['raw or runny egg', 'lightly-cooked egg (no assured-egg scheme exists in India)'],
       note:     'Cook until both white and yolk are solid — this is the studied safe form and avoids the salmonella risk. Raw or runny egg is not safe for a baby.',
@@ -16759,6 +16765,7 @@ const FOOD_EFFECTS = {
       paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
     },
     safeForm: {
+      glance:   'Soft tofu — not whole edamame',
       ok:       ['soft or silken tofu, smushable or blended', 'well-cooked soybeans, mashed', 'soy yoghurt, or soya stirred into food'],
       never:    ['whole edamame or whole soybeans (round and firm — a choking risk)', 'soy milk as a main drink in the first year'],
       note:     'Soft tofu needs no special prep. Shell and mash edamame; soy milk is not a substitute for breastmilk or formula.',
@@ -16770,7 +16777,7 @@ const FOOD_EFFECTS = {
       thenWhat: 'if it goes well, keep offering as part of the normal diet',
       oneAtATime: true,
     },
-    watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting or diarrhoea'],
+    watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting or diarrhoea', 'forceful or repeated vomiting a few hours after eating, not just right away (possible FPIES)'],
     severeSigns:['trouble breathing or wheezing', 'swelling of the face, lips, or tongue', 'going floppy, pale, or very sleepy', 'repeated forceful vomiting with paleness or floppiness a few hours later (possible FPIES)'],
     seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away. Repeated forceful vomiting with paleness or floppiness a few hours after soy (possible FPIES): seek urgent care even without a rash.',
     confidence: 'high',
@@ -16789,6 +16796,7 @@ const FOOD_EFFECTS = {
       paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
     },
     safeForm: {
+      glance:   'Soft cereal or softened roti',
       ok:       ['soft wheat or multigrain cereal or porridge', 'well-cooked soft pasta', 'roti or chapati torn small and softened in milk, dal, or sabzi'],
       never:    ['large or doughy pieces of fresh bread (they ball up into a sticky clump — toast it or use firm strips)', 'loose dry cooked wheat or dalia that scatters in the mouth (mash or bind it)'],
       note:     'Wheat allergy is not the same as celiac disease — this is about the allergy.',
@@ -16808,7 +16816,7 @@ const FOOD_EFFECTS = {
   'sesame': {
     foodClass:  'allergen-introduce-early',
     severity:   'caution',
-    aliases:    ['til', 'tahini', 'gingelly', 'gingelly oil', 'sesame seeds', 'sesame oil', 'sim sim', 'benne', 'gomashio', 'hummus', 'halva', 'halwa', 'gajak', 'til laddoo'],
+    aliases:    ['til', 'tahini', 'gingelly', 'gingelly oil', 'sesame seeds', 'sesame oil', 'sim sim', 'benne', 'gomashio', 'hummus', 'gajak', 'til laddoo'],  // no 'halva'/'halwa' — collides with carrot/banana/ragi halwa (Kael B-1)
     effect:     'food allergy (often lifelong)',
     title:      'Sesame — introduce early, as thinned tahini',
     why:        'Around 6 months, sesame is good to introduce — best as smooth tahini (sesame paste) thinned into food, not whole seeds or a thick glob. There is no reason to delay it. Sesame allergy tends to be lifelong, so watch the first tastes closely and keep an eye out as you continue.',
@@ -16819,6 +16827,7 @@ const FOOD_EFFECTS = {
       paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
     },
     safeForm: {
+      glance:   'Thinned tahini — not whole seeds',
       ok:       ['smooth tahini (sesame paste) thinned with water, milk, or puree', 'finely ground sesame stirred into food'],
       never:    ['a thick glob of tahini (sticky — a choking risk; thin it like nut butter)', 'whole sesame seeds in quantity for a young baby'],
       chokingUntilYears: 4,
@@ -69661,10 +69670,11 @@ var AI_ALLERGEN_SET = [
 //   returns FOOD_EFFECTS records by reference (module-level singletons) — every
 //   getFoodEffect("almond")/("tree nut") yields the identical object. A future
 //   refactor that clones records would silently break this; keep it by-ref.
-//   LIMITATION (spec §6/§9): culinary synonyms with no alias table — "tofu"→soy,
-//   "roti"→wheat, "scrambled egg"→egg — do not resolve on EITHER reader (the app
-//   has no such alias data anywhere). Both readers agree on the miss, so the card
-//   stays internally consistent; closing the gap is a data.js alias-table task.
+//   Culinary synonyms RESOLVE as of food-effects-v2 Phase δ — the egg/soy/wheat/
+//   sesame FOOD_EFFECTS records carry culinary-rich aliases (tofu→soy, roti→wheat,
+//   til→sesame, anda→egg), so getFoodEffect now matches them on both readers.
+//   (Residual: a few unauthored synonyms still miss; both readers agree on any miss,
+//   so the card stays internally consistent.)
 function _aiFoodMatches(foodName, canonEff, base) {
   if (!foodName) return false;
   var fn = String(foodName).toLowerCase().trim();
@@ -69733,12 +69743,13 @@ function _aiComputeAllergenIntro() {
     // safe-form note: FOOD_EFFECTS note (peanut/tree-nut) preferred; else the
     // allergen's own AGE_RULES `reason` (egg's "cook well, yolk first" floor) —
     // never the generic "in a safe form" where a real per-food floor exists (Maren M-1).
-    // The `reason` is a full age-gate sentence-pair; surface only its first
-    // sentence on the one-line glance so it doesn't wrap (the full floor rides
-    // the tap-through detail sheet). Phase δ will replace this with a crisp
-    // FOOD_EFFECTS `safeForm.note` authored for the row.
+    // Prefer the crisp authored `safeForm.glance` (≤44, Phase δ / Vela V-V-208-3) —
+    // the per-food row cue; fall back to the full `note` (the length-gate routes it
+    // to the tap-through), then to the AGE_RULES reason's first sentence.
     var reasonShort = (ageRule && ageRule.reason) ? String(ageRule.reason).split('. ')[0] : null;
-    var safeForm = (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note : reasonShort;
+    var safeForm = (eff && eff.safeForm && eff.safeForm.glance) ? eff.safeForm.glance
+                 : (eff && eff.safeForm && eff.safeForm.note) ? eff.safeForm.note
+                 : reasonShort;
     return { key: a.key, label: a.label, introMonth: introMonth, ageReady: ageReady,
              tried: !!rec, date: (rec && rec.date) || null, daysSince: daysSince,
              exposureDays: exposureDays, state: state, safeForm: safeForm };

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -10773,6 +10773,10 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 .fd-tried-btn { white-space:nowrap; }
 .fd-flag { display:flex; align-items:flex-start; gap:var(--sp-6); padding:var(--sp-8) var(--sp-12); border-radius:var(--r-lg); margin-bottom:var(--sp-8); font-size:var(--fs-sm); line-height:var(--lh-relaxed); }
 .fd-flag-allergen { background:var(--rose-light); color:var(--tc-rose); }
+/* encourage polarity (food-effects-v2): introduce-early allergens read sage/calm,
+   NOT rose/alarm. Rose (.fd-flag-allergen) is reserved for true "avoid". The
+   severe-reaction floor below the banner stays serious regardless. */
+.fd-flag-encourage { background:var(--sage-light); color:var(--tc-sage); }
 .fd-flag-aged { background:var(--peach-light); color:var(--tc-caution); }
 .fd-flag-neutral { background:var(--glass-strong); color:var(--mid); }
 .fd-section { margin-top:var(--sp-12); }
@@ -16601,6 +16605,14 @@ const AGE_RULES = {
   'corn':     { minMonth:8, reason:'Hard to digest whole. After 8 months, use corn flour or well-mashed sweet corn.' },
   'spinach':  { minMonth:7, reason:'Contains oxalates — blanch before use. Fine from 7 months in small amounts.' },
   'bajra':    { minMonth:7, reason:'A warming millet — better after 7 months, avoid in very hot weather.' },
+  // food-effects-v2 Phase δ allergen gates (egg already above). minMonth:6 follows
+  // AAP/NHS/ASCIA (~6mo, don't delay); each backs a FOOD_EFFECTS record below.
+  'soy':      { minMonth:6, aliases:['soya','soybean','soya bean','tofu','edamame','soya chunks','soya granules','soya nuggets','soy milk','soya milk','tempeh','miso','natto','tamari'],
+                reason:'Fine from around 6 months — soft tofu or well-mashed soya. Whole edamame is a choking risk; mash it.' },
+  'wheat':    { minMonth:6, aliases:['atta','maida','wheat flour','suji','sooji','rava','semolina','dalia','broken wheat','roti','chapati','phulka','paratha','naan','pasta','sevai','vermicelli','durum','couscous','bulgur','seitan'],
+                reason:'Fine from around 6 months — soft cereal or softened roti. Wheat allergy is separate from celiac disease.' },
+  'sesame':   { minMonth:6, aliases:['til','tahini','gingelly','gingelly oil','sesame seeds','sesame oil','sim sim','benne','gomashio','hummus','halva','halwa','gajak','til laddoo'],
+                reason:'Fine from around 6 months — as smooth tahini thinned into food, not whole seeds.' },
 };
 
 // ── FOOD EFFECTS (consequence layer — Finding A) ──
@@ -16691,6 +16703,137 @@ const FOOD_EFFECTS = {
     watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting'],
     severeSigns:['trouble breathing or wheezing', 'swelling of the face, lips, or tongue', 'going floppy, pale, or very sleepy'],
     seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away and use a prescribed adrenaline auto-injector if you have one.',
+    confidence: 'high',
+  },
+
+  // ── food-effects-v2 Phase δ: egg, soy, wheat, sesame ──
+  // The four remaining big-9 allergens, reached by `aliases` via _lookupByFoodName
+  // (closes the culinary-synonym gap: tofu→soy, roti→wheat, til→sesame, anda→egg).
+  // All allergen-introduce-early (encourage, sage chrome — NOT honey's rose).
+  // TWO-TIER honesty (docs/research/<food>-infant-safety.md): EGG is prevention-
+  // PROVEN (PETIT/EAT) and claims it; SOY/WHEAT/SESAME are introduce-early-and-safe
+  // but earlyIntroBenefit says so plainly — EAT was null for them, so NO prevention
+  // claim. severity:'caution' (amber/sage), never 'critical' (rose = acute-toxin).
+  'egg': {
+    foodClass:  'allergen-introduce-early',
+    severity:   'caution',
+    aliases:    ['eggs', 'anda', 'egg yolk', 'whole egg', 'boiled egg', 'hard-boiled egg', 'scrambled egg', 'omelette', 'omelet'],
+    effect:     'food allergy',
+    title:      'Egg — good to introduce early, well-cooked',
+    why:        'Around 6–7 months, well-cooked egg is worth introducing — not avoiding. Introducing egg early and keeping it regular lowers the chance of an egg allergy. Give it fully cooked (solid white and yolk), starting with the yolk.',
+    whyGood:    'Complete protein, choline, iron and vitamin D — and early, regular well-cooked egg helps prevent egg allergy.',
+    earlyIntroBenefit: {
+      claim:    'Introducing well-cooked egg early and keeping it in the diet helps prevent egg allergy.',
+      evidence: 'In a randomised trial (PETIT, 2017) of higher-risk babies, heated egg from about 6 months — with eczema kept under control — cut egg allergy at 12 months from 38% to 8%.',
+      paradigm: 'This reverses the old "delay egg to avoid allergy" advice.',
+    },
+    safeForm: {
+      ok:       ['well-cooked egg — mashed hard-boiled or scrambled', 'cooked yolk first, then whole egg once that is tolerated', 'egg baked into soft food'],
+      never:    ['raw or runny egg', 'lightly-cooked egg (no assured-egg scheme exists in India)'],
+      note:     'Cook until both white and yolk are solid — this is the studied safe form and avoids the salmonella risk. Raw or runny egg is not safe for a baby.',
+    },
+    howToIntroduce: {
+      amount:   'start with a little well-cooked yolk',
+      when:     'at home, in the morning or midday',
+      watch:    'watch for about 2 hours after',
+      thenWhat: 'if it goes well, keep offering regularly; move to whole egg once yolk is tolerated',
+      oneAtATime: true,
+      highRiskNote: 'If your baby has severe eczema or a known food allergy, talk to your paediatrician before the first taste.',
+    },
+    watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting'],
+    severeSigns:['trouble breathing or wheezing', 'swelling of the face, lips, or tongue', 'going floppy, pale, or very sleepy'],
+    seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away and use a prescribed adrenaline auto-injector if you have one.',
+    confidence: 'high',
+  },
+  'soy': {
+    foodClass:  'allergen-introduce-early',
+    severity:   'caution',
+    aliases:    ['soya', 'soybean', 'soya bean', 'tofu', 'edamame', 'soya chunks', 'soya granules', 'soya nuggets', 'soy milk', 'soya milk', 'tempeh', 'miso', 'natto', 'tamari'],
+    effect:     'food allergy (including FPIES)',
+    title:      'Soy — fine to introduce early, as soft tofu',
+    why:        'Around 6 months, soy is fine to introduce alongside other foods — there is no reason to delay it. Soft tofu and well-mashed soya are valuable plant protein, especially in a vegetarian diet. Whole edamame beans are a choking risk, so mash them.',
+    whyGood:    'Valuable plant protein for a vegetarian diet — tofu and soya chunks are everyday staples.',
+    earlyIntroBenefit: {
+      claim:    'Introduce soy around 6 months — there is no reason to delay it.',
+      evidence: 'Guidelines (AAP, NHS, ASCIA) advise introducing soy early along with other allergens. Early introduction is safe — but, unlike peanut and egg, there is no trial proof that early soy prevents soy allergy.',
+      paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
+    },
+    safeForm: {
+      ok:       ['soft or silken tofu, smushable or blended', 'well-cooked soybeans, mashed', 'soy yoghurt, or soya stirred into food'],
+      never:    ['whole edamame or whole soybeans (round and firm — a choking risk)', 'soy milk as a main drink in the first year'],
+      note:     'Soft tofu needs no special prep. Shell and mash edamame; soy milk is not a substitute for breastmilk or formula.',
+    },
+    howToIntroduce: {
+      amount:   'start with a small amount of soft tofu',
+      when:     'at home, in the morning or midday',
+      watch:    'watch for about 2 hours after — and note any delayed upset (see below)',
+      thenWhat: 'if it goes well, keep offering as part of the normal diet',
+      oneAtATime: true,
+    },
+    watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting or diarrhoea'],
+    severeSigns:['trouble breathing or wheezing', 'swelling of the face, lips, or tongue', 'going floppy, pale, or very sleepy', 'repeated forceful vomiting with paleness or floppiness a few hours later (possible FPIES)'],
+    seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away. Repeated forceful vomiting with paleness or floppiness a few hours after soy (possible FPIES): seek urgent care even without a rash.',
+    confidence: 'high',
+  },
+  'wheat': {
+    foodClass:  'allergen-introduce-early',
+    severity:   'caution',
+    aliases:    ['atta', 'maida', 'wheat flour', 'suji', 'sooji', 'rava', 'semolina', 'dalia', 'broken wheat', 'roti', 'chapati', 'phulka', 'paratha', 'naan', 'pasta', 'sevai', 'vermicelli', 'durum', 'couscous', 'bulgur', 'seitan'],
+    effect:     'food allergy (different from celiac disease)',
+    title:      'Wheat — fine to introduce early, soft-cooked',
+    why:        'Around 6 months, wheat is fine to introduce — soft wheat cereal, well-cooked pasta, or softened roti. There is no benefit to delaying it. Wheat allergy is a food allergy, and is different from celiac disease — a separate, longer-term gluten condition that needs a doctor\'s diagnosis.',
+    whyGood:    'A staple grain — soft cereal, well-cooked pasta, or softened roti, introduced early alongside other solids.',
+    earlyIntroBenefit: {
+      claim:    'Introduce wheat around 6 months — there is no reason to delay it.',
+      evidence: 'Guidelines (AAP, NHS, ASCIA) advise introducing wheat early. Early introduction is safe — but, unlike peanut and egg, a trial (EAT) did not show early wheat prevents wheat allergy.',
+      paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
+    },
+    safeForm: {
+      ok:       ['soft wheat or multigrain cereal or porridge', 'well-cooked soft pasta', 'roti or chapati torn small and softened in milk, dal, or sabzi'],
+      never:    ['large or doughy pieces of fresh bread (they ball up into a sticky clump — toast it or use firm strips)', 'loose dry cooked wheat or dalia that scatters in the mouth (mash or bind it)'],
+      note:     'Wheat allergy is not the same as celiac disease — this is about the allergy.',
+    },
+    howToIntroduce: {
+      amount:   'start with a little soft wheat cereal or softened roti',
+      when:     'at home, in the morning or midday',
+      watch:    'watch for about 2 hours after',
+      thenWhat: 'if it goes well, keep offering as part of the normal diet',
+      oneAtATime: true,
+    },
+    watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting or diarrhoea'],
+    severeSigns:['trouble breathing or wheezing', 'swelling of the face, lips, or tongue', 'going floppy, pale, or very sleepy'],
+    seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away and use a prescribed adrenaline auto-injector if you have one. Ongoing tummy upset, poor growth, or loose stools over weeks is a different concern (celiac) and needs a doctor, not emergency care.',
+    confidence: 'high',
+  },
+  'sesame': {
+    foodClass:  'allergen-introduce-early',
+    severity:   'caution',
+    aliases:    ['til', 'tahini', 'gingelly', 'gingelly oil', 'sesame seeds', 'sesame oil', 'sim sim', 'benne', 'gomashio', 'hummus', 'halva', 'halwa', 'gajak', 'til laddoo'],
+    effect:     'food allergy (often lifelong)',
+    title:      'Sesame — introduce early, as thinned tahini',
+    why:        'Around 6 months, sesame is good to introduce — best as smooth tahini (sesame paste) thinned into food, not whole seeds or a thick glob. There is no reason to delay it. Sesame allergy tends to be lifelong, so watch the first tastes closely and keep an eye out as you continue.',
+    whyGood:    'A seed source of calcium, iron and healthy fats — offer as smooth tahini thinned into food.',
+    earlyIntroBenefit: {
+      claim:    'Introduce sesame around 6 months — there is no reason to delay it.',
+      evidence: 'Guidelines (AAP, NHS, ASCIA) advise introducing sesame early. Early introduction is safe — but, unlike peanut and egg, a trial (EAT) did not show early sesame prevents sesame allergy.',
+      paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
+    },
+    safeForm: {
+      ok:       ['smooth tahini (sesame paste) thinned with water, milk, or puree', 'finely ground sesame stirred into food'],
+      never:    ['a thick glob of tahini (sticky — a choking risk; thin it like nut butter)', 'whole sesame seeds in quantity for a young baby'],
+      chokingUntilYears: 4,
+      note:     'Thin tahini the same way you would thin nut butter. Unrefined gingelly (sesame) oil can still carry the allergen.',
+    },
+    howToIntroduce: {
+      amount:   'start with a little thinned tahini (about 1/8 to 1/2 tsp) stirred into a familiar food',
+      when:     'at home, in the morning or midday',
+      watch:    'watch for about 2 hours after',
+      thenWhat: 'if it goes well, keep offering regularly — and keep watching, as sesame allergy tends to persist',
+      oneAtATime: true,
+    },
+    watchFor:   ['hives or a rash', 'swelling around the mouth or eyes', 'vomiting'],
+    severeSigns:['trouble breathing or wheezing', 'swelling of the face, lips, or tongue', 'going floppy, pale, or very sleepy'],
+    seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away and use a prescribed adrenaline auto-injector if you have one. Sesame is a common cause of severe reactions — watch closely.',
     confidence: 'high',
   },
 };
@@ -38418,14 +38561,23 @@ function renderFoodDetailSheet(name) {
   // Q-3 call; the severe floor's presence is the non-negotiable, M-S-6.)
   const fdEff = (typeof getFoodEffect === 'function') ? getFoodEffect(lower) : null;
   const fdFloor = (fdEff && typeof _severeFloorHtml === 'function') ? _severeFloorHtml(fdEff) : '';
+  // Polarity (food-effects-v2): an introduce-early allergen reads ENCOURAGE —
+  // sage banner + calm sprout icon ("good to introduce, here's the safe form"),
+  // never rose/siren ("don't give"). Rose is reserved for true avoid (acute-toxin).
+  // The severe-reaction floor (fdFloor) below stays serious regardless.
+  const fdEncourage = (typeof _effHasClass === 'function') && _effHasClass(fdEff, 'allergen-introduce-early');
   if (fdFloor) {
     const head = (fdEff && fdEff.title) ? escHtml(fdEff.title) : 'Allergen';
     const sub = (fdEff && fdEff.safeForm && fdEff.safeForm.note) ? escHtml(fdEff.safeForm.note)
               : (allerg ? escHtml(allerg) : '');
-    html += `<div class="fd-flag fd-flag-allergen">${zi('siren')} <span><strong>${head}</strong>${sub ? ' ' + sub : ''}</span></div>`;
+    const flagCls = fdEncourage ? 'fd-flag-encourage' : 'fd-flag-allergen';
+    const flagIc  = fdEncourage ? zi('sprout') : zi('siren');
+    html += `<div class="fd-flag ${flagCls}">${flagIc} <span><strong>${head}</strong>${sub ? ' ' + sub : ''}</span></div>`;
     html += fdFloor; // .cons-severe / .cons-watch / .cons-seek (shared, already-styled)
   } else if (allerg) {
-    html += `<div class="fd-flag fd-flag-allergen">${zi('siren')} <span><strong>Allergen.</strong> ${escHtml(allerg)}</span></div>`;
+    // A milder allergen with no FOOD_EFFECTS record (kiwi, strawberry, oats …):
+    // informational + calm, never the rose alarm. Introduce carefully, watch.
+    html += `<div class="fd-flag fd-flag-neutral">${zi('note')} <span><strong>Allergen.</strong> ${escHtml(allerg)}</span></div>`;
   }
   if (aged) {
     html += `<div class="fd-flag fd-flag-aged">${zi('warn')} <span><strong>Not before ${ageR.minMonth} months.</strong> ${escHtml(ageR.reason)}</span></div>`;

--- a/tests/e2e/analytics-allergen-intro.spec.ts
+++ b/tests/e2e/analytics-allergen-intro.spec.ts
@@ -79,13 +79,14 @@ test.describe('analytics prototype — Allergen Introduction card', () => {
     expect(pn.daysSince, 'clamped to 0 (renders "Day 1 of 3"), not abs(2)').toBe(0);
   });
 
-  test('egg "ready" surfaces its own AGE_RULES floor, not the generic safe-form line (M-1)', async ({ page }) => {
+  test('egg carries its cook-well floor from its FOOD_EFFECTS record (Phase δ)', async ({ page }) => {
     const egg = byKey(await seedAndCompute(page, []), 'egg');
-    // egg has no FOOD_EFFECTS record; safeForm must fall back to the AGE_RULES
-    // reason (its cook-well / yolk-first floor), never null → generic copy.
+    // Phase δ gave egg a real FOOD_EFFECTS record, so safeForm now comes from
+    // eff.safeForm.note (the full cook-well floor), superseding the M-1 AGE_RULES
+    // first-sentence stopgap. The floor is still surfaced — never null/generic;
+    // the one-line glance budget is enforced separately by the length-gate below.
     if (egg.state === 'ready') {
-      expect(egg.safeForm, 'egg carries its own cook-well floor').toMatch(/cook/i);
-      expect(egg.safeForm.length, 'and it is short enough to render on one line').toBeLessThanOrEqual(44);
+      expect(egg.safeForm, 'egg carries its own cook-well floor (FOOD_EFFECTS)').toMatch(/cook/i);
     }
   });
 
@@ -99,11 +100,12 @@ test.describe('analytics prototype — Allergen Introduction card', () => {
       });
       return out;
     });
-    // peanut/tree-nut carry a ~150-char FOOD_EFFECTS note → must NOT dump it on the glance
+    // peanut/tree-nut/egg now all carry a long FOOD_EFFECTS note → must NOT dump
+    // it on the glance; the length-gate points them to the tap-through (Phase δ
+    // gave egg a record, so it joins peanut/tree-nut here).
     expect(metas['peanut'], 'long note points to tap-through, not wrapped inline').toBe('In a safe form — tap for how');
     expect(metas['tree nut']).toBe('In a safe form — tap for how');
-    // egg's trimmed floor fits → stays visible (M-1)
-    expect(metas['egg'], 'egg short floor stays on the glance').toMatch(/well-cooked yolk/i);
+    expect(metas['egg'], 'egg now has a FOOD_EFFECTS record → also points to tap-through').toBe('In a safe form — tap for how');
     // no ready meta should exceed the one-line budget
     Object.values(metas).forEach((m) => expect(m.length).toBeLessThanOrEqual(44));
   });

--- a/tests/e2e/analytics-allergen-intro.spec.ts
+++ b/tests/e2e/analytics-allergen-intro.spec.ts
@@ -100,13 +100,14 @@ test.describe('analytics prototype — Allergen Introduction card', () => {
       });
       return out;
     });
-    // peanut/tree-nut/egg now all carry a long FOOD_EFFECTS note → must NOT dump
-    // it on the glance; the length-gate points them to the tap-through (Phase δ
-    // gave egg a record, so it joins peanut/tree-nut here).
-    expect(metas['peanut'], 'long note points to tap-through, not wrapped inline').toBe('In a safe form — tap for how');
-    expect(metas['tree nut']).toBe('In a safe form — tap for how');
-    expect(metas['egg'], 'egg now has a FOOD_EFFECTS record → also points to tap-through').toBe('In a safe form — tap for how');
-    // no ready meta should exceed the one-line budget
+    // Phase δ: each introduce-early allergen now carries a crisp authored
+    // safeForm.glance (≤44) — a specific row cue, not the generic pointer
+    // (Vela V-V-208-3). The full note still rides the tap-through.
+    expect(metas['peanut'], 'peanut shows its specific glance cue').toMatch(/ground or smooth/i);
+    expect(metas['tree nut']).toMatch(/ground or smooth/i);
+    expect(metas['egg'], 'egg specific floor restored to the glance').toMatch(/yolk/i);
+    expect(metas['soy']).toMatch(/tofu/i);
+    // no ready meta should exceed the one-line budget (the wrap guarantee holds)
     Object.values(metas).forEach((m) => expect(m.length).toBeLessThanOrEqual(44));
   });
 


### PR DESCRIPTION
## food-effects-v2 Phase δ — wire egg/soy/wheat/sesame + polarity-aware banner

The gated build behind the Phase-δ research (PRs #206/#207). Turns the four allergen records into product **and fixes the "red = don't give" wrong-message** the Architect flagged.

### Three changes
1. **`data.js` — four `FOOD_EFFECTS` records** (egg, soy, wheat, sesame), ported from the verified research in the peanut shape (title / why / `safeForm` / `severeSigns` floor / `howToIntroduce`). **Two-tier honesty held:** egg claims prevention (PETIT 38%→8%, EAT); soy/wheat/sesame's `earlyIntroBenefit` says "safe to introduce, don't delay — but a trial (EAT) did not prove prevention." Plus **three new `AGE_RULES` gates** (soy/wheat/sesame, minMonth 6) so the food-effects **sync ship-gate passes** — the AGE_RULES reconciliation Maren flagged in the card session.
2. **`styles.css` + `diet.js` — polarity-aware detail-sheet banner** (the fix). New `.fd-flag-encourage` (sage); the banner now reads **sage + sprout** for introduce-early allergens, **rose + siren reserved for true avoid** (acute-toxin). Milder unclassified allergens (kiwi/strawberry/oats) drop to calm **neutral**, not the rose alarm. **The severe-reaction floor below stays serious regardless.** egg/soy/wheat/sesame now get peanut's full rich sheet instead of a terse red one-liner (screenshots: sage banner + amber emergency floor).
3. **Side-effect — closes the Kael B-1 gap.** The records' culinary-rich aliases mean `getFoodEffect` now resolves tofu→soy, roti→wheat, til→sesame, anda→egg, so the Allergen Introduction card's two readers resolve culinary names. egg now sources its `safeForm` from `FOOD_EFFECTS` (like peanut), so its card glance points to the tap-through — **superseding the M-1 length-gate stopgap (flagged for Maren to re-adjudicate).**

### Verification
`pnpm build` clean (**sync ship-gate green**). e2e **12/12** (two egg assertions updated to the new `FOOD_EFFECTS`-sourced reality). Egg + sesame detail sheets confirmed **sage** via screenshot.

### canon-cc-008 routing (triple-Gov — styles.css)
`data.js` (Kael) + `diet.js` (Maren) + `styles.css` (all three). Chain: **Maren + Kael + Vela** in parallel → Lyra synthesis → Cipher Edict V. **DRAFT until the chain clears.**

https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK)_