### PR TITLE
Care Research Hub — manifest-driven Index · Compare · Reactions

### DIFF
--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -11,7 +11,7 @@ Evidence base for surfacing **food effects** (acute risk, allergy, choking, timi
 | `<food>-infant-safety.md` | Full cited prose brief (source of truth). |
 | `<food>-infant-safety.html` | Long-form rendered brief. |
 | `<food>-infant-safety.visual.html` | Skim-layer dashboard (built from the template). |
-| `index.html` *(future)* | The **unified dashboard** — hub over all foods (see plan below). |
+| `index.html` | The **unified dashboard** — manifest-driven hub over all foods (Index · Compare · Reactions). Built; renders live from `food-effects.manifest.js`. |
 
 Three depth layers per food: **`.visual.html`** (skim) → **`.html`** (full prose) → **`.md`** (source). All three carry the same verified figures.
 
@@ -56,9 +56,9 @@ The data model already supports this. Per food the app holds `AGE_RULES` (gate),
 
 ### Phasing
 
-- **Phase 0 — now:** template + manifest + honey. ✅
-- **Phase 1:** 3–4 more critical/allergen foods (whole nuts · egg · cow's milk · salt), each appending to the manifest.
-- **Phase 2:** build `index.html` once the manifest has ~5 foods (Index + Compare + Reactions).
-- **Phase 3:** wire the manifest into the app `data.js FOOD_EFFECTS` for the Finding-A surfacing (separate, ratified change — canon-cc-008 applies there).
+- **Phase 0:** template + manifest + honey. ✅
+- **Phase 1:** more allergen foods — peanut + tree nut (#187), then egg · soy · wheat · sesame (Phase δ, #206/#207). Manifest now holds **7** records. ✅
+- **Phase 2:** build `index.html` — the manifest-driven hub (Index + Compare + Reactions). ✅
+- **Phase 3:** wire the manifest into the app `data.js FOOD_EFFECTS` for the Finding-A surfacing. ✅ honey + peanut + tree nut (#187), egg + soy + wheat + sesame + polarity-aware banner (#208). *Next: the broader food classes (milk · fish · the choking set).*
 
 > Net: every food we research compounds. The manifest makes the unified dashboard nearly free, and doubles as the product's data source — one spine, three consumers (research hub, skim dashboards, in-app surfacing).

--- a/docs/research/index.html
+++ b/docs/research/index.html
@@ -1,79 +1,237 @@
 <!DOCTYPE html>
+<!-- ═══════════════════════════════════════════════════════════════════════
+  CARE RESEARCH HUB · the view-join over food-effects.manifest.js
+  Renders ENTIRELY from the manifest (window.FOOD_EFFECTS_MANIFEST) — no food
+  data is hardcoded here, so the hub can never drift from the spine and every
+  new food appears the moment its record is appended. Three modes:
+    • Index     — every food, grouped by polarity (introduce-early vs avoid)
+    • Compare   — pick 2–4 foods → side-by-side table
+    • Reactions — cross-cut by reactionType → the watch-for signs
+  Docs-only research artifact; not wired into the app.
+═══════════════════════════════════════════════════════════════════════ -->
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Care Research — Food Effects · SproutLab</title>
+<title>Care Research Hub — Food Effects · SproutLab</title>
 <style>
-  :root{--bg:#faf6f0;--card:#fffdf9;--ink:#2e2a26;--mid:#6b6258;--line:#e8ddcf;
-    --accent:#9a6a3a;--honey:#d99a2b;--honey-bg:#fbeccb;--rose:#b04a5e;--rose-bg:#fbe9ec;
-    --sage:#3a7060;--sage-bg:#e8f5ef;}
-  @media(prefers-color-scheme:dark){:root{--bg:#1d1a17;--card:#262220;--ink:#ece5db;--mid:#a89c8c;--line:#3a342d;
-    --accent:#c99a6a;--honey:#e8b34a;--honey-bg:#3a2c12;--rose:#e090a0;--rose-bg:#3a2026;--sage:#7ac0a0;--sage-bg:#1e3028;}}
+  :root{
+    --bg:#faf6f0; --card:#fffdf9; --ink:#2e2a26; --mid:#6b6258; --line:#e8ddcf; --track:#efe7da;
+    --sage:#3a7060; --sage-bg:#e8f5ef; --rose:#b04a5e; --rose-bg:#fbe9ec;
+    --amber:#9a7320; --amber-bg:#fbf0d9; --accent:#9a6a3a; --honey:#d99a2b; --honey-bg:#fbeccb;
+    --hi:#2f7d5b; --hi-bg:#e3f3ea; --mod:#9a7320; --mod-bg:#f7eed6; --weak:#9a5a5a; --weak-bg:#f5e6e6;
+  }
+  @media (prefers-color-scheme:dark){:root{
+    --bg:#1d1a17; --card:#262220; --ink:#ece5db; --mid:#a89c8c; --line:#3a342d; --track:#332d26;
+    --sage:#7ac0a0; --sage-bg:#1e3028; --rose:#e090a0; --rose-bg:#3a2026;
+    --amber:#e0b060; --amber-bg:#352a16; --accent:#c99a6a; --honey:#e8b34a; --honey-bg:#3a2c12;
+    --hi:#7ac0a0; --hi-bg:#1e3028; --mod:#d8b060; --mod-bg:#332a14; --weak:#e09090; --weak-bg:#3a2222; }}
   *{box-sizing:border-box}
-  body{margin:0;background:var(--bg);color:var(--ink);font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Nunito,sans-serif;-webkit-font-smoothing:antialiased}
-  .wrap{max-width:760px;margin:0 auto;padding:34px 20px 80px}
-  h1{font:700 26px/1.2 Fraunces,Georgia,serif;margin:0 0 6px}
-  .sub{color:var(--mid);font-size:14.5px;margin:0 0 24px;max-width:600px}
-  h2{font:700 12px/1.3 Nunito;text-transform:uppercase;letter-spacing:.5px;color:var(--mid);margin:28px 0 10px}
-  .food{background:var(--card);border:1px solid var(--line);border-radius:16px;padding:18px 20px;margin:12px 0}
-  .food .top{display:flex;align-items:center;justify-content:space-between;gap:10px;flex-wrap:wrap}
-  .food .name{font:700 19px/1.2 Fraunces,serif}
-  .tier{font:700 10.5px/1 Nunito;text-transform:uppercase;letter-spacing:.4px;padding:5px 9px;border-radius:7px;background:var(--rose-bg);color:var(--rose)}
-  .tier.good{background:var(--sage-bg);color:var(--sage)}
-  .one{color:var(--mid);font-size:13.5px;margin:8px 0 14px}
-  .links{display:flex;gap:8px;flex-wrap:wrap}
-  .links a{flex:1 1 auto;text-align:center;text-decoration:none;font:600 13px/1 Nunito;padding:11px 12px;border-radius:10px;border:1px solid var(--line);color:var(--ink);background:var(--bg)}
+  body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Nunito,sans-serif;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:980px;margin:0 auto;padding:0 18px 90px}
+  header{background:linear-gradient(160deg,var(--sage-bg),var(--bg));border-bottom:1px solid var(--line);padding:26px 0 0}
+  h1{font:700 25px/1.2 Fraunces,Georgia,serif;margin:0 0 4px}
+  .sub{color:var(--mid);font-size:14px;margin:0 0 16px;max-width:720px}
+  nav{display:flex;gap:4px;margin-top:6px;overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none}
+  nav::-webkit-scrollbar{display:none}
+  .tab{appearance:none;border:0;background:transparent;color:var(--mid);font:600 13.5px/1 Nunito,sans-serif;white-space:nowrap;flex:0 0 auto;
+    padding:11px 14px;border-radius:10px 10px 0 0;cursor:pointer;border-bottom:3px solid transparent}
+  .tab:hover{color:var(--ink);background:var(--card)}
+  .tab.on{color:var(--accent);background:var(--card);border-bottom-color:var(--accent)}
+  .panel{display:none;animation:f .25s ease}.panel.on{display:block}
+  @keyframes f{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:none}}
+  @media (prefers-reduced-motion: no-preference){
+    .panel.on .food{animation:rise .45s ease both}
+    .panel.on .food:nth-child(2){animation-delay:.05s}.panel.on .food:nth-child(3){animation-delay:.1s}
+    .panel.on .food:nth-child(4){animation-delay:.15s}.panel.on .food:nth-child(5){animation-delay:.2s}
+    @keyframes rise{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}
+  }
+  h2{font:700 12px/1.3 Nunito;text-transform:uppercase;letter-spacing:.5px;color:var(--mid);margin:26px 0 10px}
+  .grid{display:grid;gap:12px}@media(min-width:680px){.grid.g2{grid-template-columns:1fr 1fr}}
+  .food{background:var(--card);border:1px solid var(--line);border-radius:16px;padding:16px 18px}
+  .food .top{display:flex;align-items:baseline;justify-content:space-between;gap:10px;flex-wrap:wrap}
+  .food .name{font:700 18px/1.2 Fraunces,serif;text-transform:capitalize}
+  .food .age{font:600 12px/1 Nunito;color:var(--mid)}
+  .badges{margin:9px 0 2px;display:flex;gap:5px;flex-wrap:wrap}
+  .badge{display:inline-block;font:700 10px/1 Nunito;text-transform:uppercase;letter-spacing:.3px;padding:4px 8px;border-radius:6px}
+  .b-ok{background:var(--sage-bg);color:var(--sage)}.b-crit{background:var(--rose-bg);color:var(--rose)}
+  .b-amber{background:var(--amber-bg);color:var(--amber)}
+  .b-hi{background:var(--hi-bg);color:var(--hi)}.b-mod{background:var(--mod-bg);color:var(--mod)}.b-weak{background:var(--weak-bg);color:var(--weak)}
+  .head{color:var(--ink);font-size:13.5px;margin:10px 0 12px;line-height:1.5}
+  .links{display:flex;gap:7px;flex-wrap:wrap}
+  .links a{flex:1 1 auto;text-align:center;text-decoration:none;font:600 12.5px/1 Nunito;padding:10px 11px;border-radius:9px;border:1px solid var(--line);color:var(--ink);background:var(--bg)}
   .links a:hover{border-color:var(--accent);color:var(--accent)}
-  .links a.primary{background:var(--honey);color:#3a2c12;border-color:transparent}
-  .note{background:var(--sage-bg);border-radius:12px;padding:14px 16px;font-size:13.5px;color:var(--ink);margin:10px 0}
-  .meta{font-size:12.5px;color:var(--mid);margin-top:8px}
-  code{font:12.5px "SF Mono",Menlo,Consolas,monospace;background:var(--honey-bg);padding:1px 5px;border-radius:5px}
-  a.plain{color:var(--sage)}
-  footer{color:var(--mid);font-size:12.5px;margin-top:34px;border-top:1px solid var(--line);padding-top:14px}
+  .links a.primary{background:var(--sage);color:var(--card);border-color:transparent}
+  .meta{font-size:11.5px;color:var(--mid);margin-top:9px}
+  table{width:100%;border-collapse:collapse;font-size:13px;margin:8px 0}
+  th,td{padding:9px 10px;border-bottom:1px solid var(--line);text-align:left;vertical-align:top}
+  th{font:700 11px/1.2 Nunito;text-transform:uppercase;letter-spacing:.3px;color:var(--mid)}
+  td.k{font-weight:700;color:var(--mid);white-space:nowrap}
+  .pick{display:flex;gap:7px;flex-wrap:wrap;margin:6px 0 14px}
+  .pick label{font:600 12.5px/1 Nunito;padding:8px 11px;border-radius:9px;border:1px solid var(--line);background:var(--card);cursor:pointer;text-transform:capitalize;user-select:none}
+  .pick input{margin-right:6px;vertical-align:middle}
+  .pick label.sel{border-color:var(--accent);color:var(--accent);background:var(--honey-bg)}
+  .hint{font-size:11.5px;color:var(--mid);margin:6px 0 10px}
+  ul{margin:6px 0;padding-left:18px}li{margin:2px 0}
+  .foot{color:var(--mid);font-size:12px;text-align:center;margin-top:30px}
+  .empty{color:var(--mid);font-size:13px;padding:14px;text-align:center}
 </style>
 </head>
 <body>
+<header><div class="wrap">
+  <h1>Care Research Hub — Food Effects</h1>
+  <p class="sub">One view over every researched food. Each carries three depth layers — a skim dashboard, a long-form brief, and a cited source doc — all rendered from a single spine, <code>food-effects.manifest.js</code>. Two shapes so far: <b>introduce early</b> (the allergens — encourage early, in safe form) and <b>avoid</b> (honey — a true acute risk).</p>
+  <nav>
+    <button class="tab on" data-p="p-index">Index</button>
+    <button class="tab" data-p="p-compare">Compare</button>
+    <button class="tab" data-p="p-react">Reactions</button>
+  </nav>
+  <p class="hint" style="margin:6px 0 10px">Swipe ‹ › between tabs · or use ← → arrow keys · all values come from the manifest</p>
+</div></header>
+
 <div class="wrap">
-  <h1>Care Research · Food Effects</h1>
-  <p class="sub">Evidence base for surfacing food effects in SproutLab's Care layer. Each food has a skim dashboard, a long-form brief, and a cited source doc. Two shapes so far: honey (a true <i>avoid</i>) and peanut/tree nuts (a <i>guided introduction</i> — encourage early, in safe form). More foods follow.</p>
-
-  <h2>Foods</h2>
-  <div class="food">
-    <div class="top">
-      <span class="name">Honey</span>
-      <span class="tier">Critical · infant botulism</span>
-    </div>
-    <p class="one">No honey before 12 months, in any form — the danger is infant botulism, not nutrition. Cooking/baking does <b>not</b> make it safe. Treatable but a medical emergency. For an Indian family, the <i>ghutti</i> / prelacteal-feed tradition is the live vector.</p>
-    <div class="links">
-      <a class="primary" href="honey-infant-safety.visual.html">Visual dashboard ›</a>
-      <a href="honey-infant-safety.html">Long-form brief</a>
-      <a href="honey-infant-safety.md">Source (.md)</a>
-    </div>
-    <p class="meta">Reviewed 2026-05-30 · confidence: high · WHO · CDC · AAP · NHS · India MoHFW/NHM</p>
-  </div>
-
-  <div class="food">
-    <div class="top">
-      <span class="name">Peanut &amp; Tree Nuts</span>
-      <span class="tier good">Introduce early · in safe form</span>
-    </div>
-    <p class="one"><b>Not an avoid — a guided introduction.</b> Introduce around 6 months, in safe form (smooth/ground, <b>never whole</b> — choking until ~5). Early, regular nuts <b>lower</b> allergy risk (LEAP: ~81%). Two hazards — allergy &amp; choking — and grinding fixes only the choking one. For this Indian vegetarian family, groundnut/badam/akhrot/kaju are staples and soaked-ground almond paste is already a safe form.</p>
-    <div class="links">
-      <a class="primary" href="peanut-tree-nut-infant-safety.visual.html">Visual dashboard ›</a>
-      <a href="peanut-tree-nut-infant-safety.html">Long-form brief</a>
-      <a href="peanut-tree-nut-infant-safety.md">Source (.md)</a>
-    </div>
-    <p class="meta">Reviewed 2026-05-30 · confidence: high · LEAP/EAT (NEJM) · AAP · NHS · ASCIA · NIAID · IAP</p>
-  </div>
-
-  <h2>How this is built</h2>
-  <div class="note">
-    One <b>data spine</b> — <code>food-effects.manifest.js</code> — holds a summary record per food, feeding both this research layer and (eventually) the in-app surfacing. New foods are authored from <code>_TEMPLATE.food-dashboard.html</code>. Once enough foods exist, a unified hub will let you browse one food, compare several, or slice by reaction. See <a class="plain" href="README.md">README.md</a> for the full plan.
-  </div>
-  <p class="meta">Three depth layers per food: <b>visual dashboard</b> (skim) → <b>long-form</b> (full prose) → <b>.md</b> (source of truth). All carry the same verified figures.</p>
-
-  <footer>SproutLab · Care research layer · informational, not medical advice. Not yet wired into the app.</footer>
+  <section class="panel on" id="p-index"></section>
+  <section class="panel" id="p-compare">
+    <h2>Pick 2–4 foods to compare</h2>
+    <div class="pick" id="cmp-pick"></div>
+    <div id="cmp-out"></div>
+  </section>
+  <section class="panel" id="p-react"></section>
+  <p class="foot">SproutLab · Care research hub · informational, not medical advice · not yet wired into the app.<br>
+  Rendered live from <code>food-effects.manifest.js</code> — the same spine that feeds the per-food dashboards and (eventually) the in-app <code>FOOD_EFFECTS</code>.</p>
 </div>
+
+<script src="food-effects.manifest.js"></script>
+<script>
+  var M = (window.FOOD_EFFECTS_MANIFEST || []);
+  function esc(s){ return String(s == null ? '' : s).replace(/[&<>"]/g, function(c){ return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]; }); }
+  function arr(v){ return Array.isArray(v) ? v : (v == null ? [] : [v]); }
+
+  var CLASS_LABEL = {
+    'acute-toxin':              { t:'Avoid — acute risk', c:'b-crit' },
+    'allergen-introduce-early': { t:'Introduce early',    c:'b-ok' },
+    'choking-by-form':          { t:'Choking by form',    c:'b-amber' },
+    'drink-timing':             { t:'Timing',             c:'b-amber' },
+    'substitute-caveat':        { t:'Substitute caveat',  c:'b-amber' },
+  };
+  var RX_LABEL = {
+    'acute-toxin':'Acute toxin', 'allergy':'Allergy', 'choking':'Choking',
+    'digestive':'Digestive (incl. FPIES)', 'dental':'Dental', 'renal':'Renal',
+  };
+  var CONF = { high:'b-hi', moderate:'b-mod', weak:'b-weak' };
+
+  function isAvoid(r){ return arr(r.foodClass).indexOf('acute-toxin') >= 0; }
+  function classBadges(r){
+    return arr(r.foodClass).map(function(fc){
+      var d = CLASS_LABEL[fc] || { t:fc, c:'b-amber' };
+      return '<span class="badge ' + d.c + '">' + esc(d.t) + '</span>';
+    }).join('');
+  }
+  function ageLabel(r){ return r.minMonth >= 12 ? ('not before ' + r.minMonth + ' mo') : ('from ~' + r.minMonth + ' mo'); }
+
+  function foodCard(r){
+    return '<div class="food">' +
+      '<div class="top"><span class="name">' + esc(r.food) + '</span><span class="age">' + esc(ageLabel(r)) + '</span></div>' +
+      '<div class="badges">' + classBadges(r) +
+        '<span class="badge ' + (CONF[r.confidence] || 'b-mod') + '">' + esc(r.confidence || '') + '</span></div>' +
+      '<div class="head">' + esc(r.headline || '') + '</div>' +
+      '<div class="links">' +
+        '<a class="primary" href="' + esc(r.dashboard) + '">Dashboard ›</a>' +
+        '<a href="' + esc(r.longform) + '">Long-form</a>' +
+        '<a href="' + esc(r.brief) + '">Source</a>' +
+      '</div>' +
+      '<div class="meta">reviewed ' + esc(r.lastReviewed || '') + ' · ' + esc(arr(r.sources).slice(0, 5).join(' · ')) + '</div>' +
+    '</div>';
+  }
+
+  // ── Index — grouped by polarity ──
+  function renderIndex(){
+    var enc = M.filter(function(r){ return !isAvoid(r); });
+    var avoid = M.filter(isAvoid);
+    var html = '';
+    if (enc.length)   html += '<h2>Introduce early — guided introduction (' + enc.length + ')</h2><div class="grid g2">' + enc.map(foodCard).join('') + '</div>';
+    if (avoid.length) html += '<h2>Avoid — acute risk (' + avoid.length + ')</h2><div class="grid g2">' + avoid.map(foodCard).join('') + '</div>';
+    document.getElementById('p-index').innerHTML = html || '<p class="empty">No foods in the manifest yet.</p>';
+  }
+
+  // ── Compare — pick 2–4 → transposed table ──
+  function renderComparePicker(){
+    document.getElementById('cmp-pick').innerHTML = M.map(function(r, i){
+      return '<label data-i="' + i + '"><input type="checkbox" data-i="' + i + '">' + esc(r.food) + '</label>';
+    }).join('');
+  }
+  function renderCompare(){
+    var picked = Array.prototype.slice.call(document.querySelectorAll('#cmp-pick input:checked')).map(function(c){ return M[+c.dataset.i]; });
+    document.querySelectorAll('#cmp-pick label').forEach(function(l){
+      l.classList.toggle('sel', l.querySelector('input').checked);
+    });
+    var out = document.getElementById('cmp-out');
+    if (picked.length < 2){ out.innerHTML = '<p class="hint">Pick at least two foods to see them side by side.</p>'; return; }
+    if (picked.length > 4){ out.innerHTML = '<p class="hint">Pick at most four foods (the table stays readable).</p>'; return; }
+    var rows = [
+      ['Age gate', function(r){ return esc(ageLabel(r)); }],
+      ['Class',    function(r){ return classBadges(r); }],
+      ['Effect',   function(r){ return esc(r.effect || ''); }],
+      ['Watch for',function(r){ return arr(r.watchFor).map(esc).join('<br>'); }],
+      ['Severe',   function(r){ return arr(r.severeSigns).map(esc).join('<br>') || '<span style="color:var(--mid)">—</span>'; }],
+      ['Seek care',function(r){ return esc(r.seekCare || ''); }],
+      ['Confidence',function(r){ return '<span class="badge ' + (CONF[r.confidence]||'b-mod') + '">' + esc(r.confidence||'') + '</span>'; }],
+    ];
+    var html = '<table><tr><th></th>' + picked.map(function(r){ return '<th style="text-transform:capitalize">' + esc(r.food) + '</th>'; }).join('') + '</tr>';
+    rows.forEach(function(row){
+      html += '<tr><td class="k">' + row[0] + '</td>' + picked.map(function(r){ return '<td>' + row[1](r) + '</td>'; }).join('') + '</tr>';
+    });
+    html += '</table>';
+    out.innerHTML = html;
+  }
+
+  // ── Reactions — cross-cut by reactionType → watch-for ──
+  function renderReactions(){
+    var types = {};
+    M.forEach(function(r){ arr(r.reactionType).forEach(function(rx){ (types[rx] = types[rx] || []).push(r); }); });
+    var order = ['allergy','choking','acute-toxin','digestive','dental','renal'];
+    var keys = Object.keys(types).sort(function(a,b){ var ia=order.indexOf(a), ib=order.indexOf(b); return (ia<0?99:ia)-(ib<0?99:ib); });
+    var html = '<p class="hint">How each food can harm — the same food can appear under more than one reaction (peanut: allergy <i>and</i> choking).</p>';
+    keys.forEach(function(rx){
+      html += '<h2>' + esc(RX_LABEL[rx] || rx) + ' · ' + types[rx].length + '</h2><div class="grid">';
+      types[rx].forEach(function(r){
+        var signs = arr(r.watchFor).slice(0, 4);
+        html += '<div class="food"><div class="top"><span class="name">' + esc(r.food) + '</span>' +
+          '<a class="age" href="' + esc(r.dashboard) + '" style="text-decoration:none;color:var(--accent)">dashboard ›</a></div>' +
+          (signs.length ? '<ul>' + signs.map(function(s){ return '<li>' + esc(s) + '</li>'; }).join('') + '</ul>'
+                        : '<div class="head">' + esc(r.headline || '') + '</div>') +
+          '</div>';
+      });
+      html += '</div>';
+    });
+    document.getElementById('p-react').innerHTML = html;
+  }
+
+  // ── tabs / swipe / arrows (canonical pattern from the dashboard template) ──
+  var tabs = Array.prototype.slice.call(document.querySelectorAll('.tab'));
+  function activate(t){
+    if (!t) return;
+    tabs.forEach(function(x){ x.classList.remove('on'); });
+    document.querySelectorAll('.panel').forEach(function(x){ x.classList.remove('on'); });
+    t.classList.add('on');
+    var el = document.getElementById(t.dataset.p); if (el) el.classList.add('on');
+    t.scrollIntoView({ inline:'center', block:'nearest' }); window.scrollTo(0, 0);
+  }
+  tabs.forEach(function(t){ t.addEventListener('click', function(){ activate(t); }); });
+  function step(d){ var c = tabs.findIndex(function(t){ return t.classList.contains('on'); }); var n = c + d; if (n >= 0 && n < tabs.length) activate(tabs[n]); }
+  var sx = 0, sy = 0, tracking = false;
+  document.addEventListener('touchstart', function(e){ if (e.touches.length > 1){ tracking = false; return; } sx = e.changedTouches[0].clientX; sy = e.changedTouches[0].clientY; tracking = true; }, { passive:true });
+  document.addEventListener('touchend', function(e){
+    if (!tracking) return; tracking = false;
+    var dx = e.changedTouches[0].clientX - sx, dy = e.changedTouches[0].clientY - sy;
+    if (Math.abs(dx) < 55 || Math.abs(dx) < Math.abs(dy) * 1.5) return;
+    step(dx < 0 ? 1 : -1);
+  }, { passive:true });
+  document.addEventListener('keydown', function(e){ if (e.key === 'ArrowRight') step(1); else if (e.key === 'ArrowLeft') step(-1); });
+  document.getElementById('cmp-pick').addEventListener('change', renderCompare);
+
+  // initial render
+  renderIndex(); renderComparePicker(); renderCompare(); renderReactions();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Care Research Hub — the manifest-driven view-join (session capstone)

Rebuilds `docs/research/index.html` as the unified hub the README always planned — replacing the static honey/peanut-only page. It renders **entirely from `food-effects.manifest.js`** (zero hardcoded food data), so it can never drift from the spine and **every future food appears the moment its record lands**.

### Three modes, one data source
- **Index** — all **7** foods, grouped by polarity (Introduce early ×6 / Avoid ×1); each card carries its class + confidence badges, headline, age gate, and the three depth-layer links (dashboard / long-form / source).
- **Compare** — pick 2–4 foods → transposed side-by-side table (age, class, effect, watch-for, severe, seek-care, confidence). Answers "egg vs honey — what's the difference?"
- **Reactions** — cross-cut by `reactionType` → the watch-for signs. A food can appear under more than one: **Allergy ×6, Choking ×2, Acute toxin ×1, Digestive/FPIES ×1** (peanut = allergy + choking; soy = allergy + FPIES).

Reuses the dashboard template's tab/swipe/arrow pattern + entrance animations (prefers-reduced-motion gated).

### Verification
Headless render: **7 cards**, all three modes exercised, **zero console errors**. README phasing updated — Phases 0–3 now ✅.

### Scope
**Docs-only ⇒ canon-cc-008 chain-exempt** (research layer, `docs/research/`, not wired into the app). This closes the food-effects research arc: research → records → renders → in-app wiring (#208) → and now the hub over all of it.

https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkviHBJ2pMvHwnBQkDb5HK)_