### PR TITLE
Wire fish (finfish) into FOOD_EFFECTS — restore green sync-gate build · food-effects v2 P1c

### DIFF
--- a/docs/CARETICKET_STATE_MACHINE.html
+++ b/docs/CARETICKET_STATE_MACHINE.html
@@ -91,7 +91,7 @@ code { font-family: var(--mono); font-size: 12px; color: var(--ink); }
 </head>
 <body>
 <h1>CareTicket State Machine</h1>
-<p class="subtitle">SproutLab — 6-transition lifecycle, spec vs implementation. Generated <code>2026-06-01</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on transition-layout snapshots</strong>; <code>CARETICKETS_SPEC_v5.md</code> wins on transition rationale; CLAUDE.md wins on rules, HRs, build commands, persona.</p>
+<p class="subtitle">SproutLab — 6-transition lifecycle, spec vs implementation. Generated <code>2026-06-02</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on transition-layout snapshots</strong>; <code>CARETICKETS_SPEC_v5.md</code> wins on transition rationale; CLAUDE.md wins on rules, HRs, build commands, persona.</p>
 
 <div class="diagram-wrap">
 <svg viewBox="0 0 520 420" width="520" height="420">

--- a/docs/POOP_COLOR_REFERENCE.html
+++ b/docs/POOP_COLOR_REFERENCE.html
@@ -108,7 +108,7 @@ code { font-family: var(--mono); font-size: 12px; color: var(--ink-soft); }
 </head>
 <body>
 <h1>Poop-Color Reference</h1>
-<p class="subtitle">SproutLab — token + render + contrast + lexicon snapshot. Generated <code>2026-06-01</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on token-value snapshots</strong>; CLAUDE.md wins on usage rules.</p>
+<p class="subtitle">SproutLab — token + render + contrast + lexicon snapshot. Generated <code>2026-06-02</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on token-value snapshots</strong>; CLAUDE.md wins on usage rules.</p>
 
 <div class="meta-bar">
   <span>light <code>--warm</code> <code>#fef6f0</code></span>

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-06-02 &middot; graph @ <code>b574a0131b1e</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-02 &middot; graph @ <code>5af76a7b2162</code></div>
   <div class="sub" style="margin-top:8px">
     <span class="stat"><b>1,721</b> symbols</span>
     <span class="stat"><b>5,119</b> relations</span>
-    <span class="stat"><b>80,869</b> LOC</span>
+    <span class="stat"><b>80,880</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -65,14 +65,14 @@
       <div class="nums">
         <span><b>11</b> modules</span>
         <span><b>731</b> symbols</span>
-        <span><b>27,351</b> LOC</span>
+        <span><b>27,362</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,351 of 30,000 LOC">
+      <div class="bar" title="27,362 of 30,000 LOC">
         <div class="fill hot" style="width:91%"></div>
         <span class="barlbl">91% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,649 LOC headroom</div>
+      <div class="hd">2,638 LOC headroom</div>
       <div class="mods">core.js, i-illness.js, i-caretickets.js, i-qa-handlers.js, sync.js, data.js, i-qa.js, i-isl.js, config.js, i-correlate.js, start.js</div>
     </div>
     <div class="card" style="border-top:5px solid #b5d5c5">

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-06-02 &middot; graph @ <code>5af76a7b2162</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-02 &middot; graph @ <code>29457c2fe4e6</code></div>
   <div class="sub" style="margin-top:8px">
-    <span class="stat"><b>1,721</b> symbols</span>
-    <span class="stat"><b>5,119</b> relations</span>
-    <span class="stat"><b>80,880</b> LOC</span>
+    <span class="stat"><b>1,723</b> symbols</span>
+    <span class="stat"><b>5,123</b> relations</span>
+    <span class="stat"><b>80,911</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -64,15 +64,15 @@
       <div class="cgov">Governor: <b>Kael</b></div>
       <div class="nums">
         <span><b>11</b> modules</span>
-        <span><b>731</b> symbols</span>
-        <span><b>27,362</b> LOC</span>
+        <span><b>733</b> symbols</span>
+        <span><b>27,384</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,362 of 30,000 LOC">
+      <div class="bar" title="27,384 of 30,000 LOC">
         <div class="fill hot" style="width:91%"></div>
         <span class="barlbl">91% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,638 LOC headroom</div>
+      <div class="hd">2,616 LOC headroom</div>
       <div class="mods">core.js, i-illness.js, i-caretickets.js, i-qa-handlers.js, sync.js, data.js, i-qa.js, i-isl.js, config.js, i-correlate.js, start.js</div>
     </div>
     <div class="card" style="border-top:5px solid #b5d5c5">
@@ -82,14 +82,14 @@
       <div class="nums">
         <span><b>3</b> modules</span>
         <span><b>668</b> symbols</span>
-        <span><b>27,126</b> LOC</span>
+        <span><b>27,135</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,126 of 30,000 LOC">
+      <div class="bar" title="27,135 of 30,000 LOC">
         <div class="fill hot" style="width:90%"></div>
         <span class="barlbl">90% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,874 LOC headroom</div>
+      <div class="hd">2,865 LOC headroom</div>
       <div class="mods">home.js, medical.js, diet.js</div>
     </div>
     <div class="card" style="border-top:5px solid #c9b8e8">
@@ -137,7 +137,7 @@
   <h2>Cross-province coupling (highest-traffic calls across jurisdiction borders)</h2>
   <table>
     <thead><tr><th>Module</th><th>Module</th><th class="num">Calls</th><th>Border</th></tr></thead>
-    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">123</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">39</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
+    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">124</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">39</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
   </table>
 
   <h2>Connectivity hubs (highest call-degree symbols per module)</h2>

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-06-02 &middot; graph @ <code>ba5fe049d90b</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-02 &middot; graph @ <code>b574a0131b1e</code></div>
   <div class="sub" style="margin-top:8px">
     <span class="stat"><b>1,721</b> symbols</span>
     <span class="stat"><b>5,119</b> relations</span>
-    <span class="stat"><b>80,817</b> LOC</span>
+    <span class="stat"><b>80,869</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -65,14 +65,14 @@
       <div class="nums">
         <span><b>11</b> modules</span>
         <span><b>731</b> symbols</span>
-        <span><b>27,299</b> LOC</span>
+        <span><b>27,351</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,299 of 30,000 LOC">
+      <div class="bar" title="27,351 of 30,000 LOC">
         <div class="fill hot" style="width:91%"></div>
         <span class="barlbl">91% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,701 LOC headroom</div>
+      <div class="hd">2,649 LOC headroom</div>
       <div class="mods">core.js, i-illness.js, i-caretickets.js, i-qa-handlers.js, sync.js, data.js, i-qa.js, i-isl.js, config.js, i-correlate.js, start.js</div>
     </div>
     <div class="card" style="border-top:5px solid #b5d5c5">

--- a/index.html
+++ b/index.html
@@ -16593,7 +16593,11 @@ const AGE_RULES = {
   'chips':    { minMonth:24, reason:'High salt, trans fats. Not suitable for babies.' },
   'ice cream':{ minMonth:12, reason:'Contains sugar and cow milk. Avoid before 12 months.' },
   'kheer':    { minMonth:10, reason:'Often made with cow milk and sugar. Use breast milk/formula and fruit instead.' },
-  'fish':     { minMonth:7, reason:'Introduce after 7 months. Start with mild, boneless fish. Ensure it is vegetarian diet — check with parents.' },
+  // food-effects-v2 P1c: reconciled 7→6 (AAP/NHS/ASCIA ~6mo; egg-yolk:7 precedent). aliases
+  // mirror the FOOD_EFFECTS record so the gate and the consequence card agree per name
+  // (one-resolver doctrine, V-M-205-B1). A vegetarian/Jain household not giving fish is valid.
+  'fish':     { minMonth:6, aliases:['finfish','rohu','katla','catla','pomfret','bhetki','bangda','indian mackerel','mackerel','sardine','mathi','salmon','tuna','surmai','seer fish','machhli','machli','fish curry','fish fry'],
+                reason:'Fine from around 6 months — well-cooked, deboned, low-mercury fish (salmon, sardine, bangda, rohu). Avoid high-mercury fish and remove every bone. A vegetarian diet can meet a baby\'s needs, so not giving fish is a valid choice.' },
   'chicken':  { minMonth:7, reason:'Can introduce after 7 months as puree. Note: this family follows vegetarian diet.' },
   'egg':      { minMonth:7, reason:'Start with well-cooked yolk at 7+ months. White can be more allergenic.' },
   'egg yolk': { minMonth:7, reason:'Can introduce at 7+ months. Cook well. Give alone for 3 days first.' },
@@ -16845,6 +16849,51 @@ const FOOD_EFFECTS = {
     seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away and use a prescribed adrenaline auto-injector if you have one. Sesame is a common cause of severe reactions — watch closely.',
     confidence: 'high',
   },
+
+  // ── food-effects-v2 P1c: fish (finfish) ──
+  // foodClass MULTI-VALUED: allergen-introduce-early (the ESTABLISHED δ encourage polarity —
+  // surfaces via the detail/consequence surfaces exactly like egg/soy/wheat/sesame, NO new
+  // render card) + choking-by-form (BONES — folded into the safe-form gate, V-2). TWO-TIER
+  // honesty: fish is introduce-early-and-SAFE, NOT prevention-proven — EAT (NEJM 2016) was
+  // NULL for fish, so earlyIntroBenefit is framed like soy/wheat/sesame ("don't delay", never
+  // "early intro prevents this allergy"). The MERCURY axis (species selection) rides in
+  // safeForm.ok/never (low- vs high-mercury species) — no new plumbing. Evidence + citations:
+  // docs/research/fish-infant-safety.md. (AGE_RULES['fish'] reconciled 7→6, egg-yolk:7 precedent.)
+  'fish': {
+    foodClass:  ['allergen-introduce-early', 'choking-by-form'],
+    severity:   'caution',
+    aliases:    ['finfish', 'rohu', 'katla', 'catla', 'pomfret', 'bhetki', 'bangda', 'indian mackerel', 'mackerel', 'sardine', 'mathi', 'salmon', 'tuna', 'surmai', 'seer fish', 'machhli', 'machli', 'fish curry', 'fish fry'],
+    effect:     'food allergy (often lifelong) + mercury (species selection) + bones (choking)',
+    title:      'Fish — good to introduce early, deboned and low-mercury',
+    why:        'Around 6 months, well-cooked, deboned, low-mercury fish is a valuable early food — not one to delay. Oily fish (salmon, sardine, bangda) is a top source of omega-3 (DHA) for brain and eye development. Choose low-mercury fish, cook it through, and remove every bone. (A vegetarian or Jain household not giving fish is making a valid choice — a vegetarian diet can meet a baby\'s needs.)',
+    whyGood:    'Oily fish (salmon, sardine, bangda) is a top source of omega-3 (DHA) for brain and eye development, plus protein, vitamin D, and iron.',
+    earlyIntroBenefit: {
+      claim:    'Introduce fish around 6 months — there is no reason to delay it.',
+      evidence: 'Guidelines (AAP, NHS, ASCIA) advise introducing fish early. Early introduction is safe — but, unlike peanut and egg, a trial (EAT) did not show early fish prevents fish allergy.',
+      paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
+    },
+    safeForm: {
+      glance:   'Low-mercury, deboned, well-cooked',
+      ok:       ['low-mercury fish — salmon, sardine, Indian mackerel (bangda), rohu, catla, pomfret, trout — thoroughly cooked, all bones removed, flaked small', 'canned light tuna (not albacore or white)'],
+      never:    ['high-mercury fish — shark (sura), swordfish, king mackerel (surmai or seer), marlin, bigeye tuna', 'raw or undercooked fish or sushi, and raw or lightly-cooked shellfish (food poisoning)', 'fish with bones left in or not hand-checked for pin bones (rohu and catla are very bony — a choking risk)', 'dried or salted fish (Bombay duck / bombil) — too much salt for a baby'],
+      note:     'Choose low-mercury fish, cook it through, and debone meticulously. Finfish is a separate allergen from shellfish. Oily fish is great — for a girl, NHS caps oily fish at about 2 portions a week (pollutants).',
+    },
+    howToIntroduce: {
+      amount:   'a small amount of well-cooked, deboned, flaked low-mercury fish',
+      when:     'around 6 months, after a few first foods are tolerated; offer at home in the daytime',
+      watch:    'watch for about 2 hours after — fish allergy tends to be lifelong (unlike egg or milk), so treat first tastes carefully',
+      thenWhat: 'if it goes well, keep offering as part of the normal diet',
+      oneAtATime: true,
+    },
+    myth: {
+      claim:    'Fish and milk together is harmful, or causes white skin patches.',
+      truth:    'No scientific basis — skin patches (vitiligo) are autoimmune or genetic, not caused by food combinations. Well-cooked, deboned, low-mercury fish is a healthy early food.',
+    },
+    watchFor:   ['hives or a rash', 'swelling of the lips, face, or eyes', 'an itchy mouth', 'vomiting'],
+    severeSigns:['trouble breathing or wheezing', 'swelling of the tongue or throat', 'a hoarse cry', 'going floppy, pale, or very sleepy'],
+    seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, tongue or throat swelling, a hoarse cry, or floppiness: call emergency services (112 or 108) right away and use a prescribed adrenaline auto-injector if you have one — an antihistamine does not treat anaphylaxis. Fish allergy is usually lifelong; a specialist guides any testing of other species.',
+    confidence: 'high',
+  },
 };
 
 // ── ALLERGEN FLAGS ──
@@ -16862,6 +16911,9 @@ const ALLERGENS = {
   'wheat':     'Contains gluten. Watch for signs of intolerance — bloating, rash, loose stools.',
   'oats':      'May contain traces of gluten. Use certified gluten-free if family has coeliac history.',
   'egg':       'Common allergen. Start with well-cooked yolk. Introduce white separately.',
+  // food-effects-v2 P1c: fish is allergen:true (a major allergen, often lifelong). Full
+  // anaphylaxis floor lives on the FOOD_EFFECTS record; this is the terse browse flag.
+  'fish':      'Common allergen, and often lifelong. Introduce well-cooked, deboned, low-mercury fish on its own and watch ~2 hours. Finfish is a separate allergen from shellfish.',
   'egg yolk':  'Less allergenic than white. Cook well. Give alone for 3 days.',
   'kiwi':      'Can cause mouth tingling. Start with small amount. Watch for oral allergy.',
   'strawberry':'Can cause allergic reaction in some babies. Introduce carefully.',

--- a/index.html
+++ b/index.html
@@ -23615,10 +23615,32 @@ function _lookupByFoodName(table, name) {
   return byAlias || null;
 }
 
+// food-effects-v2 P1c (Cipher Edict-V, M-F-1 completion). The fish record is reached by the
+// bare 'fish' KEY, which word-boundary-matches the trailing word of a "<species> fish" host —
+// so "seer fish" / "shark fish" (documented HIGH-MERCURY species in the record's safeForm.never)
+// still resolve to the GREEN "introduce early" verdict despite the alias trim, because the leak
+// is via the KEY, not an alias. This guard suppresses a fish-record resolution whose host names
+// a high-mercury species, mirroring the _foodNameNegated host-guard pattern — so the illegal
+// state (a high-mercury fish affirmed as a safe early food) is unrepresentable on BOTH the
+// consequence card (getFoodEffect, below) and the age gate (_fdAgeRule, diet.js). Mercury is a
+// silent neurodevelopmental exposure with no verification loop, so a false-safe here cannot be
+// caught downstream — the suppression is the only floor. (The allergen-note surface intentionally
+// still fires its calm caution for "seer fish"; the suppression targets only the GREEN affirm.)
+const _FISH_HIGH_MERCURY = ['seer', 'surmai', 'shark', 'sura', 'swordfish', 'marlin', 'king mackerel', 'bigeye'];
+function _isHighMercuryFishHost(name) {
+  const n = String(name || '').toLowerCase();
+  return _FISH_HIGH_MERCURY.some(t =>
+    new RegExp('\\b' + t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b').test(n));
+}
+
 // FOOD_EFFECTS consequence record for a food, or null. Uses _lookupByFoodName so
 // resolution matches the AGE_RULES gate exactly (word-boundary, not substring).
 function getFoodEffect(name) {
-  return (typeof FOOD_EFFECTS !== 'undefined') ? _lookupByFoodName(FOOD_EFFECTS, name) : null;
+  if (typeof FOOD_EFFECTS === 'undefined') return null;
+  const eff = _lookupByFoodName(FOOD_EFFECTS, name);
+  // M-F-1: never affirm a high-mercury fish as a safe early food (the bare 'fish' KEY leak).
+  if (eff && eff === FOOD_EFFECTS['fish'] && _isHighMercuryFishHost(name)) return null;
+  return eff;
 }
 
 // Combo-result schema tag (food-effects v2 R1, M-R1-1). The combo checker caches
@@ -38490,6 +38512,15 @@ function _fdAgeRule(name) {
   // 'honeydew' no longer inherits honey's gate, and the gate stays consistent
   // with the consequence card (getFoodEffect uses the same resolver).
   const rule = _lookupByFoodName(AGE_RULES, name);
+  // M-F-1 (Cipher Edict-V completion): the same bare-'fish'-KEY leak that fed the
+  // consequence card also feeds this gate — "seer fish" / "shark fish" resolve to
+  // AGE_RULES['fish'] (6mo) and would show a green "fine from ~6 months" badge for a
+  // high-mercury species. Suppress identically to getFoodEffect, so the card and the
+  // gate agree (one-resolver doctrine): a high-mercury fish host gets neither surface.
+  if (rule && typeof AGE_RULES !== 'undefined' && rule === AGE_RULES['fish']
+      && typeof _isHighMercuryFishHost === 'function' && _isHighMercuryFishHost(name)) {
+    return null;
+  }
   // V-M-206 (Care, food-effects-v2 P1a): a NAMED whole/chopped nut — "whole
   // almond", "chopped cashew", "whole peanut" — must hit the 60-month whole-nut
   // CHOKING gate, not the 6-month introduce-early floor its base nut resolves

--- a/index.html
+++ b/index.html
@@ -16596,7 +16596,11 @@ const AGE_RULES = {
   // food-effects-v2 P1c: reconciled 7→6 (AAP/NHS/ASCIA ~6mo; egg-yolk:7 precedent). aliases
   // mirror the FOOD_EFFECTS record so the gate and the consequence card agree per name
   // (one-resolver doctrine, V-M-205-B1). A vegetarian/Jain household not giving fish is valid.
-  'fish':     { minMonth:6, aliases:['finfish','rohu','katla','catla','pomfret','bhetki','bangda','indian mackerel','mackerel','sardine','mathi','salmon','tuna','surmai','seer fish','machhli','machli','fish curry','fish fry'],
+  // aliases mirror the FOOD_EFFECTS record (one-resolver doctrine) — incl. the M-F-1 trim:
+  // high-mercury/ambiguous names (surmai/seer fish/bare mackerel/bare tuna) are NOT gated here
+  // either, so the gate and the card agree per name (both absent → a logged "surmai" gets no
+  // green verdict AND no gate badge, the safest neutral state).
+  'fish':     { minMonth:6, aliases:['finfish','rohu','katla','catla','pomfret','bhetki','bangda','indian mackerel','sardine','mathi','salmon','machhli','machli','fish curry','fish fry'],
                 reason:'Fine from around 6 months — well-cooked, deboned, low-mercury fish (salmon, sardine, bangda, rohu). Avoid high-mercury fish and remove every bone. A vegetarian diet can meet a baby\'s needs, so not giving fish is a valid choice.' },
   'chicken':  { minMonth:7, reason:'Can introduce after 7 months as puree. Note: this family follows vegetarian diet.' },
   'egg':      { minMonth:7, reason:'Start with well-cooked yolk at 7+ months. White can be more allergenic.' },
@@ -16862,7 +16866,14 @@ const FOOD_EFFECTS = {
   'fish': {
     foodClass:  ['allergen-introduce-early', 'choking-by-form'],
     severity:   'caution',
-    aliases:    ['finfish', 'rohu', 'katla', 'catla', 'pomfret', 'bhetki', 'bangda', 'indian mackerel', 'mackerel', 'sardine', 'mathi', 'salmon', 'tuna', 'surmai', 'seer fish', 'machhli', 'machli', 'fish curry', 'fish fry'],
+    // M-F-1 (Maren, blocking — folded): the app aliases are the SAFE-TO-ENCOURAGE subset of
+    // the manifest's research aliases. A logged name that resolves here fires the GREEN
+    // "introduce early" verdict (diet.js introEarlyOk), so HIGH-MERCURY / ambiguous names are
+    // deliberately NOT aliased — 'surmai'/'seer fish' (king mackerel, high-mercury), bare
+    // 'mackerel' (ambiguous: king vs indian), bare 'tuna' (ambiguous: light vs bigeye/albacore).
+    // They live ONLY in safeForm.never as the in-card reference, so they never auto-affirm a
+    // high-mercury fish as a safe early food. 'indian mackerel'/'bangda' (low-mercury) are kept.
+    aliases:    ['finfish', 'rohu', 'katla', 'catla', 'pomfret', 'bhetki', 'bangda', 'indian mackerel', 'sardine', 'mathi', 'salmon', 'machhli', 'machli', 'fish curry', 'fish fry'],
     effect:     'food allergy (often lifelong) + mercury (species selection) + bones (choking)',
     title:      'Fish — good to introduce early, deboned and low-mercury',
     why:        'Around 6 months, well-cooked, deboned, low-mercury fish is a valuable early food — not one to delay. Oily fish (salmon, sardine, bangda) is a top source of omega-3 (DHA) for brain and eye development. Choose low-mercury fish, cook it through, and remove every bone. (A vegetarian or Jain household not giving fish is making a valid choice — a vegetarian diet can meet a baby\'s needs.)',

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.01-9",
+  "version": "2026.06.02-1",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.02-1",
+  "version": "2026.06.02-2",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.02-2",
+  "version": "2026.06.02-3",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -4046,10 +4046,32 @@ function _lookupByFoodName(table, name) {
   return byAlias || null;
 }
 
+// food-effects-v2 P1c (Cipher Edict-V, M-F-1 completion). The fish record is reached by the
+// bare 'fish' KEY, which word-boundary-matches the trailing word of a "<species> fish" host —
+// so "seer fish" / "shark fish" (documented HIGH-MERCURY species in the record's safeForm.never)
+// still resolve to the GREEN "introduce early" verdict despite the alias trim, because the leak
+// is via the KEY, not an alias. This guard suppresses a fish-record resolution whose host names
+// a high-mercury species, mirroring the _foodNameNegated host-guard pattern — so the illegal
+// state (a high-mercury fish affirmed as a safe early food) is unrepresentable on BOTH the
+// consequence card (getFoodEffect, below) and the age gate (_fdAgeRule, diet.js). Mercury is a
+// silent neurodevelopmental exposure with no verification loop, so a false-safe here cannot be
+// caught downstream — the suppression is the only floor. (The allergen-note surface intentionally
+// still fires its calm caution for "seer fish"; the suppression targets only the GREEN affirm.)
+const _FISH_HIGH_MERCURY = ['seer', 'surmai', 'shark', 'sura', 'swordfish', 'marlin', 'king mackerel', 'bigeye'];
+function _isHighMercuryFishHost(name) {
+  const n = String(name || '').toLowerCase();
+  return _FISH_HIGH_MERCURY.some(t =>
+    new RegExp('\\b' + t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b').test(n));
+}
+
 // FOOD_EFFECTS consequence record for a food, or null. Uses _lookupByFoodName so
 // resolution matches the AGE_RULES gate exactly (word-boundary, not substring).
 function getFoodEffect(name) {
-  return (typeof FOOD_EFFECTS !== 'undefined') ? _lookupByFoodName(FOOD_EFFECTS, name) : null;
+  if (typeof FOOD_EFFECTS === 'undefined') return null;
+  const eff = _lookupByFoodName(FOOD_EFFECTS, name);
+  // M-F-1: never affirm a high-mercury fish as a safe early food (the bare 'fish' KEY leak).
+  if (eff && eff === FOOD_EFFECTS['fish'] && _isHighMercuryFishHost(name)) return null;
+  return eff;
 }
 
 // Combo-result schema tag (food-effects v2 R1, M-R1-1). The combo checker caches

--- a/split/data.js
+++ b/split/data.js
@@ -2433,7 +2433,11 @@ const AGE_RULES = {
   // food-effects-v2 P1c: reconciled 7→6 (AAP/NHS/ASCIA ~6mo; egg-yolk:7 precedent). aliases
   // mirror the FOOD_EFFECTS record so the gate and the consequence card agree per name
   // (one-resolver doctrine, V-M-205-B1). A vegetarian/Jain household not giving fish is valid.
-  'fish':     { minMonth:6, aliases:['finfish','rohu','katla','catla','pomfret','bhetki','bangda','indian mackerel','mackerel','sardine','mathi','salmon','tuna','surmai','seer fish','machhli','machli','fish curry','fish fry'],
+  // aliases mirror the FOOD_EFFECTS record (one-resolver doctrine) — incl. the M-F-1 trim:
+  // high-mercury/ambiguous names (surmai/seer fish/bare mackerel/bare tuna) are NOT gated here
+  // either, so the gate and the card agree per name (both absent → a logged "surmai" gets no
+  // green verdict AND no gate badge, the safest neutral state).
+  'fish':     { minMonth:6, aliases:['finfish','rohu','katla','catla','pomfret','bhetki','bangda','indian mackerel','sardine','mathi','salmon','machhli','machli','fish curry','fish fry'],
                 reason:'Fine from around 6 months — well-cooked, deboned, low-mercury fish (salmon, sardine, bangda, rohu). Avoid high-mercury fish and remove every bone. A vegetarian diet can meet a baby\'s needs, so not giving fish is a valid choice.' },
   'chicken':  { minMonth:7, reason:'Can introduce after 7 months as puree. Note: this family follows vegetarian diet.' },
   'egg':      { minMonth:7, reason:'Start with well-cooked yolk at 7+ months. White can be more allergenic.' },
@@ -2699,7 +2703,14 @@ const FOOD_EFFECTS = {
   'fish': {
     foodClass:  ['allergen-introduce-early', 'choking-by-form'],
     severity:   'caution',
-    aliases:    ['finfish', 'rohu', 'katla', 'catla', 'pomfret', 'bhetki', 'bangda', 'indian mackerel', 'mackerel', 'sardine', 'mathi', 'salmon', 'tuna', 'surmai', 'seer fish', 'machhli', 'machli', 'fish curry', 'fish fry'],
+    // M-F-1 (Maren, blocking — folded): the app aliases are the SAFE-TO-ENCOURAGE subset of
+    // the manifest's research aliases. A logged name that resolves here fires the GREEN
+    // "introduce early" verdict (diet.js introEarlyOk), so HIGH-MERCURY / ambiguous names are
+    // deliberately NOT aliased — 'surmai'/'seer fish' (king mackerel, high-mercury), bare
+    // 'mackerel' (ambiguous: king vs indian), bare 'tuna' (ambiguous: light vs bigeye/albacore).
+    // They live ONLY in safeForm.never as the in-card reference, so they never auto-affirm a
+    // high-mercury fish as a safe early food. 'indian mackerel'/'bangda' (low-mercury) are kept.
+    aliases:    ['finfish', 'rohu', 'katla', 'catla', 'pomfret', 'bhetki', 'bangda', 'indian mackerel', 'sardine', 'mathi', 'salmon', 'machhli', 'machli', 'fish curry', 'fish fry'],
     effect:     'food allergy (often lifelong) + mercury (species selection) + bones (choking)',
     title:      'Fish — good to introduce early, deboned and low-mercury',
     why:        'Around 6 months, well-cooked, deboned, low-mercury fish is a valuable early food — not one to delay. Oily fish (salmon, sardine, bangda) is a top source of omega-3 (DHA) for brain and eye development. Choose low-mercury fish, cook it through, and remove every bone. (A vegetarian or Jain household not giving fish is making a valid choice — a vegetarian diet can meet a baby\'s needs.)',

--- a/split/data.js
+++ b/split/data.js
@@ -2430,7 +2430,11 @@ const AGE_RULES = {
   'chips':    { minMonth:24, reason:'High salt, trans fats. Not suitable for babies.' },
   'ice cream':{ minMonth:12, reason:'Contains sugar and cow milk. Avoid before 12 months.' },
   'kheer':    { minMonth:10, reason:'Often made with cow milk and sugar. Use breast milk/formula and fruit instead.' },
-  'fish':     { minMonth:7, reason:'Introduce after 7 months. Start with mild, boneless fish. Ensure it is vegetarian diet — check with parents.' },
+  // food-effects-v2 P1c: reconciled 7→6 (AAP/NHS/ASCIA ~6mo; egg-yolk:7 precedent). aliases
+  // mirror the FOOD_EFFECTS record so the gate and the consequence card agree per name
+  // (one-resolver doctrine, V-M-205-B1). A vegetarian/Jain household not giving fish is valid.
+  'fish':     { minMonth:6, aliases:['finfish','rohu','katla','catla','pomfret','bhetki','bangda','indian mackerel','mackerel','sardine','mathi','salmon','tuna','surmai','seer fish','machhli','machli','fish curry','fish fry'],
+                reason:'Fine from around 6 months — well-cooked, deboned, low-mercury fish (salmon, sardine, bangda, rohu). Avoid high-mercury fish and remove every bone. A vegetarian diet can meet a baby\'s needs, so not giving fish is a valid choice.' },
   'chicken':  { minMonth:7, reason:'Can introduce after 7 months as puree. Note: this family follows vegetarian diet.' },
   'egg':      { minMonth:7, reason:'Start with well-cooked yolk at 7+ months. White can be more allergenic.' },
   'egg yolk': { minMonth:7, reason:'Can introduce at 7+ months. Cook well. Give alone for 3 days first.' },
@@ -2682,6 +2686,51 @@ const FOOD_EFFECTS = {
     seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away and use a prescribed adrenaline auto-injector if you have one. Sesame is a common cause of severe reactions — watch closely.',
     confidence: 'high',
   },
+
+  // ── food-effects-v2 P1c: fish (finfish) ──
+  // foodClass MULTI-VALUED: allergen-introduce-early (the ESTABLISHED δ encourage polarity —
+  // surfaces via the detail/consequence surfaces exactly like egg/soy/wheat/sesame, NO new
+  // render card) + choking-by-form (BONES — folded into the safe-form gate, V-2). TWO-TIER
+  // honesty: fish is introduce-early-and-SAFE, NOT prevention-proven — EAT (NEJM 2016) was
+  // NULL for fish, so earlyIntroBenefit is framed like soy/wheat/sesame ("don't delay", never
+  // "early intro prevents this allergy"). The MERCURY axis (species selection) rides in
+  // safeForm.ok/never (low- vs high-mercury species) — no new plumbing. Evidence + citations:
+  // docs/research/fish-infant-safety.md. (AGE_RULES['fish'] reconciled 7→6, egg-yolk:7 precedent.)
+  'fish': {
+    foodClass:  ['allergen-introduce-early', 'choking-by-form'],
+    severity:   'caution',
+    aliases:    ['finfish', 'rohu', 'katla', 'catla', 'pomfret', 'bhetki', 'bangda', 'indian mackerel', 'mackerel', 'sardine', 'mathi', 'salmon', 'tuna', 'surmai', 'seer fish', 'machhli', 'machli', 'fish curry', 'fish fry'],
+    effect:     'food allergy (often lifelong) + mercury (species selection) + bones (choking)',
+    title:      'Fish — good to introduce early, deboned and low-mercury',
+    why:        'Around 6 months, well-cooked, deboned, low-mercury fish is a valuable early food — not one to delay. Oily fish (salmon, sardine, bangda) is a top source of omega-3 (DHA) for brain and eye development. Choose low-mercury fish, cook it through, and remove every bone. (A vegetarian or Jain household not giving fish is making a valid choice — a vegetarian diet can meet a baby\'s needs.)',
+    whyGood:    'Oily fish (salmon, sardine, bangda) is a top source of omega-3 (DHA) for brain and eye development, plus protein, vitamin D, and iron.',
+    earlyIntroBenefit: {
+      claim:    'Introduce fish around 6 months — there is no reason to delay it.',
+      evidence: 'Guidelines (AAP, NHS, ASCIA) advise introducing fish early. Early introduction is safe — but, unlike peanut and egg, a trial (EAT) did not show early fish prevents fish allergy.',
+      paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
+    },
+    safeForm: {
+      glance:   'Low-mercury, deboned, well-cooked',
+      ok:       ['low-mercury fish — salmon, sardine, Indian mackerel (bangda), rohu, catla, pomfret, trout — thoroughly cooked, all bones removed, flaked small', 'canned light tuna (not albacore or white)'],
+      never:    ['high-mercury fish — shark (sura), swordfish, king mackerel (surmai or seer), marlin, bigeye tuna', 'raw or undercooked fish or sushi, and raw or lightly-cooked shellfish (food poisoning)', 'fish with bones left in or not hand-checked for pin bones (rohu and catla are very bony — a choking risk)', 'dried or salted fish (Bombay duck / bombil) — too much salt for a baby'],
+      note:     'Choose low-mercury fish, cook it through, and debone meticulously. Finfish is a separate allergen from shellfish. Oily fish is great — for a girl, NHS caps oily fish at about 2 portions a week (pollutants).',
+    },
+    howToIntroduce: {
+      amount:   'a small amount of well-cooked, deboned, flaked low-mercury fish',
+      when:     'around 6 months, after a few first foods are tolerated; offer at home in the daytime',
+      watch:    'watch for about 2 hours after — fish allergy tends to be lifelong (unlike egg or milk), so treat first tastes carefully',
+      thenWhat: 'if it goes well, keep offering as part of the normal diet',
+      oneAtATime: true,
+    },
+    myth: {
+      claim:    'Fish and milk together is harmful, or causes white skin patches.',
+      truth:    'No scientific basis — skin patches (vitiligo) are autoimmune or genetic, not caused by food combinations. Well-cooked, deboned, low-mercury fish is a healthy early food.',
+    },
+    watchFor:   ['hives or a rash', 'swelling of the lips, face, or eyes', 'an itchy mouth', 'vomiting'],
+    severeSigns:['trouble breathing or wheezing', 'swelling of the tongue or throat', 'a hoarse cry', 'going floppy, pale, or very sleepy'],
+    seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, tongue or throat swelling, a hoarse cry, or floppiness: call emergency services (112 or 108) right away and use a prescribed adrenaline auto-injector if you have one — an antihistamine does not treat anaphylaxis. Fish allergy is usually lifelong; a specialist guides any testing of other species.',
+    confidence: 'high',
+  },
 };
 
 // ── ALLERGEN FLAGS ──
@@ -2699,6 +2748,9 @@ const ALLERGENS = {
   'wheat':     'Contains gluten. Watch for signs of intolerance — bloating, rash, loose stools.',
   'oats':      'May contain traces of gluten. Use certified gluten-free if family has coeliac history.',
   'egg':       'Common allergen. Start with well-cooked yolk. Introduce white separately.',
+  // food-effects-v2 P1c: fish is allergen:true (a major allergen, often lifelong). Full
+  // anaphylaxis floor lives on the FOOD_EFFECTS record; this is the terse browse flag.
+  'fish':      'Common allergen, and often lifelong. Introduce well-cooked, deboned, low-mercury fish on its own and watch ~2 hours. Finfish is a separate allergen from shellfish.',
   'egg yolk':  'Less allergenic than white. Cook well. Give alone for 3 days.',
   'kiwi':      'Can cause mouth tingling. Start with small amount. Watch for oral allergy.',
   'strawberry':'Can cause allergic reaction in some babies. Introduce carefully.',

--- a/split/diet.js
+++ b/split/diet.js
@@ -488,6 +488,15 @@ function _fdAgeRule(name) {
   // 'honeydew' no longer inherits honey's gate, and the gate stays consistent
   // with the consequence card (getFoodEffect uses the same resolver).
   const rule = _lookupByFoodName(AGE_RULES, name);
+  // M-F-1 (Cipher Edict-V completion): the same bare-'fish'-KEY leak that fed the
+  // consequence card also feeds this gate — "seer fish" / "shark fish" resolve to
+  // AGE_RULES['fish'] (6mo) and would show a green "fine from ~6 months" badge for a
+  // high-mercury species. Suppress identically to getFoodEffect, so the card and the
+  // gate agree (one-resolver doctrine): a high-mercury fish host gets neither surface.
+  if (rule && typeof AGE_RULES !== 'undefined' && rule === AGE_RULES['fish']
+      && typeof _isHighMercuryFishHost === 'function' && _isHighMercuryFishHost(name)) {
+    return null;
+  }
   // V-M-206 (Care, food-effects-v2 P1a): a NAMED whole/chopped nut — "whole
   // almond", "chopped cashew", "whole peanut" — must hit the 60-month whole-nut
   // CHOKING gate, not the 6-month introduce-early floor its base nut resolves

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -16593,7 +16593,11 @@ const AGE_RULES = {
   'chips':    { minMonth:24, reason:'High salt, trans fats. Not suitable for babies.' },
   'ice cream':{ minMonth:12, reason:'Contains sugar and cow milk. Avoid before 12 months.' },
   'kheer':    { minMonth:10, reason:'Often made with cow milk and sugar. Use breast milk/formula and fruit instead.' },
-  'fish':     { minMonth:7, reason:'Introduce after 7 months. Start with mild, boneless fish. Ensure it is vegetarian diet — check with parents.' },
+  // food-effects-v2 P1c: reconciled 7→6 (AAP/NHS/ASCIA ~6mo; egg-yolk:7 precedent). aliases
+  // mirror the FOOD_EFFECTS record so the gate and the consequence card agree per name
+  // (one-resolver doctrine, V-M-205-B1). A vegetarian/Jain household not giving fish is valid.
+  'fish':     { minMonth:6, aliases:['finfish','rohu','katla','catla','pomfret','bhetki','bangda','indian mackerel','mackerel','sardine','mathi','salmon','tuna','surmai','seer fish','machhli','machli','fish curry','fish fry'],
+                reason:'Fine from around 6 months — well-cooked, deboned, low-mercury fish (salmon, sardine, bangda, rohu). Avoid high-mercury fish and remove every bone. A vegetarian diet can meet a baby\'s needs, so not giving fish is a valid choice.' },
   'chicken':  { minMonth:7, reason:'Can introduce after 7 months as puree. Note: this family follows vegetarian diet.' },
   'egg':      { minMonth:7, reason:'Start with well-cooked yolk at 7+ months. White can be more allergenic.' },
   'egg yolk': { minMonth:7, reason:'Can introduce at 7+ months. Cook well. Give alone for 3 days first.' },
@@ -16845,6 +16849,51 @@ const FOOD_EFFECTS = {
     seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, face or throat swelling, or floppiness: call emergency services (112) right away and use a prescribed adrenaline auto-injector if you have one. Sesame is a common cause of severe reactions — watch closely.',
     confidence: 'high',
   },
+
+  // ── food-effects-v2 P1c: fish (finfish) ──
+  // foodClass MULTI-VALUED: allergen-introduce-early (the ESTABLISHED δ encourage polarity —
+  // surfaces via the detail/consequence surfaces exactly like egg/soy/wheat/sesame, NO new
+  // render card) + choking-by-form (BONES — folded into the safe-form gate, V-2). TWO-TIER
+  // honesty: fish is introduce-early-and-SAFE, NOT prevention-proven — EAT (NEJM 2016) was
+  // NULL for fish, so earlyIntroBenefit is framed like soy/wheat/sesame ("don't delay", never
+  // "early intro prevents this allergy"). The MERCURY axis (species selection) rides in
+  // safeForm.ok/never (low- vs high-mercury species) — no new plumbing. Evidence + citations:
+  // docs/research/fish-infant-safety.md. (AGE_RULES['fish'] reconciled 7→6, egg-yolk:7 precedent.)
+  'fish': {
+    foodClass:  ['allergen-introduce-early', 'choking-by-form'],
+    severity:   'caution',
+    aliases:    ['finfish', 'rohu', 'katla', 'catla', 'pomfret', 'bhetki', 'bangda', 'indian mackerel', 'mackerel', 'sardine', 'mathi', 'salmon', 'tuna', 'surmai', 'seer fish', 'machhli', 'machli', 'fish curry', 'fish fry'],
+    effect:     'food allergy (often lifelong) + mercury (species selection) + bones (choking)',
+    title:      'Fish — good to introduce early, deboned and low-mercury',
+    why:        'Around 6 months, well-cooked, deboned, low-mercury fish is a valuable early food — not one to delay. Oily fish (salmon, sardine, bangda) is a top source of omega-3 (DHA) for brain and eye development. Choose low-mercury fish, cook it through, and remove every bone. (A vegetarian or Jain household not giving fish is making a valid choice — a vegetarian diet can meet a baby\'s needs.)',
+    whyGood:    'Oily fish (salmon, sardine, bangda) is a top source of omega-3 (DHA) for brain and eye development, plus protein, vitamin D, and iron.',
+    earlyIntroBenefit: {
+      claim:    'Introduce fish around 6 months — there is no reason to delay it.',
+      evidence: 'Guidelines (AAP, NHS, ASCIA) advise introducing fish early. Early introduction is safe — but, unlike peanut and egg, a trial (EAT) did not show early fish prevents fish allergy.',
+      paradigm: 'Don\'t delay allergens — but this is "safe to introduce," not a proven prevention.',
+    },
+    safeForm: {
+      glance:   'Low-mercury, deboned, well-cooked',
+      ok:       ['low-mercury fish — salmon, sardine, Indian mackerel (bangda), rohu, catla, pomfret, trout — thoroughly cooked, all bones removed, flaked small', 'canned light tuna (not albacore or white)'],
+      never:    ['high-mercury fish — shark (sura), swordfish, king mackerel (surmai or seer), marlin, bigeye tuna', 'raw or undercooked fish or sushi, and raw or lightly-cooked shellfish (food poisoning)', 'fish with bones left in or not hand-checked for pin bones (rohu and catla are very bony — a choking risk)', 'dried or salted fish (Bombay duck / bombil) — too much salt for a baby'],
+      note:     'Choose low-mercury fish, cook it through, and debone meticulously. Finfish is a separate allergen from shellfish. Oily fish is great — for a girl, NHS caps oily fish at about 2 portions a week (pollutants).',
+    },
+    howToIntroduce: {
+      amount:   'a small amount of well-cooked, deboned, flaked low-mercury fish',
+      when:     'around 6 months, after a few first foods are tolerated; offer at home in the daytime',
+      watch:    'watch for about 2 hours after — fish allergy tends to be lifelong (unlike egg or milk), so treat first tastes carefully',
+      thenWhat: 'if it goes well, keep offering as part of the normal diet',
+      oneAtATime: true,
+    },
+    myth: {
+      claim:    'Fish and milk together is harmful, or causes white skin patches.',
+      truth:    'No scientific basis — skin patches (vitiligo) are autoimmune or genetic, not caused by food combinations. Well-cooked, deboned, low-mercury fish is a healthy early food.',
+    },
+    watchFor:   ['hives or a rash', 'swelling of the lips, face, or eyes', 'an itchy mouth', 'vomiting'],
+    severeSigns:['trouble breathing or wheezing', 'swelling of the tongue or throat', 'a hoarse cry', 'going floppy, pale, or very sleepy'],
+    seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, tongue or throat swelling, a hoarse cry, or floppiness: call emergency services (112 or 108) right away and use a prescribed adrenaline auto-injector if you have one — an antihistamine does not treat anaphylaxis. Fish allergy is usually lifelong; a specialist guides any testing of other species.',
+    confidence: 'high',
+  },
 };
 
 // ── ALLERGEN FLAGS ──
@@ -16862,6 +16911,9 @@ const ALLERGENS = {
   'wheat':     'Contains gluten. Watch for signs of intolerance — bloating, rash, loose stools.',
   'oats':      'May contain traces of gluten. Use certified gluten-free if family has coeliac history.',
   'egg':       'Common allergen. Start with well-cooked yolk. Introduce white separately.',
+  // food-effects-v2 P1c: fish is allergen:true (a major allergen, often lifelong). Full
+  // anaphylaxis floor lives on the FOOD_EFFECTS record; this is the terse browse flag.
+  'fish':      'Common allergen, and often lifelong. Introduce well-cooked, deboned, low-mercury fish on its own and watch ~2 hours. Finfish is a separate allergen from shellfish.',
   'egg yolk':  'Less allergenic than white. Cook well. Give alone for 3 days.',
   'kiwi':      'Can cause mouth tingling. Start with small amount. Watch for oral allergy.',
   'strawberry':'Can cause allergic reaction in some babies. Introduce carefully.',

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -23615,10 +23615,32 @@ function _lookupByFoodName(table, name) {
   return byAlias || null;
 }
 
+// food-effects-v2 P1c (Cipher Edict-V, M-F-1 completion). The fish record is reached by the
+// bare 'fish' KEY, which word-boundary-matches the trailing word of a "<species> fish" host —
+// so "seer fish" / "shark fish" (documented HIGH-MERCURY species in the record's safeForm.never)
+// still resolve to the GREEN "introduce early" verdict despite the alias trim, because the leak
+// is via the KEY, not an alias. This guard suppresses a fish-record resolution whose host names
+// a high-mercury species, mirroring the _foodNameNegated host-guard pattern — so the illegal
+// state (a high-mercury fish affirmed as a safe early food) is unrepresentable on BOTH the
+// consequence card (getFoodEffect, below) and the age gate (_fdAgeRule, diet.js). Mercury is a
+// silent neurodevelopmental exposure with no verification loop, so a false-safe here cannot be
+// caught downstream — the suppression is the only floor. (The allergen-note surface intentionally
+// still fires its calm caution for "seer fish"; the suppression targets only the GREEN affirm.)
+const _FISH_HIGH_MERCURY = ['seer', 'surmai', 'shark', 'sura', 'swordfish', 'marlin', 'king mackerel', 'bigeye'];
+function _isHighMercuryFishHost(name) {
+  const n = String(name || '').toLowerCase();
+  return _FISH_HIGH_MERCURY.some(t =>
+    new RegExp('\\b' + t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b').test(n));
+}
+
 // FOOD_EFFECTS consequence record for a food, or null. Uses _lookupByFoodName so
 // resolution matches the AGE_RULES gate exactly (word-boundary, not substring).
 function getFoodEffect(name) {
-  return (typeof FOOD_EFFECTS !== 'undefined') ? _lookupByFoodName(FOOD_EFFECTS, name) : null;
+  if (typeof FOOD_EFFECTS === 'undefined') return null;
+  const eff = _lookupByFoodName(FOOD_EFFECTS, name);
+  // M-F-1: never affirm a high-mercury fish as a safe early food (the bare 'fish' KEY leak).
+  if (eff && eff === FOOD_EFFECTS['fish'] && _isHighMercuryFishHost(name)) return null;
+  return eff;
 }
 
 // Combo-result schema tag (food-effects v2 R1, M-R1-1). The combo checker caches
@@ -38490,6 +38512,15 @@ function _fdAgeRule(name) {
   // 'honeydew' no longer inherits honey's gate, and the gate stays consistent
   // with the consequence card (getFoodEffect uses the same resolver).
   const rule = _lookupByFoodName(AGE_RULES, name);
+  // M-F-1 (Cipher Edict-V completion): the same bare-'fish'-KEY leak that fed the
+  // consequence card also feeds this gate — "seer fish" / "shark fish" resolve to
+  // AGE_RULES['fish'] (6mo) and would show a green "fine from ~6 months" badge for a
+  // high-mercury species. Suppress identically to getFoodEffect, so the card and the
+  // gate agree (one-resolver doctrine): a high-mercury fish host gets neither surface.
+  if (rule && typeof AGE_RULES !== 'undefined' && rule === AGE_RULES['fish']
+      && typeof _isHighMercuryFishHost === 'function' && _isHighMercuryFishHost(name)) {
+    return null;
+  }
   // V-M-206 (Care, food-effects-v2 P1a): a NAMED whole/chopped nut — "whole
   // almond", "chopped cashew", "whole peanut" — must hit the 60-month whole-nut
   // CHOKING gate, not the 6-month introduce-early floor its base nut resolves

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -16596,7 +16596,11 @@ const AGE_RULES = {
   // food-effects-v2 P1c: reconciled 7→6 (AAP/NHS/ASCIA ~6mo; egg-yolk:7 precedent). aliases
   // mirror the FOOD_EFFECTS record so the gate and the consequence card agree per name
   // (one-resolver doctrine, V-M-205-B1). A vegetarian/Jain household not giving fish is valid.
-  'fish':     { minMonth:6, aliases:['finfish','rohu','katla','catla','pomfret','bhetki','bangda','indian mackerel','mackerel','sardine','mathi','salmon','tuna','surmai','seer fish','machhli','machli','fish curry','fish fry'],
+  // aliases mirror the FOOD_EFFECTS record (one-resolver doctrine) — incl. the M-F-1 trim:
+  // high-mercury/ambiguous names (surmai/seer fish/bare mackerel/bare tuna) are NOT gated here
+  // either, so the gate and the card agree per name (both absent → a logged "surmai" gets no
+  // green verdict AND no gate badge, the safest neutral state).
+  'fish':     { minMonth:6, aliases:['finfish','rohu','katla','catla','pomfret','bhetki','bangda','indian mackerel','sardine','mathi','salmon','machhli','machli','fish curry','fish fry'],
                 reason:'Fine from around 6 months — well-cooked, deboned, low-mercury fish (salmon, sardine, bangda, rohu). Avoid high-mercury fish and remove every bone. A vegetarian diet can meet a baby\'s needs, so not giving fish is a valid choice.' },
   'chicken':  { minMonth:7, reason:'Can introduce after 7 months as puree. Note: this family follows vegetarian diet.' },
   'egg':      { minMonth:7, reason:'Start with well-cooked yolk at 7+ months. White can be more allergenic.' },
@@ -16862,7 +16866,14 @@ const FOOD_EFFECTS = {
   'fish': {
     foodClass:  ['allergen-introduce-early', 'choking-by-form'],
     severity:   'caution',
-    aliases:    ['finfish', 'rohu', 'katla', 'catla', 'pomfret', 'bhetki', 'bangda', 'indian mackerel', 'mackerel', 'sardine', 'mathi', 'salmon', 'tuna', 'surmai', 'seer fish', 'machhli', 'machli', 'fish curry', 'fish fry'],
+    // M-F-1 (Maren, blocking — folded): the app aliases are the SAFE-TO-ENCOURAGE subset of
+    // the manifest's research aliases. A logged name that resolves here fires the GREEN
+    // "introduce early" verdict (diet.js introEarlyOk), so HIGH-MERCURY / ambiguous names are
+    // deliberately NOT aliased — 'surmai'/'seer fish' (king mackerel, high-mercury), bare
+    // 'mackerel' (ambiguous: king vs indian), bare 'tuna' (ambiguous: light vs bigeye/albacore).
+    // They live ONLY in safeForm.never as the in-card reference, so they never auto-affirm a
+    // high-mercury fish as a safe early food. 'indian mackerel'/'bangda' (low-mercury) are kept.
+    aliases:    ['finfish', 'rohu', 'katla', 'catla', 'pomfret', 'bhetki', 'bangda', 'indian mackerel', 'sardine', 'mathi', 'salmon', 'machhli', 'machli', 'fish curry', 'fish fry'],
     effect:     'food allergy (often lifelong) + mercury (species selection) + bones (choking)',
     title:      'Fish — good to introduce early, deboned and low-mercury',
     why:        'Around 6 months, well-cooked, deboned, low-mercury fish is a valuable early food — not one to delay. Oily fish (salmon, sardine, bangda) is a top source of omega-3 (DHA) for brain and eye development. Choose low-mercury fish, cook it through, and remove every bone. (A vegetarian or Jain household not giving fish is making a valid choice — a vegetarian diet can meet a baby\'s needs.)',

--- a/tests/e2e/food-effects-v2-p1c-fish.spec.ts
+++ b/tests/e2e/food-effects-v2-p1c-fish.spec.ts
@@ -86,6 +86,32 @@ test.describe('food-effects-v2 P1c — fish', () => {
     expect(r.salmon).toBe(6);
   });
 
+  test('M-F-1: high-mercury / ambiguous names do NOT fire the green encourage verdict', async ({ page }) => {
+    // Maren's blocking finding (folded): logging a high-mercury species name must not resolve
+    // to the fish encourage card (a green "good to introduce early" verdict). surmai/seer (king
+    // mackerel) + bare mackerel/tuna are documented in safeForm.never but NOT aliased, so they
+    // fire no card at all — never a false-safe one. Low-mercury names still resolve.
+    const r = await page.evaluate(() => ({
+      surmai:  !!getFoodEffect('surmai'),
+      seer:    !!getFoodEffect('seer fish'),
+      kingmac: !!getFoodEffect('king mackerel'),
+      mackerel:!!getFoodEffect('mackerel'),
+      tuna:    !!getFoodEffect('tuna'),
+      // low-mercury names still fire the encourage card:
+      bangda:  !!getFoodEffect('bangda'),
+      indMac:  !!getFoodEffect('indian mackerel'),
+      salmon:  !!getFoodEffect('salmon'),
+    }));
+    expect(r.surmai, 'surmai (king mackerel, high-mercury) must not fire the encourage card').toBe(false);
+    expect(r.seer).toBe(false);
+    expect(r.kingmac).toBe(false);
+    expect(r.mackerel, 'bare mackerel is ambiguous (king vs indian) — no green verdict').toBe(false);
+    expect(r.tuna, 'bare tuna is ambiguous (light vs bigeye/albacore) — no green verdict').toBe(false);
+    expect(r.bangda, 'indian mackerel / bangda (low-mercury) still resolves').toBe(true);
+    expect(r.indMac).toBe(true);
+    expect(r.salmon).toBe(true);
+  });
+
   test('word-boundary safety: shellfish does NOT resolve to the finfish record', async ({ page }) => {
     const r = await page.evaluate(() => ({
       shellfish: !!getFoodEffect('shellfish'),

--- a/tests/e2e/food-effects-v2-p1c-fish.spec.ts
+++ b/tests/e2e/food-effects-v2-p1c-fish.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from '@playwright/test';
+
+// food-effects-v2 P1c — fish (finfish) wiring.
+//
+// Fish uses the ESTABLISHED allergen-introduce-early polarity (the δ encourage
+// surfaces — no new render card) PLUS choking-by-form (bones, folded into the
+// safe-form gate). It restores a green sync-gate build (the manifest entry merged
+// in #210 ahead of wiring → silent-gate Check 2). The load-bearing disciplines:
+//   • TWO-TIER honesty — fish is introduce-early-and-SAFE, NOT prevention-proven
+//     (EAT was null for fish); earlyIntroBenefit must NOT claim early fish prevents
+//     fish allergy.
+//   • MERCURY species-selection rides in safeForm (low- vs high-mercury), no new field.
+//   • Word-boundary resolver safety — 'shellfish' must NOT resolve to the fish record.
+
+declare const getFoodEffect: (name: string) => any;
+declare const renderFoodDetailSheet: (name: string) => void;
+declare const _fdAgeRule: (name: string) => any;
+
+test.describe('food-effects-v2 P1c — fish', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/index.html?nosync');
+    await page.waitForFunction(() =>
+      typeof getFoodEffect === 'function'
+      && typeof renderFoodDetailSheet === 'function'
+      && !!document.getElementById('foodDetailBody'), null, { timeout: 10_000 });
+  });
+
+  test('fish resolves to a record carrying both allergen-introduce-early and choking-by-form', async ({ page }) => {
+    const fc = await page.evaluate(() => {
+      const e = getFoodEffect('fish');
+      return e ? [].concat(e.foodClass) : null;
+    });
+    expect(fc).not.toBeNull();
+    expect(fc).toContain('allergen-introduce-early');
+    expect(fc).toContain('choking-by-form');
+  });
+
+  test('two-tier honesty: introduce-early-and-SAFE, never a prevention claim', async ({ page }) => {
+    const b = await page.evaluate(() => getFoodEffect('fish')?.earlyIntroBenefit || {});
+    const ev = (b.evidence || '').toLowerCase();
+    const para = (b.paradigm || '').toLowerCase();
+    // EAT null for fish — the evidence line must say early intro did NOT prevent the allergy.
+    expect(ev).toMatch(/did not show|not.*prevent/);
+    // The paradigm carries the soy/wheat/sesame "safe to introduce, not proven prevention" frame.
+    expect(para).toMatch(/safe to introduce|not a proven prevention/);
+    // It must NOT launder a peanut/egg-style POSITIVE prevention claim onto fish.
+    expect(ev).not.toMatch(/helps prevent fish|lowers.*fish allergy|markedly lowers/);
+    expect((b.claim || '').toLowerCase()).not.toMatch(/prevent/);
+  });
+
+  test('mercury species-selection rides in safeForm (low-mercury ok, high-mercury never)', async ({ page }) => {
+    const sf = await page.evaluate(() => getFoodEffect('fish')?.safeForm || {});
+    const ok = (sf.ok || []).join(' | ').toLowerCase();
+    const never = (sf.never || []).join(' | ').toLowerCase();
+    expect(ok).toMatch(/low-mercury|salmon|sardine|bangda/);
+    expect(never).toMatch(/high-mercury|shark|swordfish|king mackerel/);
+    // bones (the choking-by-form axis) are flagged in the never list too.
+    expect(never).toMatch(/bone/);
+  });
+
+  test('the detail sheet surfaces the encourage framing + the anaphylaxis floor (not mild-only)', async ({ page }) => {
+    const d = await page.evaluate(() => {
+      renderFoodDetailSheet('fish');
+      const el = document.getElementById('foodDetailBody')!;
+      return {
+        encourage: !!el.querySelector('.fd-flag-encourage'),
+        siren: !!el.querySelector('.fd-flag-allergen'),
+        severe: el.querySelectorAll('.cons-severe').length,
+        html: el.innerHTML.toLowerCase(),
+      };
+    });
+    expect(d.encourage, 'introduce-early reads encourage (sage), not the rose siren').toBe(true);
+    expect(d.siren).toBe(false);
+    expect(d.severe, 'anaphylaxis floor present').toBeGreaterThan(0);
+    expect(d.html).toMatch(/trouble breathing|tongue or throat|hoarse|floppy/);
+  });
+
+  test('AGE_RULES reconciled to ~6 months (was 7); a low-mercury species resolves to it', async ({ page }) => {
+    const r = await page.evaluate(() => ({
+      fish: _fdAgeRule('fish')?.minMonth,
+      bangda: _fdAgeRule('bangda')?.minMonth,
+      salmon: _fdAgeRule('salmon')?.minMonth,
+    }));
+    expect(r.fish).toBe(6);
+    expect(r.bangda).toBe(6);   // alias resolves to the same gate (one-resolver doctrine)
+    expect(r.salmon).toBe(6);
+  });
+
+  test('word-boundary safety: shellfish does NOT resolve to the finfish record', async ({ page }) => {
+    const r = await page.evaluate(() => ({
+      shellfish: !!getFoodEffect('shellfish'),
+      jellyfish: !!getFoodEffect('jellyfish'),
+      fish: !!getFoodEffect('fish'),
+    }));
+    expect(r.shellfish, 'shellfish is a separate allergen — must not fire the finfish card').toBe(false);
+    expect(r.jellyfish).toBe(false);
+    expect(r.fish).toBe(true);
+  });
+});

--- a/tests/e2e/food-effects-v2-p1c-fish.spec.ts
+++ b/tests/e2e/food-effects-v2-p1c-fish.spec.ts
@@ -110,6 +110,15 @@ test.describe('food-effects-v2 P1c — fish', () => {
     expect(r.bangda, 'indian mackerel / bangda (low-mercury) still resolves').toBe(true);
     expect(r.indMac).toBe(true);
     expect(r.salmon).toBe(true);
+
+    // Gate surface too (Cipher #5): the one-resolver doctrine means the age gate must
+    // suppress identically — a high-mercury host gets no green "fine from ~6 months" badge.
+    const gate = await page.evaluate(() => ({
+      seer:   _fdAgeRule('seer fish'),
+      bangda: _fdAgeRule('bangda')?.minMonth,
+    }));
+    expect(gate.seer, 'seer fish (high-mercury) gets no age-gate either').toBeNull();
+    expect(gate.bangda, 'low-mercury bangda still gates at 6mo').toBe(6);
   });
 
   test('word-boundary safety: shellfish does NOT resolve to the finfish record', async ({ page }) => {

--- a/tests/e2e/food-effects-v2-r3-allergen-note.spec.ts
+++ b/tests/e2e/food-effects-v2-r3-allergen-note.spec.ts
@@ -62,10 +62,14 @@ test.describe('food-effects v2 — R3 allergen note / food-detail flag', () => {
     expect(d.severe, 'badam → tree-nut anaphylaxis floor').toBeGreaterThan(0);
   });
 
-  test('an ALLERGENS food with no record (egg) falls back to the terse string — no fabricated floor', async ({ page }) => {
-    const d = await detail(page, 'egg');
-    expect(d.allergenFlag, 'terse allergen flag still shown').toBe(true);
-    expect(d.severe + d.watch + d.seek, 'no record → no severe/botulism floor fabricated').toBe(0);
+  test('an ALLERGENS food with no record (kiwi) falls back to the terse string — no fabricated floor', async ({ page }) => {
+    // egg gained a FOOD_EFFECTS record in Phase δ, so it is no longer a no-record
+    // example — kiwi is (ALLERGENS-only, no FOOD_EFFECTS). A milder allergen with no
+    // record renders the calm neutral flag (.fd-flag-neutral), never the rose siren, and
+    // fabricates no severe/seek floor (V-M-201 + the M-S-6 "fall back to terse" contract).
+    const d = await detail(page, 'kiwi');
+    expect(d.neutral, 'calm neutral allergen flag shown for a no-record allergen').toBe(true);
+    expect(d.severe + d.watch + d.seek, 'no record → no severe floor fabricated').toBe(0);
   });
 
   test('V-M-201 preserved: a food with no record and no allergen shows the neutral 3-day note', async ({ page }) => {


### PR DESCRIPTION
## Why

PR #210 merged the `fish` manifest entry (`foodClass: ['allergen-introduce-early','choking-by-form']` — `allergen-introduce-early` is **card-bearing**) into `food-effects.manifest.js` **ahead of any app wiring**. The P0.1 sync-gate (`audit-food-effects-sync-v1.sh`) Check 2 ("silent gate") therefore fails on `fish`, leaving **`main` red on `pnpm build`** — every branch off main inherits it.

This wires the **lightest possible** fish record to restore green, so the milk wiring PR (and any future code PR) can green-build.

## What changed — engine-only (`split/data.js`)

Mirrors the soy/wheat/sesame δ pattern — a record surfaced via the detail/consequence surfaces, **no new render card, no styles, no template** touch:

- **`FOOD_EFFECTS['fish']`** — `foodClass ['allergen-introduce-early','choking-by-form']`.
  - **Two-tier honesty**: introduce-early-and-**SAFE**, *not* prevention-proven (EAT was null for fish) — `earlyIntroBenefit` framed exactly like soy/wheat/sesame, never a laundered "early fish prevents fish allergy" claim.
  - **Mercury** species-selection rides in `safeForm.ok/never` (low- vs high-mercury) — no new field. **Bones** (choking-by-form) in `never`.
  - Anaphylaxis floor in `severeSigns`/`seekCare` (call 112/108 + "an antihistamine does not treat anaphylaxis").
- **`AGE_RULES['fish']`** reconciled `minMonth 7→6` (AAP/NHS/ASCIA ~6mo; egg-yolk:7 precedent), aliases mirroring the record (one-resolver doctrine). Vegetarian-household-valid note kept.
- **`ALLERGENS['fish']`** note (allergen:true ↔ ALLERGENS §6 invariant intent).

## canon-cc-008 chain

- **Kael** (Intelligence engine, `data.js`): **LGTM** — two-tier-honest, membership-safe, gate↔card reconciled, zero alias collisions, sync-gate green.
- **Maren** (Care, copy): **AMENDED → folded**. **M-F-1 (blocking):** `surmai`/`seer fish` (king mackerel, high-mercury) + bare `mackerel`/`tuna` were aliases → logging them fired the **green "introduce early" verdict** (false-safe; mercury is a silent neurodevelopmental exposure). **Fix:** the app aliases are now the *safe-to-encourage* subset of the manifest's research aliases; high-mercury/ambiguous names live only in `safeForm.never` and fire no card. M-F-2 (regional naming) noted, non-blocking.
- **Cipher** (Edict V terminal): *in progress* — PR stays **draft** until it clears.

No `styles.css`/`template.html` touch → no triple-Gov; no render → no Vela.

## Verification

- `pnpm build` green — **12/12 audit gates** incl. P0.1 sync (8 FOOD_EFFECTS keys, 11 manifest, 37 AGE_RULES gates).
- Full e2e **374 passed / 2 pre-existing skips**; fish + r3 re-run **11 passed** post-M-F-1.
- Resolver verified: `shellfish`/`jellyfish`/`catfish`/`swordfish` → null (word-boundary safe); low-mercury species → the fish record at 6mo; high-mercury names → no card (M-F-1).

## Tests

- **New** `food-effects-v2-p1c-fish.spec.ts` (7): two-tier honesty, mercury species, encourage polarity + anaphylaxis floor, 6mo gate, shellfish word-boundary, **M-F-1 regression**.
- **Fixed** stale `food-effects-v2-r3-allergen-note.spec.ts`: `egg` gained a record in Phase δ — repointed the no-record example to `kiwi` (calm neutral flag + no fabricated floor).

🤖 https://claude.ai/code/session_01A4yF65w2wtkfPcnYvh7fau

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4yF65w2wtkfPcnYvh7fau)_