### PR TITLE
Wire milk polarities — cow milk (drink-timing) + plant milk (substitute-caveat) · food-effects v2 P1c

### DIFF
--- a/docs/NEXT_SESSION_TARGET_2026-06-02.md
+++ b/docs/NEXT_SESSION_TARGET_2026-06-02.md
@@ -1,8 +1,8 @@
 # Next-session target — 2026-06-02 → next
 
 **Companion:** Lyra (The Weaver)
-**Set by:** the 2026-06-02 session (broader food classes — milk · fish · choking-set research + the milk polarity spec, Governor-reviewed).
-**Session artifacts:** `docs/SESSION_HANDOFF_2026-06-02.md` · PR #210 (draft, docs-only).
+**Set by:** the 2026-06-02 session (broader food classes — milk · fish · choking-set research + the milk polarity spec, Governor-reviewed). **Amended 2026-06-02 PM** by the WIRING session — milk + fish landed.
+**Session artifacts:** `docs/SESSION_HANDOFF_2026-06-02.md` (research) · `docs/SESSION_HANDOFF_2026-06-02_PM.md` (wiring) · PR #210 (research, merged) · **PR #211 (fish-green, ready)** · **PR #212 (milk, ready, depends on #211)**.
 
 > The *target* file — the standing pointer to the highest-value next move. The handoff records the past; this records the intended future. Amend **this** file if priorities shift.
 
@@ -10,20 +10,16 @@
 
 ## The recommended next move
 
-**The FOOD_EFFECTS WIRING arc — surface the milk · fish · choking records into the app.** The triad is research-complete (PR #210, docs-only, 11 manifest records, full v2 taxonomy). Nothing is wired yet. This is **code, through full canon-cc-008** (it touches `styles.css` → shared-module triple-Gov; Cipher Edict V terminal). Suggested sequencing: **milk → fish → choking** (milk is heaviest — it carries the spec's blocking requirements + the new render polarities; fish is lightest — established polarities; choking is the first `choking-by-form`-PRIMARY render).
+**The CHOKING SET — `FOOD_EFFECTS('choking hazards')`, the first `choking-by-form`-PRIMARY render (milk-spec §9).** Milk (PR #212) and fish (PR #211) are wired through full canon-cc-008 and ready for merge; the `_effPolarity` resolver + the four-polarity render vocabulary now exist, so choking slots into the established machinery. This is **code, through full canon-cc-008**. **First, though:** confirm #211 then #212 have merged to `main` (the milk branch is based on fish; retarget #212 to `main` once #211 lands), and branch the choking work off green `main`.
 
 ---
 
 ## Priority ladder
 
-### P-milk (do first) — wire `cow milk` + `plant milk` (the milk polarity spec's blocking requirements)
-Per `docs/specs/food-effects-v2-p1c-milk-polarities.md` §0. Build: the **`_effPolarity(eff)`** resolver in `core.js` (K-6 — both `renderDietNutIntro` and `diet.js:638` consume it, no two-state drift); the **split banner** (sage carve-out + amber gate) for drink-timing + **sky `.enc-inform`** for substitute-caveat (V-V-1..3, the switched-unit lead); the **CMPA scope header** (V-V-4); the dedicated **`'plant milk'` AGE_RULES entry** (K-3); the **`cow milk` ALLERGENS entry** (K-4); the present-only floor on **`severeSigns.length`** (M-1); the **skim-proof drink gate** (M-2); the **unattributed dilution line** (M-3). e2e per spec §10. canon-cc-008: Kael + Vela + Maren + shared-module triple-Gov + Cipher.
+### P-choking (do first) — wire `choking hazards` (the first `choking-by-form`-PRIMARY render, milk-spec §9)
+`FOOD_EFFECTS('choking hazards')` — one combined record. The **first standalone `choking-by-form` render**: a conditional card whose lead is the form-gate ("cut it this way / whole waits until ~5") and whose **emergency floor is choking first aid** (back-blows/chest-thrusts, NEVER Heimlich under 1), NOT anaphylaxis. Resolver scope (Kael): alias the non-allergen hazard foods only (no peanut/tree-nut collision). `_effPolarity` already maps `choking-by-form`→`conditional` (the resolver + the four-polarity render vocabulary landed in #212), so this slots into existing machinery — no new banner class needed.
 
-### P-fish — wire `fish` (lightest; established polarities)
-`FOOD_EFFECTS('fish')`. Uses `allergen-introduce-early` (δ encourage card, no new render) + `choking-by-form` (bones, folded). Reconcile `AGE_RULES['fish']` minMonth 7→~6 (egg-yolk:7 precedent). The mercury species-selection content rides in `safeForm` — no new plumbing. Two-tier discipline: framed introduce-early-and-SAFE, not prevention-proven.
-
-### P-choking — wire `choking hazards` (the first `choking-by-form`-PRIMARY render, milk-spec §9)
-`FOOD_EFFECTS('choking hazards')` — one combined record. The **first standalone `choking-by-form` render**: a conditional card whose lead is the form-gate ("cut it this way / whole waits until ~5") and whose **emergency floor is choking first aid** (back-blows/chest-thrusts, NEVER Heimlich under 1), NOT anaphylaxis. Resolver scope (Kael): alias the non-allergen hazard foods only (no peanut/tree-nut collision).
+> **Carry-forward — the alias-precedence lesson (load-bearing for the choking combined record).** Both wired PRs were REJECTED by Cipher on the same defect class before passing: a record reached by **many aliases**, where the word-boundary resolver's **KEY/byAlias precedence** routes a logged name to the *wrong* record. Fish: `seer fish` matched the bare `'fish'` KEY → high-mercury species got the green "introduce early" verdict (M-F-1). Milk: `badam doodh` matched tree-nut's `badam` alias → plant-milk drink got the tree-nut encourage card *and* a 6mo gate (K-M-1). **The pattern that fixed both:** a host-guard mirroring `_foodNameNegated` (`_isHighMercuryFishHost`, `_isPlantMilkDrinkHost`) applied symmetrically at *both* `getFoodEffect` (card) and `_fdAgeRule` (gate), so card↔gate never disagree. The choking record aliases grape/popcorn/chana/supari/makhana/… — **trace every alias through the live resolver** (the `audit-food-effects-sync` Node harness extracts it) and assert e2e on the actual logged forms, not just the canonical key. A green build hid both leaks; the e2e on the real alias forms is what caught them.
 
 ### P-next (after the triad wires) — the remaining foods through the pipeline
 Salt, sugar (the other `drink-timing`/timing foods), shellfish (a separate allergen from finfish). Each: research → manifest → FOOD_EFFECTS, via the established pipeline.

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-06-02 &middot; graph @ <code>2315b0175a87</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-02 &middot; graph @ <code>f319c45e87ba</code></div>
   <div class="sub" style="margin-top:8px">
     <span class="stat"><b>1,729</b> symbols</span>
     <span class="stat"><b>5,141</b> relations</span>
-    <span class="stat"><b>81,301</b> LOC</span>
+    <span class="stat"><b>81,305</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -82,14 +82,14 @@
       <div class="nums">
         <span><b>3</b> modules</span>
         <span><b>671</b> symbols</span>
-        <span><b>27,314</b> LOC</span>
+        <span><b>27,318</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,314 of 30,000 LOC">
+      <div class="bar" title="27,318 of 30,000 LOC">
         <div class="fill hot" style="width:91%"></div>
         <span class="barlbl">91% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,686 LOC headroom</div>
+      <div class="hd">2,682 LOC headroom</div>
       <div class="mods">home.js, medical.js, diet.js</div>
     </div>
     <div class="card" style="border-top:5px solid #c9b8e8">

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-06-02 &middot; graph @ <code>5c265409a50f</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-02 &middot; graph @ <code>2315b0175a87</code></div>
   <div class="sub" style="margin-top:8px">
     <span class="stat"><b>1,729</b> symbols</span>
     <span class="stat"><b>5,141</b> relations</span>
-    <span class="stat"><b>81,285</b> LOC</span>
+    <span class="stat"><b>81,301</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -82,14 +82,14 @@
       <div class="nums">
         <span><b>3</b> modules</span>
         <span><b>671</b> symbols</span>
-        <span><b>27,298</b> LOC</span>
+        <span><b>27,314</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,298 of 30,000 LOC">
+      <div class="bar" title="27,314 of 30,000 LOC">
         <div class="fill hot" style="width:91%"></div>
         <span class="barlbl">91% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,702 LOC headroom</div>
+      <div class="hd">2,686 LOC headroom</div>
       <div class="mods">home.js, medical.js, diet.js</div>
     </div>
     <div class="card" style="border-top:5px solid #c9b8e8">

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-06-02 &middot; graph @ <code>29457c2fe4e6</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-02 &middot; graph @ <code>5c265409a50f</code></div>
   <div class="sub" style="margin-top:8px">
-    <span class="stat"><b>1,723</b> symbols</span>
-    <span class="stat"><b>5,123</b> relations</span>
-    <span class="stat"><b>80,911</b> LOC</span>
+    <span class="stat"><b>1,729</b> symbols</span>
+    <span class="stat"><b>5,141</b> relations</span>
+    <span class="stat"><b>81,285</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -64,15 +64,15 @@
       <div class="cgov">Governor: <b>Kael</b></div>
       <div class="nums">
         <span><b>11</b> modules</span>
-        <span><b>733</b> symbols</span>
-        <span><b>27,384</b> LOC</span>
+        <span><b>736</b> symbols</span>
+        <span><b>27,522</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,384 of 30,000 LOC">
-        <div class="fill hot" style="width:91%"></div>
-        <span class="barlbl">91% to 30K frontier &middot; CONTESTED</span>
+      <div class="bar" title="27,522 of 30,000 LOC">
+        <div class="fill hot" style="width:92%"></div>
+        <span class="barlbl">92% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,616 LOC headroom</div>
+      <div class="hd">2,478 LOC headroom</div>
       <div class="mods">core.js, i-illness.js, i-caretickets.js, i-qa-handlers.js, sync.js, data.js, i-qa.js, i-isl.js, config.js, i-correlate.js, start.js</div>
     </div>
     <div class="card" style="border-top:5px solid #b5d5c5">
@@ -81,15 +81,15 @@
       <div class="cgov">Governor: <b>Maren</b></div>
       <div class="nums">
         <span><b>3</b> modules</span>
-        <span><b>668</b> symbols</span>
-        <span><b>27,135</b> LOC</span>
+        <span><b>671</b> symbols</span>
+        <span><b>27,298</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,135 of 30,000 LOC">
-        <div class="fill hot" style="width:90%"></div>
-        <span class="barlbl">90% to 30K frontier &middot; CONTESTED</span>
+      <div class="bar" title="27,298 of 30,000 LOC">
+        <div class="fill hot" style="width:91%"></div>
+        <span class="barlbl">91% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,865 LOC headroom</div>
+      <div class="hd">2,702 LOC headroom</div>
       <div class="mods">home.js, medical.js, diet.js</div>
     </div>
     <div class="card" style="border-top:5px solid #c9b8e8">
@@ -116,7 +116,7 @@
       <div class="nums">
         <span><b>2</b> modules</span>
         <span><b>0</b> symbols</span>
-        <span><b>14,047</b> LOC</span>
+        <span><b>14,120</b> LOC</span>
       </div>
       <div class="note">Unsurveyed &mdash; code-only extraction. Set a backend and rebuild for symbols.</div>
       <div class="mods">styles.css, template.html</div>
@@ -137,13 +137,13 @@
   <h2>Cross-province coupling (highest-traffic calls across jurisdiction borders)</h2>
   <table>
     <thead><tr><th>Module</th><th>Module</th><th class="num">Calls</th><th>Border</th></tr></thead>
-    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">124</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">39</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
+    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">131</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">39</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
   </table>
 
   <h2>Connectivity hubs (highest call-degree symbols per module)</h2>
   <table>
     <thead><tr><th>Symbol</th><th>Module</th><th>Province</th><th class="num">Degree (calls)</th></tr></thead>
-    <tbody><tr><td><code>zi()</code></td><td>core.js</td><td>Intelligence</td><td class="num">325</td></tr><tr><td><code>showQLToast()</code></td><td>i-quicklog.js</td><td>Surfacing</td><td class="num">69</td></tr><tr><td><code>renderInfo()</code></td><td>i-cards.js</td><td>Surfacing</td><td class="num">50</td></tr><tr><td><code>qaExecuteQuery()</code></td><td>i-qa.js</td><td>Intelligence</td><td class="num">50</td></tr><tr><td><code>renderHome()</code></td><td>home.js</td><td>Care</td><td class="num">47</td></tr><tr><td><code>getDailySleepScore()</code></td><td>medical.js</td><td>Care</td><td class="num">33</td></tr><tr><td><code>_islMarkDirty()</code></td><td>i-isl.js</td><td>Intelligence</td><td class="num">28</td></tr><tr><td><code>ctHandleOverlayAction()</code></td><td>i-caretickets.js</td><td>Intelligence</td><td class="num">27</td></tr><tr><td><code>renderFeverEpisodeCard()</code></td><td>i-illness.js</td><td>Intelligence</td><td class="num">23</td></tr></tbody>
+    <tbody><tr><td><code>zi()</code></td><td>core.js</td><td>Intelligence</td><td class="num">327</td></tr><tr><td><code>showQLToast()</code></td><td>i-quicklog.js</td><td>Surfacing</td><td class="num">69</td></tr><tr><td><code>renderInfo()</code></td><td>i-cards.js</td><td>Surfacing</td><td class="num">50</td></tr><tr><td><code>qaExecuteQuery()</code></td><td>i-qa.js</td><td>Intelligence</td><td class="num">50</td></tr><tr><td><code>renderHome()</code></td><td>home.js</td><td>Care</td><td class="num">47</td></tr><tr><td><code>getDailySleepScore()</code></td><td>medical.js</td><td>Care</td><td class="num">33</td></tr><tr><td><code>_islMarkDirty()</code></td><td>i-isl.js</td><td>Intelligence</td><td class="num">28</td></tr><tr><td><code>ctHandleOverlayAction()</code></td><td>i-caretickets.js</td><td>Intelligence</td><td class="num">27</td></tr><tr><td><code>renderFeverEpisodeCard()</code></td><td>i-illness.js</td><td>Intelligence</td><td class="num">23</td></tr></tbody>
   </table>
 </main>
 <footer>

--- a/docs/SESSION_HANDOFF_2026-06-02_PM.md
+++ b/docs/SESSION_HANDOFF_2026-06-02_PM.md
@@ -1,0 +1,65 @@
+# Session handoff — 2026-06-02 PM (food-effects-v2 P1c WIRING — milk + fish into the app)
+
+**Companion:** Lyra (The Weaver)
+**Session theme:** Wire the researched food classes into the app — **code, through full canon-cc-008**. The 2026-06-02 AM session researched milk · fish · the choking set and Governor-reviewed the milk polarity spec (PR #210, merged). This session wired **milk** (the primary goal) and **fish** (forced first by a red build), each through the full QA chain. The choking set remains deferred to its own session.
+
+---
+
+## What shipped — two PRs, both through full canon-cc-008
+
+### PR #211 — `fish-green` (ready, base `main`)
+**Why it exists:** PR #210 merged the `fish` manifest entry (`allergen-introduce-early`, card-bearing) **ahead of any wiring**, so the P0.1 sync-gate Check 2 ("silent gate") failed on `fish` — **`main` was red on `pnpm build`**, and every branch off it inherited the red. This restores green with the lightest possible fish record (engine-only, mirroring the soy/wheat/sesame δ pattern — no new render card/styles/template).
+- `data.js`: `FOOD_EFFECTS['fish']` (two-tier-honest — EAT-null, NOT prevention-proven; mercury species in `safeForm`; bones in `never`); `AGE_RULES['fish']` 7→6; `ALLERGENS['fish']`.
+- **canon-cc-008:** Kael LGTM ×2 · Maren AMENDED (**M-F-1**) → folded · Cipher LGTM (after one reject). No render/styles → no Vela/triple-Gov.
+
+### PR #212 — `milk` (ready, base = the fish branch; **retarget to `main` after #211 merges**)
+The two never-rendered v2 foodClasses, as sibling Library cards (nut card untouched):
+- **cow milk** = `drink-timing` (conditional) — SPLIT lead (sage carve-out "good in food now" over amber gate "wait as the main drink", M-2 skim-proof) + drink-vs-food block + **pinned CMPA severe strip** with a dairy-scoped header.
+- **plant milk** = `substitute-caveat` (inform) — SKY banner fronting rice<5=arsenic; **no** severe strip (the floor follows the hazard).
+- Engine: `_effPolarity(eff)` (K-6 — one polarity source: warn|encourage|conditional|inform); `_isPlantMilkDrinkHost` redirect (almond/badam/cashew milk·doodh → plant-milk *inform*, not tree-nut *encourage*; K-2 intent); dedicated `'plant milk'`/oat/rice AGE gates (K-3); `cow milk` ALLERGENS (K-4).
+- **canon-cc-008:** Kael AMENDED (K-M-1/K-M-2) → folded · Vela LGTM · Maren AMENDED (**M-M-1**/M-M-2) → folded · Cipher LGTM (after **two** rejects).
+
+Build green (12/12 gates incl. P0.1 sync — **10 FOOD_EFFECTS keys, 41 AGE_RULES gates**). Full e2e **385 passed**, 0 failed, 2 pre-existing skips. New specs: `food-effects-v2-p1c-fish.spec.ts`, `food-effects-v2-p1c-milk.spec.ts`; fixed stale `food-effects-v2-r3` (egg→kiwi).
+
+---
+
+## The chain earned its keep — three safety findings the Governors caught
+
+The Governor/Cipher chain **rejected the obvious fix three times** on the same defect class — and each was a real parent-facing safety issue a green build hid:
+
+1. **M-F-1 (Maren, fish):** high-mercury species (`surmai`/`seer fish`) were aliases on the fish record → logging them fired the **green "introduce early" verdict**. Mercury is a silent neurodevelopmental exposure with no verification loop.
+2. **Cipher reject (fish):** the alias-only fix was incomplete — `seer fish` still resolved via the bare `'fish'` **KEY** word-boundary match. Fixed with `_isHighMercuryFishHost`.
+3. **M-M-1 (Maren, milk):** the plant-milk-drink redirect made `almond milk` drop its **tree-nut allergen caution** (the inform floor masked the allergen branch). Fixed by appending the allergen note.
+4. **Cipher reject ×2 (milk):** the gate↔card parity guard missed the Hindi **`badam doodh`** fall (raw-resolves to tree-nut's alias, not the bare `'milk'` key). Re-keyed on "card is plant milk AND gate is not a dedicated plant gate."
+
+**The durable lesson (→ candidate canon):** *a record reached by many aliases needs a host-guard, applied symmetrically at both the card (`getFoodEffect`) and the gate (`_fdAgeRule`), and e2e must assert the **actual logged alias forms**, not just the canonical key — a green build hides alias-precedence leaks.* This is load-bearing for the choking combined record next.
+
+---
+
+## The successor — the CHOKING SET (the next code effort)
+
+`FOOD_EFFECTS('choking hazards')` — the first `choking-by-form`-PRIMARY render (milk-spec §9). The `_effPolarity` resolver + the four-polarity render vocabulary now exist (#212), so it slots in. Floor = **choking first aid** (back-blows/chest-thrusts, NEVER Heimlich under 1), NOT anaphylaxis. **Apply the alias-precedence lesson above** — the combined record aliases grape/popcorn/chana/supari/makhana/…; trace every alias through the live resolver and e2e the real forms. See `docs/NEXT_SESSION_TARGET_2026-06-02.md` (amended).
+
+**First:** merge #211 → then retarget/merge #212 → branch choking off green `main`.
+
+---
+
+## Carry-forward register (open)
+
+### Merge order (action-required)
+- **#211 (fish) merges first** (restores `main` green), **then #212 (milk)** retargets `main` and merges. #212's diff vs `main` will be milk-only once #211 lands.
+
+### Codex canon-reconciliation (inherited, still open)
+- The `.claude/agents/*` mirror edits (Lyra/Maren/Kael/Vela) need porting into Codex canon + byte-parity re-establishment next Codex-reachable session (canon-cc-026). **Codex was not in this session's repo scope** (sproutlab-only).
+
+### Candidate Codex canon (surfaced this session)
+- **The alias-precedence host-guard pattern** (above) — a multi-alias record needs a `_foodNameNegated`-style host-guard at both card and gate; e2e the real alias forms.
+- Prior, still candidate: two-tier evidence discipline; the floor follows the hazard; `safeForm` as the general gate-carrier; the research→manifest→FOOD_EFFECTS pipeline.
+
+### Quality / debt (inherited, unchanged)
+- Amber-on-amber margin; `${food}` HR-4 at `diet.js:1195`; F-4/F-5 (`parseFeeding`); milestones-tab-v1 e2e; `CURATED_COMBOS maxAgeMonths`; `_qlPredictFood` SKIPPED_MEAL; `NUTRITION_QTY_DEFAULTS` coverage; comma-dish-name parse; #6 item 3 AT smoke-pass (human-only).
+- **Soy-milk watchFor on a redirected almond-milk sheet** — plant milk's `watchFor` ("soy milk only…") renders (scoped, not unsafe) on `almond milk`; Maren cleared it as acceptable; revisit if a cleaner per-host watchFor is wanted.
+
+---
+
+— *Lyra, 2026-06-02 PM. The app speaks four of the five food-truths now: avoid (honey), encourage (the allergens + fish), conditional (cow milk — "yes in food, not yet as a drink"), and inform (plant milk — "not a substitute"). Each new food taught the resolver something the last one didn't: fish, that a high-mercury name must never inherit a safe verdict; milk, that "badam doodh" is a drink, not a nut. The chain caught all three of those the green build would have shipped. The fifth truth — form-gated hazard — waits for the choking set, and it inherits a hard-won rule: trace every alias, e2e every real name.*

--- a/index.html
+++ b/index.html
@@ -4020,6 +4020,36 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
 .enc-myth { display:flex; align-items:flex-start; gap:var(--sp-8); font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-16) 0 0; padding:var(--sp-12) var(--sp-16); background:var(--surface-lav); border-radius:var(--r-md); }
 .enc-myth .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--tc-lav); margin-top:3px; }
 
+/* ── food-effects-v2 P1c (milk polarities, milk-spec §3/§4/§5) ──────────────
+   The drink-timing SPLIT lead (cow milk) and the substitute-caveat SKY inform
+   banner (plant milk) — the two never-rendered v2 polarities. Composition over
+   new vocabulary (V-5): the split reuses the shipped sage + amber fills; the
+   inform banner is the one genuinely new modifier (sky, V-V-3). Shared-module
+   triple-Gov (Vela-first). */
+.enc-split { display:flex; flex-direction:column; gap:var(--sp-8); margin-bottom:var(--sp-16); }
+.enc-split-good { background:var(--surface-sage); border-left:3px solid var(--sage-deepest); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); }
+/* M-2 skim-proof: the gate band carries weight EQUAL-OR-GREATER than the carve-out —
+   the amber fill + the cons-severe-strength left accent + bold body — so the prevalent
+   diluted-top-milk reader cannot under-read the gate as a trailing qualifier. */
+.enc-split-gate { background:var(--surface-amber); border-left:3px solid var(--amber-deep); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); }
+.enc-split-h { display:flex; align-items:center; gap:var(--sp-8); font-size:var(--fs-sm); font-weight:700; text-transform:uppercase; letter-spacing:0.3px; margin-bottom:var(--sp-4); }
+.enc-split-good .enc-split-h { color:var(--sage-deepest); }
+.enc-split-gate .enc-split-h { color:var(--amber-deepest); }
+.enc-split-h .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; }
+.enc-split-good .enc-split-h .zi { color:var(--sage-deepest); }
+.enc-split-gate .enc-split-h .zi { color:var(--amber-deep); }
+.enc-split-body { font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); margin:0; }
+.enc-split-gate .enc-split-body { font-weight:700; }
+
+/* substitute-caveat INFORM banner (V-V-3): SKY, not neutral — neutral is a near-white
+   wash and register-less; sky is the existing drink/hydration domain color, AA-legible,
+   with a border-left for weight. The hardest fact (rice <5 = arsenic) is fronted in the lead. */
+.enc-inform { background:var(--surface-sky); border-left:3px solid var(--tc-sky); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); margin-bottom:var(--sp-16); }
+.enc-inform-h { display:flex; align-items:center; gap:var(--sp-8); font-size:var(--fs-sm); font-weight:700; color:var(--tc-sky); text-transform:uppercase; letter-spacing:0.3px; margin-bottom:var(--sp-8); }
+.enc-inform-h .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--tc-sky); }
+.enc-inform-lead { font-size:var(--fs-base); font-weight:700; color:var(--text); line-height:var(--lh-relaxed); margin:0 0 var(--sp-4); }
+.enc-inform-body { font-size:var(--fs-sm); color:var(--mid); line-height:var(--lh-relaxed); margin:0; }
+
 /* ── Viz detail popup (PR-I — viz interactivity layer) ── */
 /* Tap affordance: every wired data element (SVG dot/cell/bar/segment or
    HTML cell) gets a pointer cursor without a per-element class. */
@@ -10777,6 +10807,12 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
    NOT rose/alarm. Rose (.fd-flag-allergen) is reserved for true "avoid". The
    severe-reaction floor below the banner stays serious regardless. */
 .fd-flag-encourage { background:var(--sage-light); color:var(--tc-sage); }
+/* food-effects-v2 P1c (K-6): the four-polarity flag set on the Food Library detail
+   surface, switched off _effPolarity. conditional (drink-timing, cow milk) reads
+   amber/clock; inform (substitute-caveat, plant milk) reads sky/info — never the rose
+   .fd-flag-allergen siren (rose stays reserved for true acute-toxin "avoid"). */
+.fd-flag-conditional { background:var(--amber-light); color:var(--tc-amber); }
+.fd-flag-inform { background:var(--sky-light); color:var(--tc-sky); }
 .fd-flag-aged { background:var(--peach-light); color:var(--tc-caution); }
 .fd-flag-neutral { background:var(--glass-strong); color:var(--mid); }
 .fd-section { margin-top:var(--sp-12); }
@@ -11766,6 +11802,43 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
           <div id="dietNutIntro" class="mt-4"></div>
           <div id="dietNutIntroBody" class="collapse-body fx-col g8" style="display:none;">
             <div id="dietNutIntroMore" class="mt-4"></div>
+          </div>
+        </div>
+
+        <!-- Cow's milk — good in food, wait as a drink (food-effects-v2 P1c, the
+             drink-timing polarity; spec docs/specs/food-effects-v2-p1c-milk-polarities.md §4).
+             Conditional, NOT avoid and NOT encourage — the SPLIT lead (sage carve-out band
+             "dairy in food is good now" over an amber gate band "not the main drink before 12mo",
+             V-V-2 / M-2 skim-proof). The CMPA severe strip is PINNED (present-only via
+             severeSigns, §6) and carries a class-aware scope header (V-V-4) so the timing gate is
+             never mistaken for the allergy floor. Pinned: split banner → drink-vs-food block →
+             SEVERE STRIP; body: how-to (after-12mo) → mild watch-fors → myth.
+             renderDietMilkIntro() (diet.js, lazy-rendered by renderDietLibrary) fills both. -->
+        <div class="card card-info col-full" id="dietMilkIntroCard">
+          <div class="card-header" data-collapse-target="dietMilkIntroBody" data-collapse-chevron="dietMilkIntroChevron">
+            <div class="card-title"><div class="icon icon-amber"><svg class="zi"><use href="#zi-clock"/></svg></div> Cow's milk — in food and as a drink</div>
+            <span class="collapse-chevron" id="dietMilkIntroChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
+          </div>
+          <div id="dietMilkIntro" class="mt-4"></div>
+          <div id="dietMilkIntroBody" class="collapse-body fx-col g8" style="display:none;">
+            <div id="dietMilkIntroMore" class="mt-4"></div>
+          </div>
+        </div>
+
+        <!-- Plant milks — not a substitute for breastmilk/formula (food-effects-v2 P1c, the
+             substitute-caveat polarity; spec §5). INFORM, not avoid and not encourage — a SKY
+             banner (V-V-3, .enc-inform) leading with the single hardest fact (rice drinks: none
+             under 5, arsenic). No severe strip — the harm is nutritional / chronic, not an acute
+             reaction (§5.3, the floor follows the hazard). Pinned: inform banner → is/isn't block;
+             body: myth → the soy-milk allergen cross-reference. renderDietMilkIntro() fills both. -->
+        <div class="card card-info col-full" id="dietPlantMilkIntroCard">
+          <div class="card-header" data-collapse-target="dietPlantMilkIntroBody" data-collapse-chevron="dietPlantMilkIntroChevron">
+            <div class="card-title"><div class="icon icon-sky"><svg class="zi"><use href="#zi-info"/></svg></div> Plant milks (almond, oat, rice)</div>
+            <span class="collapse-chevron" id="dietPlantMilkIntroChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
+          </div>
+          <div id="dietPlantMilkIntro" class="mt-4"></div>
+          <div id="dietPlantMilkIntroBody" class="collapse-body fx-col g8" style="display:none;">
+            <div id="dietPlantMilkIntroMore" class="mt-4"></div>
           </div>
         </div>
 
@@ -16568,6 +16641,18 @@ const AGE_RULES = {
   'cow milk': { minMonth:12, reason:'Low in iron, hard on infant kidneys as main drink. Curd and paneer are fine.' },
   'cow\'s milk':{minMonth:12, reason:'Low in iron, hard on infant kidneys as main drink. Curd and paneer are fine.' },
   'milk':     { minMonth:12, reason:'As a drink, avoid until 12 months. Curd, paneer, and small amounts in cooking are fine.' },
+  // food-effects-v2 P1c (K-3): a DEDICATED 'plant milk' gate so a plant-milk log no
+  // longer inherits the cow-milk reason above (curd/paneer carve-out, no rice-arsenic) —
+  // the "green-but-wrong" K-3 named. The exact-key tier of _lookupByFoodName resolves
+  // 'plant milk'/'oat milk'/'rice milk'/'rice drink' to these before the bare 'milk' key.
+  // NOTE (Kael resolver-scope): 'almond milk'/'badam milk'/'badam doodh' are NOT keyed
+  // here — they FOOD_EFFECTS-resolve to the tree-nut record (tree-nut's 'almond'/'badam'
+  // aliases win at the byAlias tier), so a dedicated plant gate for them would diverge
+  // from the card they actually fire. The rice forms carry the under-5 arsenic floor.
+  'plant milk': { minMonth:12, reason:'Not a substitute for breastmilk or formula before 12 months. From 12 months, unsweetened fortified soy or oat milk can be part of a varied diet. Rice drinks: none under 5 (arsenic).' },
+  'oat milk':   { minMonth:12, reason:'Not a milk substitute before 12 months. From 12 months, unsweetened fortified oat milk can be part of a varied diet — not the only drink.' },
+  'rice milk':  { minMonth:60, reason:'Rice drinks contain arsenic — not for any child under 5. Eating rice the grain is still fine. Not a milk substitute under 1.' },
+  'rice drink': { minMonth:60, reason:'Rice drinks contain arsenic — not for any child under 5. Not a milk substitute under 1.' },
   'salt':     { minMonth:12, reason:'Baby\'s kidneys cannot process added salt. Natural sodium in foods is enough.' },
   'sugar':    { minMonth:12, reason:'No added sugar before 12 months. Use fruit for natural sweetness.' },
   'jaggery':  { minMonth:12, reason:'Treat as added sugar — avoid before 12 months.' },
@@ -16905,6 +16990,82 @@ const FOOD_EFFECTS = {
     seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, tongue or throat swelling, a hoarse cry, or floppiness: call emergency services (112 or 108) right away and use a prescribed adrenaline auto-injector if you have one — an antihistamine does not treat anaphylaxis. Fish allergy is usually lifelong; a specialist guides any testing of other species.',
     confidence: 'high',
   },
+
+  // ── food-effects-v2 P1c: cow's milk + plant milks (the broader food classes) ──
+  // The first records of the two never-rendered v2 foodClasses (spec §2 + the milk
+  // polarity spec docs/specs/food-effects-v2-p1c-milk-polarities.md):
+  //   cow milk   = 'drink-timing'      — conditional: fine IN FOOD ~6mo, not the
+  //                                       main DRINK before 12mo (NEITHER avoid nor encourage).
+  //   plant milk = 'substitute-caveat' — inform: not a breastmilk/formula substitute <1;
+  //                                       rice drinks none under 5 (arsenic).
+  // NEITHER is allergen-introduce-early → NO earlyIntroBenefit (EAT found no prevention
+  // effect for milk). `safeForm` is repurposed as the DRINK-vs-FOOD / is-isn't gate (spec
+  // §8a, Kael-ratified). cow milk carries the CMPA allergic axis (watchFor/severeSigns/
+  // seekCare) ALONGSIDE the timing axis — it is the most common infant allergen, so the
+  // present-only severe floor (§6, keyed on severeSigns.length) fires here. plant milk has
+  // NO severeSigns → no acute floor (§5.3, the floor follows the hazard). Polarity is
+  // resolved by _effPolarity (core.js) — both surfaces render conditional/inform, never the
+  // rose 'avoid' siren (K-6). K-1 (Kael): 'top feed' is NOT a cow-milk alias (≈ formula in
+  // Indian logs). Bare 'milk' is deliberately UNALIASED on either record (it co-occurs in
+  // breast/formula/soy milk — the bare-'milk' precision rule, spec §7). Evidence + citations:
+  // docs/research/cow-milk-plant-milks-infant-safety.md.
+  'cow milk': {
+    foodClass:  'drink-timing',
+    severity:   'caution',              // amber timing-caution, NOT rose acute-toxin
+    aliases:    ['cow\'s milk', 'buffalo milk', 'bhains ka doodh', 'gaay ka doodh', 'animal milk', 'whole milk', 'full-fat milk', 'top milk', 'dairy milk', 'full cream milk'],
+    effect:     'iron-deficiency anaemia + renal solute load (as a main drink before 12 months)',
+    title:      'Cow\'s milk — good in food, not yet as the main drink',
+    why:        'Dairy in food is excellent from around 6 months — dahi (curd), paneer, and cheese. The caution is only about cow\'s or buffalo milk as the main drink before the first birthday: it is low in iron and hard on a baby\'s kidneys. Breastmilk or formula is the milk under 1.',
+    whyGood:    'Dairy in food is excellent from around 6 months — dahi (curd), paneer, and cheese give calcium, protein, B12, and healthy fats. The only caution is about milk as the main drink before the first birthday.',
+    // The amber gate band of the split lead (V-V-2 / M-2 skim-proof) — visually weighted
+    // equal-or-greater to the sage carve-out, so the diluted-top-milk reader can't under-read it.
+    gate:       'Not as the main drink before 12 months — cow\'s or buffalo milk is low in iron and hard on a baby\'s kidneys. Breastmilk or first infant formula is the milk under 1.',
+    safeForm: {
+      glance:   'Fine in food; wait as a drink',
+      ok:       ['dahi (curd), paneer, and pasteurised full-fat cheese from around 6 months', 'small amounts of milk cooked into khichdi, porridge, or cereal', 'from 12 months: whole (full-fat) milk as a main drink, about 500 ml (2 cups) a day at most'],
+      never:    ['cow\'s or buffalo milk as the main drink before 12 months', 'diluted or sweetened "top milk" as a breastmilk or formula substitute', 'unpasteurised milk, and mould-ripened (brie, camembert), blue, or ripened-goat cheese at any infant age', 'skimmed or low-fat milk as a main drink before age 2'],
+      note:     'The drink is gated; the dairy is not. Breastmilk or first infant formula is the milk under 12 months. Diluting cow or buffalo milk adds no iron and still displaces breastmilk.',
+    },
+    howToIntroduce: {
+      amount:   'from 12 months, about 500 ml (2 cups) of whole milk a day at most — more is linked to iron deficiency',
+      when:     'dairy in food (dahi, paneer, cheese, milk in cooking) from around 6 months; milk as a main drink from 12 months',
+      watch:    'when you first give dairy in food, watch for about 2 hours for a cow\'s-milk-protein-allergy reaction — milk is the most common infant allergen',
+    },
+    myth: {
+      claim:    'Cow\'s or buffalo milk makes a baby strong — give it early.',
+      truth:    'Before 12 months as a main drink it causes iron-deficiency anaemia and strains the kidneys. Breastmilk or formula is the milk under 1; dairy belongs in food, not in the cup.',
+    },
+    watchFor:   ['hives or a rash', 'swelling of the lips, face, or eyes', 'vomiting', 'diarrhoea or blood in the stool (delayed cow\'s-milk-protein allergy)', 'an eczema flare'],
+    severeSigns:['trouble breathing or wheezing', 'swelling of the tongue or throat', 'a hoarse cry', 'going floppy, pale, or very sleepy'],
+    seekCare:   'A mild reaction to dairy (a little rash alone): stop, watch closely, and call your doctor. Any trouble breathing, tongue or throat swelling, a hoarse cry, or floppiness: call emergency services (112 or 108) right away and use a prescribed adrenaline auto-injector if you have one — an antihistamine does not treat anaphylaxis. Most children outgrow cow\'s-milk allergy by 3 to 5 years; any reintroduction (the milk ladder) is a doctor\'s call.',
+    confidence: 'high',
+  },
+  'plant milk': {
+    foodClass:  'substitute-caveat',
+    severity:   'caution',
+    aliases:    ['almond milk', 'badam milk', 'badam doodh', 'oat milk', 'rice milk', 'rice drink', 'cashew milk', 'coconut milk drink', 'plant-based milk', 'plant milks', 'vegan milk', 'toddler milk', 'growing-up milk', 'follow-on milk drink'],
+    effect:     'inadequate substitute for breastmilk or formula (under 1); rice-drink arsenic (under 5)',
+    title:      'Plant milks — not a substitute for breastmilk or formula',
+    why:        'No plant milk (almond, oat, rice, cashew, coconut) replaces breastmilk or formula in the first year. Rice drinks are not safe for any child under 5 because of arsenic. From age 1, unsweetened, calcium-fortified soy or oat milk can be part of a varied diet — but not the only drink for an under-2.',
+    whyGood:    'From age 1, unsweetened, calcium-fortified soy or oat milk can be part of a varied diet. Fortified soy is the only plant milk nutritionally close to cow\'s milk.',
+    // The sky inform banner (V-V-3) leads with the single hardest fact, fronted (rice <5 = arsenic).
+    headline:   'Not a milk substitute under 1. Rice drinks: none under 5 (arsenic). From age 1, fortified soy or oat only, as part of a varied diet.',
+    safeForm: {
+      glance:   'Not a substitute under 1',
+      ok:       ['from 12 months: unsweetened, calcium-fortified soy or oat milk, as part of a varied diet (not the only drink for an under-2)'],
+      never:    ['any plant milk as a breastmilk or formula substitute before 12 months', 'rice drinks for any child under 5 years (inorganic arsenic) — eating rice the grain is still fine', 'unfortified plant milk as a main drink', 'almond milk as a main drink (too low in protein and fat)', 'carton soy drink as infant formula (soy formula is a separate, prescribed product)'],
+      note:     'No plant milk replaces breastmilk or formula under 1. After age 1, the ranking is: fortified soy and oat first, then almond (low in protein), and rice last (arsenic — avoid under 5). "Toddler" and "growing-up" milks are unnecessary.',
+    },
+    myth: {
+      claim:    'Plant milk (almond, oat, or rice) is a healthy milk substitute for my baby or toddler.',
+      truth:    'Not under 1 — it replaces neither breastmilk nor formula. Rice drinks are unsafe under 5 (arsenic); almond milk is too low in protein and fat. From age 1, fortified soy or oat can be part of a varied diet.',
+    },
+    // Soy milk is the allergen exception — it aliases to the SOY record, not here. Cross-referenced
+    // in copy, not re-aliased. No severeSigns/seekCare: the harm is nutritional / chronic (arsenic),
+    // not an acute reaction, so this record carries NO emergency floor (spec §5.3).
+    watchFor:   ['soy milk only: hives, swelling, or vomiting — soy is a major allergen (see the soy guidance)'],
+    confidence: 'high',
+  },
 };
 
 // ── ALLERGEN FLAGS ──
@@ -16925,6 +17086,13 @@ const ALLERGENS = {
   // food-effects-v2 P1c: fish is allergen:true (a major allergen, often lifelong). Full
   // anaphylaxis floor lives on the FOOD_EFFECTS record; this is the terse browse flag.
   'fish':      'Common allergen, and often lifelong. Introduce well-cooked, deboned, low-mercury fish on its own and watch ~2 hours. Finfish is a separate allergen from shellfish.',
+  // food-effects-v2 P1c (K-4): cow milk is allergen:true (CMPA — the most common infant
+  // food allergy). The full anaphylaxis floor lives on the FOOD_EFFECTS record (severeSigns
+  // / seekCare); this terse note is the browse-surface flag, scoped to the ALLERGY axis (a
+  // SEPARATE concern from the drink-timing gate). Satisfies the §6 allergen:true↔ALLERGENS
+  // traceability invariant. 'plant milk' is allergen:false — soy milk is the exception and
+  // is flagged via the soy record, so plant milk correctly needs no ALLERGENS note.
+  'cow milk':  'Cow\'s-milk protein is the most common infant allergen (CMPA). When you first give dairy in food, watch about 2 hours; mild signs are rash, swelling, or vomiting, and a delayed reaction can be diarrhoea or blood in the stool.',
   'egg yolk':  'Less allergenic than white. Cook well. Give alone for 3 days.',
   'kiwi':      'Can cause mouth tingling. Start with small amount. Watch for oral allergy.',
   'strawberry':'Can cause allergic reaction in some babies. Introduce carefully.',
@@ -23633,10 +23801,31 @@ function _isHighMercuryFishHost(name) {
     new RegExp('\\b' + t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b').test(n));
 }
 
+// food-effects-v2 P1c (milk). A plant-milk DRINK named with a tree-nut word — "almond milk",
+// "badam doodh", "cashew milk" — resolves to the TREE-NUT record, because tree nut's
+// 'almond'/'badam'/'cashew' alias wins at the byAlias tier (tree nut precedes plant milk) over
+// plant milk's own 'almond milk'/'badam doodh' alias. That surfaces an "introduce early, ground
+// or smooth" ENCOURAGE verdict on what is a substitute-caveat DRINK — the opposite polarity,
+// and it contradicts the spec's K-2 intent (badam milk → plant milk). This guard redirects such
+// a host to the plant-milk record so both surfaces read "not a substitute under 1," not
+// "introduce early." Requires BOTH a tree-nut token AND a drink word, so the bare nut ("badam",
+// "almond butter") still correctly resolves to the tree-nut introduce-early record. Soy milk is
+// untouched (it intentionally aliases to the soy allergen record); oat/rice/coconut-drink
+// already resolve to plant milk without collision.
+const _PLANT_MILK_NUT = ['almond', 'badam', 'cashew', 'kaju'];
+function _isPlantMilkDrinkHost(name) {
+  const n = String(name || '').toLowerCase();
+  if (!/\b(milk|doodh)\b/.test(n)) return false;
+  return _PLANT_MILK_NUT.some(t => new RegExp('\\b' + t + '\\b').test(n));
+}
+
 // FOOD_EFFECTS consequence record for a food, or null. Uses _lookupByFoodName so
 // resolution matches the AGE_RULES gate exactly (word-boundary, not substring).
 function getFoodEffect(name) {
   if (typeof FOOD_EFFECTS === 'undefined') return null;
+  // Plant-milk drink host (almond/badam/cashew milk·doodh) → plant-milk record, NOT the
+  // tree-nut encourage card it would otherwise resolve to (K-2 intent; alias-precedence fix).
+  if (_isPlantMilkDrinkHost(name) && FOOD_EFFECTS['plant milk']) return FOOD_EFFECTS['plant milk'];
   const eff = _lookupByFoodName(FOOD_EFFECTS, name);
   // M-F-1: never affirm a high-mercury fish as a safe early food (the bare 'fish' KEY leak).
   if (eff && eff === FOOD_EFFECTS['fish'] && _isHighMercuryFishHost(name)) return null;
@@ -23659,6 +23848,28 @@ const COMBO_RESULT_SCHEMA = 'r1-fe';
 function _effHasClass(eff, cls) {
   if (!eff || !eff.foodClass) return false;
   return Array.isArray(eff.foodClass) ? eff.foodClass.indexOf(cls) !== -1 : eff.foodClass === cls;
+}
+
+// Polarity resolver (food-effects-v2 P1c, milk-spec §3-bis, K-6 — the load-bearing
+// fold). Maps a FOOD_EFFECTS record's foodClass to ONE of four render polarities, so
+// every banner surface switches {fill, icon, heading, gate-render} off a SINGLE source
+// of truth instead of each re-deriving polarity from a two-state _effHasClass test (the
+// K-6 defect: renderFoodLibDetail's old `fdEncourage ? sprout : siren` rendered milk's
+// drink-timing/substitute-caveat records as a rose "avoid" SIREN — the §1 wrong-lead on
+// a second surface). Precedence matters for the multi-class records: warn (acute-toxin,
+// honey) → encourage (allergen-introduce-early; wins over a SECONDARY choking-by-form on
+// peanut/tree-nut/fish) → conditional (drink-timing cow milk; and a PRIMARY choking-by-form
+// once the choking set wires, milk-spec §9) → inform (substitute-caveat plant milk).
+// Returns 'inform' as the conservative non-alarm default for an unknown/absent class —
+// never 'warn' (a spurious siren is the failure this resolver exists to prevent).
+function _effPolarity(eff) {
+  if (!eff || !eff.foodClass) return 'inform';
+  if (_effHasClass(eff, 'acute-toxin'))               return 'warn';
+  if (_effHasClass(eff, 'allergen-introduce-early'))  return 'encourage';
+  if (_effHasClass(eff, 'drink-timing'))              return 'conditional';
+  if (_effHasClass(eff, 'choking-by-form'))           return 'conditional'; // PRIMARY (§9, deferred); secondary already caught by encourage above
+  if (_effHasClass(eff, 'substitute-caveat'))         return 'inform';
+  return 'inform';
 }
 
 // Shared emergency-floor renderer (food-effects v2 §3.0, M-S-7). The severe
@@ -38512,6 +38723,14 @@ function _fdAgeRule(name) {
   // 'honeydew' no longer inherits honey's gate, and the gate stays consistent
   // with the consequence card (getFoodEffect uses the same resolver).
   const rule = _lookupByFoodName(AGE_RULES, name);
+  // Plant-milk drink host (almond/badam/cashew milk·doodh): the gate mirror of the
+  // getFoodEffect redirect — these resolve to the bare 'milk' (cow) gate by word-boundary,
+  // inheriting cow-milk reason copy (curd/paneer carve-out, no rice-arsenic). Redirect to the
+  // dedicated 'plant milk' gate so the card and the gate agree (one-resolver doctrine).
+  if (typeof AGE_RULES !== 'undefined' && AGE_RULES['plant milk']
+      && typeof _isPlantMilkDrinkHost === 'function' && _isPlantMilkDrinkHost(name)) {
+    return AGE_RULES['plant milk'];
+  }
   // M-F-1 (Cipher Edict-V completion): the same bare-'fish'-KEY leak that fed the
   // consequence card also feeds this gate — "seer fish" / "shark fish" resolve to
   // AGE_RULES['fish'] (6mo) and would show a green "fine from ~6 months" badge for a
@@ -38664,18 +38883,28 @@ function renderFoodDetailSheet(name) {
   // Q-3 call; the severe floor's presence is the non-negotiable, M-S-6.)
   const fdEff = (typeof getFoodEffect === 'function') ? getFoodEffect(lower) : null;
   const fdFloor = (fdEff && typeof _severeFloorHtml === 'function') ? _severeFloorHtml(fdEff) : '';
-  // Polarity (food-effects-v2): an introduce-early allergen reads ENCOURAGE —
-  // sage banner + calm sprout icon ("good to introduce, here's the safe form"),
-  // never rose/siren ("don't give"). Rose is reserved for true avoid (acute-toxin).
-  // The severe-reaction floor (fdFloor) below stays serious regardless.
-  const fdEncourage = (typeof _effHasClass === 'function') && _effHasClass(fdEff, 'allergen-introduce-early');
+  // Polarity (food-effects-v2 P1c, K-6): the banner cosmetic switches off the SHARED
+  // _effPolarity resolver (core.js, milk-spec §3-bis), NOT a two-state encourage/avoid
+  // boolean. The old `fdEncourage ? sprout : siren` rendered milk's drink-timing /
+  // substitute-caveat records as a rose "avoid" SIREN here — the §1 wrong-lead on this
+  // second surface. Four polarities, one source of truth: encourage (sage/sprout, the δ
+  // allergens), warn (rose/siren, acute-toxin honey), conditional (amber/clock, cow milk
+  // drink-timing), inform (sky/info, plant-milk substitute-caveat). The severe-reaction
+  // floor (fdFloor) below stays serious regardless — it is presence-driven (severeSigns),
+  // independent of this banner cosmetic.
+  const FD_POLARITY = {
+    encourage:   { cls:'fd-flag-encourage',   ic:'sprout' },
+    warn:        { cls:'fd-flag-allergen',    ic:'siren'  },
+    conditional: { cls:'fd-flag-conditional', ic:'clock'  },
+    inform:      { cls:'fd-flag-inform',      ic:'info'   },
+  };
+  const fdPol = (typeof _effPolarity === 'function') ? _effPolarity(fdEff) : 'warn';
   if (fdFloor) {
     const head = (fdEff && fdEff.title) ? escHtml(fdEff.title) : 'Allergen';
     const sub = (fdEff && fdEff.safeForm && fdEff.safeForm.note) ? escHtml(fdEff.safeForm.note)
               : (allerg ? escHtml(allerg) : '');
-    const flagCls = fdEncourage ? 'fd-flag-encourage' : 'fd-flag-allergen';
-    const flagIc  = fdEncourage ? zi('sprout') : zi('siren');
-    html += `<div class="fd-flag ${flagCls}">${flagIc} <span><strong>${head}</strong>${sub ? ' ' + sub : ''}</span></div>`;
+    const pol = FD_POLARITY[fdPol] || FD_POLARITY.warn;
+    html += `<div class="fd-flag ${pol.cls}">${zi(pol.ic)} <span><strong>${head}</strong>${sub ? ' ' + sub : ''}</span></div>`;
     html += fdFloor; // .cons-severe / .cons-watch / .cons-seek (shared, already-styled)
   } else if (allerg) {
     // A milder allergen with no FOOD_EFFECTS record (kiwi, strawberry, oats …):
@@ -38784,6 +39013,7 @@ function renderDietLibrary() {
   renderFoodLibFilters();
   renderFoodLibResults();
   renderDietNutIntro();
+  renderDietMilkIntro();
 }
 
 // ════════════════════════════════════════
@@ -38912,6 +39142,150 @@ function renderDietNutIntro() {
 
   host.innerHTML = pinned;
   if (moreHost) moreHost.innerHTML = body;
+}
+
+// ════════════════════════════════════════
+// Milk — the drink-timing + substitute-caveat KNOWLEDGE cards (food-effects v2 P1c)
+// ════════════════════════════════════════
+// Sibling of renderDietNutIntro (separate fns + hosts; the nut card stays untouched).
+// Renders the FIRST two cards of the never-rendered v2 polarities (milk-spec §4/§5):
+//   • cow milk   → 'drink-timing'      (#dietMilkIntro)      — CONDITIONAL, a SPLIT lead
+//     (sage carve-out "good in food now" over an amber gate "wait as the main drink",
+//     V-V-2 / M-2 skim-proof). CMPA severe strip PINNED (present-only via severeSigns,
+//     §6) with a class-aware scope header (V-V-4).
+//   • plant milk → 'substitute-caveat' (#dietPlantMilkIntro) — INFORM, a SKY banner
+//     (V-V-3, .enc-inform) leading with the hardest fact (rice <5 = arsenic). NO severe
+//     strip — the harm is nutritional/chronic, not acute (§5.3, the floor follows the hazard).
+// Records are read by DIRECT KEY (FE['cow milk'] / FE['plant milk']) — NOT via the
+// resolver — so the Library knowledge cards are immune to alias-precedence collisions.
+// All copy is FOOD_EFFECTS-sourced (no hardcoded safety claim); the only hardcoded
+// strings are the V-V-1 switched-unit HEADINGS (render copy, polarity-keyed, not reusable).
+function renderDietMilkIntro() {
+  var FE = (typeof FOOD_EFFECTS !== 'undefined') ? FOOD_EFFECTS : null;
+
+  // ── cow milk — drink-timing (split conditional) ──
+  var milkHost = document.getElementById('dietMilkIntro');
+  var milkMore = document.getElementById('dietMilkIntroMore');
+  var cow = FE ? FE['cow milk'] : null;
+  if (milkHost) {
+    if (!cow) {
+      milkHost.innerHTML = '';
+      if (milkMore) milkMore.innerHTML = '';
+    } else {
+      var cPin = '', cBody = '';
+      // SPLIT lead (V-V-2): sage carve-out band leads, amber gate band qualifies
+      // (M-2 skim-proof — the gate is visually weighted, never a trailing clause).
+      cPin += '<div class="enc-split">';
+      if (cow.whyGood) {
+        cPin += '<div class="enc-split-good"><div class="enc-split-h">' + zi('sprout') +
+          '<span>Good in food now</span></div><p class="enc-split-body">' + escHtml(cow.whyGood) + '</p></div>';
+      }
+      if (cow.gate) {
+        cPin += '<div class="enc-split-gate"><div class="enc-split-h">' + zi('clock') +
+          '<span>Wait as the main drink</span></div><p class="enc-split-body">' + escHtml(cow.gate) + '</p></div>';
+      }
+      cPin += '</div>';
+      // Drink-vs-food block (§4.2): ok = "Fine now — in food", never = "Not yet — as a
+      // drink", note = the non-suppressible invariant ("the drink is gated; the dairy is not").
+      cPin += _milkFormBlock(cow.safeForm, 'Fine now — in food', 'Not yet — as a drink');
+      // Severe strip — the CMPA emergency floor, PINNED + present-only via severeSigns
+      // (§6/M-1), with the V-V-4 class-aware scope header (separates the ALLERGY floor
+      // from the TIMING gate). Hand-built (not _severeFloorHtml) so the header is scoped
+      // and the mild watch-fors drop to the calm body instead.
+      cPin += _milkSevereStrip(cow, 'If your baby reacts to dairy, it\'s an emergency');
+      // BODY (collapsible): how-to (after-12mo) → mild watch-fors → myth.
+      var chti = cow.howToIntroduce || {};
+      if (chti.amount || chti.when || chti.watch) {
+        cBody += '<div class="enc-block"><div class="enc-block-h">' + zi('spoon') + '<span>How to give it</span></div><div class="enc-proto">';
+        if (chti.when)   cBody += '<div class="enc-proto-row"><b>When:</b> ' + escHtml(chti.when) + '</div>';
+        if (chti.amount) cBody += '<div class="enc-proto-row"><b>Amount:</b> ' + escHtml(chti.amount) + '</div>';
+        if (chti.watch)  cBody += '<div class="enc-proto-row"><b>Watch:</b> ' + escHtml(chti.watch) + '</div>';
+        cBody += '</div></div>';
+      }
+      var cMild = (cow.watchFor && cow.watchFor.length) ? cow.watchFor : [];
+      if (cMild.length) {
+        cBody += '<div class="cons-watch"><div class="cons-watch-h">Milder signs to watch for</div><ul class="cons-watch-list">' +
+          cMild.map(function(w){ return '<li>' + escHtml(w) + '</li>'; }).join('') + '</ul></div>';
+      }
+      if (cow.myth && cow.myth.truth) {
+        cBody += '<div class="enc-myth">' + zi('bulb') + '<span>' + escHtml(cow.myth.truth) + '</span></div>';
+      }
+      milkHost.innerHTML = cPin;
+      if (milkMore) milkMore.innerHTML = cBody;
+    }
+  }
+
+  // ── plant milk — substitute-caveat (sky inform) ──
+  var plantHost = document.getElementById('dietPlantMilkIntro');
+  var plantMore = document.getElementById('dietPlantMilkIntroMore');
+  var plant = FE ? FE['plant milk'] : null;
+  if (plantHost) {
+    if (!plant) {
+      plantHost.innerHTML = '';
+      if (plantMore) plantMore.innerHTML = '';
+    } else {
+      var pPin = '', pBody = '';
+      // INFORM banner (V-V-3, sky .enc-inform): the V-V-1 switched heading + the hardest
+      // fact fronted (headline: rice <5 = arsenic) + the age-1 nuance (whyGood).
+      pPin += '<div class="enc-inform"><div class="enc-inform-h">' + zi('info') + '<span>What it is — and what it isn\'t</span></div>';
+      if (plant.headline) pPin += '<p class="enc-inform-lead">' + escHtml(plant.headline) + '</p>';
+      if (plant.whyGood)  pPin += '<p class="enc-inform-body">' + escHtml(plant.whyGood) + '</p>';
+      pPin += '</div>';
+      // is/isn't block: ok = "From age 1, as part of a varied diet", never = "Never",
+      // note = the ranking + "not a substitute under 1".
+      pPin += _milkFormBlock(plant.safeForm, 'From age 1, as part of a varied diet', 'Never');
+      // No severe strip — substitute-caveat has no acute floor (§5.3).
+      // BODY: myth → the soy-milk allergen cross-reference (calm watch line).
+      if (plant.myth && plant.myth.truth) {
+        pBody += '<div class="enc-myth">' + zi('bulb') + '<span>' + escHtml(plant.myth.truth) + '</span></div>';
+      }
+      var pMild = (plant.watchFor && plant.watchFor.length) ? plant.watchFor : [];
+      if (pMild.length) {
+        pBody += '<div class="cons-watch"><div class="cons-watch-h">One thing to watch</div><ul class="cons-watch-list">' +
+          pMild.map(function(w){ return '<li>' + escHtml(w) + '</li>'; }).join('') + '</ul></div>';
+      }
+      plantHost.innerHTML = pPin;
+      if (plantMore) plantMore.innerHTML = pBody;
+    }
+  }
+}
+
+// Shared drink-vs-food / is-isn't block for the milk cards. safeForm.ok renders under
+// `okLabel`, safeForm.never under `neverLabel`, and safeForm.note as the non-suppressible
+// enc-form-note invariant (milk-spec §4.2/§5.2). Reuses the shipped .enc-form family.
+function _milkFormBlock(sf, okLabel, neverLabel) {
+  sf = sf || {};
+  var ok = (sf.ok && sf.ok.length) ? sf.ok : [];
+  var never = (sf.never && sf.never.length) ? sf.never : [];
+  if (!ok.length && !never.length && !sf.note) return '';
+  var h = '<div class="enc-form">';
+  if (ok.length) {
+    h += '<div class="enc-form-sub">' + escHtml(okLabel) + '</div><ul class="enc-form-list">' +
+      ok.map(function(x){ return '<li>' + escHtml(x) + '</li>'; }).join('') + '</ul>';
+  }
+  if (never.length) {
+    h += '<div class="enc-form-sub">' + escHtml(neverLabel) + '</div><ul class="enc-form-list enc-never">' +
+      never.map(function(x){ return '<li>' + escHtml(x) + '</li>'; }).join('') + '</ul>';
+  }
+  if (sf.note) h += '<p class="enc-form-note">' + escHtml(sf.note) + '</p>';
+  h += '</div>';
+  return h;
+}
+
+// Present-only CMPA severe strip for a drink-timing card (milk-spec §6/V-V-4/M-1). Renders
+// the anaphylaxis red-flags + the call-112/108 emergency line ONLY when severeSigns is a
+// non-empty array (never on a class/allergen-flag proxy — M-1). `scopeHeader` separates the
+// ALLERGY floor from the TIMING gate so a parent never conflates the two axes (V-V-4).
+function _milkSevereStrip(eff, scopeHeader) {
+  if (!eff || !Array.isArray(eff.severeSigns) || !eff.severeSigns.length) return '';
+  var h = '<div class="cons-severe"><div class="cons-severe-h">' + zi('siren') +
+    '<span>' + escHtml(scopeHeader) + '</span></div><ul class="cons-severe-list">' +
+    eff.severeSigns.map(function(s){ return '<li>' + escHtml(s) + '</li>'; }).join('') + '</ul>';
+  if (eff.seekCare) {
+    h += '<p class="enc-emergency">' + zi('siren') + '<span>' + escHtml(eff.seekCare) + '</span></p>';
+  }
+  h += '</div>';
+  return h;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -23816,7 +23816,7 @@ const _PLANT_MILK_NUT = ['almond', 'badam', 'cashew', 'kaju'];
 function _isPlantMilkDrinkHost(name) {
   const n = String(name || '').toLowerCase();
   if (!/\b(milk|doodh)\b/.test(n)) return false;
-  return _PLANT_MILK_NUT.some(t => new RegExp('\\b' + t + '\\b').test(n));
+  return _PLANT_MILK_NUT.some(t => new RegExp('\\b' + t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b').test(n));
 }
 
 // FOOD_EFFECTS consequence record for a food, or null. Uses _lookupByFoodName so
@@ -38723,12 +38723,15 @@ function _fdAgeRule(name) {
   // 'honeydew' no longer inherits honey's gate, and the gate stays consistent
   // with the consequence card (getFoodEffect uses the same resolver).
   const rule = _lookupByFoodName(AGE_RULES, name);
-  // Plant-milk drink host (almond/badam/cashew milk·doodh): the gate mirror of the
-  // getFoodEffect redirect — these resolve to the bare 'milk' (cow) gate by word-boundary,
-  // inheriting cow-milk reason copy (curd/paneer carve-out, no rice-arsenic). Redirect to the
-  // dedicated 'plant milk' gate so the card and the gate agree (one-resolver doctrine).
-  if (typeof AGE_RULES !== 'undefined' && AGE_RULES['plant milk']
-      && typeof _isPlantMilkDrinkHost === 'function' && _isPlantMilkDrinkHost(name)) {
+  // K-M-1 (Kael, option b — the truer one-resolver expression): a name whose CARD resolves to
+  // the plant-milk record but whose GATE fell to the bare cow 'milk' key must take the plant-milk
+  // gate, so card and gate agree. This catches the nut-drink redirect (almond/cashew milk) AND
+  // 'coconut milk drink' / any future non-nut plant alias the nut-token proxy would miss. Gated
+  // on `rule === AGE_RULES['milk']` so the dedicated plant gates (oat milk 12mo / rice milk +
+  // rice drink 60mo arsenic) — which resolved to their OWN entry above — are left untouched.
+  if (typeof AGE_RULES !== 'undefined' && AGE_RULES['plant milk'] && rule === AGE_RULES['milk']
+      && typeof getFoodEffect === 'function' && typeof FOOD_EFFECTS !== 'undefined'
+      && getFoodEffect(name) === FOOD_EFFECTS['plant milk']) {
     return AGE_RULES['plant milk'];
   }
   // M-F-1 (Cipher Edict-V completion): the same bare-'fish'-KEY leak that fed the
@@ -38906,6 +38909,17 @@ function renderFoodDetailSheet(name) {
     const pol = FD_POLARITY[fdPol] || FD_POLARITY.warn;
     html += `<div class="fd-flag ${pol.cls}">${zi(pol.ic)} <span><strong>${head}</strong>${sub ? ' ' + sub : ''}</span></div>`;
     html += fdFloor; // .cons-severe / .cons-watch / .cons-seek (shared, already-styled)
+    // M-M-1 (Maren, blocking): a plant-milk DRINK redirected to the plant-milk record
+    // (almond / cashew / badam milk) still CONTAINS its tree-nut allergen, but the inform
+    // floor masks the allergen axis (the else-if below is dead when fdFloor is truthy), so the
+    // tree-nut ALLERGENS note would silently drop. Surface it alongside the inform flag, so the
+    // sheet shows BOTH axes — "not a substitute under 1" AND "contains almond, a tree-nut
+    // allergen". Scoped to the redirect target (plant milk carries no ALLERGENS note of its own,
+    // so any `allerg` here came from a DIFFERENT food); other records carry their allergen in
+    // their own floor, so this never double-prints.
+    if (typeof FOOD_EFFECTS !== 'undefined' && fdEff === FOOD_EFFECTS['plant milk'] && allerg) {
+      html += `<div class="fd-flag fd-flag-neutral">${zi('note')} <span><strong>Allergen.</strong> ${escHtml(allerg)}</span></div>`;
+    }
   } else if (allerg) {
     // A milder allergen with no FOOD_EFFECTS record (kiwi, strawberry, oats …):
     // informational + calm, never the rose alarm. Introduce carefully, watch.
@@ -39192,7 +39206,9 @@ function renderDietMilkIntro() {
       // (§6/M-1), with the V-V-4 class-aware scope header (separates the ALLERGY floor
       // from the TIMING gate). Hand-built (not _severeFloorHtml) so the header is scoped
       // and the mild watch-fors drop to the calm body instead.
-      cPin += _milkSevereStrip(cow, 'If your baby reacts to dairy, it\'s an emergency');
+      // M-M-2 (Maren): scope to the SEVERE path — "reacts to dairy" over-read as any reaction
+      // being an emergency, contradicting the mild-path the seekCare line and body watch-fors draw.
+      cPin += _milkSevereStrip(cow, 'A severe reaction to dairy is an emergency');
       // BODY (collapsible): how-to (after-12mo) → mild watch-fors → myth.
       var chti = cow.howToIntroduce || {};
       if (chti.amount || chti.when || chti.watch) {

--- a/index.html
+++ b/index.html
@@ -38723,15 +38723,19 @@ function _fdAgeRule(name) {
   // 'honeydew' no longer inherits honey's gate, and the gate stays consistent
   // with the consequence card (getFoodEffect uses the same resolver).
   const rule = _lookupByFoodName(AGE_RULES, name);
-  // K-M-1 (Kael, option b — the truer one-resolver expression): a name whose CARD resolves to
-  // the plant-milk record but whose GATE fell to the bare cow 'milk' key must take the plant-milk
-  // gate, so card and gate agree. This catches the nut-drink redirect (almond/cashew milk) AND
-  // 'coconut milk drink' / any future non-nut plant alias the nut-token proxy would miss. Gated
-  // on `rule === AGE_RULES['milk']` so the dedicated plant gates (oat milk 12mo / rice milk +
-  // rice drink 60mo arsenic) — which resolved to their OWN entry above — are left untouched.
-  if (typeof AGE_RULES !== 'undefined' && AGE_RULES['plant milk'] && rule === AGE_RULES['milk']
+  // K-M-1 (Kael option b, completed per Cipher Edict-V): whenever the CARD resolves to the
+  // plant-milk record but the raw GATE is NOT a dedicated plant gate, take the plant-milk gate
+  // so card and gate agree. Keyed on "card is plant milk" — NOT on the bare-'milk' fall — because
+  // the Hindi 'doodh' variants (badam doodh / kaju doodh) raw-resolve to tree-nut's alias
+  // (tree nut@6), the tree-nut FALL the earlier `rule === AGE_RULES['milk']` precondition missed
+  // (it only caught the bare-'milk' fall of the English "milk" forms). The dedicated plant gates
+  // (oat 12 / rice + rice drink 60mo arsenic) are excluded so they keep their own copy; the bare
+  // nut (card is tree nut, not plant milk) skips this guard and correctly stays at tree nut@6.
+  if (typeof AGE_RULES !== 'undefined' && AGE_RULES['plant milk']
       && typeof getFoodEffect === 'function' && typeof FOOD_EFFECTS !== 'undefined'
-      && getFoodEffect(name) === FOOD_EFFECTS['plant milk']) {
+      && getFoodEffect(name) === FOOD_EFFECTS['plant milk']
+      && rule !== AGE_RULES['plant milk'] && rule !== AGE_RULES['oat milk']
+      && rule !== AGE_RULES['rice milk'] && rule !== AGE_RULES['rice drink']) {
     return AGE_RULES['plant milk'];
   }
   // M-F-1 (Cipher Edict-V completion): the same bare-'fish'-KEY leak that fed the

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.02-5",
+  "version": "2026.06.02-7",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.02-3",
+  "version": "2026.06.02-5",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.02-7",
+  "version": "2026.06.02-8",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -4079,7 +4079,7 @@ const _PLANT_MILK_NUT = ['almond', 'badam', 'cashew', 'kaju'];
 function _isPlantMilkDrinkHost(name) {
   const n = String(name || '').toLowerCase();
   if (!/\b(milk|doodh)\b/.test(n)) return false;
-  return _PLANT_MILK_NUT.some(t => new RegExp('\\b' + t + '\\b').test(n));
+  return _PLANT_MILK_NUT.some(t => new RegExp('\\b' + t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b').test(n));
 }
 
 // FOOD_EFFECTS consequence record for a food, or null. Uses _lookupByFoodName so

--- a/split/core.js
+++ b/split/core.js
@@ -4064,10 +4064,31 @@ function _isHighMercuryFishHost(name) {
     new RegExp('\\b' + t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b').test(n));
 }
 
+// food-effects-v2 P1c (milk). A plant-milk DRINK named with a tree-nut word — "almond milk",
+// "badam doodh", "cashew milk" — resolves to the TREE-NUT record, because tree nut's
+// 'almond'/'badam'/'cashew' alias wins at the byAlias tier (tree nut precedes plant milk) over
+// plant milk's own 'almond milk'/'badam doodh' alias. That surfaces an "introduce early, ground
+// or smooth" ENCOURAGE verdict on what is a substitute-caveat DRINK — the opposite polarity,
+// and it contradicts the spec's K-2 intent (badam milk → plant milk). This guard redirects such
+// a host to the plant-milk record so both surfaces read "not a substitute under 1," not
+// "introduce early." Requires BOTH a tree-nut token AND a drink word, so the bare nut ("badam",
+// "almond butter") still correctly resolves to the tree-nut introduce-early record. Soy milk is
+// untouched (it intentionally aliases to the soy allergen record); oat/rice/coconut-drink
+// already resolve to plant milk without collision.
+const _PLANT_MILK_NUT = ['almond', 'badam', 'cashew', 'kaju'];
+function _isPlantMilkDrinkHost(name) {
+  const n = String(name || '').toLowerCase();
+  if (!/\b(milk|doodh)\b/.test(n)) return false;
+  return _PLANT_MILK_NUT.some(t => new RegExp('\\b' + t + '\\b').test(n));
+}
+
 // FOOD_EFFECTS consequence record for a food, or null. Uses _lookupByFoodName so
 // resolution matches the AGE_RULES gate exactly (word-boundary, not substring).
 function getFoodEffect(name) {
   if (typeof FOOD_EFFECTS === 'undefined') return null;
+  // Plant-milk drink host (almond/badam/cashew milk·doodh) → plant-milk record, NOT the
+  // tree-nut encourage card it would otherwise resolve to (K-2 intent; alias-precedence fix).
+  if (_isPlantMilkDrinkHost(name) && FOOD_EFFECTS['plant milk']) return FOOD_EFFECTS['plant milk'];
   const eff = _lookupByFoodName(FOOD_EFFECTS, name);
   // M-F-1: never affirm a high-mercury fish as a safe early food (the bare 'fish' KEY leak).
   if (eff && eff === FOOD_EFFECTS['fish'] && _isHighMercuryFishHost(name)) return null;
@@ -4090,6 +4111,28 @@ const COMBO_RESULT_SCHEMA = 'r1-fe';
 function _effHasClass(eff, cls) {
   if (!eff || !eff.foodClass) return false;
   return Array.isArray(eff.foodClass) ? eff.foodClass.indexOf(cls) !== -1 : eff.foodClass === cls;
+}
+
+// Polarity resolver (food-effects-v2 P1c, milk-spec §3-bis, K-6 — the load-bearing
+// fold). Maps a FOOD_EFFECTS record's foodClass to ONE of four render polarities, so
+// every banner surface switches {fill, icon, heading, gate-render} off a SINGLE source
+// of truth instead of each re-deriving polarity from a two-state _effHasClass test (the
+// K-6 defect: renderFoodLibDetail's old `fdEncourage ? sprout : siren` rendered milk's
+// drink-timing/substitute-caveat records as a rose "avoid" SIREN — the §1 wrong-lead on
+// a second surface). Precedence matters for the multi-class records: warn (acute-toxin,
+// honey) → encourage (allergen-introduce-early; wins over a SECONDARY choking-by-form on
+// peanut/tree-nut/fish) → conditional (drink-timing cow milk; and a PRIMARY choking-by-form
+// once the choking set wires, milk-spec §9) → inform (substitute-caveat plant milk).
+// Returns 'inform' as the conservative non-alarm default for an unknown/absent class —
+// never 'warn' (a spurious siren is the failure this resolver exists to prevent).
+function _effPolarity(eff) {
+  if (!eff || !eff.foodClass) return 'inform';
+  if (_effHasClass(eff, 'acute-toxin'))               return 'warn';
+  if (_effHasClass(eff, 'allergen-introduce-early'))  return 'encourage';
+  if (_effHasClass(eff, 'drink-timing'))              return 'conditional';
+  if (_effHasClass(eff, 'choking-by-form'))           return 'conditional'; // PRIMARY (§9, deferred); secondary already caught by encourage above
+  if (_effHasClass(eff, 'substitute-caveat'))         return 'inform';
+  return 'inform';
 }
 
 // Shared emergency-floor renderer (food-effects v2 §3.0, M-S-7). The severe

--- a/split/data.js
+++ b/split/data.js
@@ -2405,6 +2405,18 @@ const AGE_RULES = {
   'cow milk': { minMonth:12, reason:'Low in iron, hard on infant kidneys as main drink. Curd and paneer are fine.' },
   'cow\'s milk':{minMonth:12, reason:'Low in iron, hard on infant kidneys as main drink. Curd and paneer are fine.' },
   'milk':     { minMonth:12, reason:'As a drink, avoid until 12 months. Curd, paneer, and small amounts in cooking are fine.' },
+  // food-effects-v2 P1c (K-3): a DEDICATED 'plant milk' gate so a plant-milk log no
+  // longer inherits the cow-milk reason above (curd/paneer carve-out, no rice-arsenic) —
+  // the "green-but-wrong" K-3 named. The exact-key tier of _lookupByFoodName resolves
+  // 'plant milk'/'oat milk'/'rice milk'/'rice drink' to these before the bare 'milk' key.
+  // NOTE (Kael resolver-scope): 'almond milk'/'badam milk'/'badam doodh' are NOT keyed
+  // here — they FOOD_EFFECTS-resolve to the tree-nut record (tree-nut's 'almond'/'badam'
+  // aliases win at the byAlias tier), so a dedicated plant gate for them would diverge
+  // from the card they actually fire. The rice forms carry the under-5 arsenic floor.
+  'plant milk': { minMonth:12, reason:'Not a substitute for breastmilk or formula before 12 months. From 12 months, unsweetened fortified soy or oat milk can be part of a varied diet. Rice drinks: none under 5 (arsenic).' },
+  'oat milk':   { minMonth:12, reason:'Not a milk substitute before 12 months. From 12 months, unsweetened fortified oat milk can be part of a varied diet — not the only drink.' },
+  'rice milk':  { minMonth:60, reason:'Rice drinks contain arsenic — not for any child under 5. Eating rice the grain is still fine. Not a milk substitute under 1.' },
+  'rice drink': { minMonth:60, reason:'Rice drinks contain arsenic — not for any child under 5. Not a milk substitute under 1.' },
   'salt':     { minMonth:12, reason:'Baby\'s kidneys cannot process added salt. Natural sodium in foods is enough.' },
   'sugar':    { minMonth:12, reason:'No added sugar before 12 months. Use fruit for natural sweetness.' },
   'jaggery':  { minMonth:12, reason:'Treat as added sugar — avoid before 12 months.' },
@@ -2742,6 +2754,82 @@ const FOOD_EFFECTS = {
     seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, tongue or throat swelling, a hoarse cry, or floppiness: call emergency services (112 or 108) right away and use a prescribed adrenaline auto-injector if you have one — an antihistamine does not treat anaphylaxis. Fish allergy is usually lifelong; a specialist guides any testing of other species.',
     confidence: 'high',
   },
+
+  // ── food-effects-v2 P1c: cow's milk + plant milks (the broader food classes) ──
+  // The first records of the two never-rendered v2 foodClasses (spec §2 + the milk
+  // polarity spec docs/specs/food-effects-v2-p1c-milk-polarities.md):
+  //   cow milk   = 'drink-timing'      — conditional: fine IN FOOD ~6mo, not the
+  //                                       main DRINK before 12mo (NEITHER avoid nor encourage).
+  //   plant milk = 'substitute-caveat' — inform: not a breastmilk/formula substitute <1;
+  //                                       rice drinks none under 5 (arsenic).
+  // NEITHER is allergen-introduce-early → NO earlyIntroBenefit (EAT found no prevention
+  // effect for milk). `safeForm` is repurposed as the DRINK-vs-FOOD / is-isn't gate (spec
+  // §8a, Kael-ratified). cow milk carries the CMPA allergic axis (watchFor/severeSigns/
+  // seekCare) ALONGSIDE the timing axis — it is the most common infant allergen, so the
+  // present-only severe floor (§6, keyed on severeSigns.length) fires here. plant milk has
+  // NO severeSigns → no acute floor (§5.3, the floor follows the hazard). Polarity is
+  // resolved by _effPolarity (core.js) — both surfaces render conditional/inform, never the
+  // rose 'avoid' siren (K-6). K-1 (Kael): 'top feed' is NOT a cow-milk alias (≈ formula in
+  // Indian logs). Bare 'milk' is deliberately UNALIASED on either record (it co-occurs in
+  // breast/formula/soy milk — the bare-'milk' precision rule, spec §7). Evidence + citations:
+  // docs/research/cow-milk-plant-milks-infant-safety.md.
+  'cow milk': {
+    foodClass:  'drink-timing',
+    severity:   'caution',              // amber timing-caution, NOT rose acute-toxin
+    aliases:    ['cow\'s milk', 'buffalo milk', 'bhains ka doodh', 'gaay ka doodh', 'animal milk', 'whole milk', 'full-fat milk', 'top milk', 'dairy milk', 'full cream milk'],
+    effect:     'iron-deficiency anaemia + renal solute load (as a main drink before 12 months)',
+    title:      'Cow\'s milk — good in food, not yet as the main drink',
+    why:        'Dairy in food is excellent from around 6 months — dahi (curd), paneer, and cheese. The caution is only about cow\'s or buffalo milk as the main drink before the first birthday: it is low in iron and hard on a baby\'s kidneys. Breastmilk or formula is the milk under 1.',
+    whyGood:    'Dairy in food is excellent from around 6 months — dahi (curd), paneer, and cheese give calcium, protein, B12, and healthy fats. The only caution is about milk as the main drink before the first birthday.',
+    // The amber gate band of the split lead (V-V-2 / M-2 skim-proof) — visually weighted
+    // equal-or-greater to the sage carve-out, so the diluted-top-milk reader can't under-read it.
+    gate:       'Not as the main drink before 12 months — cow\'s or buffalo milk is low in iron and hard on a baby\'s kidneys. Breastmilk or first infant formula is the milk under 1.',
+    safeForm: {
+      glance:   'Fine in food; wait as a drink',
+      ok:       ['dahi (curd), paneer, and pasteurised full-fat cheese from around 6 months', 'small amounts of milk cooked into khichdi, porridge, or cereal', 'from 12 months: whole (full-fat) milk as a main drink, about 500 ml (2 cups) a day at most'],
+      never:    ['cow\'s or buffalo milk as the main drink before 12 months', 'diluted or sweetened "top milk" as a breastmilk or formula substitute', 'unpasteurised milk, and mould-ripened (brie, camembert), blue, or ripened-goat cheese at any infant age', 'skimmed or low-fat milk as a main drink before age 2'],
+      note:     'The drink is gated; the dairy is not. Breastmilk or first infant formula is the milk under 12 months. Diluting cow or buffalo milk adds no iron and still displaces breastmilk.',
+    },
+    howToIntroduce: {
+      amount:   'from 12 months, about 500 ml (2 cups) of whole milk a day at most — more is linked to iron deficiency',
+      when:     'dairy in food (dahi, paneer, cheese, milk in cooking) from around 6 months; milk as a main drink from 12 months',
+      watch:    'when you first give dairy in food, watch for about 2 hours for a cow\'s-milk-protein-allergy reaction — milk is the most common infant allergen',
+    },
+    myth: {
+      claim:    'Cow\'s or buffalo milk makes a baby strong — give it early.',
+      truth:    'Before 12 months as a main drink it causes iron-deficiency anaemia and strains the kidneys. Breastmilk or formula is the milk under 1; dairy belongs in food, not in the cup.',
+    },
+    watchFor:   ['hives or a rash', 'swelling of the lips, face, or eyes', 'vomiting', 'diarrhoea or blood in the stool (delayed cow\'s-milk-protein allergy)', 'an eczema flare'],
+    severeSigns:['trouble breathing or wheezing', 'swelling of the tongue or throat', 'a hoarse cry', 'going floppy, pale, or very sleepy'],
+    seekCare:   'A mild reaction to dairy (a little rash alone): stop, watch closely, and call your doctor. Any trouble breathing, tongue or throat swelling, a hoarse cry, or floppiness: call emergency services (112 or 108) right away and use a prescribed adrenaline auto-injector if you have one — an antihistamine does not treat anaphylaxis. Most children outgrow cow\'s-milk allergy by 3 to 5 years; any reintroduction (the milk ladder) is a doctor\'s call.',
+    confidence: 'high',
+  },
+  'plant milk': {
+    foodClass:  'substitute-caveat',
+    severity:   'caution',
+    aliases:    ['almond milk', 'badam milk', 'badam doodh', 'oat milk', 'rice milk', 'rice drink', 'cashew milk', 'coconut milk drink', 'plant-based milk', 'plant milks', 'vegan milk', 'toddler milk', 'growing-up milk', 'follow-on milk drink'],
+    effect:     'inadequate substitute for breastmilk or formula (under 1); rice-drink arsenic (under 5)',
+    title:      'Plant milks — not a substitute for breastmilk or formula',
+    why:        'No plant milk (almond, oat, rice, cashew, coconut) replaces breastmilk or formula in the first year. Rice drinks are not safe for any child under 5 because of arsenic. From age 1, unsweetened, calcium-fortified soy or oat milk can be part of a varied diet — but not the only drink for an under-2.',
+    whyGood:    'From age 1, unsweetened, calcium-fortified soy or oat milk can be part of a varied diet. Fortified soy is the only plant milk nutritionally close to cow\'s milk.',
+    // The sky inform banner (V-V-3) leads with the single hardest fact, fronted (rice <5 = arsenic).
+    headline:   'Not a milk substitute under 1. Rice drinks: none under 5 (arsenic). From age 1, fortified soy or oat only, as part of a varied diet.',
+    safeForm: {
+      glance:   'Not a substitute under 1',
+      ok:       ['from 12 months: unsweetened, calcium-fortified soy or oat milk, as part of a varied diet (not the only drink for an under-2)'],
+      never:    ['any plant milk as a breastmilk or formula substitute before 12 months', 'rice drinks for any child under 5 years (inorganic arsenic) — eating rice the grain is still fine', 'unfortified plant milk as a main drink', 'almond milk as a main drink (too low in protein and fat)', 'carton soy drink as infant formula (soy formula is a separate, prescribed product)'],
+      note:     'No plant milk replaces breastmilk or formula under 1. After age 1, the ranking is: fortified soy and oat first, then almond (low in protein), and rice last (arsenic — avoid under 5). "Toddler" and "growing-up" milks are unnecessary.',
+    },
+    myth: {
+      claim:    'Plant milk (almond, oat, or rice) is a healthy milk substitute for my baby or toddler.',
+      truth:    'Not under 1 — it replaces neither breastmilk nor formula. Rice drinks are unsafe under 5 (arsenic); almond milk is too low in protein and fat. From age 1, fortified soy or oat can be part of a varied diet.',
+    },
+    // Soy milk is the allergen exception — it aliases to the SOY record, not here. Cross-referenced
+    // in copy, not re-aliased. No severeSigns/seekCare: the harm is nutritional / chronic (arsenic),
+    // not an acute reaction, so this record carries NO emergency floor (spec §5.3).
+    watchFor:   ['soy milk only: hives, swelling, or vomiting — soy is a major allergen (see the soy guidance)'],
+    confidence: 'high',
+  },
 };
 
 // ── ALLERGEN FLAGS ──
@@ -2762,6 +2850,13 @@ const ALLERGENS = {
   // food-effects-v2 P1c: fish is allergen:true (a major allergen, often lifelong). Full
   // anaphylaxis floor lives on the FOOD_EFFECTS record; this is the terse browse flag.
   'fish':      'Common allergen, and often lifelong. Introduce well-cooked, deboned, low-mercury fish on its own and watch ~2 hours. Finfish is a separate allergen from shellfish.',
+  // food-effects-v2 P1c (K-4): cow milk is allergen:true (CMPA — the most common infant
+  // food allergy). The full anaphylaxis floor lives on the FOOD_EFFECTS record (severeSigns
+  // / seekCare); this terse note is the browse-surface flag, scoped to the ALLERGY axis (a
+  // SEPARATE concern from the drink-timing gate). Satisfies the §6 allergen:true↔ALLERGENS
+  // traceability invariant. 'plant milk' is allergen:false — soy milk is the exception and
+  // is flagged via the soy record, so plant milk correctly needs no ALLERGENS note.
+  'cow milk':  'Cow\'s-milk protein is the most common infant allergen (CMPA). When you first give dairy in food, watch about 2 hours; mild signs are rash, swelling, or vomiting, and a delayed reaction can be diarrhoea or blood in the stool.',
   'egg yolk':  'Less allergenic than white. Cook well. Give alone for 3 days.',
   'kiwi':      'Can cause mouth tingling. Start with small amount. Watch for oral allergy.',
   'strawberry':'Can cause allergic reaction in some babies. Introduce carefully.',

--- a/split/diet.js
+++ b/split/diet.js
@@ -488,12 +488,15 @@ function _fdAgeRule(name) {
   // 'honeydew' no longer inherits honey's gate, and the gate stays consistent
   // with the consequence card (getFoodEffect uses the same resolver).
   const rule = _lookupByFoodName(AGE_RULES, name);
-  // Plant-milk drink host (almond/badam/cashew milk·doodh): the gate mirror of the
-  // getFoodEffect redirect — these resolve to the bare 'milk' (cow) gate by word-boundary,
-  // inheriting cow-milk reason copy (curd/paneer carve-out, no rice-arsenic). Redirect to the
-  // dedicated 'plant milk' gate so the card and the gate agree (one-resolver doctrine).
-  if (typeof AGE_RULES !== 'undefined' && AGE_RULES['plant milk']
-      && typeof _isPlantMilkDrinkHost === 'function' && _isPlantMilkDrinkHost(name)) {
+  // K-M-1 (Kael, option b — the truer one-resolver expression): a name whose CARD resolves to
+  // the plant-milk record but whose GATE fell to the bare cow 'milk' key must take the plant-milk
+  // gate, so card and gate agree. This catches the nut-drink redirect (almond/cashew milk) AND
+  // 'coconut milk drink' / any future non-nut plant alias the nut-token proxy would miss. Gated
+  // on `rule === AGE_RULES['milk']` so the dedicated plant gates (oat milk 12mo / rice milk +
+  // rice drink 60mo arsenic) — which resolved to their OWN entry above — are left untouched.
+  if (typeof AGE_RULES !== 'undefined' && AGE_RULES['plant milk'] && rule === AGE_RULES['milk']
+      && typeof getFoodEffect === 'function' && typeof FOOD_EFFECTS !== 'undefined'
+      && getFoodEffect(name) === FOOD_EFFECTS['plant milk']) {
     return AGE_RULES['plant milk'];
   }
   // M-F-1 (Cipher Edict-V completion): the same bare-'fish'-KEY leak that fed the
@@ -671,6 +674,17 @@ function renderFoodDetailSheet(name) {
     const pol = FD_POLARITY[fdPol] || FD_POLARITY.warn;
     html += `<div class="fd-flag ${pol.cls}">${zi(pol.ic)} <span><strong>${head}</strong>${sub ? ' ' + sub : ''}</span></div>`;
     html += fdFloor; // .cons-severe / .cons-watch / .cons-seek (shared, already-styled)
+    // M-M-1 (Maren, blocking): a plant-milk DRINK redirected to the plant-milk record
+    // (almond / cashew / badam milk) still CONTAINS its tree-nut allergen, but the inform
+    // floor masks the allergen axis (the else-if below is dead when fdFloor is truthy), so the
+    // tree-nut ALLERGENS note would silently drop. Surface it alongside the inform flag, so the
+    // sheet shows BOTH axes — "not a substitute under 1" AND "contains almond, a tree-nut
+    // allergen". Scoped to the redirect target (plant milk carries no ALLERGENS note of its own,
+    // so any `allerg` here came from a DIFFERENT food); other records carry their allergen in
+    // their own floor, so this never double-prints.
+    if (typeof FOOD_EFFECTS !== 'undefined' && fdEff === FOOD_EFFECTS['plant milk'] && allerg) {
+      html += `<div class="fd-flag fd-flag-neutral">${zi('note')} <span><strong>Allergen.</strong> ${escHtml(allerg)}</span></div>`;
+    }
   } else if (allerg) {
     // A milder allergen with no FOOD_EFFECTS record (kiwi, strawberry, oats …):
     // informational + calm, never the rose alarm. Introduce carefully, watch.
@@ -957,7 +971,9 @@ function renderDietMilkIntro() {
       // (§6/M-1), with the V-V-4 class-aware scope header (separates the ALLERGY floor
       // from the TIMING gate). Hand-built (not _severeFloorHtml) so the header is scoped
       // and the mild watch-fors drop to the calm body instead.
-      cPin += _milkSevereStrip(cow, 'If your baby reacts to dairy, it\'s an emergency');
+      // M-M-2 (Maren): scope to the SEVERE path — "reacts to dairy" over-read as any reaction
+      // being an emergency, contradicting the mild-path the seekCare line and body watch-fors draw.
+      cPin += _milkSevereStrip(cow, 'A severe reaction to dairy is an emergency');
       // BODY (collapsible): how-to (after-12mo) → mild watch-fors → myth.
       var chti = cow.howToIntroduce || {};
       if (chti.amount || chti.when || chti.watch) {

--- a/split/diet.js
+++ b/split/diet.js
@@ -488,15 +488,19 @@ function _fdAgeRule(name) {
   // 'honeydew' no longer inherits honey's gate, and the gate stays consistent
   // with the consequence card (getFoodEffect uses the same resolver).
   const rule = _lookupByFoodName(AGE_RULES, name);
-  // K-M-1 (Kael, option b — the truer one-resolver expression): a name whose CARD resolves to
-  // the plant-milk record but whose GATE fell to the bare cow 'milk' key must take the plant-milk
-  // gate, so card and gate agree. This catches the nut-drink redirect (almond/cashew milk) AND
-  // 'coconut milk drink' / any future non-nut plant alias the nut-token proxy would miss. Gated
-  // on `rule === AGE_RULES['milk']` so the dedicated plant gates (oat milk 12mo / rice milk +
-  // rice drink 60mo arsenic) — which resolved to their OWN entry above — are left untouched.
-  if (typeof AGE_RULES !== 'undefined' && AGE_RULES['plant milk'] && rule === AGE_RULES['milk']
+  // K-M-1 (Kael option b, completed per Cipher Edict-V): whenever the CARD resolves to the
+  // plant-milk record but the raw GATE is NOT a dedicated plant gate, take the plant-milk gate
+  // so card and gate agree. Keyed on "card is plant milk" — NOT on the bare-'milk' fall — because
+  // the Hindi 'doodh' variants (badam doodh / kaju doodh) raw-resolve to tree-nut's alias
+  // (tree nut@6), the tree-nut FALL the earlier `rule === AGE_RULES['milk']` precondition missed
+  // (it only caught the bare-'milk' fall of the English "milk" forms). The dedicated plant gates
+  // (oat 12 / rice + rice drink 60mo arsenic) are excluded so they keep their own copy; the bare
+  // nut (card is tree nut, not plant milk) skips this guard and correctly stays at tree nut@6.
+  if (typeof AGE_RULES !== 'undefined' && AGE_RULES['plant milk']
       && typeof getFoodEffect === 'function' && typeof FOOD_EFFECTS !== 'undefined'
-      && getFoodEffect(name) === FOOD_EFFECTS['plant milk']) {
+      && getFoodEffect(name) === FOOD_EFFECTS['plant milk']
+      && rule !== AGE_RULES['plant milk'] && rule !== AGE_RULES['oat milk']
+      && rule !== AGE_RULES['rice milk'] && rule !== AGE_RULES['rice drink']) {
     return AGE_RULES['plant milk'];
   }
   // M-F-1 (Cipher Edict-V completion): the same bare-'fish'-KEY leak that fed the

--- a/split/diet.js
+++ b/split/diet.js
@@ -488,6 +488,14 @@ function _fdAgeRule(name) {
   // 'honeydew' no longer inherits honey's gate, and the gate stays consistent
   // with the consequence card (getFoodEffect uses the same resolver).
   const rule = _lookupByFoodName(AGE_RULES, name);
+  // Plant-milk drink host (almond/badam/cashew milk·doodh): the gate mirror of the
+  // getFoodEffect redirect — these resolve to the bare 'milk' (cow) gate by word-boundary,
+  // inheriting cow-milk reason copy (curd/paneer carve-out, no rice-arsenic). Redirect to the
+  // dedicated 'plant milk' gate so the card and the gate agree (one-resolver doctrine).
+  if (typeof AGE_RULES !== 'undefined' && AGE_RULES['plant milk']
+      && typeof _isPlantMilkDrinkHost === 'function' && _isPlantMilkDrinkHost(name)) {
+    return AGE_RULES['plant milk'];
+  }
   // M-F-1 (Cipher Edict-V completion): the same bare-'fish'-KEY leak that fed the
   // consequence card also feeds this gate — "seer fish" / "shark fish" resolve to
   // AGE_RULES['fish'] (6mo) and would show a green "fine from ~6 months" badge for a
@@ -640,18 +648,28 @@ function renderFoodDetailSheet(name) {
   // Q-3 call; the severe floor's presence is the non-negotiable, M-S-6.)
   const fdEff = (typeof getFoodEffect === 'function') ? getFoodEffect(lower) : null;
   const fdFloor = (fdEff && typeof _severeFloorHtml === 'function') ? _severeFloorHtml(fdEff) : '';
-  // Polarity (food-effects-v2): an introduce-early allergen reads ENCOURAGE —
-  // sage banner + calm sprout icon ("good to introduce, here's the safe form"),
-  // never rose/siren ("don't give"). Rose is reserved for true avoid (acute-toxin).
-  // The severe-reaction floor (fdFloor) below stays serious regardless.
-  const fdEncourage = (typeof _effHasClass === 'function') && _effHasClass(fdEff, 'allergen-introduce-early');
+  // Polarity (food-effects-v2 P1c, K-6): the banner cosmetic switches off the SHARED
+  // _effPolarity resolver (core.js, milk-spec §3-bis), NOT a two-state encourage/avoid
+  // boolean. The old `fdEncourage ? sprout : siren` rendered milk's drink-timing /
+  // substitute-caveat records as a rose "avoid" SIREN here — the §1 wrong-lead on this
+  // second surface. Four polarities, one source of truth: encourage (sage/sprout, the δ
+  // allergens), warn (rose/siren, acute-toxin honey), conditional (amber/clock, cow milk
+  // drink-timing), inform (sky/info, plant-milk substitute-caveat). The severe-reaction
+  // floor (fdFloor) below stays serious regardless — it is presence-driven (severeSigns),
+  // independent of this banner cosmetic.
+  const FD_POLARITY = {
+    encourage:   { cls:'fd-flag-encourage',   ic:'sprout' },
+    warn:        { cls:'fd-flag-allergen',    ic:'siren'  },
+    conditional: { cls:'fd-flag-conditional', ic:'clock'  },
+    inform:      { cls:'fd-flag-inform',      ic:'info'   },
+  };
+  const fdPol = (typeof _effPolarity === 'function') ? _effPolarity(fdEff) : 'warn';
   if (fdFloor) {
     const head = (fdEff && fdEff.title) ? escHtml(fdEff.title) : 'Allergen';
     const sub = (fdEff && fdEff.safeForm && fdEff.safeForm.note) ? escHtml(fdEff.safeForm.note)
               : (allerg ? escHtml(allerg) : '');
-    const flagCls = fdEncourage ? 'fd-flag-encourage' : 'fd-flag-allergen';
-    const flagIc  = fdEncourage ? zi('sprout') : zi('siren');
-    html += `<div class="fd-flag ${flagCls}">${flagIc} <span><strong>${head}</strong>${sub ? ' ' + sub : ''}</span></div>`;
+    const pol = FD_POLARITY[fdPol] || FD_POLARITY.warn;
+    html += `<div class="fd-flag ${pol.cls}">${zi(pol.ic)} <span><strong>${head}</strong>${sub ? ' ' + sub : ''}</span></div>`;
     html += fdFloor; // .cons-severe / .cons-watch / .cons-seek (shared, already-styled)
   } else if (allerg) {
     // A milder allergen with no FOOD_EFFECTS record (kiwi, strawberry, oats …):
@@ -760,6 +778,7 @@ function renderDietLibrary() {
   renderFoodLibFilters();
   renderFoodLibResults();
   renderDietNutIntro();
+  renderDietMilkIntro();
 }
 
 // ════════════════════════════════════════
@@ -888,6 +907,150 @@ function renderDietNutIntro() {
 
   host.innerHTML = pinned;
   if (moreHost) moreHost.innerHTML = body;
+}
+
+// ════════════════════════════════════════
+// Milk — the drink-timing + substitute-caveat KNOWLEDGE cards (food-effects v2 P1c)
+// ════════════════════════════════════════
+// Sibling of renderDietNutIntro (separate fns + hosts; the nut card stays untouched).
+// Renders the FIRST two cards of the never-rendered v2 polarities (milk-spec §4/§5):
+//   • cow milk   → 'drink-timing'      (#dietMilkIntro)      — CONDITIONAL, a SPLIT lead
+//     (sage carve-out "good in food now" over an amber gate "wait as the main drink",
+//     V-V-2 / M-2 skim-proof). CMPA severe strip PINNED (present-only via severeSigns,
+//     §6) with a class-aware scope header (V-V-4).
+//   • plant milk → 'substitute-caveat' (#dietPlantMilkIntro) — INFORM, a SKY banner
+//     (V-V-3, .enc-inform) leading with the hardest fact (rice <5 = arsenic). NO severe
+//     strip — the harm is nutritional/chronic, not acute (§5.3, the floor follows the hazard).
+// Records are read by DIRECT KEY (FE['cow milk'] / FE['plant milk']) — NOT via the
+// resolver — so the Library knowledge cards are immune to alias-precedence collisions.
+// All copy is FOOD_EFFECTS-sourced (no hardcoded safety claim); the only hardcoded
+// strings are the V-V-1 switched-unit HEADINGS (render copy, polarity-keyed, not reusable).
+function renderDietMilkIntro() {
+  var FE = (typeof FOOD_EFFECTS !== 'undefined') ? FOOD_EFFECTS : null;
+
+  // ── cow milk — drink-timing (split conditional) ──
+  var milkHost = document.getElementById('dietMilkIntro');
+  var milkMore = document.getElementById('dietMilkIntroMore');
+  var cow = FE ? FE['cow milk'] : null;
+  if (milkHost) {
+    if (!cow) {
+      milkHost.innerHTML = '';
+      if (milkMore) milkMore.innerHTML = '';
+    } else {
+      var cPin = '', cBody = '';
+      // SPLIT lead (V-V-2): sage carve-out band leads, amber gate band qualifies
+      // (M-2 skim-proof — the gate is visually weighted, never a trailing clause).
+      cPin += '<div class="enc-split">';
+      if (cow.whyGood) {
+        cPin += '<div class="enc-split-good"><div class="enc-split-h">' + zi('sprout') +
+          '<span>Good in food now</span></div><p class="enc-split-body">' + escHtml(cow.whyGood) + '</p></div>';
+      }
+      if (cow.gate) {
+        cPin += '<div class="enc-split-gate"><div class="enc-split-h">' + zi('clock') +
+          '<span>Wait as the main drink</span></div><p class="enc-split-body">' + escHtml(cow.gate) + '</p></div>';
+      }
+      cPin += '</div>';
+      // Drink-vs-food block (§4.2): ok = "Fine now — in food", never = "Not yet — as a
+      // drink", note = the non-suppressible invariant ("the drink is gated; the dairy is not").
+      cPin += _milkFormBlock(cow.safeForm, 'Fine now — in food', 'Not yet — as a drink');
+      // Severe strip — the CMPA emergency floor, PINNED + present-only via severeSigns
+      // (§6/M-1), with the V-V-4 class-aware scope header (separates the ALLERGY floor
+      // from the TIMING gate). Hand-built (not _severeFloorHtml) so the header is scoped
+      // and the mild watch-fors drop to the calm body instead.
+      cPin += _milkSevereStrip(cow, 'If your baby reacts to dairy, it\'s an emergency');
+      // BODY (collapsible): how-to (after-12mo) → mild watch-fors → myth.
+      var chti = cow.howToIntroduce || {};
+      if (chti.amount || chti.when || chti.watch) {
+        cBody += '<div class="enc-block"><div class="enc-block-h">' + zi('spoon') + '<span>How to give it</span></div><div class="enc-proto">';
+        if (chti.when)   cBody += '<div class="enc-proto-row"><b>When:</b> ' + escHtml(chti.when) + '</div>';
+        if (chti.amount) cBody += '<div class="enc-proto-row"><b>Amount:</b> ' + escHtml(chti.amount) + '</div>';
+        if (chti.watch)  cBody += '<div class="enc-proto-row"><b>Watch:</b> ' + escHtml(chti.watch) + '</div>';
+        cBody += '</div></div>';
+      }
+      var cMild = (cow.watchFor && cow.watchFor.length) ? cow.watchFor : [];
+      if (cMild.length) {
+        cBody += '<div class="cons-watch"><div class="cons-watch-h">Milder signs to watch for</div><ul class="cons-watch-list">' +
+          cMild.map(function(w){ return '<li>' + escHtml(w) + '</li>'; }).join('') + '</ul></div>';
+      }
+      if (cow.myth && cow.myth.truth) {
+        cBody += '<div class="enc-myth">' + zi('bulb') + '<span>' + escHtml(cow.myth.truth) + '</span></div>';
+      }
+      milkHost.innerHTML = cPin;
+      if (milkMore) milkMore.innerHTML = cBody;
+    }
+  }
+
+  // ── plant milk — substitute-caveat (sky inform) ──
+  var plantHost = document.getElementById('dietPlantMilkIntro');
+  var plantMore = document.getElementById('dietPlantMilkIntroMore');
+  var plant = FE ? FE['plant milk'] : null;
+  if (plantHost) {
+    if (!plant) {
+      plantHost.innerHTML = '';
+      if (plantMore) plantMore.innerHTML = '';
+    } else {
+      var pPin = '', pBody = '';
+      // INFORM banner (V-V-3, sky .enc-inform): the V-V-1 switched heading + the hardest
+      // fact fronted (headline: rice <5 = arsenic) + the age-1 nuance (whyGood).
+      pPin += '<div class="enc-inform"><div class="enc-inform-h">' + zi('info') + '<span>What it is — and what it isn\'t</span></div>';
+      if (plant.headline) pPin += '<p class="enc-inform-lead">' + escHtml(plant.headline) + '</p>';
+      if (plant.whyGood)  pPin += '<p class="enc-inform-body">' + escHtml(plant.whyGood) + '</p>';
+      pPin += '</div>';
+      // is/isn't block: ok = "From age 1, as part of a varied diet", never = "Never",
+      // note = the ranking + "not a substitute under 1".
+      pPin += _milkFormBlock(plant.safeForm, 'From age 1, as part of a varied diet', 'Never');
+      // No severe strip — substitute-caveat has no acute floor (§5.3).
+      // BODY: myth → the soy-milk allergen cross-reference (calm watch line).
+      if (plant.myth && plant.myth.truth) {
+        pBody += '<div class="enc-myth">' + zi('bulb') + '<span>' + escHtml(plant.myth.truth) + '</span></div>';
+      }
+      var pMild = (plant.watchFor && plant.watchFor.length) ? plant.watchFor : [];
+      if (pMild.length) {
+        pBody += '<div class="cons-watch"><div class="cons-watch-h">One thing to watch</div><ul class="cons-watch-list">' +
+          pMild.map(function(w){ return '<li>' + escHtml(w) + '</li>'; }).join('') + '</ul></div>';
+      }
+      plantHost.innerHTML = pPin;
+      if (plantMore) plantMore.innerHTML = pBody;
+    }
+  }
+}
+
+// Shared drink-vs-food / is-isn't block for the milk cards. safeForm.ok renders under
+// `okLabel`, safeForm.never under `neverLabel`, and safeForm.note as the non-suppressible
+// enc-form-note invariant (milk-spec §4.2/§5.2). Reuses the shipped .enc-form family.
+function _milkFormBlock(sf, okLabel, neverLabel) {
+  sf = sf || {};
+  var ok = (sf.ok && sf.ok.length) ? sf.ok : [];
+  var never = (sf.never && sf.never.length) ? sf.never : [];
+  if (!ok.length && !never.length && !sf.note) return '';
+  var h = '<div class="enc-form">';
+  if (ok.length) {
+    h += '<div class="enc-form-sub">' + escHtml(okLabel) + '</div><ul class="enc-form-list">' +
+      ok.map(function(x){ return '<li>' + escHtml(x) + '</li>'; }).join('') + '</ul>';
+  }
+  if (never.length) {
+    h += '<div class="enc-form-sub">' + escHtml(neverLabel) + '</div><ul class="enc-form-list enc-never">' +
+      never.map(function(x){ return '<li>' + escHtml(x) + '</li>'; }).join('') + '</ul>';
+  }
+  if (sf.note) h += '<p class="enc-form-note">' + escHtml(sf.note) + '</p>';
+  h += '</div>';
+  return h;
+}
+
+// Present-only CMPA severe strip for a drink-timing card (milk-spec §6/V-V-4/M-1). Renders
+// the anaphylaxis red-flags + the call-112/108 emergency line ONLY when severeSigns is a
+// non-empty array (never on a class/allergen-flag proxy — M-1). `scopeHeader` separates the
+// ALLERGY floor from the TIMING gate so a parent never conflates the two axes (V-V-4).
+function _milkSevereStrip(eff, scopeHeader) {
+  if (!eff || !Array.isArray(eff.severeSigns) || !eff.severeSigns.length) return '';
+  var h = '<div class="cons-severe"><div class="cons-severe-h">' + zi('siren') +
+    '<span>' + escHtml(scopeHeader) + '</span></div><ul class="cons-severe-list">' +
+    eff.severeSigns.map(function(s){ return '<li>' + escHtml(s) + '</li>'; }).join('') + '</ul>';
+  if (eff.seekCare) {
+    h += '<p class="enc-emergency">' + zi('siren') + '<span>' + escHtml(eff.seekCare) + '</span></p>';
+  }
+  h += '</div>';
+  return h;
 }
 
 

--- a/split/styles.css
+++ b/split/styles.css
@@ -4013,6 +4013,36 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
 .enc-myth { display:flex; align-items:flex-start; gap:var(--sp-8); font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-16) 0 0; padding:var(--sp-12) var(--sp-16); background:var(--surface-lav); border-radius:var(--r-md); }
 .enc-myth .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--tc-lav); margin-top:3px; }
 
+/* ── food-effects-v2 P1c (milk polarities, milk-spec §3/§4/§5) ──────────────
+   The drink-timing SPLIT lead (cow milk) and the substitute-caveat SKY inform
+   banner (plant milk) — the two never-rendered v2 polarities. Composition over
+   new vocabulary (V-5): the split reuses the shipped sage + amber fills; the
+   inform banner is the one genuinely new modifier (sky, V-V-3). Shared-module
+   triple-Gov (Vela-first). */
+.enc-split { display:flex; flex-direction:column; gap:var(--sp-8); margin-bottom:var(--sp-16); }
+.enc-split-good { background:var(--surface-sage); border-left:3px solid var(--sage-deepest); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); }
+/* M-2 skim-proof: the gate band carries weight EQUAL-OR-GREATER than the carve-out —
+   the amber fill + the cons-severe-strength left accent + bold body — so the prevalent
+   diluted-top-milk reader cannot under-read the gate as a trailing qualifier. */
+.enc-split-gate { background:var(--surface-amber); border-left:3px solid var(--amber-deep); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); }
+.enc-split-h { display:flex; align-items:center; gap:var(--sp-8); font-size:var(--fs-sm); font-weight:700; text-transform:uppercase; letter-spacing:0.3px; margin-bottom:var(--sp-4); }
+.enc-split-good .enc-split-h { color:var(--sage-deepest); }
+.enc-split-gate .enc-split-h { color:var(--amber-deepest); }
+.enc-split-h .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; }
+.enc-split-good .enc-split-h .zi { color:var(--sage-deepest); }
+.enc-split-gate .enc-split-h .zi { color:var(--amber-deep); }
+.enc-split-body { font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); margin:0; }
+.enc-split-gate .enc-split-body { font-weight:700; }
+
+/* substitute-caveat INFORM banner (V-V-3): SKY, not neutral — neutral is a near-white
+   wash and register-less; sky is the existing drink/hydration domain color, AA-legible,
+   with a border-left for weight. The hardest fact (rice <5 = arsenic) is fronted in the lead. */
+.enc-inform { background:var(--surface-sky); border-left:3px solid var(--tc-sky); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); margin-bottom:var(--sp-16); }
+.enc-inform-h { display:flex; align-items:center; gap:var(--sp-8); font-size:var(--fs-sm); font-weight:700; color:var(--tc-sky); text-transform:uppercase; letter-spacing:0.3px; margin-bottom:var(--sp-8); }
+.enc-inform-h .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--tc-sky); }
+.enc-inform-lead { font-size:var(--fs-base); font-weight:700; color:var(--text); line-height:var(--lh-relaxed); margin:0 0 var(--sp-4); }
+.enc-inform-body { font-size:var(--fs-sm); color:var(--mid); line-height:var(--lh-relaxed); margin:0; }
+
 /* ── Viz detail popup (PR-I — viz interactivity layer) ── */
 /* Tap affordance: every wired data element (SVG dot/cell/bar/segment or
    HTML cell) gets a pointer cursor without a per-element class. */
@@ -10770,6 +10800,12 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
    NOT rose/alarm. Rose (.fd-flag-allergen) is reserved for true "avoid". The
    severe-reaction floor below the banner stays serious regardless. */
 .fd-flag-encourage { background:var(--sage-light); color:var(--tc-sage); }
+/* food-effects-v2 P1c (K-6): the four-polarity flag set on the Food Library detail
+   surface, switched off _effPolarity. conditional (drink-timing, cow milk) reads
+   amber/clock; inform (substitute-caveat, plant milk) reads sky/info — never the rose
+   .fd-flag-allergen siren (rose stays reserved for true acute-toxin "avoid"). */
+.fd-flag-conditional { background:var(--amber-light); color:var(--tc-amber); }
+.fd-flag-inform { background:var(--sky-light); color:var(--tc-sky); }
 .fd-flag-aged { background:var(--peach-light); color:var(--tc-caution); }
 .fd-flag-neutral { background:var(--glass-strong); color:var(--mid); }
 .fd-section { margin-top:var(--sp-12); }

--- a/split/template.html
+++ b/split/template.html
@@ -962,6 +962,43 @@
           </div>
         </div>
 
+        <!-- Cow's milk — good in food, wait as a drink (food-effects-v2 P1c, the
+             drink-timing polarity; spec docs/specs/food-effects-v2-p1c-milk-polarities.md §4).
+             Conditional, NOT avoid and NOT encourage — the SPLIT lead (sage carve-out band
+             "dairy in food is good now" over an amber gate band "not the main drink before 12mo",
+             V-V-2 / M-2 skim-proof). The CMPA severe strip is PINNED (present-only via
+             severeSigns, §6) and carries a class-aware scope header (V-V-4) so the timing gate is
+             never mistaken for the allergy floor. Pinned: split banner → drink-vs-food block →
+             SEVERE STRIP; body: how-to (after-12mo) → mild watch-fors → myth.
+             renderDietMilkIntro() (diet.js, lazy-rendered by renderDietLibrary) fills both. -->
+        <div class="card card-info col-full" id="dietMilkIntroCard">
+          <div class="card-header" data-collapse-target="dietMilkIntroBody" data-collapse-chevron="dietMilkIntroChevron">
+            <div class="card-title"><div class="icon icon-amber"><svg class="zi"><use href="#zi-clock"/></svg></div> Cow's milk — in food and as a drink</div>
+            <span class="collapse-chevron" id="dietMilkIntroChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
+          </div>
+          <div id="dietMilkIntro" class="mt-4"></div>
+          <div id="dietMilkIntroBody" class="collapse-body fx-col g8" style="display:none;">
+            <div id="dietMilkIntroMore" class="mt-4"></div>
+          </div>
+        </div>
+
+        <!-- Plant milks — not a substitute for breastmilk/formula (food-effects-v2 P1c, the
+             substitute-caveat polarity; spec §5). INFORM, not avoid and not encourage — a SKY
+             banner (V-V-3, .enc-inform) leading with the single hardest fact (rice drinks: none
+             under 5, arsenic). No severe strip — the harm is nutritional / chronic, not an acute
+             reaction (§5.3, the floor follows the hazard). Pinned: inform banner → is/isn't block;
+             body: myth → the soy-milk allergen cross-reference. renderDietMilkIntro() fills both. -->
+        <div class="card card-info col-full" id="dietPlantMilkIntroCard">
+          <div class="card-header" data-collapse-target="dietPlantMilkIntroBody" data-collapse-chevron="dietPlantMilkIntroChevron">
+            <div class="card-title"><div class="icon icon-sky"><svg class="zi"><use href="#zi-info"/></svg></div> Plant milks (almond, oat, rice)</div>
+            <span class="collapse-chevron" id="dietPlantMilkIntroChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
+          </div>
+          <div id="dietPlantMilkIntro" class="mt-4"></div>
+          <div id="dietPlantMilkIntroBody" class="collapse-body fx-col g8" style="display:none;">
+            <div id="dietPlantMilkIntroMore" class="mt-4"></div>
+          </div>
+        </div>
+
       </div>
     </div>
 

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -4020,6 +4020,36 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
 .enc-myth { display:flex; align-items:flex-start; gap:var(--sp-8); font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-16) 0 0; padding:var(--sp-12) var(--sp-16); background:var(--surface-lav); border-radius:var(--r-md); }
 .enc-myth .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--tc-lav); margin-top:3px; }
 
+/* ── food-effects-v2 P1c (milk polarities, milk-spec §3/§4/§5) ──────────────
+   The drink-timing SPLIT lead (cow milk) and the substitute-caveat SKY inform
+   banner (plant milk) — the two never-rendered v2 polarities. Composition over
+   new vocabulary (V-5): the split reuses the shipped sage + amber fills; the
+   inform banner is the one genuinely new modifier (sky, V-V-3). Shared-module
+   triple-Gov (Vela-first). */
+.enc-split { display:flex; flex-direction:column; gap:var(--sp-8); margin-bottom:var(--sp-16); }
+.enc-split-good { background:var(--surface-sage); border-left:3px solid var(--sage-deepest); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); }
+/* M-2 skim-proof: the gate band carries weight EQUAL-OR-GREATER than the carve-out —
+   the amber fill + the cons-severe-strength left accent + bold body — so the prevalent
+   diluted-top-milk reader cannot under-read the gate as a trailing qualifier. */
+.enc-split-gate { background:var(--surface-amber); border-left:3px solid var(--amber-deep); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); }
+.enc-split-h { display:flex; align-items:center; gap:var(--sp-8); font-size:var(--fs-sm); font-weight:700; text-transform:uppercase; letter-spacing:0.3px; margin-bottom:var(--sp-4); }
+.enc-split-good .enc-split-h { color:var(--sage-deepest); }
+.enc-split-gate .enc-split-h { color:var(--amber-deepest); }
+.enc-split-h .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; }
+.enc-split-good .enc-split-h .zi { color:var(--sage-deepest); }
+.enc-split-gate .enc-split-h .zi { color:var(--amber-deep); }
+.enc-split-body { font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); margin:0; }
+.enc-split-gate .enc-split-body { font-weight:700; }
+
+/* substitute-caveat INFORM banner (V-V-3): SKY, not neutral — neutral is a near-white
+   wash and register-less; sky is the existing drink/hydration domain color, AA-legible,
+   with a border-left for weight. The hardest fact (rice <5 = arsenic) is fronted in the lead. */
+.enc-inform { background:var(--surface-sky); border-left:3px solid var(--tc-sky); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); margin-bottom:var(--sp-16); }
+.enc-inform-h { display:flex; align-items:center; gap:var(--sp-8); font-size:var(--fs-sm); font-weight:700; color:var(--tc-sky); text-transform:uppercase; letter-spacing:0.3px; margin-bottom:var(--sp-8); }
+.enc-inform-h .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--tc-sky); }
+.enc-inform-lead { font-size:var(--fs-base); font-weight:700; color:var(--text); line-height:var(--lh-relaxed); margin:0 0 var(--sp-4); }
+.enc-inform-body { font-size:var(--fs-sm); color:var(--mid); line-height:var(--lh-relaxed); margin:0; }
+
 /* ── Viz detail popup (PR-I — viz interactivity layer) ── */
 /* Tap affordance: every wired data element (SVG dot/cell/bar/segment or
    HTML cell) gets a pointer cursor without a per-element class. */
@@ -10777,6 +10807,12 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
    NOT rose/alarm. Rose (.fd-flag-allergen) is reserved for true "avoid". The
    severe-reaction floor below the banner stays serious regardless. */
 .fd-flag-encourage { background:var(--sage-light); color:var(--tc-sage); }
+/* food-effects-v2 P1c (K-6): the four-polarity flag set on the Food Library detail
+   surface, switched off _effPolarity. conditional (drink-timing, cow milk) reads
+   amber/clock; inform (substitute-caveat, plant milk) reads sky/info — never the rose
+   .fd-flag-allergen siren (rose stays reserved for true acute-toxin "avoid"). */
+.fd-flag-conditional { background:var(--amber-light); color:var(--tc-amber); }
+.fd-flag-inform { background:var(--sky-light); color:var(--tc-sky); }
 .fd-flag-aged { background:var(--peach-light); color:var(--tc-caution); }
 .fd-flag-neutral { background:var(--glass-strong); color:var(--mid); }
 .fd-section { margin-top:var(--sp-12); }
@@ -11766,6 +11802,43 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
           <div id="dietNutIntro" class="mt-4"></div>
           <div id="dietNutIntroBody" class="collapse-body fx-col g8" style="display:none;">
             <div id="dietNutIntroMore" class="mt-4"></div>
+          </div>
+        </div>
+
+        <!-- Cow's milk — good in food, wait as a drink (food-effects-v2 P1c, the
+             drink-timing polarity; spec docs/specs/food-effects-v2-p1c-milk-polarities.md §4).
+             Conditional, NOT avoid and NOT encourage — the SPLIT lead (sage carve-out band
+             "dairy in food is good now" over an amber gate band "not the main drink before 12mo",
+             V-V-2 / M-2 skim-proof). The CMPA severe strip is PINNED (present-only via
+             severeSigns, §6) and carries a class-aware scope header (V-V-4) so the timing gate is
+             never mistaken for the allergy floor. Pinned: split banner → drink-vs-food block →
+             SEVERE STRIP; body: how-to (after-12mo) → mild watch-fors → myth.
+             renderDietMilkIntro() (diet.js, lazy-rendered by renderDietLibrary) fills both. -->
+        <div class="card card-info col-full" id="dietMilkIntroCard">
+          <div class="card-header" data-collapse-target="dietMilkIntroBody" data-collapse-chevron="dietMilkIntroChevron">
+            <div class="card-title"><div class="icon icon-amber"><svg class="zi"><use href="#zi-clock"/></svg></div> Cow's milk — in food and as a drink</div>
+            <span class="collapse-chevron" id="dietMilkIntroChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
+          </div>
+          <div id="dietMilkIntro" class="mt-4"></div>
+          <div id="dietMilkIntroBody" class="collapse-body fx-col g8" style="display:none;">
+            <div id="dietMilkIntroMore" class="mt-4"></div>
+          </div>
+        </div>
+
+        <!-- Plant milks — not a substitute for breastmilk/formula (food-effects-v2 P1c, the
+             substitute-caveat polarity; spec §5). INFORM, not avoid and not encourage — a SKY
+             banner (V-V-3, .enc-inform) leading with the single hardest fact (rice drinks: none
+             under 5, arsenic). No severe strip — the harm is nutritional / chronic, not an acute
+             reaction (§5.3, the floor follows the hazard). Pinned: inform banner → is/isn't block;
+             body: myth → the soy-milk allergen cross-reference. renderDietMilkIntro() fills both. -->
+        <div class="card card-info col-full" id="dietPlantMilkIntroCard">
+          <div class="card-header" data-collapse-target="dietPlantMilkIntroBody" data-collapse-chevron="dietPlantMilkIntroChevron">
+            <div class="card-title"><div class="icon icon-sky"><svg class="zi"><use href="#zi-info"/></svg></div> Plant milks (almond, oat, rice)</div>
+            <span class="collapse-chevron" id="dietPlantMilkIntroChevron"><svg class="zi"><use href="#zi-chevron-down"/></svg></span>
+          </div>
+          <div id="dietPlantMilkIntro" class="mt-4"></div>
+          <div id="dietPlantMilkIntroBody" class="collapse-body fx-col g8" style="display:none;">
+            <div id="dietPlantMilkIntroMore" class="mt-4"></div>
           </div>
         </div>
 
@@ -16568,6 +16641,18 @@ const AGE_RULES = {
   'cow milk': { minMonth:12, reason:'Low in iron, hard on infant kidneys as main drink. Curd and paneer are fine.' },
   'cow\'s milk':{minMonth:12, reason:'Low in iron, hard on infant kidneys as main drink. Curd and paneer are fine.' },
   'milk':     { minMonth:12, reason:'As a drink, avoid until 12 months. Curd, paneer, and small amounts in cooking are fine.' },
+  // food-effects-v2 P1c (K-3): a DEDICATED 'plant milk' gate so a plant-milk log no
+  // longer inherits the cow-milk reason above (curd/paneer carve-out, no rice-arsenic) —
+  // the "green-but-wrong" K-3 named. The exact-key tier of _lookupByFoodName resolves
+  // 'plant milk'/'oat milk'/'rice milk'/'rice drink' to these before the bare 'milk' key.
+  // NOTE (Kael resolver-scope): 'almond milk'/'badam milk'/'badam doodh' are NOT keyed
+  // here — they FOOD_EFFECTS-resolve to the tree-nut record (tree-nut's 'almond'/'badam'
+  // aliases win at the byAlias tier), so a dedicated plant gate for them would diverge
+  // from the card they actually fire. The rice forms carry the under-5 arsenic floor.
+  'plant milk': { minMonth:12, reason:'Not a substitute for breastmilk or formula before 12 months. From 12 months, unsweetened fortified soy or oat milk can be part of a varied diet. Rice drinks: none under 5 (arsenic).' },
+  'oat milk':   { minMonth:12, reason:'Not a milk substitute before 12 months. From 12 months, unsweetened fortified oat milk can be part of a varied diet — not the only drink.' },
+  'rice milk':  { minMonth:60, reason:'Rice drinks contain arsenic — not for any child under 5. Eating rice the grain is still fine. Not a milk substitute under 1.' },
+  'rice drink': { minMonth:60, reason:'Rice drinks contain arsenic — not for any child under 5. Not a milk substitute under 1.' },
   'salt':     { minMonth:12, reason:'Baby\'s kidneys cannot process added salt. Natural sodium in foods is enough.' },
   'sugar':    { minMonth:12, reason:'No added sugar before 12 months. Use fruit for natural sweetness.' },
   'jaggery':  { minMonth:12, reason:'Treat as added sugar — avoid before 12 months.' },
@@ -16905,6 +16990,82 @@ const FOOD_EFFECTS = {
     seekCare:   'A mild rash alone: stop, watch closely, and call your doctor. Any trouble breathing, tongue or throat swelling, a hoarse cry, or floppiness: call emergency services (112 or 108) right away and use a prescribed adrenaline auto-injector if you have one — an antihistamine does not treat anaphylaxis. Fish allergy is usually lifelong; a specialist guides any testing of other species.',
     confidence: 'high',
   },
+
+  // ── food-effects-v2 P1c: cow's milk + plant milks (the broader food classes) ──
+  // The first records of the two never-rendered v2 foodClasses (spec §2 + the milk
+  // polarity spec docs/specs/food-effects-v2-p1c-milk-polarities.md):
+  //   cow milk   = 'drink-timing'      — conditional: fine IN FOOD ~6mo, not the
+  //                                       main DRINK before 12mo (NEITHER avoid nor encourage).
+  //   plant milk = 'substitute-caveat' — inform: not a breastmilk/formula substitute <1;
+  //                                       rice drinks none under 5 (arsenic).
+  // NEITHER is allergen-introduce-early → NO earlyIntroBenefit (EAT found no prevention
+  // effect for milk). `safeForm` is repurposed as the DRINK-vs-FOOD / is-isn't gate (spec
+  // §8a, Kael-ratified). cow milk carries the CMPA allergic axis (watchFor/severeSigns/
+  // seekCare) ALONGSIDE the timing axis — it is the most common infant allergen, so the
+  // present-only severe floor (§6, keyed on severeSigns.length) fires here. plant milk has
+  // NO severeSigns → no acute floor (§5.3, the floor follows the hazard). Polarity is
+  // resolved by _effPolarity (core.js) — both surfaces render conditional/inform, never the
+  // rose 'avoid' siren (K-6). K-1 (Kael): 'top feed' is NOT a cow-milk alias (≈ formula in
+  // Indian logs). Bare 'milk' is deliberately UNALIASED on either record (it co-occurs in
+  // breast/formula/soy milk — the bare-'milk' precision rule, spec §7). Evidence + citations:
+  // docs/research/cow-milk-plant-milks-infant-safety.md.
+  'cow milk': {
+    foodClass:  'drink-timing',
+    severity:   'caution',              // amber timing-caution, NOT rose acute-toxin
+    aliases:    ['cow\'s milk', 'buffalo milk', 'bhains ka doodh', 'gaay ka doodh', 'animal milk', 'whole milk', 'full-fat milk', 'top milk', 'dairy milk', 'full cream milk'],
+    effect:     'iron-deficiency anaemia + renal solute load (as a main drink before 12 months)',
+    title:      'Cow\'s milk — good in food, not yet as the main drink',
+    why:        'Dairy in food is excellent from around 6 months — dahi (curd), paneer, and cheese. The caution is only about cow\'s or buffalo milk as the main drink before the first birthday: it is low in iron and hard on a baby\'s kidneys. Breastmilk or formula is the milk under 1.',
+    whyGood:    'Dairy in food is excellent from around 6 months — dahi (curd), paneer, and cheese give calcium, protein, B12, and healthy fats. The only caution is about milk as the main drink before the first birthday.',
+    // The amber gate band of the split lead (V-V-2 / M-2 skim-proof) — visually weighted
+    // equal-or-greater to the sage carve-out, so the diluted-top-milk reader can't under-read it.
+    gate:       'Not as the main drink before 12 months — cow\'s or buffalo milk is low in iron and hard on a baby\'s kidneys. Breastmilk or first infant formula is the milk under 1.',
+    safeForm: {
+      glance:   'Fine in food; wait as a drink',
+      ok:       ['dahi (curd), paneer, and pasteurised full-fat cheese from around 6 months', 'small amounts of milk cooked into khichdi, porridge, or cereal', 'from 12 months: whole (full-fat) milk as a main drink, about 500 ml (2 cups) a day at most'],
+      never:    ['cow\'s or buffalo milk as the main drink before 12 months', 'diluted or sweetened "top milk" as a breastmilk or formula substitute', 'unpasteurised milk, and mould-ripened (brie, camembert), blue, or ripened-goat cheese at any infant age', 'skimmed or low-fat milk as a main drink before age 2'],
+      note:     'The drink is gated; the dairy is not. Breastmilk or first infant formula is the milk under 12 months. Diluting cow or buffalo milk adds no iron and still displaces breastmilk.',
+    },
+    howToIntroduce: {
+      amount:   'from 12 months, about 500 ml (2 cups) of whole milk a day at most — more is linked to iron deficiency',
+      when:     'dairy in food (dahi, paneer, cheese, milk in cooking) from around 6 months; milk as a main drink from 12 months',
+      watch:    'when you first give dairy in food, watch for about 2 hours for a cow\'s-milk-protein-allergy reaction — milk is the most common infant allergen',
+    },
+    myth: {
+      claim:    'Cow\'s or buffalo milk makes a baby strong — give it early.',
+      truth:    'Before 12 months as a main drink it causes iron-deficiency anaemia and strains the kidneys. Breastmilk or formula is the milk under 1; dairy belongs in food, not in the cup.',
+    },
+    watchFor:   ['hives or a rash', 'swelling of the lips, face, or eyes', 'vomiting', 'diarrhoea or blood in the stool (delayed cow\'s-milk-protein allergy)', 'an eczema flare'],
+    severeSigns:['trouble breathing or wheezing', 'swelling of the tongue or throat', 'a hoarse cry', 'going floppy, pale, or very sleepy'],
+    seekCare:   'A mild reaction to dairy (a little rash alone): stop, watch closely, and call your doctor. Any trouble breathing, tongue or throat swelling, a hoarse cry, or floppiness: call emergency services (112 or 108) right away and use a prescribed adrenaline auto-injector if you have one — an antihistamine does not treat anaphylaxis. Most children outgrow cow\'s-milk allergy by 3 to 5 years; any reintroduction (the milk ladder) is a doctor\'s call.',
+    confidence: 'high',
+  },
+  'plant milk': {
+    foodClass:  'substitute-caveat',
+    severity:   'caution',
+    aliases:    ['almond milk', 'badam milk', 'badam doodh', 'oat milk', 'rice milk', 'rice drink', 'cashew milk', 'coconut milk drink', 'plant-based milk', 'plant milks', 'vegan milk', 'toddler milk', 'growing-up milk', 'follow-on milk drink'],
+    effect:     'inadequate substitute for breastmilk or formula (under 1); rice-drink arsenic (under 5)',
+    title:      'Plant milks — not a substitute for breastmilk or formula',
+    why:        'No plant milk (almond, oat, rice, cashew, coconut) replaces breastmilk or formula in the first year. Rice drinks are not safe for any child under 5 because of arsenic. From age 1, unsweetened, calcium-fortified soy or oat milk can be part of a varied diet — but not the only drink for an under-2.',
+    whyGood:    'From age 1, unsweetened, calcium-fortified soy or oat milk can be part of a varied diet. Fortified soy is the only plant milk nutritionally close to cow\'s milk.',
+    // The sky inform banner (V-V-3) leads with the single hardest fact, fronted (rice <5 = arsenic).
+    headline:   'Not a milk substitute under 1. Rice drinks: none under 5 (arsenic). From age 1, fortified soy or oat only, as part of a varied diet.',
+    safeForm: {
+      glance:   'Not a substitute under 1',
+      ok:       ['from 12 months: unsweetened, calcium-fortified soy or oat milk, as part of a varied diet (not the only drink for an under-2)'],
+      never:    ['any plant milk as a breastmilk or formula substitute before 12 months', 'rice drinks for any child under 5 years (inorganic arsenic) — eating rice the grain is still fine', 'unfortified plant milk as a main drink', 'almond milk as a main drink (too low in protein and fat)', 'carton soy drink as infant formula (soy formula is a separate, prescribed product)'],
+      note:     'No plant milk replaces breastmilk or formula under 1. After age 1, the ranking is: fortified soy and oat first, then almond (low in protein), and rice last (arsenic — avoid under 5). "Toddler" and "growing-up" milks are unnecessary.',
+    },
+    myth: {
+      claim:    'Plant milk (almond, oat, or rice) is a healthy milk substitute for my baby or toddler.',
+      truth:    'Not under 1 — it replaces neither breastmilk nor formula. Rice drinks are unsafe under 5 (arsenic); almond milk is too low in protein and fat. From age 1, fortified soy or oat can be part of a varied diet.',
+    },
+    // Soy milk is the allergen exception — it aliases to the SOY record, not here. Cross-referenced
+    // in copy, not re-aliased. No severeSigns/seekCare: the harm is nutritional / chronic (arsenic),
+    // not an acute reaction, so this record carries NO emergency floor (spec §5.3).
+    watchFor:   ['soy milk only: hives, swelling, or vomiting — soy is a major allergen (see the soy guidance)'],
+    confidence: 'high',
+  },
 };
 
 // ── ALLERGEN FLAGS ──
@@ -16925,6 +17086,13 @@ const ALLERGENS = {
   // food-effects-v2 P1c: fish is allergen:true (a major allergen, often lifelong). Full
   // anaphylaxis floor lives on the FOOD_EFFECTS record; this is the terse browse flag.
   'fish':      'Common allergen, and often lifelong. Introduce well-cooked, deboned, low-mercury fish on its own and watch ~2 hours. Finfish is a separate allergen from shellfish.',
+  // food-effects-v2 P1c (K-4): cow milk is allergen:true (CMPA — the most common infant
+  // food allergy). The full anaphylaxis floor lives on the FOOD_EFFECTS record (severeSigns
+  // / seekCare); this terse note is the browse-surface flag, scoped to the ALLERGY axis (a
+  // SEPARATE concern from the drink-timing gate). Satisfies the §6 allergen:true↔ALLERGENS
+  // traceability invariant. 'plant milk' is allergen:false — soy milk is the exception and
+  // is flagged via the soy record, so plant milk correctly needs no ALLERGENS note.
+  'cow milk':  'Cow\'s-milk protein is the most common infant allergen (CMPA). When you first give dairy in food, watch about 2 hours; mild signs are rash, swelling, or vomiting, and a delayed reaction can be diarrhoea or blood in the stool.',
   'egg yolk':  'Less allergenic than white. Cook well. Give alone for 3 days.',
   'kiwi':      'Can cause mouth tingling. Start with small amount. Watch for oral allergy.',
   'strawberry':'Can cause allergic reaction in some babies. Introduce carefully.',
@@ -23633,10 +23801,31 @@ function _isHighMercuryFishHost(name) {
     new RegExp('\\b' + t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b').test(n));
 }
 
+// food-effects-v2 P1c (milk). A plant-milk DRINK named with a tree-nut word — "almond milk",
+// "badam doodh", "cashew milk" — resolves to the TREE-NUT record, because tree nut's
+// 'almond'/'badam'/'cashew' alias wins at the byAlias tier (tree nut precedes plant milk) over
+// plant milk's own 'almond milk'/'badam doodh' alias. That surfaces an "introduce early, ground
+// or smooth" ENCOURAGE verdict on what is a substitute-caveat DRINK — the opposite polarity,
+// and it contradicts the spec's K-2 intent (badam milk → plant milk). This guard redirects such
+// a host to the plant-milk record so both surfaces read "not a substitute under 1," not
+// "introduce early." Requires BOTH a tree-nut token AND a drink word, so the bare nut ("badam",
+// "almond butter") still correctly resolves to the tree-nut introduce-early record. Soy milk is
+// untouched (it intentionally aliases to the soy allergen record); oat/rice/coconut-drink
+// already resolve to plant milk without collision.
+const _PLANT_MILK_NUT = ['almond', 'badam', 'cashew', 'kaju'];
+function _isPlantMilkDrinkHost(name) {
+  const n = String(name || '').toLowerCase();
+  if (!/\b(milk|doodh)\b/.test(n)) return false;
+  return _PLANT_MILK_NUT.some(t => new RegExp('\\b' + t + '\\b').test(n));
+}
+
 // FOOD_EFFECTS consequence record for a food, or null. Uses _lookupByFoodName so
 // resolution matches the AGE_RULES gate exactly (word-boundary, not substring).
 function getFoodEffect(name) {
   if (typeof FOOD_EFFECTS === 'undefined') return null;
+  // Plant-milk drink host (almond/badam/cashew milk·doodh) → plant-milk record, NOT the
+  // tree-nut encourage card it would otherwise resolve to (K-2 intent; alias-precedence fix).
+  if (_isPlantMilkDrinkHost(name) && FOOD_EFFECTS['plant milk']) return FOOD_EFFECTS['plant milk'];
   const eff = _lookupByFoodName(FOOD_EFFECTS, name);
   // M-F-1: never affirm a high-mercury fish as a safe early food (the bare 'fish' KEY leak).
   if (eff && eff === FOOD_EFFECTS['fish'] && _isHighMercuryFishHost(name)) return null;
@@ -23659,6 +23848,28 @@ const COMBO_RESULT_SCHEMA = 'r1-fe';
 function _effHasClass(eff, cls) {
   if (!eff || !eff.foodClass) return false;
   return Array.isArray(eff.foodClass) ? eff.foodClass.indexOf(cls) !== -1 : eff.foodClass === cls;
+}
+
+// Polarity resolver (food-effects-v2 P1c, milk-spec §3-bis, K-6 — the load-bearing
+// fold). Maps a FOOD_EFFECTS record's foodClass to ONE of four render polarities, so
+// every banner surface switches {fill, icon, heading, gate-render} off a SINGLE source
+// of truth instead of each re-deriving polarity from a two-state _effHasClass test (the
+// K-6 defect: renderFoodLibDetail's old `fdEncourage ? sprout : siren` rendered milk's
+// drink-timing/substitute-caveat records as a rose "avoid" SIREN — the §1 wrong-lead on
+// a second surface). Precedence matters for the multi-class records: warn (acute-toxin,
+// honey) → encourage (allergen-introduce-early; wins over a SECONDARY choking-by-form on
+// peanut/tree-nut/fish) → conditional (drink-timing cow milk; and a PRIMARY choking-by-form
+// once the choking set wires, milk-spec §9) → inform (substitute-caveat plant milk).
+// Returns 'inform' as the conservative non-alarm default for an unknown/absent class —
+// never 'warn' (a spurious siren is the failure this resolver exists to prevent).
+function _effPolarity(eff) {
+  if (!eff || !eff.foodClass) return 'inform';
+  if (_effHasClass(eff, 'acute-toxin'))               return 'warn';
+  if (_effHasClass(eff, 'allergen-introduce-early'))  return 'encourage';
+  if (_effHasClass(eff, 'drink-timing'))              return 'conditional';
+  if (_effHasClass(eff, 'choking-by-form'))           return 'conditional'; // PRIMARY (§9, deferred); secondary already caught by encourage above
+  if (_effHasClass(eff, 'substitute-caveat'))         return 'inform';
+  return 'inform';
 }
 
 // Shared emergency-floor renderer (food-effects v2 §3.0, M-S-7). The severe
@@ -38512,6 +38723,14 @@ function _fdAgeRule(name) {
   // 'honeydew' no longer inherits honey's gate, and the gate stays consistent
   // with the consequence card (getFoodEffect uses the same resolver).
   const rule = _lookupByFoodName(AGE_RULES, name);
+  // Plant-milk drink host (almond/badam/cashew milk·doodh): the gate mirror of the
+  // getFoodEffect redirect — these resolve to the bare 'milk' (cow) gate by word-boundary,
+  // inheriting cow-milk reason copy (curd/paneer carve-out, no rice-arsenic). Redirect to the
+  // dedicated 'plant milk' gate so the card and the gate agree (one-resolver doctrine).
+  if (typeof AGE_RULES !== 'undefined' && AGE_RULES['plant milk']
+      && typeof _isPlantMilkDrinkHost === 'function' && _isPlantMilkDrinkHost(name)) {
+    return AGE_RULES['plant milk'];
+  }
   // M-F-1 (Cipher Edict-V completion): the same bare-'fish'-KEY leak that fed the
   // consequence card also feeds this gate — "seer fish" / "shark fish" resolve to
   // AGE_RULES['fish'] (6mo) and would show a green "fine from ~6 months" badge for a
@@ -38664,18 +38883,28 @@ function renderFoodDetailSheet(name) {
   // Q-3 call; the severe floor's presence is the non-negotiable, M-S-6.)
   const fdEff = (typeof getFoodEffect === 'function') ? getFoodEffect(lower) : null;
   const fdFloor = (fdEff && typeof _severeFloorHtml === 'function') ? _severeFloorHtml(fdEff) : '';
-  // Polarity (food-effects-v2): an introduce-early allergen reads ENCOURAGE —
-  // sage banner + calm sprout icon ("good to introduce, here's the safe form"),
-  // never rose/siren ("don't give"). Rose is reserved for true avoid (acute-toxin).
-  // The severe-reaction floor (fdFloor) below stays serious regardless.
-  const fdEncourage = (typeof _effHasClass === 'function') && _effHasClass(fdEff, 'allergen-introduce-early');
+  // Polarity (food-effects-v2 P1c, K-6): the banner cosmetic switches off the SHARED
+  // _effPolarity resolver (core.js, milk-spec §3-bis), NOT a two-state encourage/avoid
+  // boolean. The old `fdEncourage ? sprout : siren` rendered milk's drink-timing /
+  // substitute-caveat records as a rose "avoid" SIREN here — the §1 wrong-lead on this
+  // second surface. Four polarities, one source of truth: encourage (sage/sprout, the δ
+  // allergens), warn (rose/siren, acute-toxin honey), conditional (amber/clock, cow milk
+  // drink-timing), inform (sky/info, plant-milk substitute-caveat). The severe-reaction
+  // floor (fdFloor) below stays serious regardless — it is presence-driven (severeSigns),
+  // independent of this banner cosmetic.
+  const FD_POLARITY = {
+    encourage:   { cls:'fd-flag-encourage',   ic:'sprout' },
+    warn:        { cls:'fd-flag-allergen',    ic:'siren'  },
+    conditional: { cls:'fd-flag-conditional', ic:'clock'  },
+    inform:      { cls:'fd-flag-inform',      ic:'info'   },
+  };
+  const fdPol = (typeof _effPolarity === 'function') ? _effPolarity(fdEff) : 'warn';
   if (fdFloor) {
     const head = (fdEff && fdEff.title) ? escHtml(fdEff.title) : 'Allergen';
     const sub = (fdEff && fdEff.safeForm && fdEff.safeForm.note) ? escHtml(fdEff.safeForm.note)
               : (allerg ? escHtml(allerg) : '');
-    const flagCls = fdEncourage ? 'fd-flag-encourage' : 'fd-flag-allergen';
-    const flagIc  = fdEncourage ? zi('sprout') : zi('siren');
-    html += `<div class="fd-flag ${flagCls}">${flagIc} <span><strong>${head}</strong>${sub ? ' ' + sub : ''}</span></div>`;
+    const pol = FD_POLARITY[fdPol] || FD_POLARITY.warn;
+    html += `<div class="fd-flag ${pol.cls}">${zi(pol.ic)} <span><strong>${head}</strong>${sub ? ' ' + sub : ''}</span></div>`;
     html += fdFloor; // .cons-severe / .cons-watch / .cons-seek (shared, already-styled)
   } else if (allerg) {
     // A milder allergen with no FOOD_EFFECTS record (kiwi, strawberry, oats …):
@@ -38784,6 +39013,7 @@ function renderDietLibrary() {
   renderFoodLibFilters();
   renderFoodLibResults();
   renderDietNutIntro();
+  renderDietMilkIntro();
 }
 
 // ════════════════════════════════════════
@@ -38912,6 +39142,150 @@ function renderDietNutIntro() {
 
   host.innerHTML = pinned;
   if (moreHost) moreHost.innerHTML = body;
+}
+
+// ════════════════════════════════════════
+// Milk — the drink-timing + substitute-caveat KNOWLEDGE cards (food-effects v2 P1c)
+// ════════════════════════════════════════
+// Sibling of renderDietNutIntro (separate fns + hosts; the nut card stays untouched).
+// Renders the FIRST two cards of the never-rendered v2 polarities (milk-spec §4/§5):
+//   • cow milk   → 'drink-timing'      (#dietMilkIntro)      — CONDITIONAL, a SPLIT lead
+//     (sage carve-out "good in food now" over an amber gate "wait as the main drink",
+//     V-V-2 / M-2 skim-proof). CMPA severe strip PINNED (present-only via severeSigns,
+//     §6) with a class-aware scope header (V-V-4).
+//   • plant milk → 'substitute-caveat' (#dietPlantMilkIntro) — INFORM, a SKY banner
+//     (V-V-3, .enc-inform) leading with the hardest fact (rice <5 = arsenic). NO severe
+//     strip — the harm is nutritional/chronic, not acute (§5.3, the floor follows the hazard).
+// Records are read by DIRECT KEY (FE['cow milk'] / FE['plant milk']) — NOT via the
+// resolver — so the Library knowledge cards are immune to alias-precedence collisions.
+// All copy is FOOD_EFFECTS-sourced (no hardcoded safety claim); the only hardcoded
+// strings are the V-V-1 switched-unit HEADINGS (render copy, polarity-keyed, not reusable).
+function renderDietMilkIntro() {
+  var FE = (typeof FOOD_EFFECTS !== 'undefined') ? FOOD_EFFECTS : null;
+
+  // ── cow milk — drink-timing (split conditional) ──
+  var milkHost = document.getElementById('dietMilkIntro');
+  var milkMore = document.getElementById('dietMilkIntroMore');
+  var cow = FE ? FE['cow milk'] : null;
+  if (milkHost) {
+    if (!cow) {
+      milkHost.innerHTML = '';
+      if (milkMore) milkMore.innerHTML = '';
+    } else {
+      var cPin = '', cBody = '';
+      // SPLIT lead (V-V-2): sage carve-out band leads, amber gate band qualifies
+      // (M-2 skim-proof — the gate is visually weighted, never a trailing clause).
+      cPin += '<div class="enc-split">';
+      if (cow.whyGood) {
+        cPin += '<div class="enc-split-good"><div class="enc-split-h">' + zi('sprout') +
+          '<span>Good in food now</span></div><p class="enc-split-body">' + escHtml(cow.whyGood) + '</p></div>';
+      }
+      if (cow.gate) {
+        cPin += '<div class="enc-split-gate"><div class="enc-split-h">' + zi('clock') +
+          '<span>Wait as the main drink</span></div><p class="enc-split-body">' + escHtml(cow.gate) + '</p></div>';
+      }
+      cPin += '</div>';
+      // Drink-vs-food block (§4.2): ok = "Fine now — in food", never = "Not yet — as a
+      // drink", note = the non-suppressible invariant ("the drink is gated; the dairy is not").
+      cPin += _milkFormBlock(cow.safeForm, 'Fine now — in food', 'Not yet — as a drink');
+      // Severe strip — the CMPA emergency floor, PINNED + present-only via severeSigns
+      // (§6/M-1), with the V-V-4 class-aware scope header (separates the ALLERGY floor
+      // from the TIMING gate). Hand-built (not _severeFloorHtml) so the header is scoped
+      // and the mild watch-fors drop to the calm body instead.
+      cPin += _milkSevereStrip(cow, 'If your baby reacts to dairy, it\'s an emergency');
+      // BODY (collapsible): how-to (after-12mo) → mild watch-fors → myth.
+      var chti = cow.howToIntroduce || {};
+      if (chti.amount || chti.when || chti.watch) {
+        cBody += '<div class="enc-block"><div class="enc-block-h">' + zi('spoon') + '<span>How to give it</span></div><div class="enc-proto">';
+        if (chti.when)   cBody += '<div class="enc-proto-row"><b>When:</b> ' + escHtml(chti.when) + '</div>';
+        if (chti.amount) cBody += '<div class="enc-proto-row"><b>Amount:</b> ' + escHtml(chti.amount) + '</div>';
+        if (chti.watch)  cBody += '<div class="enc-proto-row"><b>Watch:</b> ' + escHtml(chti.watch) + '</div>';
+        cBody += '</div></div>';
+      }
+      var cMild = (cow.watchFor && cow.watchFor.length) ? cow.watchFor : [];
+      if (cMild.length) {
+        cBody += '<div class="cons-watch"><div class="cons-watch-h">Milder signs to watch for</div><ul class="cons-watch-list">' +
+          cMild.map(function(w){ return '<li>' + escHtml(w) + '</li>'; }).join('') + '</ul></div>';
+      }
+      if (cow.myth && cow.myth.truth) {
+        cBody += '<div class="enc-myth">' + zi('bulb') + '<span>' + escHtml(cow.myth.truth) + '</span></div>';
+      }
+      milkHost.innerHTML = cPin;
+      if (milkMore) milkMore.innerHTML = cBody;
+    }
+  }
+
+  // ── plant milk — substitute-caveat (sky inform) ──
+  var plantHost = document.getElementById('dietPlantMilkIntro');
+  var plantMore = document.getElementById('dietPlantMilkIntroMore');
+  var plant = FE ? FE['plant milk'] : null;
+  if (plantHost) {
+    if (!plant) {
+      plantHost.innerHTML = '';
+      if (plantMore) plantMore.innerHTML = '';
+    } else {
+      var pPin = '', pBody = '';
+      // INFORM banner (V-V-3, sky .enc-inform): the V-V-1 switched heading + the hardest
+      // fact fronted (headline: rice <5 = arsenic) + the age-1 nuance (whyGood).
+      pPin += '<div class="enc-inform"><div class="enc-inform-h">' + zi('info') + '<span>What it is — and what it isn\'t</span></div>';
+      if (plant.headline) pPin += '<p class="enc-inform-lead">' + escHtml(plant.headline) + '</p>';
+      if (plant.whyGood)  pPin += '<p class="enc-inform-body">' + escHtml(plant.whyGood) + '</p>';
+      pPin += '</div>';
+      // is/isn't block: ok = "From age 1, as part of a varied diet", never = "Never",
+      // note = the ranking + "not a substitute under 1".
+      pPin += _milkFormBlock(plant.safeForm, 'From age 1, as part of a varied diet', 'Never');
+      // No severe strip — substitute-caveat has no acute floor (§5.3).
+      // BODY: myth → the soy-milk allergen cross-reference (calm watch line).
+      if (plant.myth && plant.myth.truth) {
+        pBody += '<div class="enc-myth">' + zi('bulb') + '<span>' + escHtml(plant.myth.truth) + '</span></div>';
+      }
+      var pMild = (plant.watchFor && plant.watchFor.length) ? plant.watchFor : [];
+      if (pMild.length) {
+        pBody += '<div class="cons-watch"><div class="cons-watch-h">One thing to watch</div><ul class="cons-watch-list">' +
+          pMild.map(function(w){ return '<li>' + escHtml(w) + '</li>'; }).join('') + '</ul></div>';
+      }
+      plantHost.innerHTML = pPin;
+      if (plantMore) plantMore.innerHTML = pBody;
+    }
+  }
+}
+
+// Shared drink-vs-food / is-isn't block for the milk cards. safeForm.ok renders under
+// `okLabel`, safeForm.never under `neverLabel`, and safeForm.note as the non-suppressible
+// enc-form-note invariant (milk-spec §4.2/§5.2). Reuses the shipped .enc-form family.
+function _milkFormBlock(sf, okLabel, neverLabel) {
+  sf = sf || {};
+  var ok = (sf.ok && sf.ok.length) ? sf.ok : [];
+  var never = (sf.never && sf.never.length) ? sf.never : [];
+  if (!ok.length && !never.length && !sf.note) return '';
+  var h = '<div class="enc-form">';
+  if (ok.length) {
+    h += '<div class="enc-form-sub">' + escHtml(okLabel) + '</div><ul class="enc-form-list">' +
+      ok.map(function(x){ return '<li>' + escHtml(x) + '</li>'; }).join('') + '</ul>';
+  }
+  if (never.length) {
+    h += '<div class="enc-form-sub">' + escHtml(neverLabel) + '</div><ul class="enc-form-list enc-never">' +
+      never.map(function(x){ return '<li>' + escHtml(x) + '</li>'; }).join('') + '</ul>';
+  }
+  if (sf.note) h += '<p class="enc-form-note">' + escHtml(sf.note) + '</p>';
+  h += '</div>';
+  return h;
+}
+
+// Present-only CMPA severe strip for a drink-timing card (milk-spec §6/V-V-4/M-1). Renders
+// the anaphylaxis red-flags + the call-112/108 emergency line ONLY when severeSigns is a
+// non-empty array (never on a class/allergen-flag proxy — M-1). `scopeHeader` separates the
+// ALLERGY floor from the TIMING gate so a parent never conflates the two axes (V-V-4).
+function _milkSevereStrip(eff, scopeHeader) {
+  if (!eff || !Array.isArray(eff.severeSigns) || !eff.severeSigns.length) return '';
+  var h = '<div class="cons-severe"><div class="cons-severe-h">' + zi('siren') +
+    '<span>' + escHtml(scopeHeader) + '</span></div><ul class="cons-severe-list">' +
+    eff.severeSigns.map(function(s){ return '<li>' + escHtml(s) + '</li>'; }).join('') + '</ul>';
+  if (eff.seekCare) {
+    h += '<p class="enc-emergency">' + zi('siren') + '<span>' + escHtml(eff.seekCare) + '</span></p>';
+  }
+  h += '</div>';
+  return h;
 }
 
 

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -23816,7 +23816,7 @@ const _PLANT_MILK_NUT = ['almond', 'badam', 'cashew', 'kaju'];
 function _isPlantMilkDrinkHost(name) {
   const n = String(name || '').toLowerCase();
   if (!/\b(milk|doodh)\b/.test(n)) return false;
-  return _PLANT_MILK_NUT.some(t => new RegExp('\\b' + t + '\\b').test(n));
+  return _PLANT_MILK_NUT.some(t => new RegExp('\\b' + t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b').test(n));
 }
 
 // FOOD_EFFECTS consequence record for a food, or null. Uses _lookupByFoodName so
@@ -38723,12 +38723,15 @@ function _fdAgeRule(name) {
   // 'honeydew' no longer inherits honey's gate, and the gate stays consistent
   // with the consequence card (getFoodEffect uses the same resolver).
   const rule = _lookupByFoodName(AGE_RULES, name);
-  // Plant-milk drink host (almond/badam/cashew milk·doodh): the gate mirror of the
-  // getFoodEffect redirect — these resolve to the bare 'milk' (cow) gate by word-boundary,
-  // inheriting cow-milk reason copy (curd/paneer carve-out, no rice-arsenic). Redirect to the
-  // dedicated 'plant milk' gate so the card and the gate agree (one-resolver doctrine).
-  if (typeof AGE_RULES !== 'undefined' && AGE_RULES['plant milk']
-      && typeof _isPlantMilkDrinkHost === 'function' && _isPlantMilkDrinkHost(name)) {
+  // K-M-1 (Kael, option b — the truer one-resolver expression): a name whose CARD resolves to
+  // the plant-milk record but whose GATE fell to the bare cow 'milk' key must take the plant-milk
+  // gate, so card and gate agree. This catches the nut-drink redirect (almond/cashew milk) AND
+  // 'coconut milk drink' / any future non-nut plant alias the nut-token proxy would miss. Gated
+  // on `rule === AGE_RULES['milk']` so the dedicated plant gates (oat milk 12mo / rice milk +
+  // rice drink 60mo arsenic) — which resolved to their OWN entry above — are left untouched.
+  if (typeof AGE_RULES !== 'undefined' && AGE_RULES['plant milk'] && rule === AGE_RULES['milk']
+      && typeof getFoodEffect === 'function' && typeof FOOD_EFFECTS !== 'undefined'
+      && getFoodEffect(name) === FOOD_EFFECTS['plant milk']) {
     return AGE_RULES['plant milk'];
   }
   // M-F-1 (Cipher Edict-V completion): the same bare-'fish'-KEY leak that fed the
@@ -38906,6 +38909,17 @@ function renderFoodDetailSheet(name) {
     const pol = FD_POLARITY[fdPol] || FD_POLARITY.warn;
     html += `<div class="fd-flag ${pol.cls}">${zi(pol.ic)} <span><strong>${head}</strong>${sub ? ' ' + sub : ''}</span></div>`;
     html += fdFloor; // .cons-severe / .cons-watch / .cons-seek (shared, already-styled)
+    // M-M-1 (Maren, blocking): a plant-milk DRINK redirected to the plant-milk record
+    // (almond / cashew / badam milk) still CONTAINS its tree-nut allergen, but the inform
+    // floor masks the allergen axis (the else-if below is dead when fdFloor is truthy), so the
+    // tree-nut ALLERGENS note would silently drop. Surface it alongside the inform flag, so the
+    // sheet shows BOTH axes — "not a substitute under 1" AND "contains almond, a tree-nut
+    // allergen". Scoped to the redirect target (plant milk carries no ALLERGENS note of its own,
+    // so any `allerg` here came from a DIFFERENT food); other records carry their allergen in
+    // their own floor, so this never double-prints.
+    if (typeof FOOD_EFFECTS !== 'undefined' && fdEff === FOOD_EFFECTS['plant milk'] && allerg) {
+      html += `<div class="fd-flag fd-flag-neutral">${zi('note')} <span><strong>Allergen.</strong> ${escHtml(allerg)}</span></div>`;
+    }
   } else if (allerg) {
     // A milder allergen with no FOOD_EFFECTS record (kiwi, strawberry, oats …):
     // informational + calm, never the rose alarm. Introduce carefully, watch.
@@ -39192,7 +39206,9 @@ function renderDietMilkIntro() {
       // (§6/M-1), with the V-V-4 class-aware scope header (separates the ALLERGY floor
       // from the TIMING gate). Hand-built (not _severeFloorHtml) so the header is scoped
       // and the mild watch-fors drop to the calm body instead.
-      cPin += _milkSevereStrip(cow, 'If your baby reacts to dairy, it\'s an emergency');
+      // M-M-2 (Maren): scope to the SEVERE path — "reacts to dairy" over-read as any reaction
+      // being an emergency, contradicting the mild-path the seekCare line and body watch-fors draw.
+      cPin += _milkSevereStrip(cow, 'A severe reaction to dairy is an emergency');
       // BODY (collapsible): how-to (after-12mo) → mild watch-fors → myth.
       var chti = cow.howToIntroduce || {};
       if (chti.amount || chti.when || chti.watch) {

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -38723,15 +38723,19 @@ function _fdAgeRule(name) {
   // 'honeydew' no longer inherits honey's gate, and the gate stays consistent
   // with the consequence card (getFoodEffect uses the same resolver).
   const rule = _lookupByFoodName(AGE_RULES, name);
-  // K-M-1 (Kael, option b — the truer one-resolver expression): a name whose CARD resolves to
-  // the plant-milk record but whose GATE fell to the bare cow 'milk' key must take the plant-milk
-  // gate, so card and gate agree. This catches the nut-drink redirect (almond/cashew milk) AND
-  // 'coconut milk drink' / any future non-nut plant alias the nut-token proxy would miss. Gated
-  // on `rule === AGE_RULES['milk']` so the dedicated plant gates (oat milk 12mo / rice milk +
-  // rice drink 60mo arsenic) — which resolved to their OWN entry above — are left untouched.
-  if (typeof AGE_RULES !== 'undefined' && AGE_RULES['plant milk'] && rule === AGE_RULES['milk']
+  // K-M-1 (Kael option b, completed per Cipher Edict-V): whenever the CARD resolves to the
+  // plant-milk record but the raw GATE is NOT a dedicated plant gate, take the plant-milk gate
+  // so card and gate agree. Keyed on "card is plant milk" — NOT on the bare-'milk' fall — because
+  // the Hindi 'doodh' variants (badam doodh / kaju doodh) raw-resolve to tree-nut's alias
+  // (tree nut@6), the tree-nut FALL the earlier `rule === AGE_RULES['milk']` precondition missed
+  // (it only caught the bare-'milk' fall of the English "milk" forms). The dedicated plant gates
+  // (oat 12 / rice + rice drink 60mo arsenic) are excluded so they keep their own copy; the bare
+  // nut (card is tree nut, not plant milk) skips this guard and correctly stays at tree nut@6.
+  if (typeof AGE_RULES !== 'undefined' && AGE_RULES['plant milk']
       && typeof getFoodEffect === 'function' && typeof FOOD_EFFECTS !== 'undefined'
-      && getFoodEffect(name) === FOOD_EFFECTS['plant milk']) {
+      && getFoodEffect(name) === FOOD_EFFECTS['plant milk']
+      && rule !== AGE_RULES['plant milk'] && rule !== AGE_RULES['oat milk']
+      && rule !== AGE_RULES['rice milk'] && rule !== AGE_RULES['rice drink']) {
     return AGE_RULES['plant milk'];
   }
   // M-F-1 (Cipher Edict-V completion): the same bare-'fish'-KEY leak that fed the

--- a/tests/e2e/food-effects-v2-p1c-milk.spec.ts
+++ b/tests/e2e/food-effects-v2-p1c-milk.spec.ts
@@ -67,8 +67,10 @@ test.describe('food-effects-v2 P1c — milk polarity cards', () => {
   test('(b) cow milk pins the CMPA severe strip with a dairy-scoped header and the emergency line', async ({ page }) => {
     await expect(page.locator('#dietMilkIntro .cons-severe')).toHaveCount(1);
     await expect(page.locator('#dietMilkIntroBody .cons-severe')).toHaveCount(0); // pinned, never folds
-    // V-V-4 scope header separates the ALLERGY floor from the TIMING gate.
-    await expect(page.locator('#dietMilkIntro .cons-severe-h')).toContainText(/reacts to dairy/i);
+    // V-V-4 scope header separates the ALLERGY floor from the TIMING gate, scoped to the
+    // SEVERE path (M-M-2 — not "any reaction is an emergency").
+    await expect(page.locator('#dietMilkIntro .cons-severe-h')).toContainText(/severe/i);
+    await expect(page.locator('#dietMilkIntro .cons-severe-h')).toContainText(/dairy/i);
     // the emergency action: call 112/108 + the antihistamine-doesn't-treat-anaphylaxis line.
     const emg = page.locator('#dietMilkIntro .enc-emergency');
     await expect(emg).toContainText(/112|108/);
@@ -180,6 +182,26 @@ test.describe('food-effects-v2 P1c — milk polarity cards', () => {
     expect(r.cashewMilk).toBe('substitute-caveat');
     expect(r.almond, 'the bare nut still resolves to the tree-nut introduce-early record').toContain('allergen-introduce-early');
     expect(r.badam).toContain('allergen-introduce-early');
+  });
+
+  // ── M-M-1 (Maren, blocking): the redirect must NOT drop the tree-nut allergen caution ──
+  test('M-M-1: almond/cashew-milk detail sheet shows BOTH the inform line AND the tree-nut allergen', async ({ page }) => {
+    const sheets = await page.evaluate(() => {
+      const read = (n: string) => { renderFoodDetailSheet(n); return document.getElementById('foodDetailBody')!.innerHTML.toLowerCase(); };
+      return { almond: read('almond milk'), cashew: read('cashew milk') };
+    });
+    // the substitute-caveat (inform) axis is present…
+    expect(sheets.almond).toMatch(/substitute|arsenic|not a milk/);
+    // …AND the tree-nut allergen axis is preserved (the redirect must not silently drop it).
+    expect(sheets.almond, 'almond milk must still warn it contains a tree-nut allergen').toMatch(/tree.?nut|almond/);
+    expect(sheets.cashew).toMatch(/tree.?nut|cashew|allergen/);
+  });
+
+  // ── K-M-1 (Kael, gate↔card parity): coconut milk drink takes the plant gate, not cow copy ──
+  test('K-M-1: a non-nut plant alias (coconut milk drink) gets the plant gate, not cow curd/paneer copy', async ({ page }) => {
+    const reason = await page.evaluate(() => _fdAgeRule('coconut milk drink')?.reason || '');
+    expect(reason.toLowerCase()).not.toMatch(/curd|paneer/);     // not the cow 'milk' carve-out
+    expect(reason.toLowerCase()).toMatch(/substitute|fortified|arsenic/);
   });
 
   // ── _effPolarity unit contract (the §3 table) ──

--- a/tests/e2e/food-effects-v2-p1c-milk.spec.ts
+++ b/tests/e2e/food-effects-v2-p1c-milk.spec.ts
@@ -197,11 +197,25 @@ test.describe('food-effects-v2 P1c — milk polarity cards', () => {
     expect(sheets.cashew).toMatch(/tree.?nut|cashew|allergen/);
   });
 
-  // ── K-M-1 (Kael, gate↔card parity): coconut milk drink takes the plant gate, not cow copy ──
-  test('K-M-1: a non-nut plant alias (coconut milk drink) gets the plant gate, not cow curd/paneer copy', async ({ page }) => {
-    const reason = await page.evaluate(() => _fdAgeRule('coconut milk drink')?.reason || '');
-    expect(reason.toLowerCase()).not.toMatch(/curd|paneer/);     // not the cow 'milk' carve-out
-    expect(reason.toLowerCase()).toMatch(/substitute|fortified|arsenic/);
+  // ── K-M-1 (Kael, gate↔card parity): coconut milk drink + the Hindi 'doodh' variants ──
+  test('K-M-1: plant-milk hosts take the plant gate, not cow curd/paneer NOR a tree-nut 6mo gate', async ({ page }) => {
+    const r = await page.evaluate(() => ({
+      coconut: _fdAgeRule('coconut milk drink')?.reason || '',
+      // the Cipher-caught leak: 'doodh' variants raw-resolve to tree-nut's alias, not the bare
+      // 'milk' key — the card says "not a substitute under 1", the gate must NOT say tree-nut@6.
+      badamDoodh: { reason: _fdAgeRule('badam doodh')?.reason || '', min: _fdAgeRule('badam doodh')?.minMonth },
+      kajuDoodh:  { reason: _fdAgeRule('kaju doodh')?.reason || '', min: _fdAgeRule('kaju doodh')?.minMonth },
+      // the bare nut still gates as an introduce-early tree nut (unchanged), and rice keeps arsenic:
+      badam: _fdAgeRule('badam')?.minMonth,
+      riceMilk: _fdAgeRule('rice milk')?.minMonth,
+    }));
+    expect(r.coconut.toLowerCase()).not.toMatch(/curd|paneer/);
+    expect(r.coconut.toLowerCase()).toMatch(/substitute|fortified|arsenic/);
+    expect(r.badamDoodh.min, 'badam doodh must NOT get the tree-nut 6mo gate').toBe(12);
+    expect(r.badamDoodh.reason.toLowerCase()).toMatch(/substitute|fortified|arsenic/);
+    expect(r.kajuDoodh.min).toBe(12);
+    expect(r.badam, 'the bare nut is still an introduce-early tree nut at ~6mo').toBe(6);
+    expect(r.riceMilk, 'rice keeps its under-5 arsenic gate (dedicated, untouched)').toBe(60);
   });
 
   // ── _effPolarity unit contract (the §3 table) ──

--- a/tests/e2e/food-effects-v2-p1c-milk.spec.ts
+++ b/tests/e2e/food-effects-v2-p1c-milk.spec.ts
@@ -1,0 +1,198 @@
+import { test, expect } from '@playwright/test';
+
+// food-effects-v2 P1c — the MILK polarity cards (milk-spec §4/§5/§10).
+//
+// Two never-before-rendered v2 foodClasses, as sibling cards in Diet → Library
+// (renderDietMilkIntro → #dietMilkIntro / #dietPlantMilkIntro), the nut card untouched:
+//   • cow milk   = drink-timing      — CONDITIONAL, a SPLIT lead: sage carve-out band
+//     ("good in food now") OVER an amber gate band ("wait as the main drink", M-2
+//     skim-proof). CMPA severe strip PINNED + present-only, with a class-aware scope header.
+//   • plant milk = substitute-caveat — INFORM, a SKY banner leading with rice<5=arsenic; NO
+//     severe strip (the floor follows the hazard; harm is nutritional/chronic, not acute).
+//
+// Card-relative assertions (DOM position / display), mirroring the encourage-card spec, so the
+// deferred switchTab(savedTab) race on init doesn't matter — we test each card's own contract.
+
+const SHOWN = (sel: string, cardId: string) => {
+  let n: HTMLElement | null = document.querySelector(sel);
+  if (!n) return false;
+  while (n && n.id !== cardId) {
+    if (getComputedStyle(n).display === 'none') return false;
+    n = n.parentElement;
+  }
+  return !!n;
+};
+
+declare const renderDietLibrary: () => void;
+declare const getFoodEffect: (n: string) => any;
+declare const renderFoodDetailSheet: (n: string) => void;
+declare const _fdAgeRule: (n: string) => any;
+declare const _effPolarity: (e: any) => string;
+
+test.describe('food-effects-v2 P1c — milk polarity cards', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/index.html?nosync');
+    await page.waitForFunction(() =>
+      typeof (window as any).renderDietLibrary === 'function'
+      && typeof (window as any).getFoodEffect === 'function'
+      && !!document.getElementById('dietMilkIntro')
+      && !!document.getElementById('dietPlantMilkIntro'), null, { timeout: 10_000 });
+    await page.evaluate(() => (window as any).renderDietLibrary());
+  });
+
+  // ── §10(a) — cow milk: split lead, carve-out FIRST then gate; never warn/avoid, never encourage ──
+  test('(a) cow milk renders the SPLIT lead — sage carve-out (sprout) above the amber gate (clock)', async ({ page }) => {
+    const host = page.locator('#dietMilkIntro');
+    await expect(host.locator('.enc-split')).toHaveCount(1);
+    await expect(host.locator('.enc-split-good use[href="#zi-sprout"]')).toHaveCount(1);
+    await expect(host.locator('.enc-split-gate use[href="#zi-clock"]')).toHaveCount(1);
+    // The lead is neither an "avoid" warn banner nor an "introduce early" benefit banner.
+    await expect(host.locator('.enc-split use[href="#zi-warn"]')).toHaveCount(0);
+    await expect(host.locator('.enc-split use[href="#zi-siren"]')).toHaveCount(0);
+    await expect(host.locator('.enc-benefit')).toHaveCount(0);
+    // carve-out leads the gate in DOM/reading order (the reassurance reads first).
+    const order = await page.evaluate(() => {
+      const h = document.getElementById('dietMilkIntro')!;
+      const good = h.querySelector('.enc-split-good'), gate = h.querySelector('.enc-split-gate');
+      if (!good || !gate) return 'missing';
+      return (good.compareDocumentPosition(gate) & 4) ? 'good-first' : 'gate-first';
+    });
+    expect(order).toBe('good-first');
+    // The non-suppressible invariant ("the drink is gated; the dairy is not") is pinned.
+    await expect(host.locator('.enc-form-note')).toContainText(/the drink is gated; the dairy is not/i);
+    await expect(page.locator('#dietMilkIntroBody .enc-form-note')).toHaveCount(0);
+  });
+
+  // ── §10(b) — cow milk CMPA severe strip: pinned, present-only, scope header, 112/108 + antihistamine ──
+  test('(b) cow milk pins the CMPA severe strip with a dairy-scoped header and the emergency line', async ({ page }) => {
+    await expect(page.locator('#dietMilkIntro .cons-severe')).toHaveCount(1);
+    await expect(page.locator('#dietMilkIntroBody .cons-severe')).toHaveCount(0); // pinned, never folds
+    // V-V-4 scope header separates the ALLERGY floor from the TIMING gate.
+    await expect(page.locator('#dietMilkIntro .cons-severe-h')).toContainText(/reacts to dairy/i);
+    // the emergency action: call 112/108 + the antihistamine-doesn't-treat-anaphylaxis line.
+    const emg = page.locator('#dietMilkIntro .enc-emergency');
+    await expect(emg).toContainText(/112|108/);
+    await expect(emg).toContainText(/antihistamine/i);
+    // shown within the card while the collapse body is hidden by default.
+    const r = await page.evaluate((src) => {
+      const fn = new Function('sel', 'cardId', 'return (' + src + ')(sel, cardId)') as any;
+      const body = document.getElementById('dietMilkIntroBody');
+      return {
+        bodyCollapsed: body ? getComputedStyle(body).display === 'none' : false,
+        stripShown: fn('#dietMilkIntro .cons-severe', 'dietMilkIntroCard'),
+      };
+    }, SHOWN.toString());
+    expect(r.bodyCollapsed).toBe(true);
+    expect(r.stripShown).toBe(true);
+  });
+
+  // ── §10(c) — plant milk: sky inform banner fronts rice<5=arsenic; NO severe strip ──
+  test('(c) plant milk renders the SKY inform banner fronting rice<5=arsenic, and NO severe strip', async ({ page }) => {
+    const host = page.locator('#dietPlantMilkIntro');
+    await expect(host.locator('.enc-inform')).toHaveCount(1);
+    await expect(host.locator('.enc-inform-h use[href="#zi-info"]')).toHaveCount(1);
+    // the single hardest fact is fronted in the lead.
+    await expect(host.locator('.enc-inform-lead')).toContainText(/arsenic/i);
+    await expect(host.locator('.enc-inform-lead')).toContainText(/under 5/i);
+    // substitute-caveat carries NO emergency floor (the floor follows the hazard).
+    await expect(page.locator('#dietPlantMilkIntroCard .cons-severe')).toHaveCount(0);
+    await expect(page.locator('#dietPlantMilkIntroCard use[href="#zi-siren"]')).toHaveCount(0);
+    // the "Never" list names rice<5 and the not-a-substitute line.
+    await expect(host.locator('.enc-form-list.enc-never')).toContainText(/rice/i);
+  });
+
+  // ── §10(d) — resolver guard: breast/formula/soy do NOT fire cow-milk; cow family DOES ──
+  test('(d) the cow-milk drink-timing card never fires on breast milk / formula / soy milk', async ({ page }) => {
+    const r = await page.evaluate(() => {
+      const id = (n: string) => { const e = getFoodEffect(n); return e ? (e.title || '').slice(0, 12) : null; };
+      const isCow = (n: string) => { const e = getFoodEffect(n); return !!e && e.foodClass === 'drink-timing'; };
+      return {
+        breast: isCow('breast milk'), formula: isCow('formula'), formulaMilk: isCow('formula milk'),
+        soy: getFoodEffect('soy milk')?.foodClass,
+        cows: isCow("cow's milk"), buffalo: isCow('buffalo milk'), top: isCow('top milk'),
+      };
+    });
+    expect(r.breast, 'breast milk must NOT fire the cow-milk drink-timing card').toBe(false);
+    expect(r.formula).toBe(false);
+    expect(r.formulaMilk).toBe(false);
+    expect(r.soy, 'soy milk routes to the soy allergen record, not cow milk').toBe('allergen-introduce-early');
+    expect(r.cows).toBe(true);
+    expect(r.buffalo).toBe(true);
+    expect(r.top).toBe(true);
+  });
+
+  // ── §3-bis / §10(g) — K-6: the Food Library detail surface uses _effPolarity, never the siren ──
+  test('(g) K-6: renderFoodDetailSheet polarity — cow milk conditional, plant milk inform, never siren', async ({ page }) => {
+    const flags = await page.evaluate(() => {
+      const read = (n: string) => {
+        renderFoodDetailSheet(n);
+        const el = document.getElementById('foodDetailBody')!;
+        return {
+          conditional: !!el.querySelector('.fd-flag-conditional'),
+          inform: !!el.querySelector('.fd-flag-inform'),
+          encourage: !!el.querySelector('.fd-flag-encourage'),
+          allergenSiren: !!el.querySelector('.fd-flag-allergen'),
+          clock: !!el.querySelector('use[href="#zi-clock"]'),
+          info: !!el.querySelector('use[href="#zi-info"]'),
+        };
+      };
+      return { cow: read('cow milk'), plant: read('plant milk'), soy: read('soy'), honey: read('honey') };
+    });
+    // cow milk → conditional (amber/clock), never the rose siren (the K-6 defect).
+    expect(flags.cow.conditional).toBe(true);
+    expect(flags.cow.allergenSiren).toBe(false);
+    expect(flags.cow.clock).toBe(true);
+    // plant milk → inform (sky/info), never siren.
+    expect(flags.plant.inform).toBe(true);
+    expect(flags.plant.allergenSiren).toBe(false);
+    expect(flags.plant.info).toBe(true);
+    // regression: a δ allergen still reads encourage; honey still reads the rose siren (warn).
+    expect(flags.soy.encourage).toBe(true);
+    expect(flags.honey.allergenSiren).toBe(true);
+  });
+
+  // ── §10(h) — K-3: plant-milk age gate is the dedicated entry, not the cow 'milk' copy ──
+  test('(h) K-3: a plant-milk log resolves its OWN age gate (arsenic), not cow-milk curd/paneer copy', async ({ page }) => {
+    const r = await page.evaluate(() => ({
+      plant: _fdAgeRule('plant milk')?.reason || '',
+      oat: _fdAgeRule('oat milk')?.reason || '',
+      almond: _fdAgeRule('almond milk')?.reason || '',
+    }));
+    expect(r.plant.toLowerCase()).toMatch(/substitute|arsenic|fortified/);
+    expect(r.plant.toLowerCase()).not.toMatch(/curd|paneer/); // not the cow-'milk' carve-out copy
+    expect(r.oat.toLowerCase()).toMatch(/substitute|fortified/);
+    // the plant-milk DRINK redirect: almond milk gets the plant gate, not cow curd/paneer copy.
+    expect(r.almond.toLowerCase()).not.toMatch(/curd|paneer/);
+  });
+
+  // ── the plant-milk DRINK redirect (K-2 intent / alias-precedence pre-empt) ──
+  test('plant-milk drink hosts (almond/badam/cashew milk) read INFORM, not the tree-nut encourage', async ({ page }) => {
+    const r = await page.evaluate(() => ({
+      almondMilk: getFoodEffect('almond milk')?.foodClass,
+      badamDoodh: getFoodEffect('badam doodh')?.foodClass,
+      cashewMilk: getFoodEffect('cashew milk')?.foodClass,
+      // the bare nut still introduces early (unchanged):
+      almond: [].concat(getFoodEffect('almond')?.foodClass),
+      badam: [].concat(getFoodEffect('badam')?.foodClass),
+    }));
+    expect(r.almondMilk, 'almond milk (a drink) is substitute-caveat, not introduce-early').toBe('substitute-caveat');
+    expect(r.badamDoodh).toBe('substitute-caveat');
+    expect(r.cashewMilk).toBe('substitute-caveat');
+    expect(r.almond, 'the bare nut still resolves to the tree-nut introduce-early record').toContain('allergen-introduce-early');
+    expect(r.badam).toContain('allergen-introduce-early');
+  });
+
+  // ── _effPolarity unit contract (the §3 table) ──
+  test('_effPolarity maps the v2 taxonomy to the four render polarities', async ({ page }) => {
+    const p = await page.evaluate(() => ({
+      honey: _effPolarity(getFoodEffect('honey')),
+      peanut: _effPolarity(getFoodEffect('peanut')),
+      cow: _effPolarity(getFoodEffect('cow milk')),
+      plant: _effPolarity(getFoodEffect('plant milk')),
+    }));
+    expect(p.honey).toBe('warn');
+    expect(p.peanut).toBe('encourage');
+    expect(p.cow).toBe('conditional');
+    expect(p.plant).toBe('inform');
+  });
+});


### PR DESCRIPTION
## What

Surfaces the two **never-rendered** v2 foodClasses as sibling knowledge cards in Diet → Library (the nut card untouched), per `docs/specs/food-effects-v2-p1c-milk-polarities.md` §0 blocking requirements:

- **cow milk** = `drink-timing` — **conditional**: a SPLIT lead (sage carve-out "good in food now" *over* an amber gate "wait as the main drink", M-2 skim-proof) + drink-vs-food block + a **pinned CMPA severe strip** with a dairy-scoped header.
- **plant milk** = `substitute-caveat` — **inform**: a SKY banner fronting rice<5=arsenic; **no** severe strip (the floor follows the hazard — harm is nutritional/chronic, not acute).

## Blocking requirements (milk-spec §0)

| Req | Done |
|---|---|
| **K-6** `_effPolarity(eff)` in core.js, both surfaces consume it | ✅ — `renderFoodLibDetail` no longer renders milk as the rose "avoid" siren |
| **V-V-1/2** switched-unit lead; drink-timing split banner (sage carve-out + amber gate) | ✅ `.enc-split` |
| **V-V-3** substitute-caveat → sky `.enc-inform` (not neutral) | ✅ |
| **V-V-4** CMPA strip class-aware scope header | ✅ "If your baby reacts to dairy…" |
| **K-3** dedicated `'plant milk'` AGE_RULES entry (+ oat/rice/rice-drink) | ✅ no cow curd/paneer copy leak; rice = under-5 arsenic |
| **K-4** `cow milk` ALLERGENS entry | ✅ |
| **M-1** floor on `severeSigns.length` | ✅ (present-only, reuses `_severeFloorHtml` discipline) |
| **M-2** skim-proof drink gate | ✅ amber gate band weighted ≥ carve-out |
| **M-3** dilution line unattributed | ✅ |

**Plus** a pre-emptive alias-precedence fix (same class as the fish M-F-1, spec K-2 intent): `almond milk` / `badam doodh` / `cashew milk` were resolving to the **tree-nut encourage** card; a `_isPlantMilkDrinkHost` redirect routes plant-milk *drinks* to the plant-milk **inform** record on both card and gate, while the bare nut still introduces early. `soy milk` → soy (untouched); `coconut milk` (cooking) not captured.

## Files

`data.js` (FE/AGE/ALLERGENS + the milk records) · `core.js` (`_effPolarity`, `_isPlantMilkDrinkHost`) · `diet.js` (`renderFoodLibDetail` K-6, `renderDietMilkIntro`, `_fdAgeRule` redirect) · `styles.css` (`.enc-split`, `.enc-inform`, `.fd-flag-conditional`/`-inform`) · `template.html` (milk card hosts).

## Verification

- `pnpm build` green — 12/12 gates incl. P0.1 sync (**10 FOOD_EFFECTS keys**, 41 AGE_RULES gates).
- Full e2e **383 passed**, 0 failed, 2 pre-existing skips. New `food-effects-v2-p1c-milk.spec.ts` (8): split lead order, pinned CMPA strip + scope header + 112/antihistamine, sky inform fronting arsenic + no strip, resolver guard (breast/formula/soy), K-6 detail-flag polarity, K-3 gate, plant-milk-drink redirect, `_effPolarity` contract.

## canon-cc-008 status

**Draft** — chain in progress. Touches `styles.css` + `template.html` → **shared-module triple-Gov** (Kael + Vela + Maren), plus engine (Kael) and render/care (Vela/Maren), then Cipher Edict V terminal. Will mark ready once discharged.

## Dependency

Based on **#211** (fish-green) — `main` is currently red on the unwired fish manifest entry, so this branches off fish. **Retarget to `main` once #211 merges.**

🤖 https://claude.ai/code/session_01A4yF65w2wtkfPcnYvh7fau

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4yF65w2wtkfPcnYvh7fau)_