### PR TITLE
Diet-preference surfacing gate — 4 classes (veg / eggetarian / pescatarian / non-veg)

### DIFF
--- a/docs/NEXT_SESSION_TARGET_2026-06-02.md
+++ b/docs/NEXT_SESSION_TARGET_2026-06-02.md
@@ -35,6 +35,18 @@ Salt, sugar (the other `drink-timing`/timing foods), shellfish (a separate aller
 
 ---
 
+## Food-effects gap audit (2026-06-02) — what the model is still missing
+Asked during the diet-preference-gate session. The model covers 11 records (honey · peanut · tree nut · egg · soy · wheat · sesame · fish · cow milk · plant milk · choking hazards). Gaps, prioritized:
+- **Shellfish** — the one missing *major* allergen (Big 9). Separate from finfish, often lifelong, frequently severe; diet-contingent. Already P-next; **the cleanest first test of the preference gate.**
+- **Salt + sugar/jaggery** — have `AGE_RULES` gates, no `FOOD_EFFECTS` record (renal load / added-sugar + dental). The `drink-timing`/quantity-caveat siblings. Already P-next.
+- **FPIES — a missing *reaction axis*, not a food.** The whole model is IgE-shaped (rash→anaphylaxis→adrenaline). FPIES (non-IgE) is profuse repeat vomiting + lethargy **1–4h** after a food (cow milk, soy, rice, oats), no rash, no adrenaline — needs rehydration. A parent seeing repeat 2h-post-food vomiting gets no fitting guidance today. Worth a cross-cutting note like "the floor follows the hazard" did for choking.
+- **India-context allergens:** mustard (sarson/rai/kasundi); buckwheat (kuttu — a real anaphylaxis trigger in vrat/fasting foods).
+- **Flag-only / niche:** favism (fava/broad beans + G6PD deficiency — hemolysis; needs G6PD status); caffeine cluster (tea/coffee/**chocolate**) + juice (gates exist); gelatin (allergen + veg/vegan/halal).
+
+## Diet-preference surfacing gate — ✅ 4 classes LANDED; vegan SPEC'd
+- **Built (this session, through canon-cc-008):** veg / **eggetarian** / **pescatarian (+egg)** / non-veg. One source of truth in `core.js` (`DIET_PREF_NONVEG_SIDS` → `_dietAllowsNonvegSid`/`_dietAllowsParent`/`_dietAllowsFood`/`_dietNonvegSid`, word-boundary classified). Gates the proactive surfaces only (Library grid + cat modal, both meal dropdowns, Foods-to-Try, combo-checker note). **Safety invariant held: the consequence path is never gated** — a food given off-preference still fires its full safety record.
+- **Deferred (spec'd, ready for Governor review):** **vegan** — `docs/specs/diet-preference-gate-vegan.md`. The hard class: it gates foods currently classed *veg* (dairy + honey) and carries a nutritional-adequacy obligation (B12/calcium/DHA) — a filter *plus* a redirect, not a one-liner. Needs a vegan-infant research brief first (research→manifest→surface).
+
 ## Carry-forward register (inherited + new)
 
 ### Human-only gate (Architect)

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-06-02 &middot; graph @ <code>f38e8b8157ef</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-02 &middot; graph @ <code>5a2ebeb5a56f</code></div>
   <div class="sub" style="margin-top:8px">
-    <span class="stat"><b>1,730</b> symbols</span>
-    <span class="stat"><b>5,147</b> relations</span>
-    <span class="stat"><b>81,497</b> LOC</span>
+    <span class="stat"><b>1,737</b> symbols</span>
+    <span class="stat"><b>5,160</b> relations</span>
+    <span class="stat"><b>81,584</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -64,15 +64,15 @@
       <div class="cgov">Governor: <b>Kael</b></div>
       <div class="nums">
         <span><b>11</b> modules</span>
-        <span><b>736</b> symbols</span>
-        <span><b>27,599</b> LOC</span>
+        <span><b>743</b> symbols</span>
+        <span><b>27,664</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,599 of 30,000 LOC">
+      <div class="bar" title="27,664 of 30,000 LOC">
         <div class="fill hot" style="width:92%"></div>
         <span class="barlbl">92% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,401 LOC headroom</div>
+      <div class="hd">2,336 LOC headroom</div>
       <div class="mods">core.js, i-illness.js, i-caretickets.js, i-qa-handlers.js, sync.js, data.js, i-qa.js, i-isl.js, config.js, i-correlate.js, start.js</div>
     </div>
     <div class="card" style="border-top:5px solid #b5d5c5">
@@ -82,14 +82,14 @@
       <div class="nums">
         <span><b>3</b> modules</span>
         <span><b>672</b> symbols</span>
-        <span><b>27,411</b> LOC</span>
+        <span><b>27,429</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,411 of 30,000 LOC">
+      <div class="bar" title="27,429 of 30,000 LOC">
         <div class="fill hot" style="width:91%"></div>
         <span class="barlbl">91% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,589 LOC headroom</div>
+      <div class="hd">2,571 LOC headroom</div>
       <div class="mods">home.js, medical.js, diet.js</div>
     </div>
     <div class="card" style="border-top:5px solid #c9b8e8">
@@ -99,14 +99,14 @@
       <div class="nums">
         <span><b>2</b> modules</span>
         <span><b>185</b> symbols</span>
-        <span><b>8,647</b> LOC</span>
+        <span><b>8,649</b> LOC</span>
       </div>
       
-      <div class="bar" title="8,647 of 30,000 LOC">
+      <div class="bar" title="8,649 of 30,000 LOC">
         <div class="fill " style="width:29%"></div>
         <span class="barlbl">29% to 30K frontier</span>
       </div>
-      <div class="hd">21,353 LOC headroom</div>
+      <div class="hd">21,351 LOC headroom</div>
       <div class="mods">i-quicklog.js, i-cards.js</div>
     </div>
     <div class="card" style="border-top:5px solid #e8b86d">
@@ -116,7 +116,7 @@
       <div class="nums">
         <span><b>2</b> modules</span>
         <span><b>0</b> symbols</span>
-        <span><b>14,142</b> LOC</span>
+        <span><b>14,144</b> LOC</span>
       </div>
       <div class="note">Unsurveyed &mdash; code-only extraction. Set a backend and rebuild for symbols.</div>
       <div class="mods">styles.css, template.html</div>
@@ -137,7 +137,7 @@
   <h2>Cross-province coupling (highest-traffic calls across jurisdiction borders)</h2>
   <table>
     <thead><tr><th>Module</th><th>Module</th><th class="num">Calls</th><th>Border</th></tr></thead>
-    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">133</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">39</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
+    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">135</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">39</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
   </table>
 
   <h2>Connectivity hubs (highest call-degree symbols per module)</h2>

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-06-02 &middot; graph @ <code>5a2ebeb5a56f</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-02 &middot; graph @ <code>d5b1cc6ae2cc</code></div>
   <div class="sub" style="margin-top:8px">
     <span class="stat"><b>1,737</b> symbols</span>
     <span class="stat"><b>5,160</b> relations</span>
-    <span class="stat"><b>81,584</b> LOC</span>
+    <span class="stat"><b>81,597</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -65,14 +65,14 @@
       <div class="nums">
         <span><b>11</b> modules</span>
         <span><b>743</b> symbols</span>
-        <span><b>27,664</b> LOC</span>
+        <span><b>27,668</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,664 of 30,000 LOC">
+      <div class="bar" title="27,668 of 30,000 LOC">
         <div class="fill hot" style="width:92%"></div>
         <span class="barlbl">92% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,336 LOC headroom</div>
+      <div class="hd">2,332 LOC headroom</div>
       <div class="mods">core.js, i-illness.js, i-caretickets.js, i-qa-handlers.js, sync.js, data.js, i-qa.js, i-isl.js, config.js, i-correlate.js, start.js</div>
     </div>
     <div class="card" style="border-top:5px solid #b5d5c5">
@@ -82,14 +82,14 @@
       <div class="nums">
         <span><b>3</b> modules</span>
         <span><b>672</b> symbols</span>
-        <span><b>27,429</b> LOC</span>
+        <span><b>27,436</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,429 of 30,000 LOC">
+      <div class="bar" title="27,436 of 30,000 LOC">
         <div class="fill hot" style="width:91%"></div>
         <span class="barlbl">91% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,571 LOC headroom</div>
+      <div class="hd">2,564 LOC headroom</div>
       <div class="mods">home.js, medical.js, diet.js</div>
     </div>
     <div class="card" style="border-top:5px solid #c9b8e8">
@@ -99,14 +99,14 @@
       <div class="nums">
         <span><b>2</b> modules</span>
         <span><b>185</b> symbols</span>
-        <span><b>8,649</b> LOC</span>
+        <span><b>8,651</b> LOC</span>
       </div>
       
-      <div class="bar" title="8,649 of 30,000 LOC">
+      <div class="bar" title="8,651 of 30,000 LOC">
         <div class="fill " style="width:29%"></div>
         <span class="barlbl">29% to 30K frontier</span>
       </div>
-      <div class="hd">21,351 LOC headroom</div>
+      <div class="hd">21,349 LOC headroom</div>
       <div class="mods">i-quicklog.js, i-cards.js</div>
     </div>
     <div class="card" style="border-top:5px solid #e8b86d">

--- a/docs/specs/diet-preference-gate-vegan.md
+++ b/docs/specs/diet-preference-gate-vegan.md
@@ -1,0 +1,101 @@
+# Diet-Preference Gate — the VEGAN class (deferred extension)
+
+**Companion:** Lyra (The Weaver)
+**Status:** SPEC — authored alongside the 4-class gate (veg / eggetarian / pescatarian / non-veg), which shipped as code. Vegan was **deferred to this spec by Architect decision** ("build the easy part now, spec vegan") because it is the only preference that cuts into foods currently classified *veg* (dairy + honey), and because a vegan **infant** gate has a nutritional-safety dimension the other three classes don't. Ready for Governor spec-review before any code.
+**Date opened:** 2026-06-02.
+**Descends from:** the shipped 4-class gate (`split/core.js` — `DIET_PREF_NONVEG_SIDS`, `_dietNonvegSid`, `_dietAllowsNonvegSid`, `_dietAllowsParent`, `_dietAllowsFood`) · `FOOD_TAX` (`split/data.js`) · the food-effects v2 model (the surfacing-vs-consequence boundary).
+
+---
+
+## 1. The problem vegan adds that the other three classes don't
+
+The four shipped classes are all expressible from **FOOD_TAX `nonveg` subcategory ids (sids)** — eggs / poultry / fish / meat — because everything they gate already lives under the `nonveg` parent. Each class is just a subset of those four sids; veg foods (the other six parents) are always surfaced.
+
+**Vegan breaks that model in two ways:**
+
+1. **It gates foods currently classed *veg*.** A vegan eats no animal product at all — so beyond the four `nonveg` sids it must also exclude **dairy** (`FOOD_TAX.dairy.subs.dairy`: ghee, curd/dahi, paneer, cheese, butter/makhan, cream/malai, buttermilk/chaas, kheer, raita) and **honey** (not even in `FOOD_TAX` today — it lives only in `AGE_RULES`/`FOOD_EFFECTS`). These are *veg* foods the current `_dietAllowsParent`/`_dietAllowsFood` always pass. So vegan needs a **new exclusion axis**, not just a new sid-subset.
+
+2. **It carries a nutritional-safety obligation the others don't.** Removing the four `nonveg` sids loses nothing a vegetarian infant relies on. Removing **dairy** removes the lacto-vegetarian infant's principal source of **calcium, B12, and energy-dense fat**, and a vegan infant additionally has no dietary **B12** source at all without fortification/supplementation, plus heightened **iron, zinc, DHA, vitamin D, and protein-density** concerns. **A vegan gate that silently hides dairy without surfacing substitution guidance is a Care defect, not a feature.** (This is the Maren-altitude line: the gate must not just *subtract* — it must *redirect*.)
+
+---
+
+## 2. Scope
+
+**In scope:** add `vegan` as a fifth `ziva_diet_pref` value; extend the surfacing gate so no animal-derived food (nonveg sids + dairy + honey + ghee/gelatin) is *proactively surfaced* to a vegan; surface a **vegan nutritional-adequacy guidance card** (the redirect); keep the plant-milk record's relevance elevated.
+
+**Out of scope (unchanged invariants):** the **consequence path is never gated** (same as the 4-class gate — if a vegan family logs dairy or a grandparent gives honey, the full safety record still fires); the food-effects records themselves; the honey botulism floor (universal, ungated).
+
+---
+
+## 3. The exclusion model — `_isAnimalDerived(food)`
+
+The 4-class gate keys on `nonveg` sids. Vegan needs a broader predicate. Proposed: a single **vegan-exclusion classifier** in `core.js`, layered over the existing `_dietNonvegSid`:
+
+```
+ANIMAL_DERIVED_TOKEN = {
+  // the four nonveg sids (already covered by _dietNonvegSid) PLUS:
+  dairy:  ['milk','dairy','ghee','curd','dahi','yogurt','yoghurt','paneer','cheese',
+           'butter','makhan','cream','malai','buttermilk','chaas','khoya','mawa','kheer','raita'],
+  honey:  ['honey','shahad'],
+  other:  ['gelatin','gelatine','isinglass','rennet','lard','tallow'],
+}
+```
+- `_isAnimalDerived(name)` returns true when `_dietNonvegSid(name)` is non-null **OR** a word-boundary match hits any `dairy`/`honey`/`other` token. (Word-boundary, per the 4-class gate's `eggplant`/`shellfish` lesson — e.g. `\bmilk\b` must match "cow milk" / "milk in cooking" but the gate must not over-fire on plant-milk **substitutes**, see §3.1.)
+- `DIET_PREF_NONVEG_SIDS.vegan = []` (no nonveg sids), and `_dietAllowsFood`/`_dietAllowsParent` gain a vegan branch: for `vegan`, a food is surfaced iff **not** `_isAnimalDerived(name)`; the `dairy` parent (and any honey surface) is not shown.
+
+### 3.1 The plant-milk wrinkle (load-bearing — Kael consult)
+The food-effects `plant milk` record is the vegan's **recommended** dairy substitute — it must stay surfaced for a vegan. But `\bmilk\b` is in the dairy exclusion tokens, and "almond milk"/"oat milk"/"soy milk" contain `milk`. The classifier must **not** exclude plant milks. Resolution: `_isAnimalDerived` must run the existing `_isPlantMilkDrinkHost` / plant-milk-resolver guard FIRST and return `false` for a plant-milk drink (almond/oat/rice/soy/cashew/coconut milk·doodh). Equivalently: the dairy `\bmilk\b` token is governed by a "not a plant-milk host" guard — the same alias-precedence discipline the food-effects resolver uses. **e2e must assert `oat milk`/`almond milk` are surfaced to a vegan while `cow milk`/`paneer`/`ghee` are not.**
+
+### 3.2 Honey is mostly moot for the in-scope infant, but not forever
+Honey is **avoid-for-all under 12 months** (botulism) regardless of diet — so for Ziva today, honey's vegan-exclusion changes nothing the universal age-gate doesn't already enforce. It becomes a live vegan distinction only **after 12 months**, when honey-as-a-sweetener would otherwise be surfaceable. The spec records it so the classifier is complete, but flags that the honey botulism floor stays universal and ungated (it is the consequence path).
+
+---
+
+## 4. The nutritional-adequacy redirect (the Maren-altitude requirement)
+
+Selecting `vegan` MUST surface a **vegan-infant nutritional-adequacy card** (a Diet → Library knowledge card, sibling of the nut/milk/choking cards — or a settings-adjacent note). It is the "redirect" that makes the subtraction safe. Content (FOOD_EFFECTS/research-sourced, not hardcoded claims — needs a research brief first, per the research→manifest→surface pipeline):
+- **B12** — no plant food reliably provides it; a vegan infant needs a fortified source or supplement (pediatrician-guided). This is the single most important line — infant B12 deficiency is a documented, serious harm.
+- **Calcium + vitamin D** — fortified soy/oat milk (from 12 months), ragi, tofu, leafy greens; vitamin D supplementation.
+- **Iron + zinc** — legumes, fortified cereals, pair with vitamin C (the existing iron tip already covers this — reuse).
+- **DHA / omega-3** — no fish; algal DHA, ground flax/walnut (the existing brain-fat tip).
+- **Energy + protein density** — dairy fat is removed; nut/seed butters (thinned — choking-set cross-ref), avocado, oils.
+- **Framing:** "A well-planned vegan infant diet can meet a baby's needs **with attention to B12, vitamin D, calcium, iron, DHA, and energy density** — discuss a B12 source with your pediatrician." Honest, non-alarmist, pediatrician-deferring. **No fabricated authority attribution** (the no-laundering discipline).
+
+> **Maren pair-note (anticipated):** this card is the reason vegan can't be a one-line filter. The gate that hides paneer must, in the same surface, point to what replaces its calcium/B12/fat. Without it, a parent reads "vegan selected" as "the app approves" while the app has silently removed the infant's main micronutrient source.
+
+---
+
+## 5. Surfacing sites (same as the 4-class gate, plus the redirect)
+All sites already route through the shipped helpers, so vegan mostly "falls out" once `_dietAllowsFood`/`_dietAllowsParent` gain the vegan branch:
+- Library food grid + category modal (`renderFoods`/`openFoodCatModal`) — the **dairy** parent card is now also gated (new: a veg parent becomes preference-contingent for the first time → `_dietAllowsParent` must special-case dairy under vegan).
+- Meal-search dropdowns (`showMealDropdown` ×2), Foods-to-Try (`getUntriedSuggestions`), combo-checker note — all already call the helpers.
+- Curated combos — **today every CURATED_COMBO contains `Ghee (cow)` or dairy**, so for vegan they must be filtered or a vegan combo set added (a real gap: the cold-start autofill would otherwise surface ghee to a vegan). **This is new work vegan introduces that the 4 classes didn't** (the 4 classes never gated a veg combo).
+- The settings dropdown gains a `vegan` option.
+- NEW: the §4 adequacy card surfaces when `getDietPref() === 'vegan'`.
+
+---
+
+## 6. e2e plan
+- `_isAnimalDerived`: dairy (ghee/curd/paneer/cheese/butter/kheer) + honey + gelatin → true; plant milks (oat/almond/soy/rice/coconut milk) → **false** (§3.1); veg foods (ragi/banana/spinach/tofu) → false.
+- Per-pref surfacing: vegan surfaces no dairy/honey/egg/fish/poultry/meat; surfaces plant milks + all other veg.
+- The dairy parent card is hidden in the Library grid under vegan, shown under veg.
+- Curated combos: under vegan, no surfaced combo contains ghee/dairy.
+- The adequacy card renders under vegan (and not under the other four).
+- **Safety invariant (unchanged):** logging cow milk / honey under vegan still fires the full consequence record (CMPA floor / botulism floor) — the gate never touches the consequence path.
+
+## 7. canon-cc-008 routing (at vegan-implementation time)
+- `core.js` (`_isAnimalDerived`, vegan branch) → **Kael**.
+- `data.js` (vegan curated combos, any FOOD_TAX honey entry, the adequacy-card record + a vegan research brief through the manifest pipeline) → **Kael** + research.
+- `diet.js`/`home.js` (`renderFoods`, dropdowns, the adequacy card render) → **Maren**.
+- `intelligence-quicklog.js` (foods-to-try) → **Vela**.
+- `template.html`/`styles.css` (settings option + the adequacy card host) → **shared → triple-Gov**.
+- → Lyra synthesis → **Cipher** Edict V. The §4 adequacy card is the Maren-primary review surface.
+
+## 8. Out of scope / registered
+- **Jain** preference (no onion/garlic/root vegetables) — a *different axis* from animal-derived (it gates `vegs.roots` + `aromatics`, both veg). Mentioned in milestone copy today but not a diet-pref class. Could reuse this gate's machinery (a parent/sub exclusion set) in a later pass; out of scope here.
+- **Halal / kosher** — slaughter-method axes, not food-class; out of scope.
+- The vegan **research brief** (B12/calcium/DHA/iron infant-vegan evidence) must precede the §4 card copy — the research→manifest→surface pipeline, no hardcoded safety claim.
+
+---
+
+— *Lyra. The first four preferences only ever subtracted from the non-veg shelf — nothing a vegetarian baby leaned on. Vegan is the one that takes the paneer off the plate, and a baby's calcium and B12 with it. So vegan is not a filter; it is a filter plus a redirect — hide the dairy, and in the same breath show what carries the calcium now. That is why it waited for a spec.*

--- a/index.html
+++ b/index.html
@@ -13733,6 +13733,8 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
               </div>
               <select id="settingsDietPref" onchange="saveDietPref()" style="padding:6px 10px;border-radius:var(--r-lg);border:1.5px solid var(--peach-light);font-family:'Nunito',sans-serif;font-size:var(--fs-base);background:var(--card-bg);color:var(--text);outline:none;">
                 <option value="veg">Vegetarian</option>
+                <option value="eggetarian">Eggetarian (veg + egg)</option>
+                <option value="pescatarian">Pescatarian (veg + egg + seafood)</option>
                 <option value="nonveg">Non-Vegetarian</option>
               </select>
             </div>
@@ -24316,6 +24318,71 @@ function getDietPref() {
   return localStorage.getItem('ziva_diet_pref') || 'veg';
 }
 
+// ── Dietary-preference SURFACING GATE (4 classes; vegan deferred to its own spec) ──
+// The preference filters which foods are PROACTIVELY surfaced/recommended (the Library
+// grid + category modal, the meal-search dropdowns, the "Foods to Try Next" list, the
+// combo-checker preference note). It maps the stored `ziva_diet_pref` to the set of
+// FOOD_TAX `nonveg` subcategory ids (sids) it surfaces:
+//   veg          → none                     (today's default — lacto-vegetarian)
+//   eggetarian   → eggs                      (vegetarian + egg)
+//   pescatarian  → eggs + fish (seafood)     (vegetarian + egg + fish/seafood)
+//   nonveg       → eggs + poultry + fish + meat  (all)
+// SAFETY INVARIANT (load-bearing): this gate is SURFACING-ONLY. It must NEVER sit on the
+// consequence path — getFoodEffect / foodConsequenceCard / renderFoodDetailSheet / the combo
+// emergency floor are NOT gated. A food given despite the preference (a grandparent's spoonful)
+// must still surface its full safety record when logged. The gate hides SUGGESTIONS, never
+// SAFETY. (Vegan — which would additionally gate dairy + honey, foods currently classed veg —
+// is deferred to docs/specs/; the four classes here are all expressible from FOOD_TAX sids.)
+const DIET_PREF_NONVEG_SIDS = {
+  veg:         [],
+  eggetarian:  ['eggs'],
+  pescatarian: ['eggs', 'fish'],
+  nonveg:      ['eggs', 'poultry', 'fish', 'meat'],
+};
+const DIET_PREF_LABEL = {
+  veg:         'vegetarian',
+  eggetarian:  'eggetarian',
+  pescatarian: 'pescatarian (with egg)',
+  nonveg:      'non-vegetarian',
+};
+// Non-veg food token → FOOD_TAX subcategory id. A superset of FOOD_TAX.nonveg keys — adds the
+// synonyms the combo-checker sees (lamb/pork/beef → meat; crab → seafood) so the gate classifies
+// every animal food the app references from one source.
+const NONVEG_TOKEN_SID = {
+  egg: 'eggs',
+  chicken: 'poultry',
+  fish: 'fish', prawn: 'fish', shrimp: 'fish', crab: 'fish', seafood: 'fish',
+  mutton: 'meat', lamb: 'meat', pork: 'meat', beef: 'meat', meat: 'meat',
+};
+// Resolve a food NAME to its non-veg sid, or null if it is not a non-veg food. WORD-BOUNDARY
+// matched (not substring) so "Egg yolk"/"Chicken (puree)" classify but "eggplant" does NOT, and
+// "shellfish" does NOT match \bfish\b (shellfish is a separate concern, not gated here).
+function _dietNonvegSid(name) {
+  const n = String(name || '').toLowerCase();
+  for (const tok in NONVEG_TOKEN_SID) {
+    if (new RegExp('\\b' + tok + '\\b').test(n)) return NONVEG_TOKEN_SID[tok];
+  }
+  return null;
+}
+// Is a FOOD_TAX nonveg subcategory (sid) surfaced under the current preference?
+function _dietAllowsNonvegSid(sid) {
+  const allowed = DIET_PREF_NONVEG_SIDS[getDietPref()] || DIET_PREF_NONVEG_SIDS.veg;
+  return allowed.indexOf(sid) !== -1;
+}
+// Is a whole FOOD_TAX parent (pid) surfaced at all? Only 'nonveg' is preference-contingent for
+// the four non-vegan classes — every veg parent (grains/fruits/vegs/dairy/nuts/spices) is always
+// surfaced. (Vegan, which would gate dairy, is the deferred spec.)
+function _dietAllowsParent(pid) {
+  if (pid !== 'nonveg') return true;
+  return (DIET_PREF_NONVEG_SIDS[getDietPref()] || []).length > 0;
+}
+// Is a food NAME surfaced under the current preference? Veg foods (no nonveg sid) always pass;
+// a nonveg food passes iff its sid is in the preference's allowed set.
+function _dietAllowsFood(name) {
+  const sid = _dietNonvegSid(name);
+  return sid === null || _dietAllowsNonvegSid(sid);
+}
+
 function updateStorageUsage() {
   const MAX_BYTES = 5 * 1024 * 1024; // 5MB typical localStorage limit
 
@@ -32055,12 +32122,14 @@ function showMealDropdown(meal, query) {
   const q = query.toLowerCase();
   let html = '';
   let totalMatches = 0;
-  const isVeg = getDietPref() === 'veg';
 
   Object.entries(FOOD_SUGGESTIONS).forEach(([cat, items]) => {
-    // Hide non-veg category when diet pref is vegetarian
-    if (isVeg && cat.includes('Non-Veg')) return;
-    const filtered = items.filter(f => f.toLowerCase().includes(q));
+    // Surfacing gate (4-class diet preference): within the non-veg category keep only the
+    // items the preference surfaces — eggetarian → egg only, pescatarian → egg + fish, veg →
+    // none (category drops out). Per-item sid, since the list mixes egg/chicken/fish/meat.
+    const isNonvegCat = cat.includes('Non-Veg');
+    let filtered = items.filter(f => f.toLowerCase().includes(q));
+    if (isNonvegCat) filtered = filtered.filter(f => _dietAllowsNonvegSid(_dietNonvegSid(f)));
     if (filtered.length === 0) return;
     html += `<div class="meal-dd-cat">${cat}</div>`;
     filtered.forEach(food => {
@@ -38512,10 +38581,11 @@ function renderFoods() {
   if (countEl) countEl.textContent = `${foods.length} foods`;
 
   const grouped = _categorizeFoods();
-  const isVeg = getDietPref() === 'veg';
-  const parentOrder = isVeg
-    ? ['grains','fruits','vegs','dairy','nuts','spices']
-    : ['grains','fruits','vegs','dairy','nuts','spices','nonveg'];
+  // Dietary-preference surfacing gate: show the nonveg parent only when the preference
+  // surfaces at least one nonveg subcategory (veg → no nonveg card; eggetarian/pescatarian/
+  // nonveg → shown, with only the surfaced subcategories counted below).
+  const parentOrder = ['grains','fruits','vegs','dairy','nuts','spices'];
+  if (_dietAllowsParent('nonveg')) parentOrder.push('nonveg');
 
   let html = '<div class="food-cats">';
 
@@ -38524,6 +38594,9 @@ function renderFoods() {
     const col = parent.color;
     let parentTotal = 0, parentCount = 0;
     Object.entries(parent.subs).forEach(([sid, sub]) => {
+      // Within nonveg, count only the subcategories the preference surfaces (so an
+      // eggetarian's card reads "of eggs", not "of egg+poultry+fish+meat").
+      if (pid === 'nonveg' && !_dietAllowsNonvegSid(sid)) return;
       parentTotal += sub.keys.length;
       parentCount += grouped[pid][sid].length;
     });
@@ -38559,7 +38632,9 @@ function openFoodCatModal(pid) {
 
   document.getElementById('foodCatModalTitle').innerHTML = `${parent.icon} ${parent.label}`;
 
-  const subIds = Object.keys(parent.subs);
+  // Surfacing gate: within nonveg, show only the subcategories the preference surfaces.
+  let subIds = Object.keys(parent.subs);
+  if (pid === 'nonveg') subIds = subIds.filter(sid => _dietAllowsNonvegSid(sid));
   const tabsEl = document.getElementById('foodCatModalTabs');
   tabsEl.style.background = _foodColorMap[col];
 
@@ -40136,12 +40211,19 @@ function checkFoodCombo() {
     else headline = 'Looks good for Ziva\'s age!';
   }
 
-  // Vegetarian check
-  const nonVeg = rawFoods.filter(f => ['chicken','fish','mutton','lamb','pork','prawn','shrimp','crab','meat'].includes(f));
-  if (nonVeg.length > 0) {
+  // Diet-preference note (4-class gate): flag only foods OUTSIDE the current preference —
+  // a pescatarian sees no note for fish, an eggetarian none for egg, a non-veg none at all.
+  // This is a preference note, NOT a safety gate: it never downgrades an acute-toxin/below-floor
+  // 'avoid', and the food's own consequence/allergen record still fires unchanged below.
+  const offPref = rawFoods.filter(f => {
+    const sid = _dietNonvegSid(f);
+    return sid && !_dietAllowsNonvegSid(sid);
+  });
+  if (offPref.length > 0) {
     if (verdict !== 'avoid') { verdict = 'caution'; verdictEmoji = zi('warn'); }  // never downgrade an acute-toxin/below-floor avoid
-    warnings.push(`Ziva follows a vegetarian diet. ${nonVeg.join(', ')} is non-vegetarian.`);
-    headline = `Note: ${nonVeg.join(', ')} is non-vegetarian — Ziva\'s diet is vegetarian`;
+    const prefLabel = DIET_PREF_LABEL[getDietPref()] || 'vegetarian';
+    warnings.push(`Ziva's diet preference is ${prefLabel}. ${offPref.join(', ')} is outside it.`);
+    headline = `Note: ${offPref.join(', ')} is outside Ziva\'s ${prefLabel} preference`;
   }
 
   // ── 8b. food-effects headline (food-effects v2 §3.1, M-S-2) ──
@@ -43406,13 +43488,16 @@ function updateQLFeedDropdown() {
   }
 
   const q = query.toLowerCase();
-  const isVeg = getDietPref() === 'veg';
   let html = '';
   let totalMatches = 0;
 
   Object.entries(FOOD_SUGGESTIONS).forEach(([cat, items]) => {
-    if (isVeg && cat.includes('Non-Veg')) return;
-    const filtered = items.filter(f => f.toLowerCase().includes(q));
+    const isNonvegCat = cat.includes('Non-Veg');
+    let filtered = items.filter(f => f.toLowerCase().includes(q));
+    // Surfacing gate: within the non-veg category, keep only the items the preference
+    // surfaces (eggetarian → egg items only; pescatarian → egg + fish; veg → none, so the
+    // whole category drops out below). Per-item sid, since the list mixes egg/chicken/fish/meat.
+    if (isNonvegCat) filtered = filtered.filter(f => _dietAllowsNonvegSid(_dietNonvegSid(f)));
     if (filtered.length === 0) return;
     html += `<div class="meal-dd-cat">${cat}</div>`;
     filtered.slice(0, 8).forEach(food => {
@@ -68533,18 +68618,20 @@ function getUntriedSuggestions(n) {
   n = n || 5;
   const introduced = new Set((foods || []).map(f => f.name.toLowerCase().trim()));
   const ageM = ageAt().months;
-  // V-M-19 amendment: respect the user's diet preference. If settings has
-  // dietPref === 'veg', non-veg foods must not surface as "Foods to Try Next."
-  // A parent who set a dietary boundary expects the app to honor it everywhere.
-  const isVeg = (typeof getDietPref === 'function') && getDietPref() === 'veg';
+  // V-M-19 amendment: respect the user's diet preference — non-veg foods outside the
+  // preference must not surface as "Foods to Try Next." A parent who set a dietary boundary
+  // expects the app to honor it everywhere. (4-class gate: veg surfaces no nonveg sid;
+  // eggetarian only eggs; pescatarian eggs + fish; nonveg all.)
+  const hasGate = (typeof _dietAllowsNonvegSid === 'function');
 
   // Collect all taxonomy foods not yet introduced
   const candidates = [];
   _foodTaxFlat.forEach(item => {
     const key = item.key.toLowerCase().trim();
     if (introduced.has(key)) return;
-    // Diet-preference gate
-    if (isVeg && item.pid === 'nonveg') return;
+    // Diet-preference surfacing gate: a nonveg food surfaces only if its subcategory (sid)
+    // is in the current preference's allowed set.
+    if (item.pid === 'nonveg' && hasGate && !_dietAllowsNonvegSid(item.sid)) return;
     // Age gate: skip nuts for <8m (whole), skip honey for <12m
     if (key === 'honey' && ageM < 12) return;
     if (key === 'peanut' && ageM < 8) return;

--- a/index.html
+++ b/index.html
@@ -16711,7 +16711,7 @@ const AGE_RULES = {
   // green verdict AND no gate badge, the safest neutral state).
   'fish':     { minMonth:6, aliases:['finfish','rohu','katla','catla','pomfret','bhetki','bangda','indian mackerel','sardine','mathi','salmon','machhli','machli','fish curry','fish fry'],
                 reason:'Fine from around 6 months — well-cooked, deboned, low-mercury fish (salmon, sardine, bangda, rohu). Avoid high-mercury fish and remove every bone. A vegetarian diet can meet a baby\'s needs, so not giving fish is a valid choice.' },
-  'chicken':  { minMonth:7, reason:'Can introduce after 7 months as puree. Note: this family follows vegetarian diet.' },
+  'chicken':  { minMonth:7, reason:'Can introduce after 7 months as a smooth, well-cooked puree, then minced — never in chunks or coins (a choking risk).' },
   'egg':      { minMonth:7, reason:'Start with well-cooked yolk at 7+ months. White can be more allergenic.' },
   'egg yolk': { minMonth:7, reason:'Can introduce at 7+ months. Cook well. Give alone for 3 days first.' },
   'whole egg': { minMonth:8, reason:'Introduce after egg yolk is tolerated. Cook thoroughly.' },
@@ -24359,6 +24359,10 @@ const NONVEG_TOKEN_SID = {
 // "shellfish" does NOT match \bfish\b (shellfish is a separate concern, not gated here).
 function _dietNonvegSid(name) {
   const n = String(name || '').toLowerCase();
+  // First-match-wins (K-214-1): intentional and surfacing-safe. The nonveg-category items this
+  // gates are atomic (FOOD_TAX.nonveg keys are single-token: egg/chicken/fish/prawn/shrimp/mutton),
+  // so a multi-token dish never needs union classification here. Do NOT "fix" this to union without
+  // confirming the call path — a different path (not this surfacing gate) would care.
   for (const tok in NONVEG_TOKEN_SID) {
     if (new RegExp('\\b' + tok + '\\b').test(n)) return NONVEG_TOKEN_SID[tok];
   }
@@ -40220,10 +40224,17 @@ function checkFoodCombo() {
     return sid && !_dietAllowsNonvegSid(sid);
   });
   if (offPref.length > 0) {
-    if (verdict !== 'avoid') { verdict = 'caution'; verdictEmoji = zi('warn'); }  // never downgrade an acute-toxin/below-floor avoid
     const prefLabel = DIET_PREF_LABEL[getDietPref()] || 'vegetarian';
+    // M-214-1 (Maren, blocking): the verdict AND the headline overwrite are gated together —
+    // a soft preference note must never REPLACE an 'avoid' lead line. The toxin-avoid case is
+    // restored by the §8b headline block, but a below-age-floor 'avoid' carries no toxin, so an
+    // unconditional headline overwrite here would bury the hard age-safety reason under a soft
+    // "outside your preference" note (the 2 AM under-warn). The body warning still always surfaces.
+    if (verdict !== 'avoid') {
+      verdict = 'caution'; verdictEmoji = zi('warn');
+      headline = `Note: ${offPref.join(', ')} is outside Ziva\'s ${prefLabel} preference`;
+    }
     warnings.push(`Ziva's diet preference is ${prefLabel}. ${offPref.join(', ')} is outside it.`);
-    headline = `Note: ${offPref.join(', ')} is outside Ziva\'s ${prefLabel} preference`;
   }
 
   // ── 8b. food-effects headline (food-effects v2 §3.1, M-S-2) ──
@@ -68630,7 +68641,9 @@ function getUntriedSuggestions(n) {
     const key = item.key.toLowerCase().trim();
     if (introduced.has(key)) return;
     // Diet-preference surfacing gate: a nonveg food surfaces only if its subcategory (sid)
-    // is in the current preference's allowed set.
+    // is in the current preference's allowed set. hasGate is fail-OPEN by design (V-V-31): this is
+  // a RECOMMENDATION surface — a missed withhold shows one extra food (self-correcting), it never
+  // hides a safety signal. Fail-closed could falsely declare the taxonomy complete.
     if (item.pid === 'nonveg' && hasGate && !_dietAllowsNonvegSid(item.sid)) return;
     // Age gate: skip nuts for <8m (whole), skip honey for <12m
     if (key === 'honey' && ageM < 12) return;

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.02-14",
+  "version": "2026.06.02-16",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.02-16",
+  "version": "2026.06.02-20",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -4480,6 +4480,71 @@ function getDietPref() {
   return localStorage.getItem('ziva_diet_pref') || 'veg';
 }
 
+// ── Dietary-preference SURFACING GATE (4 classes; vegan deferred to its own spec) ──
+// The preference filters which foods are PROACTIVELY surfaced/recommended (the Library
+// grid + category modal, the meal-search dropdowns, the "Foods to Try Next" list, the
+// combo-checker preference note). It maps the stored `ziva_diet_pref` to the set of
+// FOOD_TAX `nonveg` subcategory ids (sids) it surfaces:
+//   veg          → none                     (today's default — lacto-vegetarian)
+//   eggetarian   → eggs                      (vegetarian + egg)
+//   pescatarian  → eggs + fish (seafood)     (vegetarian + egg + fish/seafood)
+//   nonveg       → eggs + poultry + fish + meat  (all)
+// SAFETY INVARIANT (load-bearing): this gate is SURFACING-ONLY. It must NEVER sit on the
+// consequence path — getFoodEffect / foodConsequenceCard / renderFoodDetailSheet / the combo
+// emergency floor are NOT gated. A food given despite the preference (a grandparent's spoonful)
+// must still surface its full safety record when logged. The gate hides SUGGESTIONS, never
+// SAFETY. (Vegan — which would additionally gate dairy + honey, foods currently classed veg —
+// is deferred to docs/specs/; the four classes here are all expressible from FOOD_TAX sids.)
+const DIET_PREF_NONVEG_SIDS = {
+  veg:         [],
+  eggetarian:  ['eggs'],
+  pescatarian: ['eggs', 'fish'],
+  nonveg:      ['eggs', 'poultry', 'fish', 'meat'],
+};
+const DIET_PREF_LABEL = {
+  veg:         'vegetarian',
+  eggetarian:  'eggetarian',
+  pescatarian: 'pescatarian (with egg)',
+  nonveg:      'non-vegetarian',
+};
+// Non-veg food token → FOOD_TAX subcategory id. A superset of FOOD_TAX.nonveg keys — adds the
+// synonyms the combo-checker sees (lamb/pork/beef → meat; crab → seafood) so the gate classifies
+// every animal food the app references from one source.
+const NONVEG_TOKEN_SID = {
+  egg: 'eggs',
+  chicken: 'poultry',
+  fish: 'fish', prawn: 'fish', shrimp: 'fish', crab: 'fish', seafood: 'fish',
+  mutton: 'meat', lamb: 'meat', pork: 'meat', beef: 'meat', meat: 'meat',
+};
+// Resolve a food NAME to its non-veg sid, or null if it is not a non-veg food. WORD-BOUNDARY
+// matched (not substring) so "Egg yolk"/"Chicken (puree)" classify but "eggplant" does NOT, and
+// "shellfish" does NOT match \bfish\b (shellfish is a separate concern, not gated here).
+function _dietNonvegSid(name) {
+  const n = String(name || '').toLowerCase();
+  for (const tok in NONVEG_TOKEN_SID) {
+    if (new RegExp('\\b' + tok + '\\b').test(n)) return NONVEG_TOKEN_SID[tok];
+  }
+  return null;
+}
+// Is a FOOD_TAX nonveg subcategory (sid) surfaced under the current preference?
+function _dietAllowsNonvegSid(sid) {
+  const allowed = DIET_PREF_NONVEG_SIDS[getDietPref()] || DIET_PREF_NONVEG_SIDS.veg;
+  return allowed.indexOf(sid) !== -1;
+}
+// Is a whole FOOD_TAX parent (pid) surfaced at all? Only 'nonveg' is preference-contingent for
+// the four non-vegan classes — every veg parent (grains/fruits/vegs/dairy/nuts/spices) is always
+// surfaced. (Vegan, which would gate dairy, is the deferred spec.)
+function _dietAllowsParent(pid) {
+  if (pid !== 'nonveg') return true;
+  return (DIET_PREF_NONVEG_SIDS[getDietPref()] || []).length > 0;
+}
+// Is a food NAME surfaced under the current preference? Veg foods (no nonveg sid) always pass;
+// a nonveg food passes iff its sid is in the preference's allowed set.
+function _dietAllowsFood(name) {
+  const sid = _dietNonvegSid(name);
+  return sid === null || _dietAllowsNonvegSid(sid);
+}
+
 function updateStorageUsage() {
   const MAX_BYTES = 5 * 1024 * 1024; // 5MB typical localStorage limit
 

--- a/split/core.js
+++ b/split/core.js
@@ -4521,6 +4521,10 @@ const NONVEG_TOKEN_SID = {
 // "shellfish" does NOT match \bfish\b (shellfish is a separate concern, not gated here).
 function _dietNonvegSid(name) {
   const n = String(name || '').toLowerCase();
+  // First-match-wins (K-214-1): intentional and surfacing-safe. The nonveg-category items this
+  // gates are atomic (FOOD_TAX.nonveg keys are single-token: egg/chicken/fish/prawn/shrimp/mutton),
+  // so a multi-token dish never needs union classification here. Do NOT "fix" this to union without
+  // confirming the call path — a different path (not this surfacing gate) would care.
   for (const tok in NONVEG_TOKEN_SID) {
     if (new RegExp('\\b' + tok + '\\b').test(n)) return NONVEG_TOKEN_SID[tok];
   }

--- a/split/data.js
+++ b/split/data.js
@@ -2451,7 +2451,7 @@ const AGE_RULES = {
   // green verdict AND no gate badge, the safest neutral state).
   'fish':     { minMonth:6, aliases:['finfish','rohu','katla','catla','pomfret','bhetki','bangda','indian mackerel','sardine','mathi','salmon','machhli','machli','fish curry','fish fry'],
                 reason:'Fine from around 6 months — well-cooked, deboned, low-mercury fish (salmon, sardine, bangda, rohu). Avoid high-mercury fish and remove every bone. A vegetarian diet can meet a baby\'s needs, so not giving fish is a valid choice.' },
-  'chicken':  { minMonth:7, reason:'Can introduce after 7 months as puree. Note: this family follows vegetarian diet.' },
+  'chicken':  { minMonth:7, reason:'Can introduce after 7 months as a smooth, well-cooked puree, then minced — never in chunks or coins (a choking risk).' },
   'egg':      { minMonth:7, reason:'Start with well-cooked yolk at 7+ months. White can be more allergenic.' },
   'egg yolk': { minMonth:7, reason:'Can introduce at 7+ months. Cook well. Give alone for 3 days first.' },
   'whole egg': { minMonth:8, reason:'Introduce after egg yolk is tolerated. Cook thoroughly.' },

--- a/split/diet.js
+++ b/split/diet.js
@@ -1817,10 +1817,17 @@ function checkFoodCombo() {
     return sid && !_dietAllowsNonvegSid(sid);
   });
   if (offPref.length > 0) {
-    if (verdict !== 'avoid') { verdict = 'caution'; verdictEmoji = zi('warn'); }  // never downgrade an acute-toxin/below-floor avoid
     const prefLabel = DIET_PREF_LABEL[getDietPref()] || 'vegetarian';
+    // M-214-1 (Maren, blocking): the verdict AND the headline overwrite are gated together —
+    // a soft preference note must never REPLACE an 'avoid' lead line. The toxin-avoid case is
+    // restored by the §8b headline block, but a below-age-floor 'avoid' carries no toxin, so an
+    // unconditional headline overwrite here would bury the hard age-safety reason under a soft
+    // "outside your preference" note (the 2 AM under-warn). The body warning still always surfaces.
+    if (verdict !== 'avoid') {
+      verdict = 'caution'; verdictEmoji = zi('warn');
+      headline = `Note: ${offPref.join(', ')} is outside Ziva\'s ${prefLabel} preference`;
+    }
     warnings.push(`Ziva's diet preference is ${prefLabel}. ${offPref.join(', ')} is outside it.`);
-    headline = `Note: ${offPref.join(', ')} is outside Ziva\'s ${prefLabel} preference`;
   }
 
   // ── 8b. food-effects headline (food-effects v2 §3.1, M-S-2) ──

--- a/split/diet.js
+++ b/split/diet.js
@@ -178,10 +178,11 @@ function renderFoods() {
   if (countEl) countEl.textContent = `${foods.length} foods`;
 
   const grouped = _categorizeFoods();
-  const isVeg = getDietPref() === 'veg';
-  const parentOrder = isVeg
-    ? ['grains','fruits','vegs','dairy','nuts','spices']
-    : ['grains','fruits','vegs','dairy','nuts','spices','nonveg'];
+  // Dietary-preference surfacing gate: show the nonveg parent only when the preference
+  // surfaces at least one nonveg subcategory (veg → no nonveg card; eggetarian/pescatarian/
+  // nonveg → shown, with only the surfaced subcategories counted below).
+  const parentOrder = ['grains','fruits','vegs','dairy','nuts','spices'];
+  if (_dietAllowsParent('nonveg')) parentOrder.push('nonveg');
 
   let html = '<div class="food-cats">';
 
@@ -190,6 +191,9 @@ function renderFoods() {
     const col = parent.color;
     let parentTotal = 0, parentCount = 0;
     Object.entries(parent.subs).forEach(([sid, sub]) => {
+      // Within nonveg, count only the subcategories the preference surfaces (so an
+      // eggetarian's card reads "of eggs", not "of egg+poultry+fish+meat").
+      if (pid === 'nonveg' && !_dietAllowsNonvegSid(sid)) return;
       parentTotal += sub.keys.length;
       parentCount += grouped[pid][sid].length;
     });
@@ -225,7 +229,9 @@ function openFoodCatModal(pid) {
 
   document.getElementById('foodCatModalTitle').innerHTML = `${parent.icon} ${parent.label}`;
 
-  const subIds = Object.keys(parent.subs);
+  // Surfacing gate: within nonveg, show only the subcategories the preference surfaces.
+  let subIds = Object.keys(parent.subs);
+  if (pid === 'nonveg') subIds = subIds.filter(sid => _dietAllowsNonvegSid(sid));
   const tabsEl = document.getElementById('foodCatModalTabs');
   tabsEl.style.background = _foodColorMap[col];
 
@@ -1802,12 +1808,19 @@ function checkFoodCombo() {
     else headline = 'Looks good for Ziva\'s age!';
   }
 
-  // Vegetarian check
-  const nonVeg = rawFoods.filter(f => ['chicken','fish','mutton','lamb','pork','prawn','shrimp','crab','meat'].includes(f));
-  if (nonVeg.length > 0) {
+  // Diet-preference note (4-class gate): flag only foods OUTSIDE the current preference —
+  // a pescatarian sees no note for fish, an eggetarian none for egg, a non-veg none at all.
+  // This is a preference note, NOT a safety gate: it never downgrades an acute-toxin/below-floor
+  // 'avoid', and the food's own consequence/allergen record still fires unchanged below.
+  const offPref = rawFoods.filter(f => {
+    const sid = _dietNonvegSid(f);
+    return sid && !_dietAllowsNonvegSid(sid);
+  });
+  if (offPref.length > 0) {
     if (verdict !== 'avoid') { verdict = 'caution'; verdictEmoji = zi('warn'); }  // never downgrade an acute-toxin/below-floor avoid
-    warnings.push(`Ziva follows a vegetarian diet. ${nonVeg.join(', ')} is non-vegetarian.`);
-    headline = `Note: ${nonVeg.join(', ')} is non-vegetarian — Ziva\'s diet is vegetarian`;
+    const prefLabel = DIET_PREF_LABEL[getDietPref()] || 'vegetarian';
+    warnings.push(`Ziva's diet preference is ${prefLabel}. ${offPref.join(', ')} is outside it.`);
+    headline = `Note: ${offPref.join(', ')} is outside Ziva\'s ${prefLabel} preference`;
   }
 
   // ── 8b. food-effects headline (food-effects v2 §3.1, M-S-2) ──
@@ -5072,13 +5085,16 @@ function updateQLFeedDropdown() {
   }
 
   const q = query.toLowerCase();
-  const isVeg = getDietPref() === 'veg';
   let html = '';
   let totalMatches = 0;
 
   Object.entries(FOOD_SUGGESTIONS).forEach(([cat, items]) => {
-    if (isVeg && cat.includes('Non-Veg')) return;
-    const filtered = items.filter(f => f.toLowerCase().includes(q));
+    const isNonvegCat = cat.includes('Non-Veg');
+    let filtered = items.filter(f => f.toLowerCase().includes(q));
+    // Surfacing gate: within the non-veg category, keep only the items the preference
+    // surfaces (eggetarian → egg items only; pescatarian → egg + fish; veg → none, so the
+    // whole category drops out below). Per-item sid, since the list mixes egg/chicken/fish/meat.
+    if (isNonvegCat) filtered = filtered.filter(f => _dietAllowsNonvegSid(_dietNonvegSid(f)));
     if (filtered.length === 0) return;
     html += `<div class="meal-dd-cat">${cat}</div>`;
     filtered.slice(0, 8).forEach(food => {

--- a/split/home.js
+++ b/split/home.js
@@ -5072,12 +5072,14 @@ function showMealDropdown(meal, query) {
   const q = query.toLowerCase();
   let html = '';
   let totalMatches = 0;
-  const isVeg = getDietPref() === 'veg';
 
   Object.entries(FOOD_SUGGESTIONS).forEach(([cat, items]) => {
-    // Hide non-veg category when diet pref is vegetarian
-    if (isVeg && cat.includes('Non-Veg')) return;
-    const filtered = items.filter(f => f.toLowerCase().includes(q));
+    // Surfacing gate (4-class diet preference): within the non-veg category keep only the
+    // items the preference surfaces — eggetarian → egg only, pescatarian → egg + fish, veg →
+    // none (category drops out). Per-item sid, since the list mixes egg/chicken/fish/meat.
+    const isNonvegCat = cat.includes('Non-Veg');
+    let filtered = items.filter(f => f.toLowerCase().includes(q));
+    if (isNonvegCat) filtered = filtered.filter(f => _dietAllowsNonvegSid(_dietNonvegSid(f)));
     if (filtered.length === 0) return;
     html += `<div class="meal-dd-cat">${cat}</div>`;
     filtered.forEach(food => {

--- a/split/intelligence-quicklog.js
+++ b/split/intelligence-quicklog.js
@@ -4013,7 +4013,9 @@ function getUntriedSuggestions(n) {
     const key = item.key.toLowerCase().trim();
     if (introduced.has(key)) return;
     // Diet-preference surfacing gate: a nonveg food surfaces only if its subcategory (sid)
-    // is in the current preference's allowed set.
+    // is in the current preference's allowed set. hasGate is fail-OPEN by design (V-V-31): this is
+  // a RECOMMENDATION surface — a missed withhold shows one extra food (self-correcting), it never
+  // hides a safety signal. Fail-closed could falsely declare the taxonomy complete.
     if (item.pid === 'nonveg' && hasGate && !_dietAllowsNonvegSid(item.sid)) return;
     // Age gate: skip nuts for <8m (whole), skip honey for <12m
     if (key === 'honey' && ageM < 12) return;

--- a/split/intelligence-quicklog.js
+++ b/split/intelligence-quicklog.js
@@ -4001,18 +4001,20 @@ function getUntriedSuggestions(n) {
   n = n || 5;
   const introduced = new Set((foods || []).map(f => f.name.toLowerCase().trim()));
   const ageM = ageAt().months;
-  // V-M-19 amendment: respect the user's diet preference. If settings has
-  // dietPref === 'veg', non-veg foods must not surface as "Foods to Try Next."
-  // A parent who set a dietary boundary expects the app to honor it everywhere.
-  const isVeg = (typeof getDietPref === 'function') && getDietPref() === 'veg';
+  // V-M-19 amendment: respect the user's diet preference — non-veg foods outside the
+  // preference must not surface as "Foods to Try Next." A parent who set a dietary boundary
+  // expects the app to honor it everywhere. (4-class gate: veg surfaces no nonveg sid;
+  // eggetarian only eggs; pescatarian eggs + fish; nonveg all.)
+  const hasGate = (typeof _dietAllowsNonvegSid === 'function');
 
   // Collect all taxonomy foods not yet introduced
   const candidates = [];
   _foodTaxFlat.forEach(item => {
     const key = item.key.toLowerCase().trim();
     if (introduced.has(key)) return;
-    // Diet-preference gate
-    if (isVeg && item.pid === 'nonveg') return;
+    // Diet-preference surfacing gate: a nonveg food surfaces only if its subcategory (sid)
+    // is in the current preference's allowed set.
+    if (item.pid === 'nonveg' && hasGate && !_dietAllowsNonvegSid(item.sid)) return;
     // Age gate: skip nuts for <8m (whole), skip honey for <12m
     if (key === 'honey' && ageM < 12) return;
     if (key === 'peanut' && ageM < 8) return;

--- a/split/template.html
+++ b/split/template.html
@@ -2890,6 +2890,8 @@
               </div>
               <select id="settingsDietPref" onchange="saveDietPref()" style="padding:6px 10px;border-radius:var(--r-lg);border:1.5px solid var(--peach-light);font-family:'Nunito',sans-serif;font-size:var(--fs-base);background:var(--card-bg);color:var(--text);outline:none;">
                 <option value="veg">Vegetarian</option>
+                <option value="eggetarian">Eggetarian (veg + egg)</option>
+                <option value="pescatarian">Pescatarian (veg + egg + seafood)</option>
                 <option value="nonveg">Non-Vegetarian</option>
               </select>
             </div>

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -13733,6 +13733,8 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
               </div>
               <select id="settingsDietPref" onchange="saveDietPref()" style="padding:6px 10px;border-radius:var(--r-lg);border:1.5px solid var(--peach-light);font-family:'Nunito',sans-serif;font-size:var(--fs-base);background:var(--card-bg);color:var(--text);outline:none;">
                 <option value="veg">Vegetarian</option>
+                <option value="eggetarian">Eggetarian (veg + egg)</option>
+                <option value="pescatarian">Pescatarian (veg + egg + seafood)</option>
                 <option value="nonveg">Non-Vegetarian</option>
               </select>
             </div>
@@ -24316,6 +24318,71 @@ function getDietPref() {
   return localStorage.getItem('ziva_diet_pref') || 'veg';
 }
 
+// ── Dietary-preference SURFACING GATE (4 classes; vegan deferred to its own spec) ──
+// The preference filters which foods are PROACTIVELY surfaced/recommended (the Library
+// grid + category modal, the meal-search dropdowns, the "Foods to Try Next" list, the
+// combo-checker preference note). It maps the stored `ziva_diet_pref` to the set of
+// FOOD_TAX `nonveg` subcategory ids (sids) it surfaces:
+//   veg          → none                     (today's default — lacto-vegetarian)
+//   eggetarian   → eggs                      (vegetarian + egg)
+//   pescatarian  → eggs + fish (seafood)     (vegetarian + egg + fish/seafood)
+//   nonveg       → eggs + poultry + fish + meat  (all)
+// SAFETY INVARIANT (load-bearing): this gate is SURFACING-ONLY. It must NEVER sit on the
+// consequence path — getFoodEffect / foodConsequenceCard / renderFoodDetailSheet / the combo
+// emergency floor are NOT gated. A food given despite the preference (a grandparent's spoonful)
+// must still surface its full safety record when logged. The gate hides SUGGESTIONS, never
+// SAFETY. (Vegan — which would additionally gate dairy + honey, foods currently classed veg —
+// is deferred to docs/specs/; the four classes here are all expressible from FOOD_TAX sids.)
+const DIET_PREF_NONVEG_SIDS = {
+  veg:         [],
+  eggetarian:  ['eggs'],
+  pescatarian: ['eggs', 'fish'],
+  nonveg:      ['eggs', 'poultry', 'fish', 'meat'],
+};
+const DIET_PREF_LABEL = {
+  veg:         'vegetarian',
+  eggetarian:  'eggetarian',
+  pescatarian: 'pescatarian (with egg)',
+  nonveg:      'non-vegetarian',
+};
+// Non-veg food token → FOOD_TAX subcategory id. A superset of FOOD_TAX.nonveg keys — adds the
+// synonyms the combo-checker sees (lamb/pork/beef → meat; crab → seafood) so the gate classifies
+// every animal food the app references from one source.
+const NONVEG_TOKEN_SID = {
+  egg: 'eggs',
+  chicken: 'poultry',
+  fish: 'fish', prawn: 'fish', shrimp: 'fish', crab: 'fish', seafood: 'fish',
+  mutton: 'meat', lamb: 'meat', pork: 'meat', beef: 'meat', meat: 'meat',
+};
+// Resolve a food NAME to its non-veg sid, or null if it is not a non-veg food. WORD-BOUNDARY
+// matched (not substring) so "Egg yolk"/"Chicken (puree)" classify but "eggplant" does NOT, and
+// "shellfish" does NOT match \bfish\b (shellfish is a separate concern, not gated here).
+function _dietNonvegSid(name) {
+  const n = String(name || '').toLowerCase();
+  for (const tok in NONVEG_TOKEN_SID) {
+    if (new RegExp('\\b' + tok + '\\b').test(n)) return NONVEG_TOKEN_SID[tok];
+  }
+  return null;
+}
+// Is a FOOD_TAX nonveg subcategory (sid) surfaced under the current preference?
+function _dietAllowsNonvegSid(sid) {
+  const allowed = DIET_PREF_NONVEG_SIDS[getDietPref()] || DIET_PREF_NONVEG_SIDS.veg;
+  return allowed.indexOf(sid) !== -1;
+}
+// Is a whole FOOD_TAX parent (pid) surfaced at all? Only 'nonveg' is preference-contingent for
+// the four non-vegan classes — every veg parent (grains/fruits/vegs/dairy/nuts/spices) is always
+// surfaced. (Vegan, which would gate dairy, is the deferred spec.)
+function _dietAllowsParent(pid) {
+  if (pid !== 'nonveg') return true;
+  return (DIET_PREF_NONVEG_SIDS[getDietPref()] || []).length > 0;
+}
+// Is a food NAME surfaced under the current preference? Veg foods (no nonveg sid) always pass;
+// a nonveg food passes iff its sid is in the preference's allowed set.
+function _dietAllowsFood(name) {
+  const sid = _dietNonvegSid(name);
+  return sid === null || _dietAllowsNonvegSid(sid);
+}
+
 function updateStorageUsage() {
   const MAX_BYTES = 5 * 1024 * 1024; // 5MB typical localStorage limit
 
@@ -32055,12 +32122,14 @@ function showMealDropdown(meal, query) {
   const q = query.toLowerCase();
   let html = '';
   let totalMatches = 0;
-  const isVeg = getDietPref() === 'veg';
 
   Object.entries(FOOD_SUGGESTIONS).forEach(([cat, items]) => {
-    // Hide non-veg category when diet pref is vegetarian
-    if (isVeg && cat.includes('Non-Veg')) return;
-    const filtered = items.filter(f => f.toLowerCase().includes(q));
+    // Surfacing gate (4-class diet preference): within the non-veg category keep only the
+    // items the preference surfaces — eggetarian → egg only, pescatarian → egg + fish, veg →
+    // none (category drops out). Per-item sid, since the list mixes egg/chicken/fish/meat.
+    const isNonvegCat = cat.includes('Non-Veg');
+    let filtered = items.filter(f => f.toLowerCase().includes(q));
+    if (isNonvegCat) filtered = filtered.filter(f => _dietAllowsNonvegSid(_dietNonvegSid(f)));
     if (filtered.length === 0) return;
     html += `<div class="meal-dd-cat">${cat}</div>`;
     filtered.forEach(food => {
@@ -38512,10 +38581,11 @@ function renderFoods() {
   if (countEl) countEl.textContent = `${foods.length} foods`;
 
   const grouped = _categorizeFoods();
-  const isVeg = getDietPref() === 'veg';
-  const parentOrder = isVeg
-    ? ['grains','fruits','vegs','dairy','nuts','spices']
-    : ['grains','fruits','vegs','dairy','nuts','spices','nonveg'];
+  // Dietary-preference surfacing gate: show the nonveg parent only when the preference
+  // surfaces at least one nonveg subcategory (veg → no nonveg card; eggetarian/pescatarian/
+  // nonveg → shown, with only the surfaced subcategories counted below).
+  const parentOrder = ['grains','fruits','vegs','dairy','nuts','spices'];
+  if (_dietAllowsParent('nonveg')) parentOrder.push('nonveg');
 
   let html = '<div class="food-cats">';
 
@@ -38524,6 +38594,9 @@ function renderFoods() {
     const col = parent.color;
     let parentTotal = 0, parentCount = 0;
     Object.entries(parent.subs).forEach(([sid, sub]) => {
+      // Within nonveg, count only the subcategories the preference surfaces (so an
+      // eggetarian's card reads "of eggs", not "of egg+poultry+fish+meat").
+      if (pid === 'nonveg' && !_dietAllowsNonvegSid(sid)) return;
       parentTotal += sub.keys.length;
       parentCount += grouped[pid][sid].length;
     });
@@ -38559,7 +38632,9 @@ function openFoodCatModal(pid) {
 
   document.getElementById('foodCatModalTitle').innerHTML = `${parent.icon} ${parent.label}`;
 
-  const subIds = Object.keys(parent.subs);
+  // Surfacing gate: within nonveg, show only the subcategories the preference surfaces.
+  let subIds = Object.keys(parent.subs);
+  if (pid === 'nonveg') subIds = subIds.filter(sid => _dietAllowsNonvegSid(sid));
   const tabsEl = document.getElementById('foodCatModalTabs');
   tabsEl.style.background = _foodColorMap[col];
 
@@ -40136,12 +40211,19 @@ function checkFoodCombo() {
     else headline = 'Looks good for Ziva\'s age!';
   }
 
-  // Vegetarian check
-  const nonVeg = rawFoods.filter(f => ['chicken','fish','mutton','lamb','pork','prawn','shrimp','crab','meat'].includes(f));
-  if (nonVeg.length > 0) {
+  // Diet-preference note (4-class gate): flag only foods OUTSIDE the current preference —
+  // a pescatarian sees no note for fish, an eggetarian none for egg, a non-veg none at all.
+  // This is a preference note, NOT a safety gate: it never downgrades an acute-toxin/below-floor
+  // 'avoid', and the food's own consequence/allergen record still fires unchanged below.
+  const offPref = rawFoods.filter(f => {
+    const sid = _dietNonvegSid(f);
+    return sid && !_dietAllowsNonvegSid(sid);
+  });
+  if (offPref.length > 0) {
     if (verdict !== 'avoid') { verdict = 'caution'; verdictEmoji = zi('warn'); }  // never downgrade an acute-toxin/below-floor avoid
-    warnings.push(`Ziva follows a vegetarian diet. ${nonVeg.join(', ')} is non-vegetarian.`);
-    headline = `Note: ${nonVeg.join(', ')} is non-vegetarian — Ziva\'s diet is vegetarian`;
+    const prefLabel = DIET_PREF_LABEL[getDietPref()] || 'vegetarian';
+    warnings.push(`Ziva's diet preference is ${prefLabel}. ${offPref.join(', ')} is outside it.`);
+    headline = `Note: ${offPref.join(', ')} is outside Ziva\'s ${prefLabel} preference`;
   }
 
   // ── 8b. food-effects headline (food-effects v2 §3.1, M-S-2) ──
@@ -43406,13 +43488,16 @@ function updateQLFeedDropdown() {
   }
 
   const q = query.toLowerCase();
-  const isVeg = getDietPref() === 'veg';
   let html = '';
   let totalMatches = 0;
 
   Object.entries(FOOD_SUGGESTIONS).forEach(([cat, items]) => {
-    if (isVeg && cat.includes('Non-Veg')) return;
-    const filtered = items.filter(f => f.toLowerCase().includes(q));
+    const isNonvegCat = cat.includes('Non-Veg');
+    let filtered = items.filter(f => f.toLowerCase().includes(q));
+    // Surfacing gate: within the non-veg category, keep only the items the preference
+    // surfaces (eggetarian → egg items only; pescatarian → egg + fish; veg → none, so the
+    // whole category drops out below). Per-item sid, since the list mixes egg/chicken/fish/meat.
+    if (isNonvegCat) filtered = filtered.filter(f => _dietAllowsNonvegSid(_dietNonvegSid(f)));
     if (filtered.length === 0) return;
     html += `<div class="meal-dd-cat">${cat}</div>`;
     filtered.slice(0, 8).forEach(food => {
@@ -68533,18 +68618,20 @@ function getUntriedSuggestions(n) {
   n = n || 5;
   const introduced = new Set((foods || []).map(f => f.name.toLowerCase().trim()));
   const ageM = ageAt().months;
-  // V-M-19 amendment: respect the user's diet preference. If settings has
-  // dietPref === 'veg', non-veg foods must not surface as "Foods to Try Next."
-  // A parent who set a dietary boundary expects the app to honor it everywhere.
-  const isVeg = (typeof getDietPref === 'function') && getDietPref() === 'veg';
+  // V-M-19 amendment: respect the user's diet preference — non-veg foods outside the
+  // preference must not surface as "Foods to Try Next." A parent who set a dietary boundary
+  // expects the app to honor it everywhere. (4-class gate: veg surfaces no nonveg sid;
+  // eggetarian only eggs; pescatarian eggs + fish; nonveg all.)
+  const hasGate = (typeof _dietAllowsNonvegSid === 'function');
 
   // Collect all taxonomy foods not yet introduced
   const candidates = [];
   _foodTaxFlat.forEach(item => {
     const key = item.key.toLowerCase().trim();
     if (introduced.has(key)) return;
-    // Diet-preference gate
-    if (isVeg && item.pid === 'nonveg') return;
+    // Diet-preference surfacing gate: a nonveg food surfaces only if its subcategory (sid)
+    // is in the current preference's allowed set.
+    if (item.pid === 'nonveg' && hasGate && !_dietAllowsNonvegSid(item.sid)) return;
     // Age gate: skip nuts for <8m (whole), skip honey for <12m
     if (key === 'honey' && ageM < 12) return;
     if (key === 'peanut' && ageM < 8) return;

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -16711,7 +16711,7 @@ const AGE_RULES = {
   // green verdict AND no gate badge, the safest neutral state).
   'fish':     { minMonth:6, aliases:['finfish','rohu','katla','catla','pomfret','bhetki','bangda','indian mackerel','sardine','mathi','salmon','machhli','machli','fish curry','fish fry'],
                 reason:'Fine from around 6 months — well-cooked, deboned, low-mercury fish (salmon, sardine, bangda, rohu). Avoid high-mercury fish and remove every bone. A vegetarian diet can meet a baby\'s needs, so not giving fish is a valid choice.' },
-  'chicken':  { minMonth:7, reason:'Can introduce after 7 months as puree. Note: this family follows vegetarian diet.' },
+  'chicken':  { minMonth:7, reason:'Can introduce after 7 months as a smooth, well-cooked puree, then minced — never in chunks or coins (a choking risk).' },
   'egg':      { minMonth:7, reason:'Start with well-cooked yolk at 7+ months. White can be more allergenic.' },
   'egg yolk': { minMonth:7, reason:'Can introduce at 7+ months. Cook well. Give alone for 3 days first.' },
   'whole egg': { minMonth:8, reason:'Introduce after egg yolk is tolerated. Cook thoroughly.' },
@@ -24359,6 +24359,10 @@ const NONVEG_TOKEN_SID = {
 // "shellfish" does NOT match \bfish\b (shellfish is a separate concern, not gated here).
 function _dietNonvegSid(name) {
   const n = String(name || '').toLowerCase();
+  // First-match-wins (K-214-1): intentional and surfacing-safe. The nonveg-category items this
+  // gates are atomic (FOOD_TAX.nonveg keys are single-token: egg/chicken/fish/prawn/shrimp/mutton),
+  // so a multi-token dish never needs union classification here. Do NOT "fix" this to union without
+  // confirming the call path — a different path (not this surfacing gate) would care.
   for (const tok in NONVEG_TOKEN_SID) {
     if (new RegExp('\\b' + tok + '\\b').test(n)) return NONVEG_TOKEN_SID[tok];
   }
@@ -40220,10 +40224,17 @@ function checkFoodCombo() {
     return sid && !_dietAllowsNonvegSid(sid);
   });
   if (offPref.length > 0) {
-    if (verdict !== 'avoid') { verdict = 'caution'; verdictEmoji = zi('warn'); }  // never downgrade an acute-toxin/below-floor avoid
     const prefLabel = DIET_PREF_LABEL[getDietPref()] || 'vegetarian';
+    // M-214-1 (Maren, blocking): the verdict AND the headline overwrite are gated together —
+    // a soft preference note must never REPLACE an 'avoid' lead line. The toxin-avoid case is
+    // restored by the §8b headline block, but a below-age-floor 'avoid' carries no toxin, so an
+    // unconditional headline overwrite here would bury the hard age-safety reason under a soft
+    // "outside your preference" note (the 2 AM under-warn). The body warning still always surfaces.
+    if (verdict !== 'avoid') {
+      verdict = 'caution'; verdictEmoji = zi('warn');
+      headline = `Note: ${offPref.join(', ')} is outside Ziva\'s ${prefLabel} preference`;
+    }
     warnings.push(`Ziva's diet preference is ${prefLabel}. ${offPref.join(', ')} is outside it.`);
-    headline = `Note: ${offPref.join(', ')} is outside Ziva\'s ${prefLabel} preference`;
   }
 
   // ── 8b. food-effects headline (food-effects v2 §3.1, M-S-2) ──
@@ -68630,7 +68641,9 @@ function getUntriedSuggestions(n) {
     const key = item.key.toLowerCase().trim();
     if (introduced.has(key)) return;
     // Diet-preference surfacing gate: a nonveg food surfaces only if its subcategory (sid)
-    // is in the current preference's allowed set.
+    // is in the current preference's allowed set. hasGate is fail-OPEN by design (V-V-31): this is
+  // a RECOMMENDATION surface — a missed withhold shows one extra food (self-correcting), it never
+  // hides a safety signal. Fail-closed could falsely declare the taxonomy complete.
     if (item.pid === 'nonveg' && hasGate && !_dietAllowsNonvegSid(item.sid)) return;
     // Age gate: skip nuts for <8m (whole), skip honey for <12m
     if (key === 'honey' && ageM < 12) return;

--- a/tests/e2e/diet-preference-gate.spec.ts
+++ b/tests/e2e/diet-preference-gate.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect } from '@playwright/test';
+
+// Dietary-preference SURFACING GATE — the 4-class gate (veg / eggetarian / pescatarian / nonveg).
+// vegan is deferred to its own spec (it would additionally gate dairy + honey).
+//
+// The gate filters which foods are PROACTIVELY SURFACED (the Library food grid + category modal,
+// the meal-search dropdowns, the "Foods to Try Next" list, the combo-checker preference note).
+//   veg          → no non-veg surfaced
+//   eggetarian   → egg only
+//   pescatarian  → egg + fish/seafood
+//   nonveg       → all (egg + poultry + fish + meat)
+//
+// LOAD-BEARING SAFETY INVARIANT: the gate is SURFACING-ONLY. It must NEVER sit on the
+// consequence path — a food given despite the preference (a grandparent's spoonful) must still
+// surface its full safety record when logged. The last test pins this.
+
+declare const getDietPref: () => string;
+declare const _dietAllowsFood: (name: string) => boolean;
+declare const _dietAllowsNonvegSid: (sid: string) => boolean;
+declare const _dietNonvegSid: (name: string) => string | null;
+declare const getUntriedSuggestions: (n: number) => any[];
+declare const renderFoods: () => void;
+declare const getFoodEffect: (name: string) => any;
+declare const renderFoodDetailSheet: (name: string) => void;
+
+const setPref = (page: any, pref: string) =>
+  page.evaluate((p: string) => localStorage.setItem('ziva_diet_pref', p), pref);
+
+test.describe('dietary-preference surfacing gate (4-class)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/index.html?nosync');
+    await page.waitForFunction(() =>
+      typeof (window as any)._dietAllowsFood === 'function'
+      && typeof (window as any).getUntriedSuggestions === 'function'
+      && typeof (window as any).getFoodEffect === 'function', null, { timeout: 10_000 });
+  });
+
+  // ── the gate's single source of truth: the helper contract per preference ──
+  test('the gate helper surfaces exactly the right non-veg groups per preference', async ({ page }) => {
+    const r = await page.evaluate(() => {
+      const out: Record<string, string[]> = {};
+      const probes = ['egg', 'chicken', 'fish', 'prawn', 'crab', 'mutton', 'beef'];
+      for (const pref of ['veg', 'eggetarian', 'pescatarian', 'nonveg']) {
+        localStorage.setItem('ziva_diet_pref', pref);
+        out[pref] = probes.filter(n => _dietAllowsFood(n));
+      }
+      return out;
+    });
+    expect(r.veg).toEqual([]);                                   // no non-veg
+    expect(r.eggetarian).toEqual(['egg']);                       // egg only
+    expect(r.pescatarian.sort()).toEqual(['crab', 'egg', 'fish', 'prawn']); // egg + seafood
+    expect(r.nonveg.sort()).toEqual(['beef', 'chicken', 'crab', 'egg', 'fish', 'mutton', 'prawn']); // all
+  });
+
+  // ── classification safety: word-boundary, not substring ──
+  test('classification is word-boundary safe (eggplant is veg; shellfish is not gated as fish)', async ({ page }) => {
+    const r = await page.evaluate(() => ({
+      eggYolk: _dietNonvegSid('Egg yolk'),
+      eggplant: _dietNonvegSid('eggplant'),       // must NOT be classed as egg
+      shellfish: _dietNonvegSid('shellfish'),     // \bfish\b must not match shellfish
+      chicken: _dietNonvegSid('Chicken (puree)'),
+      paneer: _dietNonvegSid('paneer'),
+    }));
+    expect(r.eggYolk).toBe('eggs');
+    expect(r.eggplant).toBeNull();
+    expect(r.shellfish).toBeNull();
+    expect(r.chicken).toBe('poultry');
+    expect(r.paneer).toBeNull();
+  });
+
+  // ── veg foods are ALWAYS surfaced, every preference (the gate only touches non-veg) ──
+  test('veg foods are surfaced under every preference', async ({ page }) => {
+    const r = await page.evaluate(() => {
+      const vegFoods = ['paneer', 'banana', 'spinach', 'eggplant', 'ragi', 'curd'];
+      const ok: Record<string, boolean> = {};
+      for (const pref of ['veg', 'eggetarian', 'pescatarian', 'nonveg']) {
+        localStorage.setItem('ziva_diet_pref', pref);
+        ok[pref] = vegFoods.every(f => _dietAllowsFood(f));
+      }
+      return ok;
+    });
+    for (const pref of ['veg', 'eggetarian', 'pescatarian', 'nonveg']) {
+      expect(r[pref], `veg foods surfaced under ${pref}`).toBe(true);
+    }
+  });
+
+  // ── Foods to Try Next honours the preference (the proactive recommendation surface) ──
+  test('"Foods to Try Next" never recommends an off-preference food', async ({ page }) => {
+    const r = await page.evaluate(() => {
+      const out: Record<string, string[]> = {};
+      for (const pref of ['veg', 'eggetarian', 'pescatarian', 'nonveg']) {
+        localStorage.setItem('ziva_diet_pref', pref);
+        const sugg = getUntriedSuggestions(60) || [];
+        // any suggested food whose non-veg sid is NOT allowed under this pref = a leak
+        out[pref] = sugg.map((s: any) => (s && (s.key || s.name || s)))
+          .filter((n: any) => typeof n === 'string')
+          .filter((n: string) => { const sid = _dietNonvegSid(n); return sid && !_dietAllowsNonvegSid(sid); });
+      }
+      return out;
+    });
+    expect(r.veg, 'veg sees no non-veg suggestion').toEqual([]);
+    expect(r.eggetarian, 'eggetarian sees no fish/poultry/meat suggestion').toEqual([]);
+    expect(r.pescatarian, 'pescatarian sees no poultry/meat suggestion').toEqual([]);
+    expect(r.nonveg, 'non-veg has no off-preference foods').toEqual([]);
+  });
+
+  // ── the Library food grid: the Non-Veg category card appears only when surfaced ──
+  test('the Library Non-Veg category card is hidden for veg, shown for non-veg', async ({ page }) => {
+    const veg = await page.evaluate(() => {
+      localStorage.setItem('ziva_diet_pref', 'veg');
+      renderFoods();
+      return !!document.querySelector('#foodsGrid [data-action="openFoodCatModal"][data-arg="nonveg"]');
+    });
+    const nonveg = await page.evaluate(() => {
+      localStorage.setItem('ziva_diet_pref', 'nonveg');
+      renderFoods();
+      return !!document.querySelector('#foodsGrid [data-action="openFoodCatModal"][data-arg="nonveg"]');
+    });
+    expect(veg, 'veg: no Non-Veg category card').toBe(false);
+    expect(nonveg, 'non-veg: Non-Veg category card present').toBe(true);
+  });
+
+  // ── THE SAFETY INVARIANT: the gate is surfacing-only; the consequence path is NEVER gated ──
+  test('a food OUTSIDE the preference still fires its full safety record when logged (veg + fish)', async ({ page }) => {
+    const r = await page.evaluate(() => {
+      localStorage.setItem('ziva_diet_pref', 'veg');  // fish is NOT surfaced to a vegetarian...
+      // ...but if it is logged anyway, the consequence path must be untouched:
+      const eff = getFoodEffect('fish');
+      renderFoodDetailSheet('fish');
+      const el = document.getElementById('foodDetailBody')!;
+      return {
+        surfaced: _dietAllowsFood('fish'),           // gate says: do not proactively surface
+        effResolves: !!eff,                          // consequence resolver: still resolves
+        severeFloor: el.querySelectorAll('.cons-severe').length,  // safety floor: still renders
+        seekCare: el.querySelectorAll('.cons-seek').length,
+      };
+    });
+    expect(r.surfaced, 'fish is NOT proactively surfaced to a vegetarian').toBe(false);
+    expect(r.effResolves, 'but getFoodEffect still resolves fish (consequence path ungated)').toBe(true);
+    expect(r.severeFloor, 'and the anaphylaxis/safety floor still renders on the detail sheet').toBeGreaterThan(0);
+    expect(r.seekCare).toBeGreaterThan(0);
+  });
+});

--- a/tests/e2e/diet-preference-gate.spec.ts
+++ b/tests/e2e/diet-preference-gate.spec.ts
@@ -22,6 +22,7 @@ declare const getUntriedSuggestions: (n: number) => any[];
 declare const renderFoods: () => void;
 declare const getFoodEffect: (name: string) => any;
 declare const renderFoodDetailSheet: (name: string) => void;
+declare const checkFoodCombo: () => void;
 
 const setPref = (page: any, pref: string) =>
   page.evaluate((p: string) => localStorage.setItem('ziva_diet_pref', p), pref);
@@ -139,5 +140,28 @@ test.describe('dietary-preference surfacing gate (4-class)', () => {
     expect(r.effResolves, 'but getFoodEffect still resolves fish (consequence path ungated)').toBe(true);
     expect(r.severeFloor, 'and the anaphylaxis/safety floor still renders on the detail sheet').toBeGreaterThan(0);
     expect(r.seekCare).toBeGreaterThan(0);
+  });
+
+  // ── M-214-1 (Maren, blocking → fixed): the preference note must NEVER replace an 'avoid'
+  // headline. An off-preference food that is ALSO below its age floor must keep the hard
+  // age-safety reason as the lead line; the soft preference note drops to the body. ──
+  test('M-214-1: an off-preference + below-age-floor combo keeps the AGE reason as the headline', async ({ page }) => {
+    const r = await page.evaluate(() => {
+      localStorage.setItem('ziva_diet_pref', 'veg');   // chicken is off-preference...
+      const input = document.getElementById('comboInput') as HTMLInputElement;
+      input.value = 'salt + chicken';                  // ...and salt is a below-floor (12mo) NON-toxin avoid
+      checkFoodCombo();
+      const el = document.getElementById('comboResult')!;
+      return {
+        verdictAvoid: !!el.querySelector('.combo-result.avoid'),
+        headline: (el.querySelector('.combo-verdict')?.textContent || '').toLowerCase(),
+        bodyText: (el.textContent || '').toLowerCase(),
+      };
+    });
+    expect(r.verdictAvoid, 'the verdict is still avoid (salt below its age floor)').toBe(true);
+    // the LEAD line must NOT be hijacked by the soft preference note...
+    expect(r.headline).not.toMatch(/outside.*preference|preference/);
+    // ...yet the preference note still surfaces in the body (never silently dropped).
+    expect(r.bodyText, 'the off-preference note still appears in the body').toMatch(/outside it|preference/);
   });
 });


### PR DESCRIPTION
## A preference gate for what's *surfaced* — never for what's *safe*

Generalizes the binary veg/non-veg filter into a **four-class surfacing gate** so the app stops surfacing the wrong food to the wrong preference set. Vegan is **deferred to a spec** (it's the genuinely hard class — see below).

| Preference | surfaces |
|---|---|
| Vegetarian (lacto) | no non-veg |
| **Eggetarian** | egg only |
| **Pescatarian (+egg)** | egg + fish/seafood |
| Non-veg | all (egg + poultry + fish + meat) |

### The load-bearing safety invariant
The gate is **surfacing-only**. It filters the *proactive* surfaces (Library food grid + category modal, both meal-search dropdowns, "Foods to Try Next", the combo-checker note) — and it **never touches the consequence path**. A food given despite the preference (a grandparent's spoonful of fish) still fires its **full safety record** when logged. The gate hides *suggestions*, never *safety*. An e2e test pins this directly (veg + fish: not surfaced, but `getFoodEffect` resolves and the detail-sheet floor still renders).

### What landed
- **`split/core.js`** — one source of truth: `DIET_PREF_NONVEG_SIDS` (preference → allowed `FOOD_TAX` non-veg `sid`s) + `DIET_PREF_LABEL` + `NONVEG_TOKEN_SID`, and the helpers `_dietNonvegSid` (**word-boundary** classified — `'Egg yolk'`→eggs but `'eggplant'`→null, `'shellfish'`→null), `_dietAllowsNonvegSid` / `_dietAllowsParent` / `_dietAllowsFood`.
- **`split/template.html`** — settings dropdown gains Eggetarian + Pescatarian. *(shared module → triple-Gov.)*
- **`split/diet.js`** — `renderFoods` (non-veg parent shown + counted by allowed sids only), `openFoodCatModal` (only surfaced sub-tabs), `showMealDropdown` (per-item sid gate on the flat non-veg category), and the combo-checker note generalized to the current preference (still **never downgrades an acute `avoid`**).
- **`split/home.js`** — `showMealDropdown` twin.
- **`split/intelligence-quicklog.js`** — Foods-to-Try gated by `item.sid`.

### Deferred — `docs/specs/diet-preference-gate-vegan.md`
Vegan is the only class that gates foods currently classed *veg* (dairy + honey) **and** carries a nutritional-adequacy obligation (a vegan infant needs a B12/calcium/DHA redirect, not just a hidden paneer). It's a *filter plus a redirect* — spec'd, Governor-review-ready, needs a vegan-infant research brief first.

### Also
A **food-effects gap audit** (shellfish · salt+sugar · the FPIES reaction axis · mustard/buckwheat) recorded in `docs/NEXT_SESSION_TARGET_2026-06-02.md`.

### Verification
Build green; new `tests/e2e/diet-preference-gate.spec.ts` 6/6 (incl. the safety invariant); full suite verification in progress.

### canon-cc-008 routing (stays **draft** until the chain completes)
`core.js` → **Kael** · `diet.js`+`home.js` → **Maren** · `intelligence-quicklog.js` → **Vela** · `template.html` (shared) → **triple-Gov** → Lyra synthesis → **Cipher** Edict V.

https://claude.ai/code/session_01A4yF65w2wtkfPcnYvh7fau

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4yF65w2wtkfPcnYvh7fau)_