### PR TITLE
CLAUDE.md LOC refresh + Province Map regen + /design-principles skill + styles.css cascade anchor

### DIFF
--- a/.claude/skills/design-principles/SKILL.md
+++ b/.claude/skills/design-principles/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: design-principles
+description: "SproutLab's canonical visual + UX law — the design floor for every card, section, screen, component, toast, chart, color, font, animation, and render boundary. Use BEFORE designing, building, restyling, or reviewing ANY UI in SproutLab: a new feature or card, an info-tab render, a Today So Far row, a CSS token choice, a domain-color assignment, a layout, or an overlay. Surfaces docs/DESIGN_PRINCIPLES.md (7 domain colors, Fraunces/Nunito typography, HR-1..HR-12 zero-tolerance rules, animation foundation, the half-awake test). If you are about to touch how SproutLab LOOKS or FEELS, read this first."
+trigger: /design-principles
+---
+
+# /design-principles — the SproutLab design floor
+
+**The canonical body lives at `docs/DESIGN_PRINCIPLES.md`** (the `@import` floor in
+`CLAUDE.md`, ~670 lines, version-tracked). This skill is the *unmissable doorway* to it:
+a fast quick-reference plus the standing instruction to **read the full doc before you
+design**. The doc is authoritative; this is the index. When they disagree, the doc wins.
+
+> **Standing rule.** Before you create, build, restyle, or review *any* SproutLab
+> surface — a card, section, screen, component, toast, chart, overlay, color, font, or
+> animation — open `docs/DESIGN_PRINCIPLES.md`. Designing without it is how warmth drifts
+> into clinical and how `HR` violations slip in. No SproutLab UI work is exempt.
+
+## When this fires
+
+Any of these means **read `docs/DESIGN_PRINCIPLES.md` now**:
+
+- A new feature, card, section, info-tab render, or Smart Quick Log / Today So Far row.
+- Any change to color, typography, spacing, radius, shadow, or animation.
+- Any `innerHTML` string that ships visible markup (escHtml + tokens, not raw hex/px).
+- Choosing or assigning a **domain color** to a surface.
+- A toast, overlay, chip, or chart.
+- A QA pass on visual correctness (the per-build Design Principle scores live in §6).
+
+## Quick-reference (the load-bearing floor — full detail in the doc)
+
+### Personality — warm, sturdy, calm
+A cozy nursery journal, **not** a clinical health app. Soft cream (`--cream: #fffaf7`), not
+white. No hospital blues, no sharp corners, no neon, no bouncy animation. *The half-awake
+test: would a tired parent read this correctly at 2 AM holding a baby?*
+
+### Typography (§Typography)
+- **Fraunces** (serif) — hero headlines, scores, card titles, countdowns, gauge values.
+- **Nunito** (sans-serif) — body, labels, buttons, inputs, chips, navigation.
+- Never system fonts / Arial / Helvetica in new code. Text zoom: 3 tiers via `data-zoom`.
+
+### 7 domain colors (§Color System) — **every surface uses one; no ad-hoc hex**
+`sage` (diet / positive) · `rose` (medical / alert) · `amber` (caution / trends) ·
+`lavender` (milestones / intelligence) · `sky` (sleep / hydration) ·
+`indigo` (sleep intelligence / night) · `peach` (warm accents / outing).
+Status triad: sage = good, amber = fair, rose = attention.
+
+### Animation foundation (§Animation Foundation)
+Gentle, never bouncy (`--ease-med: 0.22s`). Motion One (`defer`) loads after Chart.js so
+chart cold-start wins. See `docs/DESIGN_PRINCIPLES.md` §Animation Foundation.
+
+### Icon system (§Icon System)
+`zi()` SVG sprite only — **no emojis (HR-1)**. `zi(name)` → `<svg class="zi"><use
+href="#zi-{name}"/></svg>`, set via innerHTML (HR-7).
+
+### Hard Rules — zero tolerance (§3, mirrored in CLAUDE.md HR-1..HR-12)
+No emojis · no inline styles · no inline handlers (`data-action` only) · escHtml at every
+render boundary · all spacing/font/radius via tokens (no raw px) · domain color on every
+surface · no ellipsis truncation · chip text wraps · Math.floor for currency ·
+timezone-safe dates · stubs show "Coming soon" via `showQLToast()`.
+
+### Tokens (§7) & UI systems (§5)
+Spacing `--sp-*` · font-size `--fs-*` · radius `--r-*` · icon `--icon-*` · ease `--ease-*`.
+4-tier card system, section labels, overlays (no persistent editing — HR-9), chips.
+
+## How to use
+
+```
+/design-principles            # surface this doorway + the standing rule
+```
+
+Then **read the canonical doc** for the section in play:
+
+```
+Read docs/DESIGN_PRINCIPLES.md            # full floor
+# or jump to a section by header, e.g. §3 Hard Rules, §5 UI Systems, §7 Token Reference
+```
+
+## Relationship to the QA chain
+
+This skill is the **design floor**, not a Governor audit. Per canon-cc-022, a skill run is
+an in-transcript register-flip — it does **not** discharge the canon-cc-008 QA gate. Visual
+correctness is still audited by the seated Governors (Vela leads Surfacing / render
+legibility; Maren on Care surfaces; Kael on engine→render data) and Cipher's Edict V
+final-pass. Reading the principles up front is how a surface *arrives* at that gate already
+compliant instead of being sent back.
+
+## References
+
+- Canonical doc: `docs/DESIGN_PRINCIPLES.md` (the authoritative floor).
+- Mirrored summary: `CLAUDE.md` §Design System + §Hard Rules (HR-1..HR-12).
+- Build / animation wiring: `CLAUDE.md` §Build; `docs/DESIGN_PRINCIPLES.md` §Animation Foundation.

--- a/.claude/skills/design-principles/SKILL.md
+++ b/.claude/skills/design-principles/SKILL.md
@@ -53,15 +53,20 @@ chart cold-start wins. See `docs/DESIGN_PRINCIPLES.md` §Animation Foundation.
 `zi()` SVG sprite only — **no emojis (HR-1)**. `zi(name)` → `<svg class="zi"><use
 href="#zi-{name}"/></svg>`, set via innerHTML (HR-7).
 
-### Hard Rules — zero tolerance (§3, mirrored in CLAUDE.md HR-1..HR-12)
+### Hard Rules — zero tolerance (union of `DESIGN_PRINCIPLES.md` §3 + `CLAUDE.md` §Hard Rules)
 No emojis · no inline styles · no inline handlers (`data-action` only) · escHtml at every
 render boundary · all spacing/font/radius via tokens (no raw px) · domain color on every
-surface · no ellipsis truncation · chip text wraps · Math.floor for currency ·
-timezone-safe dates · stubs show "Coming soon" via `showQLToast()`.
+surface · no ellipsis truncation · chip text wraps · no persistent editing in overlays ·
+Math.floor for currency · timezone-safe dates · stubs show "Coming soon" via `showQLToast()`.
+
+> **Numbering caveat:** the two docs number their HRs *differently* (e.g. CLAUDE.md HR-9 =
+> "post-build QA audit"; DESIGN_PRINCIPLES.md HR-9 = "no persistent editing in overlays").
+> Any `HR-N` tag in this skill follows **CLAUDE.md's** §Hard Rules table (the policy floor).
+> Read the rule by name, not number, and check both docs.
 
 ### Tokens (§7) & UI systems (§5)
 Spacing `--sp-*` · font-size `--fs-*` · radius `--r-*` · icon `--icon-*` · ease `--ease-*`.
-4-tier card system, section labels, overlays (no persistent editing — HR-9), chips.
+4-tier card system, section labels, overlays (no persistent editing), chips.
 
 ## How to use
 

--- a/.claude/skills/design-principles/SKILL.md
+++ b/.claude/skills/design-principles/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design-principles
-description: "SproutLab's canonical visual + UX law — the design floor for every card, section, screen, component, toast, chart, color, font, animation, and render boundary. Use BEFORE designing, building, restyling, or reviewing ANY UI in SproutLab: a new feature or card, an info-tab render, a Today So Far row, a CSS token choice, a domain-color assignment, a layout, or an overlay. Surfaces docs/DESIGN_PRINCIPLES.md (7 domain colors, Fraunces/Nunito typography, HR-1..HR-12 zero-tolerance rules, animation foundation, the half-awake test). If you are about to touch how SproutLab LOOKS or FEELS, read this first."
+description: "SproutLab's visual + UX floor. Use BEFORE designing, building, restyling, or reviewing ANY SproutLab UI — a card, info-tab render, Today So Far row, toast, chart, overlay, layout, CSS token choice, or domain-color pick. Surfaces docs/DESIGN_PRINCIPLES.md: 7 domain colors, Fraunces/Nunito type, HR-1..HR-12 zero-tolerance rules, animation foundation, the half-awake test. If you're about to touch how SproutLab looks or feels, read this first."
 trigger: /design-principles
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,11 +9,11 @@
 
 You are **Lyra**, The Weaver. You see connections across domains — how a sleep regression correlates with a dietary change, how a vaccination timeline intersects with a milestone window. You weave the threads of a baby's development into a coherent tapestry that tired parents can actually read.
 
-**QA chain (30K Rule — 76,500 LOC; per-jurisdiction trigger; canon-gen-001 generational expansion ratified 2026-05-23; LOC refreshed 2026-05-31 post-#187 food-effects-v2 Phase γ):**
-1. **Maren** (Governor of Care) audits home.js + diet.js + medical.js (26,892 lines). Protective, thorough, worst-case but warm. Asks "what if this data is wrong and a parent acts on it?"
-2. **Kael** (Governor of Intelligence — engine layer) audits intelligence-isl.js + intelligence-qa.js + intelligence-qa-handlers.js + intelligence-illness.js + intelligence-correlate.js + intelligence-caretickets.js + core.js + data.js + sync.js + config.js + start.js (27,024 lines). Pattern-seeking, systematic. Audits ISL, Smart Q&A, illness state machines, the cross-domain correlation primitive, CareTicket lifecycle data, Firebase sync boundaries. **The engine layer — what the data does before it renders.**
-3. **Vela** (Governor of Surfacing — render layer) audits intelligence-cards.js + intelligence-quicklog.js (8,570 lines). Second-generation Companion seated under canon-gen-001 — parent personas Lyra (Builder ancestor) + Kael (Governor predecessor; Intelligence Region split between Kael and Vela at the data→render boundary). Surface-watching, comprehension-first. Audits Info-tab cards, Activity Log + Smart Quick Log + Today So Far, sleep-info renders, cross-domain heatmap legends. **The render layer — where Kael's correct data and Maren's safe data become parent-legible.** Lens: the half-awake test — would a parent read this correctly at 2 AM holding a baby?
-4. **Shared modules** (styles.css + template.html = 13,964 lines) get sequential triple-jurisdiction review from all three Governors (rotation: Maren → Kael → Vela, with first-Governor by heaviest-touched Region).
+**QA chain (30K Rule — 77,899 LOC split-file source; per-jurisdiction trigger; canon-gen-001 generational expansion ratified 2026-05-23; LOC refreshed 2026-06-02 post-#215):**
+1. **Maren** (Governor of Care) audits home.js + diet.js + medical.js (27,436 lines). Protective, thorough, worst-case but warm. Asks "what if this data is wrong and a parent acts on it?"
+2. **Kael** (Governor of Intelligence — engine layer) audits intelligence-isl.js + intelligence-qa.js + intelligence-qa-handlers.js + intelligence-illness.js + intelligence-correlate.js + intelligence-caretickets.js + core.js + data.js + sync.js + config.js + start.js (27,668 lines). Pattern-seeking, systematic. Audits ISL, Smart Q&A, illness state machines, the cross-domain correlation primitive, CareTicket lifecycle data, Firebase sync boundaries. **The engine layer — what the data does before it renders.**
+3. **Vela** (Governor of Surfacing — render layer) audits intelligence-cards.js + intelligence-quicklog.js (8,651 lines). Second-generation Companion seated under canon-gen-001 — parent personas Lyra (Builder ancestor) + Kael (Governor predecessor; Intelligence Region split between Kael and Vela at the data→render boundary). Surface-watching, comprehension-first. Audits Info-tab cards, Activity Log + Smart Quick Log + Today So Far, sleep-info renders, cross-domain heatmap legends. **The render layer — where Kael's correct data and Maren's safe data become parent-legible.** Lens: the half-awake test — would a parent read this correctly at 2 AM holding a baby?
+4. **Shared modules** (styles.css + template.html = 14,144 lines) get sequential triple-jurisdiction review from all three Governors (rotation: Maren → Kael → Vela, with first-Governor by heaviest-touched Region).
 5. Lyra synthesizes all three Governor reports and implements fixes.
 6. **Cipher** (The Codewright) does final cross-cutting QA — HR compliance, integration across all three Governor jurisdictions.
 
@@ -83,7 +83,7 @@ Baby development tracker for **Ziva Jain** (born 4 Sep 2025). Architecture: spli
 
 ## Architecture
 
-Split-file PWA. 16 JS modules + 2 shared files (styles.css + template.html), **76,500 lines total** (refreshed 2026-05-31 post-#187 food-effects-v2 Phase γ; was 76,308 post-#184, 76,167 post-#178, 67,442 at the canon-gen-001 ratification 2026-05-23).
+Split-file PWA. 16 JS modules + 2 shared files (styles.css + template.html), **77,899 lines total** (split-file source; refreshed 2026-06-02 post-#215; was 76,500 post-#187, 76,308 post-#184, 67,442 at the canon-gen-001 ratification 2026-05-23). *(The Province Map reports a larger figure — it counts the split-file source plus the `split/*.mjs` + shell build tooling that carry graph nodes, filed under the Public Works province; this total tracks only the split-file source the 30K Rule governs. See the reconciliation note under the jurisdiction summary.)*
 
 **Jurisdiction overview:** [docs/PROVINCE_MAP.html](docs/PROVINCE_MAP.html) — a graph-derived **exec summary** (NOT a navigation tool): one card per Province with symbol/LOC counts and a headroom bar to the 30K-rule frontier, plus cross-province coupling and the top connectivity hubs. Auto-generated each build by `split/build-province-map.mjs` from `split/graphify-out/graph.json`. **Supersedes the hand-maintained `docs/MODULE_MAP.html`** — regenerated from committed source every build, so it cannot drift (no more `wc -l split/*` drift-check). *(MODULE_MAP.html is retained for now but deprecated; delete once this is trusted.)*
 
@@ -98,31 +98,33 @@ Split-file PWA. 16 JS modules + 2 shared files (styles.css + template.html), **7
 ```
 split/
 ├── build.sh           ← stdout to sproutlab.html (NOT self-copying like Codex)
-├── template.html      ← HTML shell + zi() symbol sprite (3,245 lines)        [shared — triple-Gov review]
-├── styles.css         ← All CSS (10,769 lines)                               [shared — triple-Gov review]
+├── template.html      ← HTML shell + zi() symbol sprite (3,322 lines)        [shared — triple-Gov review]
+├── styles.css         ← All CSS (10,822 lines)                               [shared — triple-Gov review]
 ├── config.js          ← Firebase config (94 lines)                           [Kael]
-├── data.js            ← Constants, food DB, milestone DB, FOOD_EFFECTS (5,195) [Kael]
-├── core.js            ← Utilities, escHtml, overlays, toasts, scoring, food resolver (7,016) [Kael]
-├── home.js            ← Home tab, Today So Far, hero score (11,351 lines)    [Maren]
-├── diet.js            ← Diet tab, food logging, nutrition, Library (4,827)   [Maren]
+├── data.js            ← Constants, food DB, milestone DB, FOOD_EFFECTS (5,578) [Kael]
+├── core.js            ← Utilities, escHtml, overlays, toasts, scoring, food resolver (7,216) [Kael]
+├── home.js            ← Home tab, Today So Far, hero score (11,353 lines)    [Maren]
+├── diet.js            ← Diet tab, food logging, nutrition, Library (5,369)   [Maren]
 ├── medical.js         ← Medical tab, vaccinations, CareTickets (10,714)      [Maren]
 ├── intelligence-isl.js          ← ISL: typeahead, time-query, domain-data (1,244)  [Kael — engine]
-├── intelligence-qa.js           ← Q&A engine, UIB, classifier (2,236)                [Kael — engine]
+├── intelligence-qa.js           ← Q&A engine, UIB, classifier (2,297)                [Kael — engine]
 ├── intelligence-qa-handlers.js  ← qaAnswer* handlers (3,656)                         [Kael — engine]
 ├── intelligence-illness.js      ← fever / diarrhoea / vomiting / cold episodes (2,667) [Kael — engine]
 ├── intelligence-correlate.js    ← v3-3 cross-domain correlation primitive (274)     [Kael — engine]
 ├── intelligence-caretickets.js  ← CareTickets data + lifecycle (2,230)               [Kael — engine]
-├── intelligence-cards.js        ← Cross-domain + info-tab renderInfo* (3,038)        [Vela — render]
-├── intelligence-quicklog.js     ← Activity Log + Smart Quick Log + Today So Far (5,532) [Vela — render]
+├── intelligence-cards.js        ← Cross-domain + info-tab renderInfo* (3,115)        [Vela — render]
+├── intelligence-quicklog.js     ← Activity Log + Smart Quick Log + Today So Far (5,536) [Vela — render]
 ├── sync.js            ← Firebase auth + Firestore sync (2,393 lines)         [Kael]
 └── start.js           ← Init + event delegation bootstrap (19 lines)          [Kael]
 ```
 
-**Jurisdiction summary (post-canon-gen-001; LOC refreshed 2026-05-31 post-#187):**
-- **Maren (Care):** home + diet + medical = 26,892 LOC (≈3,108 headroom to 30K)
-- **Kael (Intelligence engine):** isl + qa + qa-handlers + illness + correlate + caretickets + core + data + sync + config + start = 27,024 LOC (≈2,976 headroom to 30K — nearest-term split candidate; core.js + data.js carry the steepest recent growth)
-- **Vela (Surfacing render):** cards + quicklog = 8,570 LOC (≈21,430 headroom to 30K)
-- **Shared (triple-Gov):** styles.css + template.html = 14,014 LOC
+**Jurisdiction summary (post-canon-gen-001; LOC refreshed 2026-06-02 post-#215):**
+- **Maren (Care):** home + diet + medical = 27,436 LOC (≈2,564 headroom to 30K)
+- **Kael (Intelligence engine):** isl + qa + qa-handlers + illness + correlate + caretickets + core + data + sync + config + start = 27,668 LOC (≈2,332 headroom to 30K — nearest-term split candidate; core.js + data.js carry the steepest recent growth)
+- **Vela (Surfacing render):** cards + quicklog = 8,651 LOC (≈21,349 headroom to 30K)
+- **Shared (triple-Gov):** styles.css + template.html = 14,144 LOC
+
+> **Reconciliation — why the Province Map shows a bigger number.** This summary totals **77,899 LOC** of split-file source (the four jurisdictions above), which is what the 30K Rule governs. `docs/PROVINCE_MAP.html` reports **~81,597 LOC** because it sums *every file carrying a graph node* — that includes ~3,700 LOC of `split/*.mjs` + shell **build tooling** (province-map / poop-reference / careticket-state-machine generators, `build.sh`, `qa-route.sh`), filed under the **Public Works** province, which no Governor audits and the 30K Rule does not count. Both numbers are correct for their scope; per the authoritative-source rule below, the map wins on the raw count, this file wins on which scope the Rule applies to.
 
 **Concat order:** config → data → core → home → diet → medical → intelligence-isl → intelligence-qa → intelligence-qa-handlers → intelligence-illness → intelligence-correlate → intelligence-quicklog → intelligence-cards → intelligence-caretickets → sync → start
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,18 @@ These are NON-NEGOTIABLE. Every session. Every line.
 
 ## Design System
 
+**Design floor — mandatory, every agent, every surface (canon-cc-022 skill; not a Governor audit).**
+Before any Companion, Governor, or Scribe **designs, builds, restyles, or reviews any
+SproutLab surface** — a card, section, screen, component, toast, chart, overlay, color,
+font, or animation — it MUST consult [`docs/DESIGN_PRINCIPLES.md`](docs/DESIGN_PRINCIPLES.md),
+the authoritative visual + UX floor. The `/design-principles` skill
+(`.claude/skills/design-principles/SKILL.md`) is the unmissable doorway to it — a
+quick-reference plus this standing rule. Designing without reading it is how warmth drifts
+clinical and HR violations slip in; no UI work is exempt. This is the design *floor*, read
+up front so a surface arrives at the canon-cc-008 gate already compliant — it does **not**
+discharge the QA chain (Vela / Maren / Kael audit, Cipher final-pass). The summary tables
+below are a convenience mirror; the doc wins on any disagreement.
+
 ### Typography
 | Font | Use |
 |------|-----|

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -44,7 +44,7 @@
   <div class="sub" style="margin-top:8px">
     <span class="stat"><b>1,737</b> symbols</span>
     <span class="stat"><b>5,158</b> relations</span>
-    <span class="stat"><b>81,597</b> LOC</span>
+    <span class="stat"><b>81,598</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -116,7 +116,7 @@
       <div class="nums">
         <span><b>2</b> modules</span>
         <span><b>0</b> symbols</span>
-        <span><b>14,144</b> LOC</span>
+        <span><b>14,145</b> LOC</span>
       </div>
       <div class="note">Unsurveyed &mdash; code-only extraction. Set a backend and rebuild for symbols.</div>
       <div class="mods">styles.css, template.html</div>

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,10 +40,10 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-06-02 &middot; graph @ <code>d5b1cc6ae2cc</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-02 &middot; graph @ <code>4b0f20c49e49</code></div>
   <div class="sub" style="margin-top:8px">
     <span class="stat"><b>1,737</b> symbols</span>
-    <span class="stat"><b>5,160</b> relations</span>
+    <span class="stat"><b>5,158</b> relations</span>
     <span class="stat"><b>81,597</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
@@ -137,7 +137,7 @@
   <h2>Cross-province coupling (highest-traffic calls across jurisdiction borders)</h2>
   <table>
     <thead><tr><th>Module</th><th>Module</th><th class="num">Calls</th><th>Border</th></tr></thead>
-    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">135</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">39</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
+    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">346</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">133</td><td>Care &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">39</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">18</td><td>Care &harr; Intelligence</td></tr></tbody>
   </table>
 
   <h2>Connectivity hubs (highest call-degree symbols per module)</h2>

--- a/index.html
+++ b/index.html
@@ -6362,7 +6362,8 @@ body.ql-locked .dark-toggle { pointer-events:none; }
    Three tap targets: zi('check')/zi('trending-flat')/zi('arrow-right').
    Care-tier safetyTier:true border-accent uses --rose-deep (V-V-64 + V-M-124).
    Per-domain accent: consumes the canonical [data-domain] cascade
-   (styles.css ~9412 — defines --al-tint/--al-tc/--al-border per domain).
+   (search styles.css for "── Domain Color Cascade ──" — defines
+   --al-tint/--al-tc/--al-border per domain).
    Border-left + status pill colors flow via cascade; the lavender default
    only fires for cards without a data-domain attribute. HR-6 closure
    (Architect feedback 2026-05-27 #4: "don't we have domain colour codes?

--- a/index.html
+++ b/index.html
@@ -6362,7 +6362,7 @@ body.ql-locked .dark-toggle { pointer-events:none; }
    Three tap targets: zi('check')/zi('trending-flat')/zi('arrow-right').
    Care-tier safetyTier:true border-accent uses --rose-deep (V-V-64 + V-M-124).
    Per-domain accent: consumes the canonical [data-domain] cascade
-   (styles.css ~8851 — defines --al-tint/--al-tc/--al-border per domain).
+   (styles.css ~9412 — defines --al-tint/--al-tc/--al-border per domain).
    Border-left + status pill colors flow via cascade; the lavender default
    only fires for cards without a data-domain attribute. HR-6 closure
    (Architect feedback 2026-05-27 #4: "don't we have domain colour codes?

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.02-20",
+  "version": "2026.06.02-21",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.02-21",
+  "version": "2026.06.02-22",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/styles.css
+++ b/split/styles.css
@@ -6355,7 +6355,8 @@ body.ql-locked .dark-toggle { pointer-events:none; }
    Three tap targets: zi('check')/zi('trending-flat')/zi('arrow-right').
    Care-tier safetyTier:true border-accent uses --rose-deep (V-V-64 + V-M-124).
    Per-domain accent: consumes the canonical [data-domain] cascade
-   (styles.css ~9412 — defines --al-tint/--al-tc/--al-border per domain).
+   (search styles.css for "── Domain Color Cascade ──" — defines
+   --al-tint/--al-tc/--al-border per domain).
    Border-left + status pill colors flow via cascade; the lavender default
    only fires for cards without a data-domain attribute. HR-6 closure
    (Architect feedback 2026-05-27 #4: "don't we have domain colour codes?

--- a/split/styles.css
+++ b/split/styles.css
@@ -6355,7 +6355,7 @@ body.ql-locked .dark-toggle { pointer-events:none; }
    Three tap targets: zi('check')/zi('trending-flat')/zi('arrow-right').
    Care-tier safetyTier:true border-accent uses --rose-deep (V-V-64 + V-M-124).
    Per-domain accent: consumes the canonical [data-domain] cascade
-   (styles.css ~8851 — defines --al-tint/--al-tc/--al-border per domain).
+   (styles.css ~9412 — defines --al-tint/--al-tc/--al-border per domain).
    Border-left + status pill colors flow via cascade; the lavender default
    only fires for cards without a data-domain attribute. HR-6 closure
    (Architect feedback 2026-05-27 #4: "don't we have domain colour codes?

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -6362,7 +6362,8 @@ body.ql-locked .dark-toggle { pointer-events:none; }
    Three tap targets: zi('check')/zi('trending-flat')/zi('arrow-right').
    Care-tier safetyTier:true border-accent uses --rose-deep (V-V-64 + V-M-124).
    Per-domain accent: consumes the canonical [data-domain] cascade
-   (styles.css ~9412 — defines --al-tint/--al-tc/--al-border per domain).
+   (search styles.css for "── Domain Color Cascade ──" — defines
+   --al-tint/--al-tc/--al-border per domain).
    Border-left + status pill colors flow via cascade; the lavender default
    only fires for cards without a data-domain attribute. HR-6 closure
    (Architect feedback 2026-05-27 #4: "don't we have domain colour codes?

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -6362,7 +6362,7 @@ body.ql-locked .dark-toggle { pointer-events:none; }
    Three tap targets: zi('check')/zi('trending-flat')/zi('arrow-right').
    Care-tier safetyTier:true border-accent uses --rose-deep (V-V-64 + V-M-124).
    Per-domain accent: consumes the canonical [data-domain] cascade
-   (styles.css ~8851 — defines --al-tint/--al-tc/--al-border per domain).
+   (styles.css ~9412 — defines --al-tint/--al-tc/--al-border per domain).
    Border-left + status pill colors flow via cascade; the lavender default
    only fires for cards without a data-domain attribute. HR-6 closure
    (Architect feedback 2026-05-27 #4: "don't we have domain colour codes?


### PR DESCRIPTION
This branch carries four related changes (commits `b50c664`, `19ffc85`, `3863753`, `41ba1ac`, `e680464`):

## 1. `/design-principles` skill + CLAUDE.md design floor
Makes the design principles unmissable for everyone who designs in SproutLab.

- **`.claude/skills/design-principles/SKILL.md`** — a new invocable skill (directory format, like `graphify`): a discoverable doorway to the canonical `docs/DESIGN_PRINCIPLES.md`, with a quick-reference of the load-bearing floor (7 domains, Fraunces/Nunito, animation foundation, the half-awake test). **Description tightened ~90→~60 words** (`e680464`) — same trigger verbs and keyword surface, less redundancy.
- **`CLAUDE.md`** — a mandatory "Design floor" directive at the head of §Design System.
- HR-numbering disambiguated (`19ffc85`): the two docs number HRs differently, so the skill says "read by name, not number."

**The doc stays canonical at `docs/DESIGN_PRINCIPLES.md`.**

## 2. `styles.css` cascade back-reference → symbolic anchor
The comment at `styles.css:6358` cited a line number (`~8851`, then `~9412`) for the `[data-domain]` cascade definition — a pointer that goes stale on every insertion above it. **Now replaced with a symbolic search anchor** (`search styles.css for "── Domain Color Cascade ──"`) so it can never drift again. Implements the "refactor-tax" note Cipher raised in the QA chain. Comment-only — no tokens/selectors/render changed; propagated to `index.html`/`sproutlab.html`, version bumped.

## 3. CLAUDE.md LOC refresh + Province Map reconciliation (`e680464`)
The Province Map regen surfaced a confusing two-number disagreement (map: **81,597 LOC**; CLAUDE.md: **76,500**). Resolved:
- **Refreshed all CLAUDE.md figures to current actuals** — 77,899 split-file source; Maren 27,436 / Kael 27,668 / Vela 8,651 / Shared 14,144 (the old 76,500 was stale since the post-#187 refresh). Per-file table + jurisdiction summary + headroom now internally consistent.
- **Added a reconciliation note** explaining the map's larger figure: it counts **every file carrying a graph node**, including ~3,700 LOC of `split/*.mjs` + shell **build tooling** (Public Works province) that no Governor audits and the 30K Rule doesn't govern. Both numbers are correct for their scope — not a contradiction.

## 4. Province Map regen (`41ba1ac`)
Auto-generated `docs/PROVINCE_MAP.html` build artifact.

---
## QA gate — canon-cc-008
**Changes 1, 3, 4 are docs/skill/generated-artifact only** (no Governor jurisdiction). **Change 2 touches `split/styles.css`** (a shared module).

The sequential triple-jurisdiction chain ran clean and unanimous on this comment region — **Maren / Kael / Vela all LGTM, Lyra synthesis (no amendments), Cipher Edict V LGTM** (full verdict table in commit history / prior review). The subsequent `~9412 → symbolic anchor` edit (`e680464`) **strictly improves** the text the chain already approved — it implements Cipher's own refactor-tax recommendation and changes no semantics. Per Architect direction, that follow-on is **treated as covered** by the prior unanimous pass; no fresh chain. Build clean (`pnpm build`, audit gates emoji/HR-12/icon-text pass).

Gate discharged. Ready to come out of draft on the Architect's word.

https://claude.ai/code/session_01PavbZfuYicPKWiD6CA2cQZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PavbZfuYicPKWiD6CA2cQZ)_