### PR TITLE
docs: Tint System subsection in DESIGN_PRINCIPLES

### DIFF
--- a/docs/DESIGN_PRINCIPLES.md
+++ b/docs/DESIGN_PRINCIPLES.md
@@ -45,6 +45,25 @@ Never use system fonts, Arial, or Helvetica in new code. Both Fraunces and Nunit
 
 **Rule:** Every new card, section, or feature must use one of these domain colors. No ad-hoc hex values in innerHTML strings.
 
+#### Tint System
+
+**Definition.** A *tint* is a domain accent taken down to a soft, low-saturation **surface wash** — the colour a card, pill, or banner sits *on* so the surface reads as "belonging to" a domain without competing with its content. Tint is the background member of the domain triad; the accent is the structural/border member, the `--tc-*` is the text member. The **"Light BG" column of the Domain Colors table above _is_ the canonical tint scale** — `--sage-light`, `--rose-light`, `--amber-light`, `--lav-light`, `--sky-light`, `--indigo-light`, `--peach-light`.
+
+**Rule.** Tints are never hand-mixed at the call site. A component that needs a domain wash either (a) consumes a `--*-light` token directly, or (b) consumes a **component tint alias** (below) that resolves *to* a `--*-light`. No raw light-hex (`#e8f5ef`, `#f0ebfb`, …) in CSS or innerHTML — those are the 8th-instance `running-beats-reading` drift class (see Polish-3/-4 `--lav-light` corrective, line ~147).
+
+**Component tint aliases.** Where a component is colour-agnostic and inherits its domain from a parent (`data-domain`) or a variant class, it reads its wash through an alias custom-property so the same rules serve every domain:
+
+| Alias | Defined | Resolves to | Consumed by |
+|---|---|---|---|
+| `--al-tint` | `styles.css:9412–9416` (+ default `:6358`) | a `--*-light` per `data-domain` | Activity-Log rows, milestone bulk/domain chips |
+| `--vd-tint` | `styles.css:4115–4121` | a `--*-light` per `.viz-detail-*` variant | viz-detail panels |
+
+**Developmental-domain remap (`--al-tint`).** The Activity-Log alias is the one place tint crosses *namespaces*: the five **developmental** domains (`data-domain="motor|language|cognitive|social|sensory"`) remap onto **colour** domains — Motor→sage, Language→lavender, Cognitive→sky, Social→peach, Sensory→amber (`styles.css:9408–9416`). This is intentional, not a collision: a developmental domain is not a colour domain, and the mapping is documented at its definition so a Governor auditing a `data-domain` block knows the wash is a deliberate cross-walk, not an ad-hoc pick.
+
+**Dark mode.** Tints do not invert to solid darks — they **recede to an 8%-alpha domain gradient over `--warm`** (`[data-theme="dark"] #tab-* .card`, `styles.css:7634–7638`), preserving domain identity ("sage stays green, rose stays pink" — see Status Triad note) while the surface darkens. A tint must survive this: if a wash only reads in light mode, it is too saturated to be a tint.
+
+**Not tints (runtime-computed, palette-exempt).** Some surfaces *look* tinted but are computed at render-time from runtime data, not drawn from this scale — chiefly the **Growth-gauge ring percentile-tint** (`medical.js:1912–1932`). These are `--dyn-*` / locked-exclusion surfaces (see CSS-Custom-Property Pivot Convention below) and are explicitly **out of scope** for the tint token system; do not "tokenize" them into `--*-light`.
+
 #### Domain → Element Assignments
 
 | UI Element | Domain Color | Why |

--- a/docs/DESIGN_PRINCIPLES.md
+++ b/docs/DESIGN_PRINCIPLES.md
@@ -47,24 +47,51 @@ Never use system fonts, Arial, or Helvetica in new code. Both Fraunces and Nunit
 
 #### Tint System
 
-**Definition.** A *tint* is a domain accent taken down to a soft, low-saturation **surface wash** — the colour a card, pill, or banner sits *on* so the surface reads as "belonging to" a domain without competing with its content. Tint is the background member of the domain triad; the accent is the structural/border member, the `--tc-*` is the text member. The **"Light BG" column of the Domain Colors table above _is_ the canonical tint scale** — `--sage-light`, `--rose-light`, `--amber-light`, `--lav-light`, `--sky-light`, `--indigo-light`, `--peach-light`.
+**Definition.** A *tint* is how a surface signals which domain it belongs to without competing with its content — domain identity carried by the background instead of by text or icon. Tint is the background member of the domain triad (accent = structural/border member, `--tc-*` = text member). It is **not a single scale.** The app uses **two families of tint across four registers**, and the "Light BG" column of the Domain Colors table is only *one* of them.
 
-**Rule.** Tints are never hand-mixed at the call site. A component that needs a domain wash either (a) consumes a `--*-light` token directly, or (b) consumes a **component tint alias** (below) that resolves *to* a `--*-light`. No raw light-hex (`#e8f5ef`, `#f0ebfb`, …) in CSS or innerHTML — those are the 8th-instance `running-beats-reading` drift class (see Polish-3/-4 `--lav-light` corrective, line ~147).
+**Two laws hold across all four registers** — write these down because both are invisible in the token names and easy to get backwards (a wrong call here is exactly how a wash ends up "barely visible"):
 
-**Component tint aliases.** Where a component is colour-agnostic and inherits its domain from a parent (`data-domain`) or a variant class, it reads its wash through an alias custom-property so the same rules serve every domain:
+1. **Light/dark hue-swap.** Light mode tints with the **pale accent** hue (`--sage` `#b5d5c5` …); dark mode tints with the **deep `--tc`** hue (`rgba(58,112,96,…)` …). *Never the same hue in both modes.* A pale-accent wash over a dark surface muddies to grey; a deep-hue wash over cream reads as dirt. The token name doesn't tell you which — the `[data-theme="dark"]` block does.
+2. **A tint is never a bare fill.** Every legible tint travels with a companion — a `border-left` accent, a 5px stripe, and/or `--tc-*` text. A domain wash *alone* on a card does not read (especially `--*-light`, which sits at ~91% L). If you drop a tint with no border and no domain text, you have built the invisible case.
+
+---
+
+**Family 1 — Cream-card tints** *(card stays cream; the tint is layered over `--warm`)*
+
+- **Hero cards** (`.card.card-hero.*`, `styles.css:5491–5595`). The section's top card: a **two-domain directional gradient** body (`135deg`, full `--*-light` strength) **plus a 5px top stripe** (`::before`) that is a saturated accent-pair gradient. Each pairing is **semantic, not decorative** — sage→amber = nutrition (diet), indigo→lavender = night/calm (sleep), lavender→sky = clinical/trust (medical), sage→lavender = achievement (milestones), amber→peach = gut (poop), rose→peach = body (growth), peach→lavender = analysis (insights); home is the signature rose→peach→sage→lavender rainbow. In **dark mode** the body composites warm overlays over `--surface` and goes moody/low-contrast — **the un-inverted bright stripe becomes the primary section signal** (it is the fallback identity layer, which is why `::before` is *not* dark-overridden).
+- **Ambient body wash** (`#tab-* .card`, light `styles.css:5993–5997`, dark `:7634–7638`). Every *non-hero* card in a tab: `--warm` + one faint domain wash @ **8–10% α**. Faint **by design** — this is warmth, not a label. Per-tab domain map:
+
+  | Tab | Domain | Light hue | Dark hue |
+  |---|---|---|---|
+  | diet | **sage** | accent @ .10 | deep @ .08 |
+  | sleep | **indigo** | accent @ .10 | deep @ .08 |
+  | poop | **amber** | accent @ .08 | deep @ .08 |
+  | medical | **rose** | accent @ .08 | deep @ .08 |
+  | milestones | **lavender** | accent @ .08 | deep @ .08 |
+
+  **Coverage gap (deliberate):** `home` and `info/intelligence` body cards take **no** ambient wash — home leans on its hero, info-tab cards are the Receded register below. A new card in those tabs is *supposed* to be untinted; don't "fix" it.
+
+**Family 2 — Colored-card tints** *(the wash IS the surface)*
+
+- **Signaling** (`--surface-*`, defs `styles.css:81–86` light / `:5269–5274` dark). The wash that reads on its own: the **deep / `--tc` hue at ~10–12% α** (`--surface-sage: rgba(61,122,96,0.12)` — note: deep hue, *not* the pale accent). Use when the surface itself must say "domain X." Always paired with a `border-left` accent (e.g. `.enc-benefit`, `.cons-severe`, `.combo-result.caution`).
+- **Receded** (`--*-light` flat fill, defs `styles.css:31–62`). The palest tier and the **most-used** fill (130 `--sage-light` sites): info-cards, pills, chips. **Only valid inside a bordered card with `--tc-*` text** — it carries no signal alone (Law 2). This is the Info-tab "cool tint, dashed border" tier (`styles.css:2537`).
+
+---
+
+**Component tint aliases.** Where a component is colour-agnostic and inherits its domain from a parent (`data-domain`) or variant class, it reads its wash through an alias so one rule serves every domain:
 
 | Alias | Defined | Resolves to | Consumed by |
 |---|---|---|---|
 | `--al-tint` | `styles.css:9412–9416` (+ default `:6358`) | a `--*-light` per `data-domain` | Activity-Log rows, milestone bulk/domain chips |
 | `--vd-tint` | `styles.css:4115–4121` | a `--*-light` per `.viz-detail-*` variant | viz-detail panels |
 
-**Developmental-domain remap (`--al-tint`).** The Activity-Log alias is the one place tint crosses *namespaces*: the five **developmental** domains (`data-domain="motor|language|cognitive|social|sensory"`) remap onto **colour** domains — Motor→sage, Language→lavender, Cognitive→sky, Social→peach, Sensory→amber (`styles.css:9408–9416`). This is intentional, not a collision: a developmental domain is not a colour domain, and the mapping is documented at its definition so a Governor auditing a `data-domain` block knows the wash is a deliberate cross-walk, not an ad-hoc pick.
+**Developmental-domain remap (`--al-tint`).** The Activity-Log alias is the one place tint crosses *namespaces*: the five **developmental** domains (`data-domain="motor|language|cognitive|social|sensory"`) remap onto **colour** domains — Motor→sage, Language→lavender, Cognitive→sky, Social→peach, Sensory→amber (`styles.css:9408–9416`). Intentional, not a collision: a developmental domain is not a colour domain, and the mapping is documented at its definition so a Governor auditing a `data-domain` block knows it is a deliberate cross-walk, not an ad-hoc pick.
 
-**Dark mode.** Tints do not invert to solid darks — they **recede to an 8%-alpha domain gradient over `--warm`** (`[data-theme="dark"] #tab-* .card`, `styles.css:7634–7638`), preserving domain identity ("sage stays green, rose stays pink" — see Status Triad note) while the surface darkens. A tint must survive this: if a wash only reads in light mode, it is too saturated to be a tint.
+**Authoring rule.** Never hand-mix a wash at the call site. Reach for the register that matches the job — Hero gradient for a section header, Ambient for a body card in a tinted tab, Signaling `--surface-*` when the surface must read alone, Receded `--*-light` for a bordered info-card — or a component alias. No raw light-hex (`#e8f5ef`, `#f0ebfb`, …) in CSS or innerHTML — that is the 8th-instance `running-beats-reading` drift class (see Polish-3/-4 `--lav-light` corrective, line ~147).
 
 **Peach is accent-only — no `--tc-*` text token (light _or_ dark).** The `—` in the `--tc-*` column of the Domain Colors table (and in both Text columns of the dark-mode table, line ~594) is intentional: peach is reserved for warmth/accent surfaces (outing planner, ambient borders), never for text-on-wash. So `--peach-light` is a *backing* tint only — do not place domain-coloured body text on it. If a future surface genuinely needs peach text-on-wash, that token must be **defined first** (light + dark), not improvised at the call site.
 
-**Not tints (runtime-computed, palette-exempt).** Some surfaces *look* tinted but are computed at render-time from runtime data, not drawn from this scale — chiefly the **Growth-gauge ring percentile-tint** (`medical.js:1912–1932`). These are `--dyn-*` / locked-exclusion surfaces (see CSS-Custom-Property Pivot Convention below) and are explicitly **out of scope** for the tint token system; do not "tokenize" them into `--*-light`.
+**Not tints (runtime-computed, palette-exempt).** Some surfaces *look* tinted but are computed at render-time from runtime data, not drawn from any register above — chiefly the **Growth-gauge ring percentile-tint** (`medical.js:1912–1932`). These are `--dyn-*` / locked-exclusion surfaces (see CSS-Custom-Property Pivot Convention below) and are explicitly **out of scope** for the tint system; do not "tokenize" them into `--*-light`.
 
 #### Domain → Element Assignments
 

--- a/docs/DESIGN_PRINCIPLES.md
+++ b/docs/DESIGN_PRINCIPLES.md
@@ -62,6 +62,8 @@ Never use system fonts, Arial, or Helvetica in new code. Both Fraunces and Nunit
 
 **Dark mode.** Tints do not invert to solid darks — they **recede to an 8%-alpha domain gradient over `--warm`** (`[data-theme="dark"] #tab-* .card`, `styles.css:7634–7638`), preserving domain identity ("sage stays green, rose stays pink" — see Status Triad note) while the surface darkens. A tint must survive this: if a wash only reads in light mode, it is too saturated to be a tint.
 
+**Peach is accent-only — no `--tc-*` text token (light _or_ dark).** The `—` in the `--tc-*` column of the Domain Colors table (and in both Text columns of the dark-mode table, line ~594) is intentional: peach is reserved for warmth/accent surfaces (outing planner, ambient borders), never for text-on-wash. So `--peach-light` is a *backing* tint only — do not place domain-coloured body text on it. If a future surface genuinely needs peach text-on-wash, that token must be **defined first** (light + dark), not improvised at the call site.
+
 **Not tints (runtime-computed, palette-exempt).** Some surfaces *look* tinted but are computed at render-time from runtime data, not drawn from this scale — chiefly the **Growth-gauge ring percentile-tint** (`medical.js:1912–1932`). These are `--dyn-*` / locked-exclusion surfaces (see CSS-Custom-Property Pivot Convention below) and are explicitly **out of scope** for the tint token system; do not "tokenize" them into `--*-light`.
 
 #### Domain → Element Assignments


### PR DESCRIPTION
Splits the **design-principles** documentation out of #216 into its own mergeable PR (per Architect direction: "break 216 in two — only merge the one with design principles, keep 216 running as per plan").

## What this is
Adds a `§ Tint System` subsection to `docs/DESIGN_PRINCIPLES.md`, codifying the app's tint conventions which were previously undocumented (only 2 incidental references existed). Derived from a cross-tab survey of `styles.css`.

## Contents
The subsection documents tint as **two families across four registers**, plus two cross-cutting laws:

- **Two laws:** light/dark hue-swap (light tints with the pale accent, dark with the deep `--tc` hue) · a tint is never a bare fill (always carries a border/stripe/`--tc` text).
- **Family 1 — Cream-card tints:** hero cards (2-domain directional gradient + 5px semantic stripe) · ambient body wash (per-tab domain map @ 8–10%, with the deliberate home/info coverage gap).
- **Family 2 — Colored-card tints:** signaling (`--surface-*`, deep hue @ ~12% + border) · receded (`--*-light` flat, only inside a bordered card with `--tc` text).
- Component aliases (`--al-tint`, `--vd-tint`) + the developmental→colour domain remap.
- Peach is accent-only (no `--tc-*` text token, light or dark).
- Runtime `--dyn-*` surfaces (Growth-gauge percentile-tint) explicitly carved out.

Every CSS reference is a verified `styles.css` line number.

## QA gate
**Docs-only** (`docs/DESIGN_PRINCIPLES.md`, +48 lines) — not in the `split/` build path. Governor audit waived per canon-cc-008 (docs-only). Pre-commit audit gates (emoji / HR-12 / icon-text) pass.

https://claude.ai/code/session_01A4yF65w2wtkfPcnYvh7fau

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4yF65w2wtkfPcnYvh7fau)_