### PR TITLE
docs: Recipes design-system principles (§9) + session handoff

### DIFF
--- a/docs/DESIGN_PRINCIPLES.md
+++ b/docs/DESIGN_PRINCIPLES.md
@@ -740,8 +740,8 @@ Every `pnpm build` runs these gates sequentially in `split/build.sh`; any failur
 > **Forward-looking** — these describe how the recipes feature should be built when wired into `split/`.
 > The exploration is generator-backed (deterministic, data-driven); the wiring runs the canon-cc-008 Governor gate.
 
-### 9.1 `zif_food` — the food-icon namespace
-A dedicated **full-colour** ingredient icon set, separate from the monochrome `zi()` system.
+### 9.1 `zi_food` — the food-icon system (`zif-*` symbols)
+A dedicated **full-colour** ingredient icon set (system name `zi_food`, symbol namespace `zif-*`), separate from the monochrome `zi()` system.
 - **Namespace `zif-*`**, 97 symbols covering 100% of the data.js food corpus (grains, legumes, vegetables, fruits, dairy & eggs, nuts & seeds, proteins, fats & sweeteners, spices & herbs).
 - **Real food colours, not domain colours.** The edible flesh uses `fill="currentColor"` so the *consumer* sets the hue — **one symbol drives every variant** (bell pepper red/yellow/green, carrot orange/purple, toor/moong/masoor/urad dal). Natural accents (green tops, brown pit/stem, egg yolk, husk) are **baked in** at fixed colours.
 - **Style:** flat fill + a warm rgba outline (`rgba(74,48,22,.22)`) so whites/creams read on light surfaces. 24×24 viewBox, like `zi()`.
@@ -769,7 +769,7 @@ The stripe is **narrow (~4px)**, uses **soft mid-tone** hues (between the pale `
 Recipe titles: **roman Fraunces** (700) + a **Fraunces *italic*** descriptor line beneath (the warm "voice"). Italic is reserved for the descriptor — not eyebrows/sections. Titles: `max-width` guard + `text-wrap: balance` (the early wrap is a width guard, not a design break). Fraunces roman = structure; Fraunces italic = voice; Nunito = functional text.
 
 ### 9.7 Infant-food safety rules (content floor — Care/Maren jurisdiction)
-Cross-verified against WHO 2023 / WHO-PAHO / IAP / ICMR-NIN 2024 / NHS / AAP / CDC (see `docs/design/recipes-tab/RECIPE_RESEARCH.md`). **Any recipe/tagline/food surface must honour these:**
+Cross-verified against WHO 2023 / WHO-PAHO / IAP / ICMR-NIN 2024 / NHS / FAO am866e / AAP / CDC (see `docs/design/recipes-tab/RECIPE_RESEARCH.md`). **Any recipe/tagline/food surface must honour these:**
 - **Honey** — none < 12 months (infant botulism). Hard no.
 - **No added salt; no added sugar/jaggery; no fruit juice** < 12 months — **fruit sweetens** (adopted the stricter WHO/NHS line over IAP's sugar allowance).
 - **Allergens** (egg, peanut, tree nuts, dairy, sesame, fish) — introduce early (~6m), one at a time.
@@ -784,7 +784,7 @@ Cross-verified against WHO 2023 / WHO-PAHO / IAP / ICMR-NIN 2024 / NHS / AAP / C
 | Version | Date | Change |
 |---------|------|--------|
 | 1.0 | 9 Apr 2026 | Initial version. Forked from DESIGN_SYSTEM_TEMPLATE.md v1.0. Filled from styles.css audit (7,772 lines), template.html SVG sprite (54 icons), VISUAL_AUDIT.md. |
-| 1.1 | 3 Jun 2026 | Added §9 — Recipes Generative Food System (incoming patterns): `zif_food` full-colour icon namespace, whisper-fade ingredient pills, quantity-weighted generative fingerprint, warm-wave stripe, 3-layer tagline system, typography "voice" line (direction C), and the infant-food safety content floor. From the Diet→Recipes design exploration (`docs/design/recipes-tab/`). |
+| 1.1 | 3 Jun 2026 | Added §9 — Recipes Generative Food System (incoming patterns): `zi_food` full-colour icon system (`zif-*` symbols), whisper-fade ingredient pills, quantity-weighted generative fingerprint, warm-wave stripe, 3-layer tagline system, typography "voice" line (direction C), and the infant-food safety content floor. From the Diet→Recipes design exploration (`docs/design/recipes-tab/`). |
 
 ---
 

--- a/docs/DESIGN_PRINCIPLES.md
+++ b/docs/DESIGN_PRINCIPLES.md
@@ -734,11 +734,57 @@ Every `pnpm build` runs these gates sequentially in `split/build.sh`; any failur
 
 ---
 
+## 9. Recipes — Generative Food System (incoming patterns)
+
+> Patterns established in the **Diet → Recipes design exploration** (2026-06-03, `docs/design/recipes-tab/`).
+> **Forward-looking** — these describe how the recipes feature should be built when wired into `split/`.
+> The exploration is generator-backed (deterministic, data-driven); the wiring runs the canon-cc-008 Governor gate.
+
+### 9.1 `zif_food` — the food-icon namespace
+A dedicated **full-colour** ingredient icon set, separate from the monochrome `zi()` system.
+- **Namespace `zif-*`**, 97 symbols covering 100% of the data.js food corpus (grains, legumes, vegetables, fruits, dairy & eggs, nuts & seeds, proteins, fats & sweeteners, spices & herbs).
+- **Real food colours, not domain colours.** The edible flesh uses `fill="currentColor"` so the *consumer* sets the hue — **one symbol drives every variant** (bell pepper red/yellow/green, carrot orange/purple, toor/moong/masoor/urad dal). Natural accents (green tops, brown pit/stem, egg yolk, husk) are **baked in** at fixed colours.
+- **Style:** flat fill + a warm rgba outline (`rgba(74,48,22,.22)`) so whites/creams read on light surfaces. 24×24 viewBox, like `zi()`.
+- **Deliberate departure from `zi()`:** `zif-*` is multi-fill colour; it is NOT a drop-in `zi()` call and does not satisfy HR-1's "icons via zi()" by itself — it is a sibling system for ingredient representation. Wire as its own sprite block.
+
+### 9.2 Ingredient pills use the whisper fade (never flat)
+Food/ingredient chips carry the **food-domain whisper fade** (`dt-*`), not a flat tint or a naked card:
+`background: linear-gradient(135deg, transparent 40%, rgba(<accent>,.22))` over the card base + a domain-tinted border; dark theme swaps to `transparent 30%` + the deep `--tc-*` hue. This is the decided language (ported from the library rework) — reaffirms **HR-6 (domain colour on every surface)**.
+
+### 9.3 Generative recipe fingerprint (quantity-weighted)
+A recipe's hero renders a deterministic fingerprint from its ingredients:
+- **STRIPE** (top ribbon) + **FADE** (body wash) are the recipe's primary-ingredient **domains, wavelength-ordered** (rose → peach → amber → sage → sky → indigo → lav ≈ red→violet).
+- **Band-widths are weighted by ingredient quantity (grams)** — a 60% rice / 25% carrot / 15% paneer khichdi reads sage-dominant. Trace ingredients (ghee/salt/spices) are excluded so the fingerprint never muds; cap ≤ ~4 domains.
+- Domain → colour: fruit→rose, veg→peach, legume→amber, grain→sage, dairy→sky, nuts→lavender. Fade uses `--*-light` (light) / deep `rgba` hue (dark).
+
+### 9.4 Warm-wave stripe (motion)
+The stripe is **narrow (~4px)**, uses **soft mid-tone** hues (between the pale `--*` and the harsh `--tc-*` — de-neoned), and **animates**: a translucent sheen sweeps left→right (~4.4s ease loop) over the static weighted gradient — the colour band-widths stay fixed (they encode quantity); only the highlight moves. Respect `prefers-reduced-motion` at wiring time.
+
+### 9.5 Tagline system (three layers)
+1. **Curated recipe taglines** — 2–3 per named recipe, rotated by a **day-seed** (fresh daily, deterministic within a day).
+2. **Per-ingredient bank** — 2–3 taglines per ingredient for single-food logs (61 ingredients).
+3. **Composer** (`taglines.mjs`) — for any uncurated combo: each ingredient contributes an **epithet + noun**; the **minor-share ratio picks the connector** so volume shows in the words (`<12%` "just a hint" · `~20%` "a touch" · `~30%` "a little" · `~40%` "balanced with" · `~50/50` "meets"); epithets rotate by day-seed.
+
+### 9.6 Typography — recipe "voice" line (direction C)
+Recipe titles: **roman Fraunces** (700) + a **Fraunces *italic*** descriptor line beneath (the warm "voice"). Italic is reserved for the descriptor — not eyebrows/sections. Titles: `max-width` guard + `text-wrap: balance` (the early wrap is a width guard, not a design break). Fraunces roman = structure; Fraunces italic = voice; Nunito = functional text.
+
+### 9.7 Infant-food safety rules (content floor — Care/Maren jurisdiction)
+Cross-verified against WHO 2023 / WHO-PAHO / IAP / ICMR-NIN 2024 / NHS / AAP / CDC (see `docs/design/recipes-tab/RECIPE_RESEARCH.md`). **Any recipe/tagline/food surface must honour these:**
+- **Honey** — none < 12 months (infant botulism). Hard no.
+- **No added salt; no added sugar/jaggery; no fruit juice** < 12 months — **fruit sweetens** (adopted the stricter WHO/NHS line over IAP's sugar allowance).
+- **Allergens** (egg, peanut, tree nuts, dairy, sesame, fish) — introduce early (~6m), one at a time.
+- **Choking/prep** — nuts/seeds ground (never whole), grapes halved, hard veg/fruit cooked soft, egg fully cooked, fish deboned, chia soaked, raisins softened.
+- **Cow's milk** — in cooking from 6m; not a main drink until 12m.
+- **In taglines:** soft prep-cautions **fold into the phrase** ("ground almond", "halved grape"); **strict no's lead** as a prominent clause ("honey — only from age 1"). Safety **always shows first.**
+
+---
+
 ## Changelog
 
 | Version | Date | Change |
 |---------|------|--------|
 | 1.0 | 9 Apr 2026 | Initial version. Forked from DESIGN_SYSTEM_TEMPLATE.md v1.0. Filled from styles.css audit (7,772 lines), template.html SVG sprite (54 icons), VISUAL_AUDIT.md. |
+| 1.1 | 3 Jun 2026 | Added §9 — Recipes Generative Food System (incoming patterns): `zif_food` full-colour icon namespace, whisper-fade ingredient pills, quantity-weighted generative fingerprint, warm-wave stripe, 3-layer tagline system, typography "voice" line (direction C), and the infant-food safety content floor. From the Diet→Recipes design exploration (`docs/design/recipes-tab/`). |
 
 ---
 

--- a/docs/design/recipes-tab/SESSION_HANDOFF.md
+++ b/docs/design/recipes-tab/SESSION_HANDOFF.md
@@ -1,0 +1,45 @@
+# Session Handoff — Diet → Recipes design exploration
+
+**Session date:** 2026-06-03 · **Companion:** Lyra (Builder) · **Status:** design exploration complete, **app-wiring pending**
+**Where the work lives:** branch `claude/food-effects-v2-wiring-TFgRs` (PR #216), under `docs/design/` — *design records only, not yet in `split/`.*
+**This doc + the DESIGN_PRINCIPLES update:** branch `claude/recipes-design-system` (separate PR).
+
+> Session-close for the **recipes sub-thread only**. PR #216 itself stays open; the
+> food-effects-v2 wiring continues after a `/compact`.
+
+---
+
+## What was built (all in `docs/design/`, generator-backed)
+
+| Artifact | File(s) | What it is |
+|---|---|---|
+| **`zi_food` icon system** | `gen-zi-food.mjs` → `zi-food-sheet.html/.png` | 97 full-colour food symbols (`zif-*`), 104 cells incl. variants. 100% of the data.js food corpus. |
+| **Icon coverage roadmap** | `gen-zi-food-coverage.mjs` → `zi-food-coverage.*` | 102/102 base ingredients mapped to icons. |
+| **`zi` inventory** | `gen-zi-inventory.mjs` → `zi-inventory.*` | All 109 existing `zi-*` sprites categorised into 8 groups. |
+| **Generative hero** | `recipes-tab/gen-hero.mjs` → `09-hero-motion.html/.png` | Recipe-of-the-day card: quantity-weighted fingerprint + warm-wave stripe + zif watermark + typography C. Light + dark. |
+| **Warm-wave filmstrip** | `recipes-tab/09-stripe-filmstrip.*` | Static proof of the moving stripe (no GIF tooling in env). |
+| **Typography directions** | `recipes-tab/10-typography.*` | The 4 title treatments; **C (italic warmth) ratified.** |
+| **Per-ingredient tagline bank** | `gen-ingredient-taglines.mjs` → `ingredient-taglines.*` | 61 ingredients × 2–3 taglines (126), safety-aware. **Copy ratified.** |
+| **Tagline composer** | `taglines.mjs` + `gen-combo-taglines.mjs` → `combo-taglines.*` | Shared module: builds a weighted tagline for ANY combo. EP bank = full ~97-ingredient DB. |
+| **Recipe research** | `recipes-tab/RECIPE_RESEARCH.md` | Cited authoritative recipes + safety table (WHO/IAP/ICMR-NIN/NHS/FAO/AAP/CDC). |
+
+All HTML renders via `recipes-tab/render-to-png.mjs` (Playwright). Generators are
+data-driven — add an icon/recipe/tagline = one entry, re-run, re-render.
+
+## Ratified decisions (Architect, this session)
+1. **Food icons = real food colours**, not domain colours. Flesh uses `currentColor` (consumer sets hue → variants from one symbol: bell pepper r/y/g, carrot orange/purple, dals). Natural accents (green tops, brown pit/stem, yolk) baked in.
+2. **Pills use the whisper-fade** (`dt-*`: `linear-gradient(135deg, transparent 40%, rgba(accent,.22))` over the card base) — never flat fills, never naked white/dark.
+3. **Stripe** = narrow (4px), **de-neoned** soft mid-tones, **animated** warm-wave sheen sweep (~4.4s). Band-widths **weighted by ingredient quantity**, wavelength-ordered.
+4. **Fade** = same weighting (135deg `--*-light` light / deep `rgba` dark).
+5. **Typography C** — roman Fraunces title + a Fraunces *italic* "voice" descriptor. Italic = descriptor only. Title wrap fixed (`max-width:92%` + `text-wrap:balance`).
+6. **Tagline system, 3 layers:** curated recipe taglines (2–3, rotate by day-seed) → per-ingredient bank → **composer** for uncurated combos (weight-ratio picks the connector; epithets rotate; safety enforced).
+7. **Safety:** soft prep-cautions **fold** into the phrase (ground almond, halved grape, cooked egg, boneless fish, soaked chia); **strict no's lead** (honey 1y+, jaggery/added sugar). Adopted the **stricter WHO/NHS line on added sugar** over IAP's allowance.
+
+## Open items (for the wiring phase)
+- **Wire into `split/`** — this is all `docs/design/`. Real feature = move `zif-*` sprite into `template.html`, the composer + bank into the engine layer, the hero render into the Diet→Recipes surface. **Runs the canon-cc-008 Governor QA gate** (Maren = Care/safety, Kael = engine, Vela = render; Cipher final-pass).
+- **`zif-*` is full-colour** — a deliberate departure from the monochrome `zi()` `currentColor` system. Wiring decision: new sub-system, not a drop-in `zi()` call. Confirm token strategy (a `--tc-peach` token would retire the one deep-peach literal in the stripe).
+- **Minor icon polish backlog:** ginger/turmeric/garlic are acceptable but the weakest.
+- **Tagline copy** is design-quality, not clinically reviewed — Maren must audit before ship (it carries safety phrasing).
+
+## How to resume
+`pnpm`-free: `node docs/design/<generator>.mjs` then `node docs/design/recipes-tab/render-to-png.mjs <in.html> <out.png> [width]`. Start at `recipes-tab/gen-hero.mjs` (imports `../taglines.mjs`).

--- a/docs/design/recipes-tab/SESSION_HANDOFF.md
+++ b/docs/design/recipes-tab/SESSION_HANDOFF.md
@@ -37,7 +37,7 @@ data-driven — add an icon/recipe/tagline = one entry, re-run, re-render.
 
 ## Open items (for the wiring phase)
 - **Wire into `split/`** — this is all `docs/design/`. Real feature = move `zif-*` sprite into `template.html`, the composer + bank into the engine layer, the hero render into the Diet→Recipes surface. **Runs the canon-cc-008 Governor QA gate** (Maren = Care/safety, Kael = engine, Vela = render; Cipher final-pass).
-- **`zif-*` is full-colour** — a deliberate departure from the monochrome `zi()` `currentColor` system. Wiring decision: new sub-system, not a drop-in `zi()` call. Confirm token strategy (a `--tc-peach` token would retire the one deep-peach literal in the stripe).
+- **`zif-*` is full-colour** — a deliberate departure from the monochrome `zi()` `currentColor` system. Wiring decision: new sub-system, not a drop-in `zi()` call. Token cleanup: `--tc-peach` is *referenced* in `styles.css` (`.meal-time-input:focus`, lines ~486/488) but **never defined** — defining it would fix that latent dangling reference *and* retire the stripe's one deep-peach literal (`#df9356`).
 - **Minor icon polish backlog:** ginger/turmeric/garlic are acceptable but the weakest.
 - **Tagline copy** is design-quality, not clinically reviewed — Maren must audit before ship (it carries safety phrasing).
 


### PR DESCRIPTION
Session-close for the **Diet → Recipes design sub-thread** — separate from PR #216 (the food-effects-v2 wiring continues there).

Docs-only; **no `split/` changes** (canon-cc-008 Governor gate not triggered; Cipher Edict V final-pass requested).

## What's here
- **`docs/DESIGN_PRINCIPLES.md` §9 — Recipes Generative Food System (incoming patterns)** — the forward-looking floor for when the recipes feature is wired into `split/`:
  - `zif_food` full-colour icon namespace (currentColor flesh + baked accents, variant model; a deliberate sibling to monochrome `zi()`)
  - whisper-fade ingredient pills (`dt-*`, never flat)
  - quantity-weighted generative fingerprint (stripe + fade band-widths from ingredient grams, wavelength-ordered)
  - warm-wave animated stripe (narrow, de-neoned, sheen sweep)
  - 3-layer tagline system (curated rotation · per-ingredient bank · full-DB composer with ratio-driven connectors)
  - typography "voice" line (direction C — Fraunces italic descriptor)
  - **infant-food safety content floor** (Care/Maren jurisdiction): honey 1y+, no added salt/sugar, allergen + choking/prep rules, fold-vs-strict tagline handling — cross-verified WHO/IAP/ICMR-NIN/NHS/AAP/CDC.
- **`docs/design/recipes-tab/SESSION_HANDOFF.md`** — what was built, ratified decisions, open items, how to resume.

## Provenance
Design records (icons, hero, taglines, generators) + the cited `RECIPE_RESEARCH.md` live on PR #216 branch `claude/food-effects-v2-wiring-TFgRs`. This PR carries only the durable, app-wide documentation that should land independently.

https://claude.ai/code/session_01A4yF65w2wtkfPcnYvh7fau

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4yF65w2wtkfPcnYvh7fau)_