### PR TITLE
Landing refinements: hide greeting header · wire D3 logging · crowd-fit hero

### DIFF
--- a/docs/CARETICKET_STATE_MACHINE.html
+++ b/docs/CARETICKET_STATE_MACHINE.html
@@ -91,7 +91,7 @@ code { font-family: var(--mono); font-size: 12px; color: var(--ink); }
 </head>
 <body>
 <h1>CareTicket State Machine</h1>
-<p class="subtitle">SproutLab — 6-transition lifecycle, spec vs implementation. Generated <code>2026-06-03</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on transition-layout snapshots</strong>; <code>CARETICKETS_SPEC_v5.md</code> wins on transition rationale; CLAUDE.md wins on rules, HRs, build commands, persona.</p>
+<p class="subtitle">SproutLab — 6-transition lifecycle, spec vs implementation. Generated <code>2026-06-04</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on transition-layout snapshots</strong>; <code>CARETICKETS_SPEC_v5.md</code> wins on transition rationale; CLAUDE.md wins on rules, HRs, build commands, persona.</p>
 
 <div class="diagram-wrap">
 <svg viewBox="0 0 520 420" width="520" height="420">

--- a/docs/POOP_COLOR_REFERENCE.html
+++ b/docs/POOP_COLOR_REFERENCE.html
@@ -108,7 +108,7 @@ code { font-family: var(--mono); font-size: 12px; color: var(--ink-soft); }
 </head>
 <body>
 <h1>Poop-Color Reference</h1>
-<p class="subtitle">SproutLab — token + render + contrast + lexicon snapshot. Generated <code>2026-06-03</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on token-value snapshots</strong>; CLAUDE.md wins on usage rules.</p>
+<p class="subtitle">SproutLab — token + render + contrast + lexicon snapshot. Generated <code>2026-06-04</code>. Per the policy-floor clause in CLAUDE.md, <strong>this chart wins on token-value snapshots</strong>; CLAUDE.md wins on usage rules.</p>
 
 <div class="meta-bar">
   <span>light <code>--warm</code> <code>#fef6f0</code></span>

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-06-03 &middot; graph @ <code>b930d72bd68b</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-04 &middot; graph @ <code>6458ce56c1ba</code></div>
   <div class="sub" style="margin-top:8px">
     <span class="stat"><b>1,776</b> symbols</span>
     <span class="stat"><b>5,280</b> relations</span>
-    <span class="stat"><b>83,469</b> LOC</span>
+    <span class="stat"><b>83,475</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -65,14 +65,14 @@
       <div class="nums">
         <span><b>11</b> modules</span>
         <span><b>746</b> symbols</span>
-        <span><b>27,793</b> LOC</span>
+        <span><b>27,800</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,793 of 30,000 LOC">
+      <div class="bar" title="27,800 of 30,000 LOC">
         <div class="fill hot" style="width:93%"></div>
         <span class="barlbl">93% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,207 LOC headroom</div>
+      <div class="hd">2,200 LOC headroom</div>
       <div class="mods">core.js, i-illness.js, i-caretickets.js, i-qa-handlers.js, sync.js, data.js, i-qa.js, i-isl.js, config.js, i-correlate.js, start.js</div>
     </div>
     <div class="card" style="border-top:5px solid #b5d5c5">
@@ -99,14 +99,14 @@
       <div class="nums">
         <span><b>2</b> modules</span>
         <span><b>190</b> symbols</span>
-        <span><b>8,893</b> LOC</span>
+        <span><b>8,892</b> LOC</span>
       </div>
       
-      <div class="bar" title="8,893 of 30,000 LOC">
+      <div class="bar" title="8,892 of 30,000 LOC">
         <div class="fill " style="width:30%"></div>
         <span class="barlbl">30% to 30K frontier</span>
       </div>
-      <div class="hd">21,107 LOC headroom</div>
+      <div class="hd">21,108 LOC headroom</div>
       <div class="mods">i-quicklog.js, i-cards.js</div>
     </div>
     <div class="card" style="border-top:5px solid #e8b86d">

--- a/index.html
+++ b/index.html
@@ -24363,10 +24363,17 @@ function switchTab(name) {
   // Auto-scroll tab bar to centre the active tab
   if (activeBtn) scrollTabIntoView(activeBtn);
 
-  // Toggle header: full greeting on the lean Landing (and the dense Home, which
-  // keeps id 'home' = "Today" surface per the id-contract; label is presentation).
+  // Toggle header: the full greeting card shows only on the dense Home ("Today")
+  // surface. The lean Landing has its own warm-wave "Today so far" hero as its
+  // warm anchor, so the dense greeting card (avatar + age + weather) is hidden
+  // there — keeps the front door calm and lean (id 'home' = "Today"; label is
+  // presentation, per the id-contract).
+  // NB (Kael): #headerFull has no inline display:none in template — on the lean
+  // landing it's hidden by this synchronous toggle (essential-mode also CSS-
+  // suppresses it). Keep this call synchronous within init/restore, or a
+  // non-essential-mode landing restore would flash the header before it hides.
   const fullHeader = document.getElementById('headerFull');
-  fullHeader.style.display = (name === 'home' || name === 'landing') ? '' : 'none';
+  fullHeader.style.display = (name === 'home') ? '' : 'none';
 
   if (name === 'growth') { renderGrowthStats(); setTimeout(() => { drawChart(); drawHeightChart(); }, 60); }
   if (name === 'track') {
@@ -73305,11 +73312,10 @@ function _ldAnimateIn(container) {
 }
 
 function renderLanding() {
-  // Greeting + age live in the shared #headerFull block. Refresh them.
-  // Stage 2 (Kael C3): swap updateHeader() for a lean greeting-only helper to
-  // keep the cold start light.
-  if (typeof updateHeader === 'function') updateHeader();
-
+  // The dense #headerFull greeting card (avatar + age + weather) is hidden on
+  // the lean Landing (switchTab toggles it to the dense "Today" only); the
+  // warm-wave "Today so far" hero below is the Landing's own warm anchor, so we
+  // no longer refresh #headerFull from here.
   const el = document.getElementById('ldContent');
   if (!el) return;
 

--- a/index.html
+++ b/index.html
@@ -5651,6 +5651,26 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
   padding:var(--sp-8) var(--sp-16); min-height:44px; cursor:pointer;
 }
 .ld-hero-action svg.zi { width:var(--icon-base); height:var(--icon-base); }
+/* Compact hero — when _ldFitHero marks #ldContent .ld-crowded (Care pre-empts
+   pushed Emergency below the fold), the hero drops its voice line + Start-with-
+   breakfast button and reveals a single "Start with [picker]" row, reclaiming
+   the vertical space so Emergency stays reachable without a scroll. */
+.ld-hero-compact {
+  display:none; align-items:center; gap:var(--sp-8); flex-wrap:wrap; margin-top:var(--sp-4);
+}
+.ld-crowded .ld-hero-voice,
+.ld-crowded .ld-hero-action { display:none; }
+.ld-crowded .ld-hero-compact { display:flex; }
+.ld-hero-compact-label {
+  font-family:'Fraunces', serif; font-style:italic; font-weight:600;
+  font-size:var(--fs-base); color:var(--text);
+}
+.ld-hero-select {
+  font-family:'Nunito', sans-serif; font-weight:700; font-size:var(--fs-base);
+  color:var(--text); background:var(--warm);
+  border:1.5px solid var(--border-subtle); border-radius:var(--r-md);
+  padding:var(--sp-8) var(--sp-12); min-height:44px; cursor:pointer;
+}
 
 /* 2 · Three doors — soft floating tap-cards carrying the whisper-fade (§9.2):
    a domain corner-glow over the surface + a domain-tinted border (reaffirms
@@ -21946,6 +21966,7 @@ function init() {
     if (ca) {
       const action = ca.dataset.changeAction;
       if (action === 'handleAvatar') handleAvatar(e);
+      else if (action === 'ldQuickStart' && typeof ldQuickStart === 'function') ldQuickStart(e);
     }
   });
 
@@ -28937,14 +28958,16 @@ function getActiveCareSignals() {
   if (!todayStr) return out;
   var yesterdayStr = _offsetDateStr(todayStr, -1);
   // Deep-link helpers (Architect: a tapped pre-empt lands on its EXACT fix, not
-  // a generic Medical tab). vaccines → medVaccCard, meds → medMedsCard (both in
-  // Track→Medical), CareTickets → ctEntryPoint (on the Today surface).
+  // a generic Medical tab). vaccines → medVaccCard (Track→Medical); meds → the
+  // Home "Today" reminder card (supp-alert-${idx} for due, missed-${name}-${ds}
+  // for a missed streak) where the dose is actually LOGGED — the Meds inventory
+  // card is read-only and gives a parent no way to act on it; CareTickets →
+  // ctEntryPoint (on the Today surface).
   var push = function(id, severity, icon, title, sub, navArg, navTarget) {
     out.push({ id: id, severity: severity, icon: icon, title: title, sub: sub,
                action: 'ldGoto', arg: navArg, arg2: navTarget });
   };
   var vaccSig = function(id, severity, icon, title, sub) { push(id, severity, icon, title, sub, 'medical', 'medVaccCard'); };
-  var medSig  = function(id, severity, icon, title, sub) { push(id, severity, icon, title, sub, 'medical', 'medMedsCard'); };
 
   // 1 · Overdue vaccinations (past-due only; same-day is Medical-tab-only, mirrors :541)
   if (typeof vaccData !== 'undefined' && Array.isArray(vaccData)) {
@@ -28994,28 +29017,38 @@ function getActiveCareSignals() {
   if (typeof meds !== 'undefined' && Array.isArray(meds) && typeof medChecks !== 'undefined') {
     var activeMeds = meds.filter(function(m) { return m.active; });
     var trackingSince = medChecks._trackingSince || todayStr;
-    activeMeds.forEach(function(m) {
+    // idx matches renderRemindersAndAlerts' supp-alert-${idx} (same activeMeds
+    // filter, same order) so the due-today deep-link lands on that med's card.
+    activeMeds.forEach(function(m, idx) {
       var startDate = m.start || '2025-09-04';
       var earliest = startDate > trackingSince ? startDate : trackingSince;
       var missed = 0;
+      var firstMissedDs = null;  // most-recent missed day (i=1 backwards)
       for (var i = 1; i <= 14; i++) {
         var d = new Date(); d.setDate(d.getDate() - i);
         var ds = toDateStr(d);
         if (ds < earliest) continue;
         var dayLog = medChecks[ds];
-        if (!dayLog || !dayLog[m.name]) missed++;
+        if (!dayLog || !dayLog[m.name]) { missed++; if (!firstMissedDs) firstMissedDs = ds; }
       }
       if (missed > 0) {
-        medSig('med-missed-' + m.name, 'high', 'dot-red',
+        // Land on the Home missed-resolution card (Was given / Not given) — same
+        // id scheme as renderRemindersAndAlerts: missed-${name}-${ds} sanitised.
+        var missedUid = ('missed-' + m.name + '-' + firstMissedDs).replace(/[^a-zA-Z0-9-]/g, '_');
+        push('med-missed-' + m.name, 'high', 'dot-red',
             missed + ' missed ' + m.name + ' dose' + (missed > 1 ? 's' : ''),
-            'Tap to resolve the past ' + (missed > 1 ? missed + ' days' : 'day'));
+            'Tap to resolve the past ' + (missed > 1 ? missed + ' days' : 'day'),
+            'home', missedUid);
       }
       // today-pending
       var todayLog = medChecks[todayStr] || {};
       var parsed = (typeof parseMedCheck === 'function') ? parseMedCheck(todayLog[m.name]) : null;
       var resolved = !!(parsed && (parsed.status === 'done' || parsed.status === 'late' || parsed.status === 'skipped'));
       if (!resolved) {
-        medSig('med-due-' + m.name, 'med', 'warn', m.name + ' due today', m.dose ? m.dose : 'Tap to log the dose');
+        // Land on the pending reminder card (Done now / Done at… / Skip) — where
+        // the dose is logged — not the read-only Meds inventory card.
+        push('med-due-' + m.name, 'med', 'warn', m.name + ' due today',
+            m.dose ? m.dose : 'Tap to log the dose', 'home', 'supp-alert-' + idx);
       }
     });
   }
@@ -73374,6 +73407,22 @@ function renderLanding() {
   if (totalCount === 0) {
     html += '<button class="ld-hero-action" data-action="toggleQuickLog">' + zi('note') + '<span>Start with breakfast</span></button>';
   }
+  // Compact picker — revealed only when _ldFitHero adds .ld-crowded (Care
+  // pre-empts have pushed the Emergency card below the fold). The hero collapses
+  // to "Today so far · Start with [picker]" so a tired parent can jump straight
+  // into logging a category without the full hero's vertical cost. The <select>
+  // routes through the delegated change-action dispatcher to openQuickModal.
+  html += '<div class="ld-hero-compact">'
+        +   '<span class="ld-hero-compact-label">Start with</span>'
+        +   '<select class="ld-hero-select" data-change-action="ldQuickStart" aria-label="Start logging">'
+        +     '<option value="">Choose…</option>'
+        +     '<option value="feed">Food</option>'
+        +     '<option value="sleep">Sleep</option>'
+        +     '<option value="nap">Nap</option>'
+        +     '<option value="poop">Poop</option>'
+        +     '<option value="activity">Activity</option>'
+        +   '</select>'
+        + '</div>';
   html += '</div>';
 
   // 2 · Three doors — Log (primary) / Today / Ask. Domain identity on the icon
@@ -73423,7 +73472,45 @@ function renderLanding() {
         + '</div>';
 
   el.innerHTML = html;
-  _ldAnimateIn(el);
+  // Fit the hero to the viewport (compact it if the Emergency card is below the
+  // fold), then animate. rAF so layout + fonts are settled before we measure.
+  requestAnimationFrame(function() { _ldFitHero(el); _ldAnimateIn(el); });
+  // Re-fit on rotate / zoom / resize while the landing is the active panel
+  // (bound once; idempotent — _ldFitHero re-measures from the full state).
+  if (!window._ldFitBound) {
+    window._ldFitBound = true;
+    window.addEventListener('resize', function() {
+      var lc = document.getElementById('ldContent');
+      var panel = document.getElementById('tab-landing');
+      if (lc && panel && panel.classList.contains('active')) _ldFitHero(lc);
+    });
+  }
+}
+
+// Crowd-fit: if the Care pre-empts have pushed the Emergency card below the
+// fold, collapse the hero to its compact "Start with …" picker to reclaim the
+// vertical space (Architect: keep Emergency reachable without a scroll). Always
+// re-measures from the full state, so it relaxes back when the viewport grows.
+function _ldFitHero(el) {
+  if (!el) return;
+  el.classList.remove('ld-crowded');
+  var em = el.querySelector('.ld-emergency');
+  if (!em) return;
+  if (em.getBoundingClientRect().bottom > window.innerHeight) {
+    el.classList.add('ld-crowded');
+  }
+}
+
+// Compact-hero picker handler — opens the category quick-log modal directly.
+// openQuickModal assumes the body is already scroll-locked (it's normally
+// reached via openQuickLog), so we lock first. The <select> is reset so the
+// same category can be re-picked next time.
+function ldQuickStart(e) {
+  var type = (e && e.target) ? e.target.value : '';
+  if (e && e.target) e.target.value = '';
+  if (!type) return;
+  if (typeof qlLockBody === 'function') qlLockBody();
+  if (typeof openQuickModal === 'function') openQuickModal(type);
 }
 
 // Emergency chooser — STUB (wiring in PR #216). Mirrors the openOutingBriefing

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.04-2",
+  "version": "2026.06.04-3",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.03-1",
+  "version": "2026.06.04-2",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/core.js
+++ b/split/core.js
@@ -3548,10 +3548,17 @@ function switchTab(name) {
   // Auto-scroll tab bar to centre the active tab
   if (activeBtn) scrollTabIntoView(activeBtn);
 
-  // Toggle header: full greeting on the lean Landing (and the dense Home, which
-  // keeps id 'home' = "Today" surface per the id-contract; label is presentation).
+  // Toggle header: the full greeting card shows only on the dense Home ("Today")
+  // surface. The lean Landing has its own warm-wave "Today so far" hero as its
+  // warm anchor, so the dense greeting card (avatar + age + weather) is hidden
+  // there — keeps the front door calm and lean (id 'home' = "Today"; label is
+  // presentation, per the id-contract).
+  // NB (Kael): #headerFull has no inline display:none in template — on the lean
+  // landing it's hidden by this synchronous toggle (essential-mode also CSS-
+  // suppresses it). Keep this call synchronous within init/restore, or a
+  // non-essential-mode landing restore would flash the header before it hides.
   const fullHeader = document.getElementById('headerFull');
-  fullHeader.style.display = (name === 'home' || name === 'landing') ? '' : 'none';
+  fullHeader.style.display = (name === 'home') ? '' : 'none';
 
   if (name === 'growth') { renderGrowthStats(); setTimeout(() => { drawChart(); drawHeightChart(); }, 60); }
   if (name === 'track') {

--- a/split/core.js
+++ b/split/core.js
@@ -1131,6 +1131,7 @@ function init() {
     if (ca) {
       const action = ca.dataset.changeAction;
       if (action === 'handleAvatar') handleAvatar(e);
+      else if (action === 'ldQuickStart' && typeof ldQuickStart === 'function') ldQuickStart(e);
     }
   });
 

--- a/split/home.js
+++ b/split/home.js
@@ -801,14 +801,16 @@ function getActiveCareSignals() {
   if (!todayStr) return out;
   var yesterdayStr = _offsetDateStr(todayStr, -1);
   // Deep-link helpers (Architect: a tapped pre-empt lands on its EXACT fix, not
-  // a generic Medical tab). vaccines → medVaccCard, meds → medMedsCard (both in
-  // Track→Medical), CareTickets → ctEntryPoint (on the Today surface).
+  // a generic Medical tab). vaccines → medVaccCard (Track→Medical); meds → the
+  // Home "Today" reminder card (supp-alert-${idx} for due, missed-${name}-${ds}
+  // for a missed streak) where the dose is actually LOGGED — the Meds inventory
+  // card is read-only and gives a parent no way to act on it; CareTickets →
+  // ctEntryPoint (on the Today surface).
   var push = function(id, severity, icon, title, sub, navArg, navTarget) {
     out.push({ id: id, severity: severity, icon: icon, title: title, sub: sub,
                action: 'ldGoto', arg: navArg, arg2: navTarget });
   };
   var vaccSig = function(id, severity, icon, title, sub) { push(id, severity, icon, title, sub, 'medical', 'medVaccCard'); };
-  var medSig  = function(id, severity, icon, title, sub) { push(id, severity, icon, title, sub, 'medical', 'medMedsCard'); };
 
   // 1 · Overdue vaccinations (past-due only; same-day is Medical-tab-only, mirrors :541)
   if (typeof vaccData !== 'undefined' && Array.isArray(vaccData)) {
@@ -858,28 +860,38 @@ function getActiveCareSignals() {
   if (typeof meds !== 'undefined' && Array.isArray(meds) && typeof medChecks !== 'undefined') {
     var activeMeds = meds.filter(function(m) { return m.active; });
     var trackingSince = medChecks._trackingSince || todayStr;
-    activeMeds.forEach(function(m) {
+    // idx matches renderRemindersAndAlerts' supp-alert-${idx} (same activeMeds
+    // filter, same order) so the due-today deep-link lands on that med's card.
+    activeMeds.forEach(function(m, idx) {
       var startDate = m.start || '2025-09-04';
       var earliest = startDate > trackingSince ? startDate : trackingSince;
       var missed = 0;
+      var firstMissedDs = null;  // most-recent missed day (i=1 backwards)
       for (var i = 1; i <= 14; i++) {
         var d = new Date(); d.setDate(d.getDate() - i);
         var ds = toDateStr(d);
         if (ds < earliest) continue;
         var dayLog = medChecks[ds];
-        if (!dayLog || !dayLog[m.name]) missed++;
+        if (!dayLog || !dayLog[m.name]) { missed++; if (!firstMissedDs) firstMissedDs = ds; }
       }
       if (missed > 0) {
-        medSig('med-missed-' + m.name, 'high', 'dot-red',
+        // Land on the Home missed-resolution card (Was given / Not given) — same
+        // id scheme as renderRemindersAndAlerts: missed-${name}-${ds} sanitised.
+        var missedUid = ('missed-' + m.name + '-' + firstMissedDs).replace(/[^a-zA-Z0-9-]/g, '_');
+        push('med-missed-' + m.name, 'high', 'dot-red',
             missed + ' missed ' + m.name + ' dose' + (missed > 1 ? 's' : ''),
-            'Tap to resolve the past ' + (missed > 1 ? missed + ' days' : 'day'));
+            'Tap to resolve the past ' + (missed > 1 ? missed + ' days' : 'day'),
+            'home', missedUid);
       }
       // today-pending
       var todayLog = medChecks[todayStr] || {};
       var parsed = (typeof parseMedCheck === 'function') ? parseMedCheck(todayLog[m.name]) : null;
       var resolved = !!(parsed && (parsed.status === 'done' || parsed.status === 'late' || parsed.status === 'skipped'));
       if (!resolved) {
-        medSig('med-due-' + m.name, 'med', 'warn', m.name + ' due today', m.dose ? m.dose : 'Tap to log the dose');
+        // Land on the pending reminder card (Done now / Done at… / Skip) — where
+        // the dose is logged — not the read-only Meds inventory card.
+        push('med-due-' + m.name, 'med', 'warn', m.name + ' due today',
+            m.dose ? m.dose : 'Tap to log the dose', 'home', 'supp-alert-' + idx);
       }
     });
   }

--- a/split/intelligence-cards.js
+++ b/split/intelligence-cards.js
@@ -1512,11 +1512,10 @@ function _ldAnimateIn(container) {
 }
 
 function renderLanding() {
-  // Greeting + age live in the shared #headerFull block. Refresh them.
-  // Stage 2 (Kael C3): swap updateHeader() for a lean greeting-only helper to
-  // keep the cold start light.
-  if (typeof updateHeader === 'function') updateHeader();
-
+  // The dense #headerFull greeting card (avatar + age + weather) is hidden on
+  // the lean Landing (switchTab toggles it to the dense "Today" only); the
+  // warm-wave "Today so far" hero below is the Landing's own warm anchor, so we
+  // no longer refresh #headerFull from here.
   const el = document.getElementById('ldContent');
   if (!el) return;
 

--- a/split/intelligence-cards.js
+++ b/split/intelligence-cards.js
@@ -1574,6 +1574,22 @@ function renderLanding() {
   if (totalCount === 0) {
     html += '<button class="ld-hero-action" data-action="toggleQuickLog">' + zi('note') + '<span>Start with breakfast</span></button>';
   }
+  // Compact picker — revealed only when _ldFitHero adds .ld-crowded (Care
+  // pre-empts have pushed the Emergency card below the fold). The hero collapses
+  // to "Today so far · Start with [picker]" so a tired parent can jump straight
+  // into logging a category without the full hero's vertical cost. The <select>
+  // routes through the delegated change-action dispatcher to openQuickModal.
+  html += '<div class="ld-hero-compact">'
+        +   '<span class="ld-hero-compact-label">Start with</span>'
+        +   '<select class="ld-hero-select" data-change-action="ldQuickStart" aria-label="Start logging">'
+        +     '<option value="">Choose…</option>'
+        +     '<option value="feed">Food</option>'
+        +     '<option value="sleep">Sleep</option>'
+        +     '<option value="nap">Nap</option>'
+        +     '<option value="poop">Poop</option>'
+        +     '<option value="activity">Activity</option>'
+        +   '</select>'
+        + '</div>';
   html += '</div>';
 
   // 2 · Three doors — Log (primary) / Today / Ask. Domain identity on the icon
@@ -1623,7 +1639,45 @@ function renderLanding() {
         + '</div>';
 
   el.innerHTML = html;
-  _ldAnimateIn(el);
+  // Fit the hero to the viewport (compact it if the Emergency card is below the
+  // fold), then animate. rAF so layout + fonts are settled before we measure.
+  requestAnimationFrame(function() { _ldFitHero(el); _ldAnimateIn(el); });
+  // Re-fit on rotate / zoom / resize while the landing is the active panel
+  // (bound once; idempotent — _ldFitHero re-measures from the full state).
+  if (!window._ldFitBound) {
+    window._ldFitBound = true;
+    window.addEventListener('resize', function() {
+      var lc = document.getElementById('ldContent');
+      var panel = document.getElementById('tab-landing');
+      if (lc && panel && panel.classList.contains('active')) _ldFitHero(lc);
+    });
+  }
+}
+
+// Crowd-fit: if the Care pre-empts have pushed the Emergency card below the
+// fold, collapse the hero to its compact "Start with …" picker to reclaim the
+// vertical space (Architect: keep Emergency reachable without a scroll). Always
+// re-measures from the full state, so it relaxes back when the viewport grows.
+function _ldFitHero(el) {
+  if (!el) return;
+  el.classList.remove('ld-crowded');
+  var em = el.querySelector('.ld-emergency');
+  if (!em) return;
+  if (em.getBoundingClientRect().bottom > window.innerHeight) {
+    el.classList.add('ld-crowded');
+  }
+}
+
+// Compact-hero picker handler — opens the category quick-log modal directly.
+// openQuickModal assumes the body is already scroll-locked (it's normally
+// reached via openQuickLog), so we lock first. The <select> is reset so the
+// same category can be re-picked next time.
+function ldQuickStart(e) {
+  var type = (e && e.target) ? e.target.value : '';
+  if (e && e.target) e.target.value = '';
+  if (!type) return;
+  if (typeof qlLockBody === 'function') qlLockBody();
+  if (typeof openQuickModal === 'function') openQuickModal(type);
 }
 
 // Emergency chooser — STUB (wiring in PR #216). Mirrors the openOutingBriefing

--- a/split/styles.css
+++ b/split/styles.css
@@ -5644,6 +5644,26 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
   padding:var(--sp-8) var(--sp-16); min-height:44px; cursor:pointer;
 }
 .ld-hero-action svg.zi { width:var(--icon-base); height:var(--icon-base); }
+/* Compact hero — when _ldFitHero marks #ldContent .ld-crowded (Care pre-empts
+   pushed Emergency below the fold), the hero drops its voice line + Start-with-
+   breakfast button and reveals a single "Start with [picker]" row, reclaiming
+   the vertical space so Emergency stays reachable without a scroll. */
+.ld-hero-compact {
+  display:none; align-items:center; gap:var(--sp-8); flex-wrap:wrap; margin-top:var(--sp-4);
+}
+.ld-crowded .ld-hero-voice,
+.ld-crowded .ld-hero-action { display:none; }
+.ld-crowded .ld-hero-compact { display:flex; }
+.ld-hero-compact-label {
+  font-family:'Fraunces', serif; font-style:italic; font-weight:600;
+  font-size:var(--fs-base); color:var(--text);
+}
+.ld-hero-select {
+  font-family:'Nunito', sans-serif; font-weight:700; font-size:var(--fs-base);
+  color:var(--text); background:var(--warm);
+  border:1.5px solid var(--border-subtle); border-radius:var(--r-md);
+  padding:var(--sp-8) var(--sp-12); min-height:44px; cursor:pointer;
+}
 
 /* 2 · Three doors — soft floating tap-cards carrying the whisper-fade (§9.2):
    a domain corner-glow over the surface + a domain-tinted border (reaffirms

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -24363,10 +24363,17 @@ function switchTab(name) {
   // Auto-scroll tab bar to centre the active tab
   if (activeBtn) scrollTabIntoView(activeBtn);
 
-  // Toggle header: full greeting on the lean Landing (and the dense Home, which
-  // keeps id 'home' = "Today" surface per the id-contract; label is presentation).
+  // Toggle header: the full greeting card shows only on the dense Home ("Today")
+  // surface. The lean Landing has its own warm-wave "Today so far" hero as its
+  // warm anchor, so the dense greeting card (avatar + age + weather) is hidden
+  // there — keeps the front door calm and lean (id 'home' = "Today"; label is
+  // presentation, per the id-contract).
+  // NB (Kael): #headerFull has no inline display:none in template — on the lean
+  // landing it's hidden by this synchronous toggle (essential-mode also CSS-
+  // suppresses it). Keep this call synchronous within init/restore, or a
+  // non-essential-mode landing restore would flash the header before it hides.
   const fullHeader = document.getElementById('headerFull');
-  fullHeader.style.display = (name === 'home' || name === 'landing') ? '' : 'none';
+  fullHeader.style.display = (name === 'home') ? '' : 'none';
 
   if (name === 'growth') { renderGrowthStats(); setTimeout(() => { drawChart(); drawHeightChart(); }, 60); }
   if (name === 'track') {
@@ -73305,11 +73312,10 @@ function _ldAnimateIn(container) {
 }
 
 function renderLanding() {
-  // Greeting + age live in the shared #headerFull block. Refresh them.
-  // Stage 2 (Kael C3): swap updateHeader() for a lean greeting-only helper to
-  // keep the cold start light.
-  if (typeof updateHeader === 'function') updateHeader();
-
+  // The dense #headerFull greeting card (avatar + age + weather) is hidden on
+  // the lean Landing (switchTab toggles it to the dense "Today" only); the
+  // warm-wave "Today so far" hero below is the Landing's own warm anchor, so we
+  // no longer refresh #headerFull from here.
   const el = document.getElementById('ldContent');
   if (!el) return;
 

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -5651,6 +5651,26 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
   padding:var(--sp-8) var(--sp-16); min-height:44px; cursor:pointer;
 }
 .ld-hero-action svg.zi { width:var(--icon-base); height:var(--icon-base); }
+/* Compact hero — when _ldFitHero marks #ldContent .ld-crowded (Care pre-empts
+   pushed Emergency below the fold), the hero drops its voice line + Start-with-
+   breakfast button and reveals a single "Start with [picker]" row, reclaiming
+   the vertical space so Emergency stays reachable without a scroll. */
+.ld-hero-compact {
+  display:none; align-items:center; gap:var(--sp-8); flex-wrap:wrap; margin-top:var(--sp-4);
+}
+.ld-crowded .ld-hero-voice,
+.ld-crowded .ld-hero-action { display:none; }
+.ld-crowded .ld-hero-compact { display:flex; }
+.ld-hero-compact-label {
+  font-family:'Fraunces', serif; font-style:italic; font-weight:600;
+  font-size:var(--fs-base); color:var(--text);
+}
+.ld-hero-select {
+  font-family:'Nunito', sans-serif; font-weight:700; font-size:var(--fs-base);
+  color:var(--text); background:var(--warm);
+  border:1.5px solid var(--border-subtle); border-radius:var(--r-md);
+  padding:var(--sp-8) var(--sp-12); min-height:44px; cursor:pointer;
+}
 
 /* 2 · Three doors — soft floating tap-cards carrying the whisper-fade (§9.2):
    a domain corner-glow over the surface + a domain-tinted border (reaffirms
@@ -21946,6 +21966,7 @@ function init() {
     if (ca) {
       const action = ca.dataset.changeAction;
       if (action === 'handleAvatar') handleAvatar(e);
+      else if (action === 'ldQuickStart' && typeof ldQuickStart === 'function') ldQuickStart(e);
     }
   });
 
@@ -28937,14 +28958,16 @@ function getActiveCareSignals() {
   if (!todayStr) return out;
   var yesterdayStr = _offsetDateStr(todayStr, -1);
   // Deep-link helpers (Architect: a tapped pre-empt lands on its EXACT fix, not
-  // a generic Medical tab). vaccines → medVaccCard, meds → medMedsCard (both in
-  // Track→Medical), CareTickets → ctEntryPoint (on the Today surface).
+  // a generic Medical tab). vaccines → medVaccCard (Track→Medical); meds → the
+  // Home "Today" reminder card (supp-alert-${idx} for due, missed-${name}-${ds}
+  // for a missed streak) where the dose is actually LOGGED — the Meds inventory
+  // card is read-only and gives a parent no way to act on it; CareTickets →
+  // ctEntryPoint (on the Today surface).
   var push = function(id, severity, icon, title, sub, navArg, navTarget) {
     out.push({ id: id, severity: severity, icon: icon, title: title, sub: sub,
                action: 'ldGoto', arg: navArg, arg2: navTarget });
   };
   var vaccSig = function(id, severity, icon, title, sub) { push(id, severity, icon, title, sub, 'medical', 'medVaccCard'); };
-  var medSig  = function(id, severity, icon, title, sub) { push(id, severity, icon, title, sub, 'medical', 'medMedsCard'); };
 
   // 1 · Overdue vaccinations (past-due only; same-day is Medical-tab-only, mirrors :541)
   if (typeof vaccData !== 'undefined' && Array.isArray(vaccData)) {
@@ -28994,28 +29017,38 @@ function getActiveCareSignals() {
   if (typeof meds !== 'undefined' && Array.isArray(meds) && typeof medChecks !== 'undefined') {
     var activeMeds = meds.filter(function(m) { return m.active; });
     var trackingSince = medChecks._trackingSince || todayStr;
-    activeMeds.forEach(function(m) {
+    // idx matches renderRemindersAndAlerts' supp-alert-${idx} (same activeMeds
+    // filter, same order) so the due-today deep-link lands on that med's card.
+    activeMeds.forEach(function(m, idx) {
       var startDate = m.start || '2025-09-04';
       var earliest = startDate > trackingSince ? startDate : trackingSince;
       var missed = 0;
+      var firstMissedDs = null;  // most-recent missed day (i=1 backwards)
       for (var i = 1; i <= 14; i++) {
         var d = new Date(); d.setDate(d.getDate() - i);
         var ds = toDateStr(d);
         if (ds < earliest) continue;
         var dayLog = medChecks[ds];
-        if (!dayLog || !dayLog[m.name]) missed++;
+        if (!dayLog || !dayLog[m.name]) { missed++; if (!firstMissedDs) firstMissedDs = ds; }
       }
       if (missed > 0) {
-        medSig('med-missed-' + m.name, 'high', 'dot-red',
+        // Land on the Home missed-resolution card (Was given / Not given) — same
+        // id scheme as renderRemindersAndAlerts: missed-${name}-${ds} sanitised.
+        var missedUid = ('missed-' + m.name + '-' + firstMissedDs).replace(/[^a-zA-Z0-9-]/g, '_');
+        push('med-missed-' + m.name, 'high', 'dot-red',
             missed + ' missed ' + m.name + ' dose' + (missed > 1 ? 's' : ''),
-            'Tap to resolve the past ' + (missed > 1 ? missed + ' days' : 'day'));
+            'Tap to resolve the past ' + (missed > 1 ? missed + ' days' : 'day'),
+            'home', missedUid);
       }
       // today-pending
       var todayLog = medChecks[todayStr] || {};
       var parsed = (typeof parseMedCheck === 'function') ? parseMedCheck(todayLog[m.name]) : null;
       var resolved = !!(parsed && (parsed.status === 'done' || parsed.status === 'late' || parsed.status === 'skipped'));
       if (!resolved) {
-        medSig('med-due-' + m.name, 'med', 'warn', m.name + ' due today', m.dose ? m.dose : 'Tap to log the dose');
+        // Land on the pending reminder card (Done now / Done at… / Skip) — where
+        // the dose is logged — not the read-only Meds inventory card.
+        push('med-due-' + m.name, 'med', 'warn', m.name + ' due today',
+            m.dose ? m.dose : 'Tap to log the dose', 'home', 'supp-alert-' + idx);
       }
     });
   }
@@ -73374,6 +73407,22 @@ function renderLanding() {
   if (totalCount === 0) {
     html += '<button class="ld-hero-action" data-action="toggleQuickLog">' + zi('note') + '<span>Start with breakfast</span></button>';
   }
+  // Compact picker — revealed only when _ldFitHero adds .ld-crowded (Care
+  // pre-empts have pushed the Emergency card below the fold). The hero collapses
+  // to "Today so far · Start with [picker]" so a tired parent can jump straight
+  // into logging a category without the full hero's vertical cost. The <select>
+  // routes through the delegated change-action dispatcher to openQuickModal.
+  html += '<div class="ld-hero-compact">'
+        +   '<span class="ld-hero-compact-label">Start with</span>'
+        +   '<select class="ld-hero-select" data-change-action="ldQuickStart" aria-label="Start logging">'
+        +     '<option value="">Choose…</option>'
+        +     '<option value="feed">Food</option>'
+        +     '<option value="sleep">Sleep</option>'
+        +     '<option value="nap">Nap</option>'
+        +     '<option value="poop">Poop</option>'
+        +     '<option value="activity">Activity</option>'
+        +   '</select>'
+        + '</div>';
   html += '</div>';
 
   // 2 · Three doors — Log (primary) / Today / Ask. Domain identity on the icon
@@ -73423,7 +73472,45 @@ function renderLanding() {
         + '</div>';
 
   el.innerHTML = html;
-  _ldAnimateIn(el);
+  // Fit the hero to the viewport (compact it if the Emergency card is below the
+  // fold), then animate. rAF so layout + fonts are settled before we measure.
+  requestAnimationFrame(function() { _ldFitHero(el); _ldAnimateIn(el); });
+  // Re-fit on rotate / zoom / resize while the landing is the active panel
+  // (bound once; idempotent — _ldFitHero re-measures from the full state).
+  if (!window._ldFitBound) {
+    window._ldFitBound = true;
+    window.addEventListener('resize', function() {
+      var lc = document.getElementById('ldContent');
+      var panel = document.getElementById('tab-landing');
+      if (lc && panel && panel.classList.contains('active')) _ldFitHero(lc);
+    });
+  }
+}
+
+// Crowd-fit: if the Care pre-empts have pushed the Emergency card below the
+// fold, collapse the hero to its compact "Start with …" picker to reclaim the
+// vertical space (Architect: keep Emergency reachable without a scroll). Always
+// re-measures from the full state, so it relaxes back when the viewport grows.
+function _ldFitHero(el) {
+  if (!el) return;
+  el.classList.remove('ld-crowded');
+  var em = el.querySelector('.ld-emergency');
+  if (!em) return;
+  if (em.getBoundingClientRect().bottom > window.innerHeight) {
+    el.classList.add('ld-crowded');
+  }
+}
+
+// Compact-hero picker handler — opens the category quick-log modal directly.
+// openQuickModal assumes the body is already scroll-locked (it's normally
+// reached via openQuickLog), so we lock first. The <select> is reset so the
+// same category can be re-picked next time.
+function ldQuickStart(e) {
+  var type = (e && e.target) ? e.target.value : '';
+  if (e && e.target) e.target.value = '';
+  if (!type) return;
+  if (typeof qlLockBody === 'function') qlLockBody();
+  if (typeof openQuickModal === 'function') openQuickModal(type);
 }
 
 // Emergency chooser — STUB (wiring in PR #216). Mirrors the openOutingBriefing


### PR DESCRIPTION
Three refinements to the lean landing (all on the calm front door):

### 1 · Hide the dense greeting header
The "Good evening, Ziva" `#headerFull` card (avatar + age + weather) was doubling up with the landing's own warm-wave "Today so far" hero. Hidden on `landing` (kept on the dense "Today"). The warm-wave hero is now the sole warm anchor.

### 2 · Wire the Vit D3 / meds Care pre-empt to the real logging UI
Tapping "Vitamin D3 due today" landed on `medMedsCard` — a **read-only Meds inventory** card with no way to act. It now deep-links to the Home "Today" **reminder cards** where the dose is actually logged:
- **due today** → `supp-alert-${idx}` (Done now / Done at… / Skip)
- **missed streak** → `missed-${name}-${ds}` (Was given / Not given)

`idx` aligns with `renderRemindersAndAlerts` (same `activeMeds` filter/order); the missed uid mirrors that card's sanitised id scheme.

### 3 · Crowd-fit hero
When Care pre-empts push the Emergency card below the fold, `_ldFitHero` collapses the warm-wave hero to a compact **"Today so far · Start with [picker]"** row, reclaiming the vertical space so Emergency stays reachable without a scroll. The `<select>` (Food / Sleep / Nap / Poop / Activity) routes through the delegated change-action dispatcher to `openQuickModal`. Re-measures from the full state on resize/rotate, so it relaxes back when the viewport grows.

### canon-cc-008 QA chain
Diff touches `home.js` (Maren), `core.js` (Kael), `intelligence-cards.js` (Vela), `styles.css` (triple-Gov). Maren · Kael · Vela → Lyra synth → Cipher Edict V. Build clean, all gates pass.

**Preview:** https://sproutlab-git-claude-focused-sagan-o11ws-rishabh1804s-projects.vercel.app

https://claude.ai/code/session_01PavbZfuYicPKWiD6CA2cQZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PavbZfuYicPKWiD6CA2cQZ)_