### PR TITLE
Recipes Tier C: generative warm-wave hero + tagline composer + LOCKED polish

### DIFF
--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-06-04 &middot; graph @ <code>aad286e9a5e9</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-04 &middot; graph @ <code>6bdac6161866</code></div>
   <div class="sub" style="margin-top:8px">
-    <span class="stat"><b>1,778</b> symbols</span>
-    <span class="stat"><b>5,285</b> relations</span>
-    <span class="stat"><b>83,562</b> LOC</span>
+    <span class="stat"><b>1,791</b> symbols</span>
+    <span class="stat"><b>5,307</b> relations</span>
+    <span class="stat"><b>83,790</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -81,15 +81,15 @@
       <div class="cgov">Governor: <b>Maren</b></div>
       <div class="nums">
         <span><b>3</b> modules</span>
-        <span><b>696</b> symbols</span>
-        <span><b>27,975</b> LOC</span>
+        <span><b>704</b> symbols</span>
+        <span><b>28,077</b> LOC</span>
       </div>
       
-      <div class="bar" title="27,975 of 30,000 LOC">
-        <div class="fill hot" style="width:93%"></div>
-        <span class="barlbl">93% to 30K frontier &middot; CONTESTED</span>
+      <div class="bar" title="28,077 of 30,000 LOC">
+        <div class="fill hot" style="width:94%"></div>
+        <span class="barlbl">94% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">2,025 LOC headroom</div>
+      <div class="hd">1,923 LOC headroom</div>
       <div class="mods">home.js, medical.js, diet.js</div>
     </div>
     <div class="card" style="border-top:5px solid #c9b8e8">
@@ -116,7 +116,7 @@
       <div class="nums">
         <span><b>2</b> modules</span>
         <span><b>0</b> symbols</span>
-        <span><b>14,645</b> LOC</span>
+        <span><b>14,683</b> LOC</span>
       </div>
       <div class="note">Unsurveyed &mdash; code-only extraction. Set a backend and rebuild for symbols.</div>
       <div class="mods">styles.css, template.html</div>
@@ -127,8 +127,8 @@
       <div class="cgov">Governor: <b>(tooling)</b></div>
       <div class="nums">
         <span><b>22</b> modules</span>
-        <span><b>144</b> symbols</span>
-        <span><b>4,195</b> LOC</span>
+        <span><b>149</b> symbols</span>
+        <span><b>4,283</b> LOC</span>
       </div>
       
       <div class="mods">build-province-map.mjs, build-poop-reference.mjs, QA_GATE_SPEC.md, build-careticket-state-machine.mjs, recipes.js, audit-food-library-wiring-v1.sh, bump-version.mjs, build-graph.sh, audit-activity-categories-v1.sh, audit-card-priority-v3-6.sh, audit-chip-taxonomy-v3-5.sh, audit-emoji.sh, audit-feed-sheet-wiring-v1.sh, audit-food-effects-sync-v1.sh, audit-hr12-v3-3.sh, audit-icon-text.sh, audit-no-personalised-prediction-v1.sh, audit-resolve-shield.sh, audit-viz-smoke.sh, build-safe.sh, build.sh, qa-route.sh</div>
@@ -137,7 +137,7 @@
   <h2>Cross-province coupling (highest-traffic calls across jurisdiction borders)</h2>
   <table>
     <thead><tr><th>Module</th><th>Module</th><th class="num">Calls</th><th>Border</th></tr></thead>
-    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">351</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">154</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">46</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">19</td><td>Care &harr; Intelligence</td></tr></tbody>
+    <tbody><tr><td>home.js</td><td>core.js</td><td class="num">351</td><td>Care &harr; Intelligence</td></tr><tr><td>medical.js</td><td>core.js</td><td class="num">280</td><td>Care &harr; Intelligence</td></tr><tr><td>diet.js</td><td>core.js</td><td class="num">154</td><td>Care &harr; Intelligence</td></tr><tr><td>i-quicklog.js</td><td>core.js</td><td class="num">137</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>i-illness.js</td><td>i-quicklog.js</td><td class="num">49</td><td>Intelligence &harr; Surfacing</td></tr><tr><td>i-cards.js</td><td>core.js</td><td class="num">46</td><td>Surfacing &harr; Intelligence</td></tr><tr><td>home.js</td><td>i-quicklog.js</td><td class="num">44</td><td>Care &harr; Surfacing</td></tr><tr><td>i-quicklog.js</td><td>medical.js</td><td class="num">40</td><td>Surfacing &harr; Care</td></tr><tr><td>home.js</td><td>i-illness.js</td><td class="num">35</td><td>Care &harr; Intelligence</td></tr><tr><td>i-cards.js</td><td>medical.js</td><td class="num">35</td><td>Surfacing &harr; Care</td></tr><tr><td>i-qa-handlers.js</td><td>medical.js</td><td class="num">27</td><td>Intelligence &harr; Care</td></tr><tr><td>home.js</td><td>i-caretickets.js</td><td class="num">19</td><td>Care &harr; Intelligence</td></tr></tbody>
   </table>
 
   <h2>Connectivity hubs (highest call-degree symbols per module)</h2>

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-06-04 &middot; graph @ <code>6bdac6161866</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-04 &middot; graph @ <code>0c4f7c31e511</code></div>
   <div class="sub" style="margin-top:8px">
-    <span class="stat"><b>1,791</b> symbols</span>
-    <span class="stat"><b>5,307</b> relations</span>
-    <span class="stat"><b>83,790</b> LOC</span>
+    <span class="stat"><b>1,794</b> symbols</span>
+    <span class="stat"><b>5,313</b> relations</span>
+    <span class="stat"><b>83,820</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -81,15 +81,15 @@
       <div class="cgov">Governor: <b>Maren</b></div>
       <div class="nums">
         <span><b>3</b> modules</span>
-        <span><b>704</b> symbols</span>
-        <span><b>28,077</b> LOC</span>
+        <span><b>707</b> symbols</span>
+        <span><b>28,097</b> LOC</span>
       </div>
       
-      <div class="bar" title="28,077 of 30,000 LOC">
+      <div class="bar" title="28,097 of 30,000 LOC">
         <div class="fill hot" style="width:94%"></div>
         <span class="barlbl">94% to 30K frontier &middot; CONTESTED</span>
       </div>
-      <div class="hd">1,923 LOC headroom</div>
+      <div class="hd">1,903 LOC headroom</div>
       <div class="mods">home.js, medical.js, diet.js</div>
     </div>
     <div class="card" style="border-top:5px solid #c9b8e8">
@@ -116,7 +116,7 @@
       <div class="nums">
         <span><b>2</b> modules</span>
         <span><b>0</b> symbols</span>
-        <span><b>14,683</b> LOC</span>
+        <span><b>14,684</b> LOC</span>
       </div>
       <div class="note">Unsurveyed &mdash; code-only extraction. Set a backend and rebuild for symbols.</div>
       <div class="mods">styles.css, template.html</div>
@@ -128,7 +128,7 @@
       <div class="nums">
         <span><b>22</b> modules</span>
         <span><b>149</b> symbols</span>
-        <span><b>4,283</b> LOC</span>
+        <span><b>4,292</b> LOC</span>
       </div>
       
       <div class="mods">build-province-map.mjs, build-poop-reference.mjs, QA_GATE_SPEC.md, build-careticket-state-machine.mjs, recipes.js, audit-food-library-wiring-v1.sh, bump-version.mjs, build-graph.sh, audit-activity-categories-v1.sh, audit-card-priority-v3-6.sh, audit-chip-taxonomy-v3-5.sh, audit-emoji.sh, audit-feed-sheet-wiring-v1.sh, audit-food-effects-sync-v1.sh, audit-hr12-v3-3.sh, audit-icon-text.sh, audit-no-personalised-prediction-v1.sh, audit-resolve-shield.sh, audit-viz-smoke.sh, build-safe.sh, build.sh, qa-route.sh</div>

--- a/index.html
+++ b/index.html
@@ -11147,9 +11147,46 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 .recipe-hero-title { font-family:'Fraunces', serif; font-weight:700; font-size:var(--fs-2xl); line-height:1.08; color:var(--text); margin:0 0 2px; text-wrap:balance; }
 .recipe-hero-tag { font-family:'Fraunces', serif; font-style:italic; font-weight:400; font-size:var(--fs-lg); line-height:1.25; color:var(--mid); margin:0 0 var(--sp-8); }
 .recipe-hero-why { font-size:var(--fs-sm); color:var(--mid); line-height:var(--lh-relaxed); margin:0 0 var(--sp-8); }
-.recipe-hero-more { display:inline-flex; align-items:center; gap:var(--sp-4); font-size:var(--fs-xs); font-weight:700; color:var(--tc-sage); }
-.recipe-hero-more .zi { width:14px; height:14px; transition:transform var(--ease-med); }
-.recipe-hero[aria-expanded="true"] .recipe-hero-more .zi { transform:rotate(180deg); }
+/* Panel header (LOCKED 05-meal-rows) */
+.recipes-header { margin-bottom:var(--sp-8); }
+.recipes-h1 { font-family:'Fraunces', serif; font-weight:600; font-size:var(--fs-2xl); color:var(--text); margin:0 0 2px; }
+.recipes-subtitle { font-size:var(--fs-sm); color:var(--mid); margin:0; line-height:var(--lh-relaxed); }
+
+/* ── Generative "Suggested for Ziva" hero (§9.3/§9.4) ──
+   grams-weighted wavelength FADE body (--rc-fl light / --rc-fd dark) + a 4px
+   warm-wave STRIPE (--rc-stripe) with a sheen sweep (reuses @keyframes ld-wave)
+   + a corner zif watermark. Two-channel colour: the domain left-rail leads,
+   the fingerprint fade rides under. */
+.recipe-hero-gen { background:var(--rc-fl, var(--card-bg)); }
+[data-theme="dark"] .recipe-hero-gen { background:var(--rc-fd, var(--surface)); }
+.recipe-hero-gen > * { position:relative; z-index:1; }
+.recipe-hero-gen::before {
+  content:''; position:absolute; top:0; left:0; right:0; height:4px; z-index:2; border-radius:var(--r-2xl) var(--r-2xl) 0 0;
+  background-image:linear-gradient(100deg, transparent 35%, rgba(255,255,255,0.5) 50%, transparent 65%), var(--rc-stripe, var(--tc-sage));
+  background-size:35% 100%, 100% 100%; background-repeat:no-repeat; background-position:-35% 0, 0 0;
+  animation:ld-wave 4.4s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) { .recipe-hero-gen::before { animation:none; background-position:0 0, 0 0; } }
+/* corner watermark — dominant ingredient gets the big slot, non-overlapping */
+.recipe-hero-wm { position:absolute; right:0; bottom:0; width:200px; height:100px; pointer-events:none; z-index:0; }
+.recipe-hero-wm .recipe-wm { position:absolute; }
+.recipe-hero-wm .recipe-wm svg.zif { width:100%; height:100%; opacity:0.30; }
+[data-theme="dark"] .recipe-hero-wm .recipe-wm svg.zif { opacity:0.40; }
+.recipe-hero-wm .wm-1 { width:78px; height:78px; right:-4px; bottom:-6px; }
+.recipe-hero-wm .wm-2 { width:46px; height:46px; right:78px; bottom:6px; }
+.recipe-hero-wm .wm-3 { width:34px; height:34px; right:140px; bottom:-2px; }
+.recipe-hero-head { display:flex; align-items:center; justify-content:space-between; gap:var(--sp-8); margin-bottom:var(--sp-6); }
+.recipe-hero-head .recipe-hero-eyebrow { margin-bottom:0; }
+.recipe-hero-badge { flex:0 0 auto; display:inline-flex; align-items:center; background:var(--tc-sage); color:var(--card-bg); border-radius:var(--r-full); padding:var(--sp-4) var(--sp-10); font-size:var(--fs-2xs); font-weight:800; }
+/* strict no's lead the tagline (rose, never folded) */
+.recipe-strict { font-family:'Nunito', sans-serif; font-style:normal; font-weight:800; font-size:var(--fs-2xs); text-transform:uppercase; letter-spacing:0.04em; color:var(--tc-rose); }
+.recipe-hero-foot { display:flex; align-items:center; justify-content:space-between; gap:var(--sp-8); flex-wrap:wrap; }
+.recipe-hero-meta { display:flex; align-items:center; gap:var(--sp-8); flex-wrap:wrap; }
+.recipe-hero-meta span { display:inline-flex; align-items:center; gap:var(--sp-4); font-size:var(--fs-xs); color:var(--mid); }
+.recipe-hero-meta .zi { width:13px; height:13px; }
+.recipe-hero-cta { display:inline-flex; align-items:center; gap:var(--sp-4); min-height:36px; background:var(--tc-sage); color:var(--card-bg); border-radius:var(--r-full); padding:var(--sp-6) var(--sp-12); font-size:var(--fs-xs); font-weight:700; }
+.recipe-hero-cta .zi { width:14px; height:14px; transition:transform var(--ease-med); }
+.recipe-hero[aria-expanded="true"] .recipe-hero-cta .zi { transform:rotate(90deg); }
 
 /* Meal-slot groups + full-width recipe rows (.lib-book idiom) */
 .recipe-group { margin-bottom:var(--sp-16); }
@@ -11166,10 +11203,11 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 .recipe-row-icon .zif { width:30px; height:30px; }
 .recipe-row-main { flex:1; min-width:0; }
 .recipe-row-title { font-family:'Fraunces', serif; font-weight:600; font-size:var(--fs-base); color:var(--text); line-height:1.15; }
-.recipe-row-tag { font-family:'Fraunces', serif; font-style:italic; font-weight:400; font-size:var(--fs-sm); color:var(--mid); line-height:1.2; margin-top:1px; }
-.recipe-row-meta { display:flex; align-items:center; gap:var(--sp-10); margin-top:var(--sp-4); }
+.recipe-row-meta { display:flex; align-items:center; gap:var(--sp-8); margin-top:var(--sp-4); flex-wrap:wrap; }
 .recipe-row-meta span { display:inline-flex; align-items:center; gap:var(--sp-4); font-size:var(--fs-xs); color:var(--mid); }
+.recipe-row-meta span:not(:first-child)::before { content:'·'; margin-right:var(--sp-4); color:var(--light); }
 .recipe-row-meta .zi { width:13px; height:13px; }
+.recipe-row-rel { color:var(--tc-sage); font-weight:700; }
 .recipe-row-chev { flex:0 0 auto; color:var(--light); transition:transform var(--ease-med); }
 .recipe-row[aria-expanded="true"] .recipe-row-chev { transform:rotate(180deg); }
 
@@ -20389,16 +20427,19 @@ const RECIPE_SOURCES = {
 };
 
 // Each recipe:
-//   { id, title, slot, minAgeMonths,
-//     ingredients:[{name, qty}],   // name = the LIVE-resolver classifying form
+//   { id, title, slot, minAgeMonths, prepMinutes,
+//     ingredients:[{name, qty, g}], // name = the LIVE-resolver classifying form;
+//                                   // g = grams (drives the quantity-weighted
+//                                   // generative fingerprint §9.3; trace items
+//                                   // ghee/oil/spices excluded at render)
 //     foodGroups:[FOOD_TAX gid],   // gap-fill scoring + card colour
 //     steps:[…], dos:[…], donts:[…],
 //     cuisine, source:[sourceKey…] }
 const RECIPES = [
   // ─────────────────────────── BREAKFAST ───────────────────────────
   {
-    id: 'ragi-banana-porridge', title: 'Ragi Banana Porridge', slot: 'breakfast', minAgeMonths: 7,
-    ingredients: [{ name: 'ragi', qty: '1 tbsp (24 g)' }, { name: 'banana', qty: '¼, mashed (20 g)' }],
+    id: 'ragi-banana-porridge', title: 'Ragi Banana Porridge', slot: 'breakfast', minAgeMonths: 7, prepMinutes: 12,
+    ingredients: [{ name: 'ragi', qty: '1 tbsp (24 g)', g: 24 }, { name: 'banana', qty: '¼, mashed (20 g)', g: 20 }],
     foodGroups: ['grains', 'fruits'], cuisine: 'Indian',
     steps: [
       'Dry-roast 1 tbsp ragi flour on low for 2 min until fragrant.',
@@ -20411,8 +20452,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'oats-apple-porridge', title: 'Oats & Apple Porridge', slot: 'breakfast', minAgeMonths: 7,
-    ingredients: [{ name: 'oats', qty: '1 tbsp ground (24 g)' }, { name: 'apple', qty: '¼ grated (20 g)' }, { name: 'cinnamon', qty: 'a pinch' }],
+    id: 'oats-apple-porridge', title: 'Oats & Apple Porridge', slot: 'breakfast', minAgeMonths: 7, prepMinutes: 10,
+    ingredients: [{ name: 'oats', qty: '1 tbsp ground (24 g)', g: 24 }, { name: 'apple', qty: '¼ grated (20 g)', g: 20 }, { name: 'cinnamon', qty: 'a pinch', g: 1 }],
     foodGroups: ['grains', 'fruits', 'spices'], cuisine: 'Global',
     steps: [
       'Grind 1 tbsp plain rolled oats to a coarse powder.',
@@ -20425,8 +20466,8 @@ const RECIPES = [
     source: ['nhs', 'aap'],
   },
   {
-    id: 'almond-ragi-kheer', title: 'Almond Ragi Kheer (12 m+)', slot: 'breakfast', minAgeMonths: 12,
-    ingredients: [{ name: 'milk', qty: '½ cup (in cooking)' }, { name: 'ragi', qty: '1 tbsp (15 g)' }, { name: 'date', qty: '1, deseeded paste' }, { name: 'almond', qty: '¼ tsp ground (3 g)' }],
+    id: 'almond-ragi-kheer', title: 'Almond Ragi Kheer (12 m+)', slot: 'breakfast', minAgeMonths: 12, prepMinutes: 18,
+    ingredients: [{ name: 'milk', qty: '½ cup (in cooking)', g: 60 }, { name: 'ragi', qty: '1 tbsp (15 g)', g: 15 }, { name: 'date', qty: '1, deseeded paste', g: 8 }, { name: 'almond', qty: '¼ tsp ground (3 g)', g: 3 }],
     foodGroups: ['dairy', 'grains', 'fruits', 'nuts'], cuisine: 'Indian',
     steps: [
       'Soak 2 almonds, peel, and grind to an absolutely smooth paste.',
@@ -20439,8 +20480,8 @@ const RECIPES = [
     source: ['iap', 'aap'],
   },
   {
-    id: 'suji-veg-upma', title: 'Suji & Veg Upma', slot: 'breakfast', minAgeMonths: 8,
-    ingredients: [{ name: 'suji', qty: '2 tbsp (30 g)' }, { name: 'carrot', qty: '2 tbsp grated' }, { name: 'peas', qty: '1 tbsp, mashed' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'suji-veg-upma', title: 'Suji & Veg Upma', slot: 'breakfast', minAgeMonths: 8, prepMinutes: 15,
+    ingredients: [{ name: 'suji', qty: '2 tbsp (30 g)', g: 30 }, { name: 'carrot', qty: '2 tbsp grated', g: 20 }, { name: 'peas', qty: '1 tbsp, mashed', g: 12 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'vegs', 'dairy'], cuisine: 'Indian',
     steps: [
       'Dry-roast 2 tbsp suji on low until aromatic, set aside.',
@@ -20453,8 +20494,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'poha-peas-potato', title: 'Poha with Peas & Potato', slot: 'breakfast', minAgeMonths: 8,
-    ingredients: [{ name: 'poha', qty: '3 tbsp (30 g)' }, { name: 'potato', qty: '2 tbsp, boiled & mashed' }, { name: 'peas', qty: '1 tbsp, mashed' }, { name: 'turmeric', qty: 'a pinch' }],
+    id: 'poha-peas-potato', title: 'Poha with Peas & Potato', slot: 'breakfast', minAgeMonths: 8, prepMinutes: 12,
+    ingredients: [{ name: 'poha', qty: '3 tbsp (30 g)', g: 30 }, { name: 'potato', qty: '2 tbsp, boiled & mashed', g: 30 }, { name: 'peas', qty: '1 tbsp, mashed', g: 12 }, { name: 'turmeric', qty: 'a pinch', g: 1 }],
     foodGroups: ['grains', 'vegs', 'spices'], cuisine: 'Indian',
     steps: [
       'Rinse 3 tbsp thin poha in a sieve until just soft, drain.',
@@ -20467,8 +20508,8 @@ const RECIPES = [
     source: ['icmr', 'iap'],
   },
   {
-    id: 'banana-oats-egg-pancake', title: 'Banana Oats Egg Pancake', slot: 'breakfast', minAgeMonths: 8,
-    ingredients: [{ name: 'banana', qty: '½, mashed' }, { name: 'oats', qty: '1 tbsp ground' }, { name: 'egg', qty: '1, well beaten' }],
+    id: 'banana-oats-egg-pancake', title: 'Banana Oats Egg Pancake', slot: 'breakfast', minAgeMonths: 8, prepMinutes: 10,
+    ingredients: [{ name: 'banana', qty: '½, mashed', g: 25 }, { name: 'oats', qty: '1 tbsp ground', g: 20 }, { name: 'egg', qty: '1, well beaten', g: 50 }],
     foodGroups: ['fruits', 'grains', 'nonveg'], cuisine: 'Global',
     steps: [
       'Mash ½ ripe banana smooth.',
@@ -20481,8 +20522,8 @@ const RECIPES = [
     source: ['nhs', 'aap'],
   },
   {
-    id: 'dalia-porridge', title: 'Broken-Wheat Dalia Porridge', slot: 'breakfast', minAgeMonths: 8,
-    ingredients: [{ name: 'dalia', qty: '2 tbsp (30 g)' }, { name: 'date', qty: '1, paste' }],
+    id: 'dalia-porridge', title: 'Broken-Wheat Dalia Porridge', slot: 'breakfast', minAgeMonths: 8, prepMinutes: 15,
+    ingredients: [{ name: 'dalia', qty: '2 tbsp (30 g)', g: 30 }, { name: 'date', qty: '1, paste', g: 8 }],
     foodGroups: ['grains', 'fruits'], cuisine: 'Indian',
     steps: [
       'Dry-roast 2 tbsp dalia (broken wheat) 2 min.',
@@ -20497,8 +20538,8 @@ const RECIPES = [
 
   // ─────────────────────────── LUNCH ───────────────────────────
   {
-    id: 'moong-dal-khichdi', title: 'Moong Dal Khichdi', slot: 'lunch', minAgeMonths: 7,
-    ingredients: [{ name: 'rice', qty: '1 tbsp (12 g)' }, { name: 'moong dal', qty: '½ tbsp (8 g)' }, { name: 'ghee', qty: '½ tsp' }, { name: 'turmeric', qty: 'a pinch' }],
+    id: 'moong-dal-khichdi', title: 'Moong Dal Khichdi', slot: 'lunch', minAgeMonths: 7, prepMinutes: 20,
+    ingredients: [{ name: 'rice', qty: '1 tbsp (12 g)', g: 12 }, { name: 'moong dal', qty: '½ tbsp (8 g)', g: 8 }, { name: 'ghee', qty: '½ tsp', g: 3 }, { name: 'turmeric', qty: 'a pinch', g: 1 }],
     foodGroups: ['grains', 'dairy', 'spices'], cuisine: 'Indian',
     steps: [
       'Wash 1 tbsp rice and ½ tbsp moong dal, soak 20 min.',
@@ -20511,8 +20552,8 @@ const RECIPES = [
     source: ['iap', 'whopaho'],
   },
   {
-    id: 'veg-moong-khichdi', title: 'Veg & Moong Khichdi', slot: 'lunch', minAgeMonths: 8,
-    ingredients: [{ name: 'rice', qty: '1 tbsp (15 g)' }, { name: 'moong dal', qty: '½ tbsp (10 g)' }, { name: 'carrot', qty: '2 tbsp (20 g)' }, { name: 'pumpkin', qty: '2 tbsp (20 g)' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'veg-moong-khichdi', title: 'Veg & Moong Khichdi', slot: 'lunch', minAgeMonths: 8, prepMinutes: 25,
+    ingredients: [{ name: 'rice', qty: '1 tbsp (15 g)', g: 15 }, { name: 'moong dal', qty: '½ tbsp (10 g)', g: 10 }, { name: 'carrot', qty: '2 tbsp (20 g)', g: 20 }, { name: 'pumpkin', qty: '2 tbsp (20 g)', g: 20 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'vegs', 'dairy'], cuisine: 'Indian',
     steps: [
       'Wash rice and moong dal, soak 20 min.',
@@ -20525,8 +20566,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'dal-rice-palak', title: 'Dal–Rice with Palak', slot: 'lunch', minAgeMonths: 8,
-    ingredients: [{ name: 'rice', qty: '3 tbsp (45 g)' }, { name: 'toor dal', qty: '1½ tbsp (25 g)' }, { name: 'spinach', qty: '1 tbsp, blanched (15 g)' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'dal-rice-palak', title: 'Dal–Rice with Palak', slot: 'lunch', minAgeMonths: 8, prepMinutes: 25,
+    ingredients: [{ name: 'rice', qty: '3 tbsp (45 g)', g: 45 }, { name: 'toor dal', qty: '1½ tbsp (25 g)', g: 25 }, { name: 'spinach', qty: '1 tbsp, blanched (15 g)', g: 15 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'vegs', 'dairy'], cuisine: 'Indian',
     steps: [
       'Blanch a few spinach (palak) leaves 2 min, chop fine or puree.',
@@ -20539,8 +20580,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'masoor-lauki-rice', title: 'Masoor Dal & Bottle Gourd Rice', slot: 'lunch', minAgeMonths: 7,
-    ingredients: [{ name: 'rice', qty: '2 tbsp' }, { name: 'masoor dal', qty: '1 tbsp' }, { name: 'bottle gourd', qty: '2 tbsp, diced' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'masoor-lauki-rice', title: 'Masoor Dal & Bottle Gourd Rice', slot: 'lunch', minAgeMonths: 7, prepMinutes: 20,
+    ingredients: [{ name: 'rice', qty: '2 tbsp', g: 30 }, { name: 'masoor dal', qty: '1 tbsp', g: 15 }, { name: 'bottle gourd', qty: '2 tbsp, diced', g: 25 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'vegs', 'dairy'], cuisine: 'Indian',
     steps: [
       'Wash rice and masoor dal, soak 20 min.',
@@ -20553,8 +20594,8 @@ const RECIPES = [
     source: ['icmr', 'iap'],
   },
   {
-    id: 'soft-curd-rice', title: 'Soft Curd Rice', slot: 'lunch', minAgeMonths: 8,
-    ingredients: [{ name: 'rice', qty: '2 tbsp, very soft' }, { name: 'curd', qty: '1 tbsp, fresh' }],
+    id: 'soft-curd-rice', title: 'Soft Curd Rice', slot: 'lunch', minAgeMonths: 8, prepMinutes: 10,
+    ingredients: [{ name: 'rice', qty: '2 tbsp, very soft', g: 30 }, { name: 'curd', qty: '1 tbsp, fresh', g: 40 }],
     foodGroups: ['grains', 'dairy'], cuisine: 'Indian',
     steps: [
       'Cook 2 tbsp rice until very soft and mashable.',
@@ -20567,8 +20608,8 @@ const RECIPES = [
     source: ['icmr', 'iap'],
   },
   {
-    id: 'paneer-veg-pulao', title: 'Paneer & Veg Soft Pulao', slot: 'lunch', minAgeMonths: 9,
-    ingredients: [{ name: 'rice', qty: '3 tbsp' }, { name: 'paneer', qty: '1 tbsp, crumbled' }, { name: 'carrot', qty: '1 tbsp, grated' }, { name: 'peas', qty: '1 tbsp, mashed' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'paneer-veg-pulao', title: 'Paneer & Veg Soft Pulao', slot: 'lunch', minAgeMonths: 9, prepMinutes: 20,
+    ingredients: [{ name: 'rice', qty: '3 tbsp', g: 30 }, { name: 'paneer', qty: '1 tbsp, crumbled', g: 15 }, { name: 'carrot', qty: '1 tbsp, grated', g: 20 }, { name: 'peas', qty: '1 tbsp, mashed', g: 12 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'dairy', 'vegs'], cuisine: 'Indian',
     steps: [
       'Soften grated carrot and mashed peas in ½ tsp ghee for 2 min.',
@@ -20581,8 +20622,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'rohu-fish-rice', title: 'Rohu Fish & Rice Mash', slot: 'lunch', minAgeMonths: 8,
-    ingredients: [{ name: 'rice', qty: '3 tbsp' }, { name: 'rohu fish', qty: '1 tbsp, cooked & deboned' }, { name: 'ghee', qty: '½ tsp' }, { name: 'turmeric', qty: 'a pinch' }],
+    id: 'rohu-fish-rice', title: 'Rohu Fish & Rice Mash', slot: 'lunch', minAgeMonths: 8, prepMinutes: 18,
+    ingredients: [{ name: 'rice', qty: '3 tbsp', g: 30 }, { name: 'rohu fish', qty: '1 tbsp, cooked & deboned', g: 15 }, { name: 'ghee', qty: '½ tsp', g: 3 }, { name: 'turmeric', qty: 'a pinch', g: 1 }],
     foodGroups: ['grains', 'nonveg', 'dairy'], cuisine: 'Indian',
     steps: [
       'Steam a small piece of rohu with a pinch of turmeric until flaky.',
@@ -20597,8 +20638,8 @@ const RECIPES = [
 
   // ─────────────────────────── DINNER ───────────────────────────
   {
-    id: 'carrot-beet-potato-mash', title: 'Carrot Beetroot Potato Mash', slot: 'dinner', minAgeMonths: 7,
-    ingredients: [{ name: 'carrot', qty: '3 tbsp (40 g)' }, { name: 'beetroot', qty: '2 tbsp (30 g)' }, { name: 'potato', qty: '3 tbsp (40 g)' }, { name: 'ghee', qty: '¼ tsp' }],
+    id: 'carrot-beet-potato-mash', title: 'Carrot Beetroot Potato Mash', slot: 'dinner', minAgeMonths: 7, prepMinutes: 20,
+    ingredients: [{ name: 'carrot', qty: '3 tbsp (40 g)', g: 40 }, { name: 'beetroot', qty: '2 tbsp (30 g)', g: 30 }, { name: 'potato', qty: '3 tbsp (40 g)', g: 40 }, { name: 'ghee', qty: '¼ tsp', g: 3 }],
     foodGroups: ['vegs', 'dairy'], cuisine: 'Indian',
     steps: [
       'Peel and dice carrot, beetroot and potato.',
@@ -20611,8 +20652,8 @@ const RECIPES = [
     source: ['icmr', 'nhs'],
   },
   {
-    id: 'sweet-potato-moong-mash', title: 'Sweet Potato & Moong Mash', slot: 'dinner', minAgeMonths: 7,
-    ingredients: [{ name: 'sweet potato', qty: '½ small (50 g)' }, { name: 'moong dal', qty: '1 tbsp' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'sweet-potato-moong-mash', title: 'Sweet Potato & Moong Mash', slot: 'dinner', minAgeMonths: 7, prepMinutes: 18,
+    ingredients: [{ name: 'sweet potato', qty: '½ small (50 g)', g: 50 }, { name: 'moong dal', qty: '1 tbsp', g: 12 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['vegs', 'grains', 'dairy'], cuisine: 'Indian',
     steps: [
       'Steam cubed sweet potato 10 min until very soft.',
@@ -20625,8 +20666,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'palak-paneer-rice', title: 'Palak Paneer Rice', slot: 'dinner', minAgeMonths: 9,
-    ingredients: [{ name: 'rice', qty: '3 tbsp' }, { name: 'paneer', qty: '1 tbsp, crumbled' }, { name: 'spinach', qty: '1 tbsp, blanched' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'palak-paneer-rice', title: 'Palak Paneer Rice', slot: 'dinner', minAgeMonths: 9, prepMinutes: 18,
+    ingredients: [{ name: 'rice', qty: '3 tbsp', g: 30 }, { name: 'paneer', qty: '1 tbsp, crumbled', g: 15 }, { name: 'spinach', qty: '1 tbsp, blanched', g: 15 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'dairy', 'vegs'], cuisine: 'Indian',
     steps: [
       'Blanch spinach 2 min, puree smooth.',
@@ -20639,8 +20680,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'chicken-rice-bowl', title: 'Soft Chicken & Rice Bowl', slot: 'dinner', minAgeMonths: 9,
-    ingredients: [{ name: 'rice', qty: '3 tbsp' }, { name: 'chicken', qty: '1 tbsp, shredded' }, { name: 'carrot', qty: '1 tbsp, grated' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'chicken-rice-bowl', title: 'Soft Chicken & Rice Bowl', slot: 'dinner', minAgeMonths: 9, prepMinutes: 25,
+    ingredients: [{ name: 'rice', qty: '3 tbsp', g: 30 }, { name: 'chicken', qty: '1 tbsp, shredded', g: 15 }, { name: 'carrot', qty: '1 tbsp, grated', g: 20 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'nonveg', 'vegs'], cuisine: 'Global',
     steps: [
       'Boil a small piece of boneless chicken until fully cooked and tender.',
@@ -20653,8 +20694,8 @@ const RECIPES = [
     source: ['aap', 'nhs'],
   },
   {
-    id: 'mixed-veg-dal-soup', title: 'Mixed Veg & Dal Soup', slot: 'dinner', minAgeMonths: 8,
-    ingredients: [{ name: 'moong dal', qty: '1 tbsp' }, { name: 'carrot', qty: '1 tbsp' }, { name: 'tomato', qty: '1 tbsp' }, { name: 'bottle gourd', qty: '1 tbsp' }],
+    id: 'mixed-veg-dal-soup', title: 'Mixed Veg & Dal Soup', slot: 'dinner', minAgeMonths: 8, prepMinutes: 20,
+    ingredients: [{ name: 'moong dal', qty: '1 tbsp', g: 12 }, { name: 'carrot', qty: '1 tbsp', g: 20 }, { name: 'tomato', qty: '1 tbsp', g: 15 }, { name: 'bottle gourd', qty: '1 tbsp', g: 25 }],
     foodGroups: ['grains', 'vegs'], cuisine: 'Indian',
     steps: [
       'Pressure-cook moong dal with diced carrot, tomato and bottle gourd until very soft.',
@@ -20669,8 +20710,8 @@ const RECIPES = [
 
   // ─────────────────────────── SNACK ───────────────────────────
   {
-    id: 'curd-banana-bowl', title: 'Curd & Banana Bowl', slot: 'snack', minAgeMonths: 8,
-    ingredients: [{ name: 'curd', qty: '3 tbsp (60 g)' }, { name: 'banana', qty: '¼, mashed (25 g)' }],
+    id: 'curd-banana-bowl', title: 'Curd & Banana Bowl', slot: 'snack', minAgeMonths: 8, prepMinutes: 3,
+    ingredients: [{ name: 'curd', qty: '3 tbsp (60 g)', g: 60 }, { name: 'banana', qty: '¼, mashed (25 g)', g: 25 }],
     foodGroups: ['dairy', 'fruits'], cuisine: 'Indian',
     steps: [
       'Whisk 3 tbsp fresh full-fat curd smooth.',
@@ -20682,8 +20723,8 @@ const RECIPES = [
     source: ['icmr', 'nhs'],
   },
   {
-    id: 'carrot-moong-mash', title: 'Carrot Moong Mash', slot: 'snack', minAgeMonths: 6,
-    ingredients: [{ name: 'carrot', qty: '3 tbsp, grated' }, { name: 'moong dal', qty: '2 tbsp' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'carrot-moong-mash', title: 'Carrot Moong Mash', slot: 'snack', minAgeMonths: 6, prepMinutes: 18,
+    ingredients: [{ name: 'carrot', qty: '3 tbsp, grated', g: 20 }, { name: 'moong dal', qty: '2 tbsp', g: 12 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['vegs', 'grains', 'dairy'], cuisine: 'Indian',
     steps: [
       'Grate carrot and wash moong dal.',
@@ -20696,8 +20737,8 @@ const RECIPES = [
     source: ['whopaho', 'iap'],
   },
   {
-    id: 'avocado-banana-mash', title: 'Avocado & Banana Mash', slot: 'snack', minAgeMonths: 6,
-    ingredients: [{ name: 'avocado', qty: '2 tbsp' }, { name: 'banana', qty: '¼, mashed' }],
+    id: 'avocado-banana-mash', title: 'Avocado & Banana Mash', slot: 'snack', minAgeMonths: 6, prepMinutes: 3,
+    ingredients: [{ name: 'avocado', qty: '2 tbsp', g: 30 }, { name: 'banana', qty: '¼, mashed', g: 25 }],
     foodGroups: ['fruits'], cuisine: 'Global',
     steps: [
       'Scoop 2 tbsp ripe avocado.',
@@ -20709,8 +20750,8 @@ const RECIPES = [
     source: ['aap', 'nhs'],
   },
   {
-    id: 'stewed-apple-date', title: 'Stewed Apple & Date', slot: 'snack', minAgeMonths: 6,
-    ingredients: [{ name: 'apple', qty: '½, peeled & diced' }, { name: 'date', qty: '1, deseeded' }],
+    id: 'stewed-apple-date', title: 'Stewed Apple & Date', slot: 'snack', minAgeMonths: 6, prepMinutes: 10,
+    ingredients: [{ name: 'apple', qty: '½, peeled & diced', g: 40 }, { name: 'date', qty: '1, deseeded', g: 8 }],
     foodGroups: ['fruits'], cuisine: 'Global',
     steps: [
       'Peel, core and dice ½ apple.',
@@ -20723,8 +20764,8 @@ const RECIPES = [
     source: ['nhs', 'iap'],
   },
   {
-    id: 'mango-curd-bowl', title: 'Mango & Curd Bowl', slot: 'snack', minAgeMonths: 8,
-    ingredients: [{ name: 'mango', qty: '2 tbsp, ripe' }, { name: 'curd', qty: '1 tbsp, fresh' }],
+    id: 'mango-curd-bowl', title: 'Mango & Curd Bowl', slot: 'snack', minAgeMonths: 8, prepMinutes: 3,
+    ingredients: [{ name: 'mango', qty: '2 tbsp, ripe', g: 30 }, { name: 'curd', qty: '1 tbsp, fresh', g: 40 }],
     foodGroups: ['fruits', 'dairy'], cuisine: 'Indian',
     steps: [
       'Mash 2 tbsp ripe mango smooth.',
@@ -20738,8 +20779,8 @@ const RECIPES = [
 
   // ─── 12 m+ catalog item — age-gated, never suggested for an under-1 (honey) ───
   {
-    id: 'banana-honey-toast', title: 'Banana & Honey Toast (12 m+)', slot: 'snack', minAgeMonths: 12,
-    ingredients: [{ name: 'bread', qty: '1 slice, soft' }, { name: 'banana', qty: '½, mashed' }, { name: 'honey', qty: '½ tsp (12 m+ only)' }],
+    id: 'banana-honey-toast', title: 'Banana & Honey Toast (12 m+)', slot: 'snack', minAgeMonths: 12, prepMinutes: 5,
+    ingredients: [{ name: 'bread', qty: '1 slice, soft', g: 25 }, { name: 'banana', qty: '½, mashed', g: 25 }, { name: 'honey', qty: '½ tsp (12 m+ only)', g: 5 }],
     foodGroups: ['grains', 'fruits'], cuisine: 'Global',
     steps: [
       'Lightly toast a soft slice of whole-wheat bread, remove crusts, cut into soft fingers.',
@@ -20824,6 +20865,90 @@ function recipeFoodIcon(name) {
   return null;
 }
 
+// ── §9.5 Tagline composer (ported from docs/design/taglines.mjs) ─────────
+// The generative "voice" line for any recipe/combo: each ingredient
+// contributes an epithet + noun; the minor-share ratio picks the connector so
+// quantity shows in the words. Soft prep-cautions FOLD into the phrase (ground
+// almond / halved grape); STRICT no's (honey / added sugar) keep a prominent
+// LEADING clause. Epithets rotate by a day-seed (fresh daily, deterministic
+// within a day). Adapted to the app's global-script style (no ES exports);
+// keyed by zif icon id (recipeFoodIcon(name).icon) so it shares one vocabulary.
+const RECIPE_EP = {
+  // grains & cereals
+  rice:{eps:['soft','gentle','silky'],noun:'rice'}, millet:{eps:['earthy','iron-rich','nutty'],noun:'ragi'},
+  oats:{eps:['wholesome','warm','hearty'],noun:'oats'}, wheat:{eps:['hearty','wholesome'],noun:'wheat'},
+  suji:{eps:['smooth','light'],noun:'suji'}, corn:{eps:['sweet','sunny'],noun:'corn'},
+  dalia:{eps:['hearty','nutty'],noun:'dalia'}, barley:{eps:['nutty','wholesome'],noun:'barley'},
+  quinoa:{eps:['nutty','light'],noun:'quinoa'},
+  // legumes & pulses
+  dal:{eps:['savoury','soupy','hearty'],noun:'dal'}, chana:{eps:['nutty','hearty'],noun:'chana'},
+  rajma:{eps:['hearty','earthy'],noun:'rajma'}, peanut:{eps:['nutty','rich'],noun:'peanut',fold:'ground'},
+  sprouts:{eps:['fresh','green'],noun:'sprouts'},
+  // vegetables
+  carrot:{eps:['sweet','bright','sunny'],noun:'carrot'}, spinach:{eps:['leafy','green','iron-rich'],noun:'spinach'},
+  beans:{eps:['crisp','green'],noun:'green beans'}, bottlegourd:{eps:['light','soothing'],noun:'bottle gourd'},
+  beetroot:{eps:['earthy','ruby','sweet'],noun:'beetroot'}, pumpkin:{eps:['silky','golden','sweet'],noun:'pumpkin'},
+  sweetpotato:{eps:['velvety','golden','creamy'],noun:'sweet potato'}, potato:{eps:['soft','comforting'],noun:'potato'},
+  broccoli:{eps:['green','tender'],noun:'broccoli'}, cauliflower:{eps:['mild','tender'],noun:'cauliflower'},
+  tomato:{eps:['tangy','bright'],noun:'tomato'}, peas:{eps:['sweet','green'],noun:'peas'},
+  drumstick:{eps:['earthy','green'],noun:'drumstick'}, zucchini:{eps:['soft','mild'],noun:'zucchini'},
+  // fruits
+  banana:{eps:['creamy','sweet','soft'],noun:'banana'}, pear:{eps:['juicy','gentle'],noun:'pear'},
+  apple:{eps:['sweet','stewed','crisp'],noun:'apple'}, mango:{eps:['golden','silky','sweet'],noun:'mango'},
+  avocado:{eps:['buttery','creamy'],noun:'avocado'}, blueberry:{eps:['sweet','jewel-like'],noun:'blueberry'},
+  date:{eps:['caramel-sweet','rich'],noun:'date'}, coconut:{eps:['creamy','rich'],noun:'coconut'},
+  pomegranate:{eps:['ruby','jewel-like'],noun:'pomegranate'},
+  // dairy & eggs
+  paneer:{eps:['mild','soft','milky'],noun:'paneer'}, milk:{eps:['creamy','gentle'],noun:'milk'},
+  ghee:{eps:['rich','golden'],noun:'ghee'}, curd:{eps:['cooling','tangy','creamy'],noun:'curd'},
+  cheese:{eps:['savoury','melty'],noun:'cheese'}, butter:{eps:['rich','soft'],noun:'butter'},
+  buttermilk:{eps:['cooling','tangy'],noun:'buttermilk'}, egg:{eps:['protein-rich','soft'],noun:'egg',fold:'cooked'},
+  // nuts & seeds
+  almond:{eps:['nutty','buttery'],noun:'almond',fold:'ground'}, walnut:{eps:['earthy','rich'],noun:'walnut',fold:'ground'},
+  cashew:{eps:['buttery','mild'],noun:'cashew',fold:'ground'}, sesame:{eps:['nutty','toasty'],noun:'sesame',fold:'ground'},
+  chia:{eps:['tiny','nutty'],noun:'chia',fold:'soaked'}, flaxseed:{eps:['nutty','wholesome'],noun:'flaxseed',fold:'ground'},
+  // proteins
+  fish:{eps:['tender','omega-rich'],noun:'fish',fold:'boneless'}, chicken:{eps:['lean','tender'],noun:'chicken',fold:'shredded'},
+  prawn:{eps:['tender','sweet'],noun:'prawn'}, mutton:{eps:['rich','tender'],noun:'mutton',fold:'soft-cooked'},
+  // fats & sweeteners
+  jaggery:{eps:['caramel-sweet'],noun:'jaggery',strict:'go easy — added sugar'},
+  honey:{eps:['golden'],noun:'honey',strict:'honey — only from age 1'}, oil:{eps:['light'],noun:'oil'},
+  // spices & herbs
+  turmeric:{eps:['golden','earthy'],noun:'turmeric'}, cinnamon:{eps:['warm','sweet'],noun:'cinnamon'},
+  cumin:{eps:['warm','earthy'],noun:'cumin'}, coriander:{eps:['fresh','herby'],noun:'coriander'},
+  mint:{eps:['cool','fresh'],noun:'mint'}, ginger:{eps:['warming','zingy'],noun:'ginger'},
+};
+const _recipeConnector = s =>
+  s < 0.12 ? 'with just a hint of' : s < 0.22 ? 'with a touch of' :
+  s < 0.33 ? 'with a little' : s < 0.45 ? 'balanced with' : 'meets';
+const _recEpOf = (it, seed) => it.eps[seed % it.eps.length];
+const _recNounOf = it => it.fold ? `${it.fold} ${it.noun}` : it.noun;
+
+// parts: [{id, w}] (id = a RECIPE_EP key; w = grams) · seed: day-seed.
+// Returns { strict:[lead clauses], body }. Render strict first (prominent).
+function _recipeComposeTagline(parts, seed) {
+  seed = seed || 0;
+  const items = parts.map(p => ({ ...RECIPE_EP[p.id], w: p.w })).filter(i => i.noun).sort((a, b) => b.w - a.w);
+  if (!items.length) return { strict: [], body: '' };
+  const total = items.reduce((s, i) => s + i.w, 0) || 1;
+  const strict = [...new Set(items.filter(i => i.strict).map(i => i.strict))];
+  const dom = items[0];
+  let body;
+  if (items.length === 1) {
+    body = `${_recEpOf(dom, seed)} ${_recNounOf(dom)}`;
+  } else if (items.length === 2) {
+    const m = items[1], con = _recipeConnector(m.w / total);
+    body = con === 'meets'
+      ? `${_recEpOf(dom, seed)} ${_recNounOf(dom)} meets ${_recEpOf(m, seed)} ${_recNounOf(m)}`
+      : `${_recEpOf(dom, seed)} ${_recNounOf(dom)}, ${con} ${_recNounOf(m)}`;
+  } else {
+    const mids = items.slice(1, -1).map(_recNounOf);
+    const last = items.at(-1), lastCon = (last.w / total) < 0.15 ? 'a touch of' : 'a little';
+    body = `${_recEpOf(dom, seed)} ${_recNounOf(dom)}, with ${mids.join(', ')} and ${lastCon} ${_recNounOf(last)}`;
+  }
+  return { strict, body };
+}
+
 // O(1) lookup for the tap-through dispatcher (openRecipeInTab) + render helpers.
 const RECIPES_BY_ID = RECIPES.reduce((m, r) => { m[r.id] = r; return m; }, {});
 
@@ -20833,6 +20958,7 @@ window.RECIPES = RECIPES;
 window.RECIPES_BY_ID = RECIPES_BY_ID;
 window.RECIPE_SOURCES = RECIPE_SOURCES;
 window.recipeFoodIcon = recipeFoodIcon;
+window._recipeComposeTagline = _recipeComposeTagline;
 // ─────────────────────────────────────────
 // SVG ICON HELPER — Ziva Sketch icon set
 // ─────────────────────────────────────────
@@ -40296,14 +40422,81 @@ const _RECIPE_FD_POLARITY = {
   conditional: { cls: 'fd-flag-conditional', ic: 'clock'  },
   inform:      { cls: 'fd-flag-inform',      ic: 'info'   },
 };
-// A small group → epithet bank for the italic "voice" descriptor (typography C).
-// The full ratified tagline composer (docs/design/taglines.mjs, 126-tagline
-// bank) is a follow-up port flagged in recipes-tab/SESSION_HANDOFF.md; this is
-// the in-scope minimal voice.
-const _RECIPE_GROUP_EPITHET = {
-  grains: 'wholesome', fruits: 'naturally sweet', vegs: 'garden-soft',
-  dairy: 'creamy', nuts: 'nutty', spices: 'gently spiced', nonveg: 'protein-rich',
+// ── Generative fingerprint (§9.3) — quantity-weighted, wavelength-ordered ──
+// Each recipe's hero renders a deterministic colour fingerprint from its
+// ingredients: a STRIPE (top ribbon) + a FADE (body wash), band-widths weighted
+// by grams, wavelength-ordered (rose→peach→amber→sage→sky→lav). Trace items
+// (ghee/oil/spices) are excluded so the fingerprint never muds; cap ≤4 domains.
+const RECIPE_FP_DOM = {
+  fruit:   { o: 0,   sat: '#e59cb0', light: 'var(--rose-light)',  dark: 'rgba(158,62,82,0.20)' },
+  protein: { o: 0.6, sat: '#e0a285', light: 'var(--rose-light)',  dark: 'rgba(150,72,60,0.20)' },
+  veg:     { o: 1,   sat: '#ecae7e', light: 'var(--peach-light)', dark: 'rgba(138,101,32,0.18)' },
+  legume:  { o: 2,   sat: '#e6c078', light: 'var(--amber-light)', dark: 'rgba(150,110,40,0.18)' },
+  grain:   { o: 3,   sat: '#9fcdb5', light: 'var(--sage-light)',  dark: 'rgba(58,112,96,0.17)' },
+  dairy:   { o: 4,   sat: '#a0cce0', light: 'var(--sky-light)',   dark: 'rgba(58,112,144,0.18)' },
+  nuts:    { o: 6,   sat: '#c4b4e6', light: 'var(--lav-light)',   dark: 'rgba(110,94,154,0.18)' },
 };
+// zif icon id → fingerprint domain (distinguishes legumes from grains, which
+// FOOD_TAX folds together — the fingerprint wants the dal/rice colour split).
+const _RECIPE_FP_BY_ICON = {
+  rice: 'grain', millet: 'grain', oats: 'grain', wheat: 'grain', suji: 'grain', dalia: 'grain', barley: 'grain', quinoa: 'grain', corn: 'grain',
+  dal: 'legume', chana: 'legume', rajma: 'legume', peanut: 'legume', sprouts: 'legume',
+  carrot: 'veg', spinach: 'veg', beans: 'veg', bottlegourd: 'veg', beetroot: 'veg', pumpkin: 'veg', sweetpotato: 'veg', potato: 'veg', broccoli: 'veg', cauliflower: 'veg', tomato: 'veg', peas: 'veg', drumstick: 'veg', zucchini: 'veg', okra: 'veg', cabbage: 'veg', brinjal: 'veg', mushroom: 'veg', onion: 'veg',
+  banana: 'fruit', pear: 'fruit', apple: 'fruit', mango: 'fruit', avocado: 'fruit', blueberry: 'fruit', strawberry: 'fruit', grapes: 'fruit', date: 'fruit', papaya: 'fruit', orange: 'fruit', pomegranate: 'fruit', coconut: 'fruit',
+  paneer: 'dairy', milk: 'dairy', curd: 'dairy', cheese: 'dairy', butter: 'dairy', buttermilk: 'dairy',
+  almond: 'nuts', walnut: 'nuts', cashew: 'nuts', pistachio: 'nuts', sesame: 'nuts', chia: 'nuts', flaxseed: 'nuts', pumpkinseed: 'nuts',
+  egg: 'protein', fish: 'protein', chicken: 'protein', prawn: 'protein', mutton: 'protein', tofu: 'protein',
+};
+// Trace ingredients — excluded from the fingerprint + the tagline (fats,
+// spices, sweeteners; matched as substrings so "cow ghee" / "black pepper" hit).
+const _RECIPE_TRACE = ['ghee', 'oil', 'turmeric', 'cinnamon', 'cumin', 'coriander', 'mint', 'jaggery', 'honey', 'salt', 'sugar', 'cardamom', 'pepper', 'ginger', 'garlic', 'lemon'];
+function _recipeIsTrace(name) {
+  const n = String(name).toLowerCase();
+  return _RECIPE_TRACE.some(t => n.indexOf(t) !== -1);
+}
+function _recipeFpDomain(name) {
+  const ic = (typeof recipeFoodIcon === 'function') ? recipeFoodIcon(name) : null;
+  return (ic && _RECIPE_FP_BY_ICON[ic.icon]) ? _RECIPE_FP_BY_ICON[ic.icon] : null;
+}
+// Build the weighted fingerprint: { stripe, fadeL, fadeD, ranked } or null.
+function _recipeFingerprint(r) {
+  const prim = (r.ingredients || []).filter(i => !_recipeIsTrace(i.name) && _recipeFpDomain(i.name));
+  if (!prim.length) return null;
+  const byDom = {};
+  for (const i of prim) { const d = _recipeFpDomain(i.name); byDom[d] = (byDom[d] || 0) + (i.g || 10); }
+  let doms = Object.entries(byDom).map(([d, g]) => ({ d, g, ...RECIPE_FP_DOM[d] })).sort((a, b) => a.o - b.o);
+  if (doms.length > 4) doms = doms.slice().sort((a, b) => b.g - a.g).slice(0, 4).sort((a, b) => a.o - b.o);
+  const total = doms.reduce((s, x) => s + x.g, 0) || 1;
+  doms.forEach(x => { x.frac = x.g / total; });
+  const r2 = n => Math.round(n * 10) / 10;
+  const stopsAt = key => { let cum = 0; const s = []; for (const x of doms) { const mid = cum + x.frac / 2; s.push(`${x[key]} ${r2(mid * 100)}%`); cum += x.frac; } return s; };
+  const stripe = `linear-gradient(90deg, ${doms[0].sat} 0%, ${stopsAt('sat').join(', ')}, ${doms.at(-1).sat} 100%)`;
+  const fadeL = `linear-gradient(135deg, ${doms[0].light} 0%, ${stopsAt('light').join(', ')}, ${doms.at(-1).light} 100%)`;
+  const fadeD = `linear-gradient(135deg, ${doms[0].dark} 0%, ${stopsAt('dark').join(', ')}, ${doms.at(-1).dark} 100%)`;
+  const ranked = prim.slice().sort((a, b) => (b.g || 0) - (a.g || 0)).slice(0, 3);
+  return { stripe, fadeL, fadeD, ranked };
+}
+
+// Day-of-year seed — rotates the tagline epithets daily (deterministic within a
+// day). Cosmetic only; local date, timezone-safe construction (HR-12).
+function _recipeDaySeed() {
+  const d = new Date();
+  return Math.floor((d - new Date(d.getFullYear(), 0, 0)) / 864e5);
+}
+
+// Relevance tag for a catalog row (the LOCKED "uses banana"/"vitamin-A" meta) —
+// a nutrient highlight scanned from the recipe's own dos/steps, else cuisine.
+const _RECIPE_NUTRIENT_HINTS = [
+  [/\biron\b/i, 'iron-rich'], [/calcium/i, 'calcium'], [/protein/i, 'protein'],
+  [/vitamin a|beta-?carotene/i, 'vitamin A'], [/vitamin c/i, 'vitamin C'],
+  [/omega|brain-health/i, 'omega-3'], [/probiotic/i, 'probiotic'],
+  [/fibre|fiber/i, 'fibre'], [/healthy fat|brain-healthy fat/i, 'healthy fats'],
+];
+function _recipeRelevanceTag(r) {
+  const hay = ((r.dos || []).join(' ') + ' ' + (r.steps || []).join(' '));
+  for (const [re, label] of _RECIPE_NUTRIENT_HINTS) if (re.test(hay)) return label;
+  return r.cuisine || '';
+}
 
 // Pass A — surfacing gate. Every ingredient must pass the household diet
 // preference; any fail withholds the recipe (fail-OPEN if the gate is absent).
@@ -40331,18 +40524,16 @@ function _recipeRailColor(group) {
   return 'var(--tc-sage)';
 }
 
-// The italic "voice" descriptor — epithet + the two dominant ingredients.
+// The italic "voice" descriptor (§9.5/§9.6) — the ported tagline composer,
+// quantity-weighted from the non-trace ingredients, epithets day-seed-rotated.
+// Returns { strict:[lead clauses], body } — render strict first (prominent),
+// then the italic body. Reserved for the hero (Typography C: italic = voice).
 function _recipeTagline(r) {
-  const grp = _recipePrimaryGroup(r);
-  const ep = _RECIPE_GROUP_EPITHET[grp] || 'soft';
-  const names = (r.ingredients || [])
-    .map(i => i.name)
-    .filter(n => !/ghee|oil|turmeric|cinnamon|cumin|coriander|pinch/i.test(n))
-    .slice(0, 2)
-    .map(n => n.replace(/\b(dal|fish)\b/i, m => m.toLowerCase()));
-  if (!names.length) return ep;
-  if (names.length === 1) return ep + ' ' + names[0];
-  return ep + ' ' + names[0] + ' & ' + names[1];
+  if (typeof _recipeComposeTagline !== 'function') return { strict: [], body: '' };
+  const parts = (r.ingredients || [])
+    .filter(i => !_recipeIsTrace(i.name) && typeof recipeFoodIcon === 'function' && recipeFoodIcon(i.name))
+    .map(i => ({ id: recipeFoodIcon(i.name).icon, w: i.g || 10 }));
+  return _recipeComposeTagline(parts, _recipeDaySeed());
 }
 
 // The highest ingredient age-gate (months) — recipe-level age floor (§5).
@@ -40429,7 +40620,10 @@ function _recipeDetailHtml(r, ageMonths) {
   return h;
 }
 
-// One catalog/suggested row (full-width .recipe-row, expand-in-place).
+// One catalog/suggested row (full-width .recipe-row, expand-in-place). Per the
+// LOCKED 05-meal-rows: food icon + Fraunces title + a factual meta line
+// (prep · age · slot · relevance). The italic "voice" is reserved for the hero
+// (§9.6: italic = descriptor only), so rows carry facts, not voice.
 function _recipeRowHtml(r, uidPrefix, ageMonths, opts) {
   opts = opts || {};
   const uid = uidPrefix + '-' + r.id;
@@ -40439,20 +40633,20 @@ function _recipeRowHtml(r, uidPrefix, ageMonths, opts) {
   const glyph = ic ? `<svg class="zif" style="--zif-c:${ic.c}"><use href="#zif-${ic.icon}"/></svg>` : zi('bowl');
   const effMin = _recipeEffectiveMinAge(r);
   const withheld = effMin > ageMonths;
-  // V-R-1: one age statement per row. When the recipe is withheld (the amber
-  // age-gate badge shows), suppress the plain meta age span — the badge IS the
-  // age signal, and a duplicate "Xm+" twin dilutes its caution weight.
+  // V-R-1: one age statement per row — the badge IS the age signal when withheld.
   const ageBadge = withheld ? `<span class="recipe-age-badge">${zi('baby')} ${effMin}m+</span>` : '';
   const ageMeta = withheld ? '' : `<span>${zi('baby')} ${effMin}m+</span>`;
   const slot = RECIPE_SLOT_META[r.slot];
   const slotMeta = (opts.showSlot && slot) ? `<span>${zi(slot.icon)} ${escHtml(slot.label)}</span>` : '';
+  const prepMeta = r.prepMinutes ? `<span>${zi('clock')} ${r.prepMinutes} min</span>` : '';
+  const relRaw = (opts.relevance != null) ? opts.relevance : _recipeRelevanceTag(r);
+  const relMeta = relRaw ? `<span class="recipe-row-rel">${escHtml(relRaw)}</span>` : '';
   return `<div class="recipe-row dt-${grp}" id="rrow-${escAttr(uid)}" style="--rc-rail:${rail}" role="button" tabindex="0" aria-expanded="false" data-action="toggleRecipeRow" data-arg="${escAttr(uid)}">
     <div class="recipe-row-top">
       <span class="recipe-row-icon">${glyph}</span>
       <span class="recipe-row-main">
         <span class="recipe-row-title">${escHtml(r.title)}</span>
-        <span class="recipe-row-tag">${escHtml(_recipeTagline(r))}</span>
-        <span class="recipe-row-meta">${slotMeta}${ageMeta}${ageBadge}</span>
+        <span class="recipe-row-meta">${prepMeta}${ageMeta}${slotMeta}${relMeta}${ageBadge}</span>
       </span>
       <span class="recipe-row-chev">${zi('chevron-down')}</span>
     </div>
@@ -40460,17 +40654,46 @@ function _recipeRowHtml(r, uidPrefix, ageMonths, opts) {
   </div>`;
 }
 
-// The featured "Suggested for Ziva" hero card (top pick), expand-in-place.
+// The featured "Suggested for Ziva" hero (top pick) — the GENERATIVE card
+// (§9.3/§9.4): a grams-weighted wavelength fingerprint stripe + warm-wave sheen
+// + corner zif watermark, the Fraunces-italic composed voice (strict no's lead),
+// the data-driven why, a prep·age·slot meta line, and a "See recipe →" CTA.
+// Expand-in-place like the rows.
 function _recipeHeroHtml(r, whyText, ageMonths) {
   const uid = 'h-' + r.id;
   const grp = _recipePrimaryGroup(r);
   const rail = _recipeRailColor(grp);
-  return `<div class="recipe-hero dt-${grp}" id="rrow-${escAttr(uid)}" style="--rc-rail:${rail}" role="button" tabindex="0" aria-expanded="false" data-action="toggleRecipeRow" data-arg="${escAttr(uid)}">
-    <span class="recipe-hero-eyebrow">${zi('sparkle')} Suggested for Ziva</span>
+  const fp = _recipeFingerprint(r);
+  const slot = RECIPE_SLOT_META[r.slot];
+  const effMin = _recipeEffectiveMinAge(r);
+  const tag = _recipeTagline(r);
+  let wm = '';
+  if (fp && fp.ranked && fp.ranked.length) {
+    const slots = ['wm-1', 'wm-2', 'wm-3'];
+    wm = '<div class="recipe-hero-wm" aria-hidden="true">' + fp.ranked.map((ing, k) => {
+      const ic = recipeFoodIcon(ing.name);
+      return ic ? `<span class="recipe-wm ${slots[k]}"><svg class="zif" style="--zif-c:${ic.c}"><use href="#zif-${ic.icon}"/></svg></span>` : '';
+    }).join('') + '</div>';
+  }
+  const fpStyle = fp ? `--rc-stripe:${fp.stripe};--rc-fl:${fp.fadeL};--rc-fd:${fp.fadeD};` : '';
+  const strictLead = (tag.strict && tag.strict.length) ? `<span class="recipe-strict">${escHtml(tag.strict.join('; '))}</span> ` : '';
+  const meta = [];
+  if (r.prepMinutes) meta.push(`<span>${zi('clock')} ${r.prepMinutes} min</span>`);
+  meta.push(`<span>${zi('baby')} ${effMin}m+</span>`);
+  if (slot) meta.push(`<span>${zi(slot.icon)} ${escHtml(slot.label)}</span>`);
+  return `<div class="recipe-hero recipe-hero-gen dt-${grp}" id="rrow-${escAttr(uid)}" style="${fpStyle}--rc-rail:${rail}" role="button" tabindex="0" aria-expanded="false" data-action="toggleRecipeRow" data-arg="${escAttr(uid)}">
+    ${wm}
+    <div class="recipe-hero-head">
+      <span class="recipe-hero-eyebrow">${zi('sparkle')} Suggested for Ziva</span>
+      ${slot ? `<span class="recipe-hero-badge">${escHtml(slot.label)}</span>` : ''}
+    </div>
     <h3 class="recipe-hero-title">${escHtml(r.title)}</h3>
-    <p class="recipe-hero-tag">${escHtml(_recipeTagline(r))}</p>
+    <p class="recipe-hero-tag">${strictLead}${escHtml(tag.body)}</p>
     <p class="recipe-hero-why">${escHtml(whyText || '')}</p>
-    <span class="recipe-hero-more">${zi('chevron-down')} Tap for steps &amp; safety</span>
+    <div class="recipe-hero-foot">
+      <span class="recipe-hero-meta">${meta.join('')}</span>
+      <span class="recipe-hero-cta">See recipe ${zi('arrow-right')}</span>
+    </div>
     <div class="recipe-detail" id="rdet-${escAttr(uid)}" style="display:none;">${_recipeDetailHtml(r, ageMonths)}</div>
   </div>`;
 }
@@ -40524,15 +40747,20 @@ function renderDietRecipes() {
 
   let html = '';
 
-  // ── (a) Suggested for Ziva ──
+  // Panel header (LOCKED 05-meal-rows): "Recipes" + the sourced-from-logs subtitle.
+  html += `<div class="col-full recipes-header"><h2 class="recipes-h1">Recipes</h2><p class="recipes-subtitle">Sourced for Ziva's stage · cooked from what you log.</p></div>`;
+
+  // ── (a) Suggested for Ziva — featured generative hero + "More for Ziva" rows ──
   const suggested = _recipeSuggestForZiva(surfaced, ageMonths);
-  html += `<div class="col-full"><div class="recipes-sec-label">Suggested for Ziva</div>`;
+  html += `<div class="col-full">`;
   if (suggested.length) {
     const top = suggested[0];
     const topWhy = top.why || (top.r.dos && top.r.dos[0]) || 'A wholesome, age-appropriate pick for today.';
     html += _recipeHeroHtml(top.r, topWhy, ageMonths);
-    for (const s of suggested.slice(1)) {
-      html += _recipeRowHtml(s.r, 's', ageMonths, { showSlot: true });
+    const more = suggested.slice(1);
+    if (more.length) {
+      html += `<div class="recipe-group-head recipe-more-head">${zi('sprout')}<span class="recipe-group-title">More for Ziva</span><span class="recipe-group-count">${more.length}</span></div>`;
+      for (const s of more) html += _recipeRowHtml(s.r, 's', ageMonths, { showSlot: true });
     }
   } else {
     html += `<div class="recipe-empty">${zi('spoon')} Keep logging meals for a few days and personalised recipe ideas will appear here. Meanwhile, browse the catalog below.</div>`;

--- a/index.html
+++ b/index.html
@@ -11179,10 +11179,11 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 .recipe-hero-head .recipe-hero-eyebrow { margin-bottom:0; }
 .recipe-hero-badge { flex:0 0 auto; display:inline-flex; align-items:center; background:var(--tc-sage); color:var(--card-bg); border-radius:var(--r-full); padding:var(--sp-4) var(--sp-10); font-size:var(--fs-2xs); font-weight:800; }
 /* strict no's lead the tagline (rose, never folded) */
-.recipe-strict { font-family:'Nunito', sans-serif; font-style:normal; font-weight:800; font-size:var(--fs-2xs); text-transform:uppercase; letter-spacing:0.04em; color:var(--tc-rose); }
+.recipe-strict { font-family:'Nunito', sans-serif; font-style:normal; font-weight:800; font-size:var(--fs-2xs); text-transform:uppercase; letter-spacing:var(--ls-normal); color:var(--tc-rose); }
 .recipe-hero-foot { display:flex; align-items:center; justify-content:space-between; gap:var(--sp-8); flex-wrap:wrap; }
 .recipe-hero-meta { display:flex; align-items:center; gap:var(--sp-8); flex-wrap:wrap; }
 .recipe-hero-meta span { display:inline-flex; align-items:center; gap:var(--sp-4); font-size:var(--fs-xs); color:var(--mid); }
+.recipe-hero-meta span:not(:first-child)::before { content:'·'; margin-right:var(--sp-4); color:var(--light); }
 .recipe-hero-meta .zi { width:13px; height:13px; }
 .recipe-hero-cta { display:inline-flex; align-items:center; gap:var(--sp-4); min-height:36px; background:var(--tc-sage); color:var(--card-bg); border-radius:var(--r-full); padding:var(--sp-6) var(--sp-12); font-size:var(--fs-xs); font-weight:700; }
 .recipe-hero-cta .zi { width:14px; height:14px; transition:transform var(--ease-med); }
@@ -20917,6 +20918,15 @@ const RECIPE_EP = {
   turmeric:{eps:['golden','earthy'],noun:'turmeric'}, cinnamon:{eps:['warm','sweet'],noun:'cinnamon'},
   cumin:{eps:['warm','earthy'],noun:'cumin'}, coriander:{eps:['fresh','herby'],noun:'coriander'},
   mint:{eps:['cool','fresh'],noun:'mint'}, ginger:{eps:['warming','zingy'],noun:'ginger'},
+  // fold-completeness (K-T-2): keys present in the fingerprint icon map must also
+  // carry a voice, or a recipe paints a colour band for an unnamed ingredient.
+  poha:{eps:['light','flaky'],noun:'poha'}, okra:{eps:['tender','green'],noun:'okra'},
+  cabbage:{eps:['crisp','leafy'],noun:'cabbage'}, brinjal:{eps:['silky','mellow'],noun:'brinjal'},
+  mushroom:{eps:['earthy','tender'],noun:'mushroom'}, onion:{eps:['sweet','mellow'],noun:'onion'},
+  strawberry:{eps:['sweet','fragrant'],noun:'strawberry'}, grapes:{eps:['juicy','sweet'],noun:'grape',fold:'halved'},
+  papaya:{eps:['soft','sweet'],noun:'papaya'}, orange:{eps:['juicy','bright'],noun:'orange'},
+  pistachio:{eps:['nutty','green'],noun:'pistachio',fold:'ground'}, pumpkinseed:{eps:['nutty','crunchy'],noun:'pumpkin seed',fold:'ground'},
+  tofu:{eps:['silky','mild'],noun:'tofu'},
 };
 const _recipeConnector = s =>
   s < 0.12 ? 'with just a hint of' : s < 0.22 ? 'with a touch of' :
@@ -40447,13 +40457,13 @@ const _RECIPE_FP_BY_ICON = {
   almond: 'nuts', walnut: 'nuts', cashew: 'nuts', pistachio: 'nuts', sesame: 'nuts', chia: 'nuts', flaxseed: 'nuts', pumpkinseed: 'nuts',
   egg: 'protein', fish: 'protein', chicken: 'protein', prawn: 'protein', mutton: 'protein', tofu: 'protein',
 };
-// Trace ingredients — excluded from the fingerprint + the tagline (fats,
-// spices, sweeteners; matched as substrings so "cow ghee" / "black pepper" hit).
+// Trace ingredients — excluded from the fingerprint + the tagline BODY (fats,
+// spices, sweeteners). Word-boundary matched (K-T-3) so "oil" doesn't catch an
+// unrelated word; the corpus is curated, so the documented edge ("pepper" would
+// match a future "bell pepper") is a known invariant, not a live collision.
 const _RECIPE_TRACE = ['ghee', 'oil', 'turmeric', 'cinnamon', 'cumin', 'coriander', 'mint', 'jaggery', 'honey', 'salt', 'sugar', 'cardamom', 'pepper', 'ginger', 'garlic', 'lemon'];
-function _recipeIsTrace(name) {
-  const n = String(name).toLowerCase();
-  return _RECIPE_TRACE.some(t => n.indexOf(t) !== -1);
-}
+const _RECIPE_TRACE_RE = new RegExp('\\b(' + _RECIPE_TRACE.join('|') + ')\\b', 'i');
+function _recipeIsTrace(name) { return _RECIPE_TRACE_RE.test(String(name)); }
 function _recipeFpDomain(name) {
   const ic = (typeof recipeFoodIcon === 'function') ? recipeFoodIcon(name) : null;
   return (ic && _RECIPE_FP_BY_ICON[ic.icon]) ? _RECIPE_FP_BY_ICON[ic.icon] : null;
@@ -40524,15 +40534,35 @@ function _recipeRailColor(group) {
   return 'var(--tc-sage)';
 }
 
+// When an ingredient shares a zif icon with a differently-named food, the
+// composer would voice the wrong noun (M-T-2: poha shares the 'suji' icon →
+// voiced "suji"). Resolve the tagline EP key from the name first, then the icon.
+const _RECIPE_EP_KEY_OVERRIDE = { poha: 'poha' };
+function _recipeEpKey(name) {
+  const n = String(name).toLowerCase();
+  for (const k in _RECIPE_EP_KEY_OVERRIDE) if (n.indexOf(k) !== -1) return _RECIPE_EP_KEY_OVERRIDE[k];
+  const ic = (typeof recipeFoodIcon === 'function') ? recipeFoodIcon(name) : null;
+  return ic ? ic.icon : null;
+}
 // The italic "voice" descriptor (§9.5/§9.6) — the ported tagline composer,
-// quantity-weighted from the non-trace ingredients, epithets day-seed-rotated.
-// Returns { strict:[lead clauses], body } — render strict first (prominent),
-// then the italic body. Reserved for the hero (Typography C: italic = voice).
+// quantity-weighted, epithets day-seed-rotated. Returns { strict:[lead clauses],
+// body } — render strict FIRST (prominent), then the italic body. Reserved for
+// the hero (Typography C: italic = voice).
+//
+// M-T-1 / K-T-1 (BLOCKING fold): trace items are dropped from the BODY, but an
+// ingredient carrying a STRICT safety clause (honey/jaggery → RECIPE_EP[].strict)
+// is kept so the composer surfaces it as the rose lead (§9.7: strict no's lead,
+// never folded). Its tiny gram weight keeps it a "touch of" in the body while the
+// strict clause leads. (The fingerprint path excludes it separately, unchanged.)
 function _recipeTagline(r) {
-  if (typeof _recipeComposeTagline !== 'function') return { strict: [], body: '' };
-  const parts = (r.ingredients || [])
-    .filter(i => !_recipeIsTrace(i.name) && typeof recipeFoodIcon === 'function' && recipeFoodIcon(i.name))
-    .map(i => ({ id: recipeFoodIcon(i.name).icon, w: i.g || 10 }));
+  if (typeof _recipeComposeTagline !== 'function' || typeof RECIPE_EP === 'undefined') return { strict: [], body: '' };
+  const parts = [];
+  for (const i of (r.ingredients || [])) {
+    const key = _recipeEpKey(i.name);
+    if (!key || !RECIPE_EP[key]) continue;
+    if (_recipeIsTrace(i.name) && !RECIPE_EP[key].strict) continue;
+    parts.push({ id: key, w: i.g || 10 });
+  }
   return _recipeComposeTagline(parts, _recipeDaySeed());
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.04-3",
+  "version": "2026.06.05-1",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.05-1",
+  "version": "2026.06.05-2",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/diet.js
+++ b/split/diet.js
@@ -679,13 +679,13 @@ const _RECIPE_FP_BY_ICON = {
   almond: 'nuts', walnut: 'nuts', cashew: 'nuts', pistachio: 'nuts', sesame: 'nuts', chia: 'nuts', flaxseed: 'nuts', pumpkinseed: 'nuts',
   egg: 'protein', fish: 'protein', chicken: 'protein', prawn: 'protein', mutton: 'protein', tofu: 'protein',
 };
-// Trace ingredients — excluded from the fingerprint + the tagline (fats,
-// spices, sweeteners; matched as substrings so "cow ghee" / "black pepper" hit).
+// Trace ingredients — excluded from the fingerprint + the tagline BODY (fats,
+// spices, sweeteners). Word-boundary matched (K-T-3) so "oil" doesn't catch an
+// unrelated word; the corpus is curated, so the documented edge ("pepper" would
+// match a future "bell pepper") is a known invariant, not a live collision.
 const _RECIPE_TRACE = ['ghee', 'oil', 'turmeric', 'cinnamon', 'cumin', 'coriander', 'mint', 'jaggery', 'honey', 'salt', 'sugar', 'cardamom', 'pepper', 'ginger', 'garlic', 'lemon'];
-function _recipeIsTrace(name) {
-  const n = String(name).toLowerCase();
-  return _RECIPE_TRACE.some(t => n.indexOf(t) !== -1);
-}
+const _RECIPE_TRACE_RE = new RegExp('\\b(' + _RECIPE_TRACE.join('|') + ')\\b', 'i');
+function _recipeIsTrace(name) { return _RECIPE_TRACE_RE.test(String(name)); }
 function _recipeFpDomain(name) {
   const ic = (typeof recipeFoodIcon === 'function') ? recipeFoodIcon(name) : null;
   return (ic && _RECIPE_FP_BY_ICON[ic.icon]) ? _RECIPE_FP_BY_ICON[ic.icon] : null;
@@ -756,15 +756,35 @@ function _recipeRailColor(group) {
   return 'var(--tc-sage)';
 }
 
+// When an ingredient shares a zif icon with a differently-named food, the
+// composer would voice the wrong noun (M-T-2: poha shares the 'suji' icon →
+// voiced "suji"). Resolve the tagline EP key from the name first, then the icon.
+const _RECIPE_EP_KEY_OVERRIDE = { poha: 'poha' };
+function _recipeEpKey(name) {
+  const n = String(name).toLowerCase();
+  for (const k in _RECIPE_EP_KEY_OVERRIDE) if (n.indexOf(k) !== -1) return _RECIPE_EP_KEY_OVERRIDE[k];
+  const ic = (typeof recipeFoodIcon === 'function') ? recipeFoodIcon(name) : null;
+  return ic ? ic.icon : null;
+}
 // The italic "voice" descriptor (§9.5/§9.6) — the ported tagline composer,
-// quantity-weighted from the non-trace ingredients, epithets day-seed-rotated.
-// Returns { strict:[lead clauses], body } — render strict first (prominent),
-// then the italic body. Reserved for the hero (Typography C: italic = voice).
+// quantity-weighted, epithets day-seed-rotated. Returns { strict:[lead clauses],
+// body } — render strict FIRST (prominent), then the italic body. Reserved for
+// the hero (Typography C: italic = voice).
+//
+// M-T-1 / K-T-1 (BLOCKING fold): trace items are dropped from the BODY, but an
+// ingredient carrying a STRICT safety clause (honey/jaggery → RECIPE_EP[].strict)
+// is kept so the composer surfaces it as the rose lead (§9.7: strict no's lead,
+// never folded). Its tiny gram weight keeps it a "touch of" in the body while the
+// strict clause leads. (The fingerprint path excludes it separately, unchanged.)
 function _recipeTagline(r) {
-  if (typeof _recipeComposeTagline !== 'function') return { strict: [], body: '' };
-  const parts = (r.ingredients || [])
-    .filter(i => !_recipeIsTrace(i.name) && typeof recipeFoodIcon === 'function' && recipeFoodIcon(i.name))
-    .map(i => ({ id: recipeFoodIcon(i.name).icon, w: i.g || 10 }));
+  if (typeof _recipeComposeTagline !== 'function' || typeof RECIPE_EP === 'undefined') return { strict: [], body: '' };
+  const parts = [];
+  for (const i of (r.ingredients || [])) {
+    const key = _recipeEpKey(i.name);
+    if (!key || !RECIPE_EP[key]) continue;
+    if (_recipeIsTrace(i.name) && !RECIPE_EP[key].strict) continue;
+    parts.push({ id: key, w: i.g || 10 });
+  }
   return _recipeComposeTagline(parts, _recipeDaySeed());
 }
 

--- a/split/diet.js
+++ b/split/diet.js
@@ -654,14 +654,81 @@ const _RECIPE_FD_POLARITY = {
   conditional: { cls: 'fd-flag-conditional', ic: 'clock'  },
   inform:      { cls: 'fd-flag-inform',      ic: 'info'   },
 };
-// A small group → epithet bank for the italic "voice" descriptor (typography C).
-// The full ratified tagline composer (docs/design/taglines.mjs, 126-tagline
-// bank) is a follow-up port flagged in recipes-tab/SESSION_HANDOFF.md; this is
-// the in-scope minimal voice.
-const _RECIPE_GROUP_EPITHET = {
-  grains: 'wholesome', fruits: 'naturally sweet', vegs: 'garden-soft',
-  dairy: 'creamy', nuts: 'nutty', spices: 'gently spiced', nonveg: 'protein-rich',
+// ── Generative fingerprint (§9.3) — quantity-weighted, wavelength-ordered ──
+// Each recipe's hero renders a deterministic colour fingerprint from its
+// ingredients: a STRIPE (top ribbon) + a FADE (body wash), band-widths weighted
+// by grams, wavelength-ordered (rose→peach→amber→sage→sky→lav). Trace items
+// (ghee/oil/spices) are excluded so the fingerprint never muds; cap ≤4 domains.
+const RECIPE_FP_DOM = {
+  fruit:   { o: 0,   sat: '#e59cb0', light: 'var(--rose-light)',  dark: 'rgba(158,62,82,0.20)' },
+  protein: { o: 0.6, sat: '#e0a285', light: 'var(--rose-light)',  dark: 'rgba(150,72,60,0.20)' },
+  veg:     { o: 1,   sat: '#ecae7e', light: 'var(--peach-light)', dark: 'rgba(138,101,32,0.18)' },
+  legume:  { o: 2,   sat: '#e6c078', light: 'var(--amber-light)', dark: 'rgba(150,110,40,0.18)' },
+  grain:   { o: 3,   sat: '#9fcdb5', light: 'var(--sage-light)',  dark: 'rgba(58,112,96,0.17)' },
+  dairy:   { o: 4,   sat: '#a0cce0', light: 'var(--sky-light)',   dark: 'rgba(58,112,144,0.18)' },
+  nuts:    { o: 6,   sat: '#c4b4e6', light: 'var(--lav-light)',   dark: 'rgba(110,94,154,0.18)' },
 };
+// zif icon id → fingerprint domain (distinguishes legumes from grains, which
+// FOOD_TAX folds together — the fingerprint wants the dal/rice colour split).
+const _RECIPE_FP_BY_ICON = {
+  rice: 'grain', millet: 'grain', oats: 'grain', wheat: 'grain', suji: 'grain', dalia: 'grain', barley: 'grain', quinoa: 'grain', corn: 'grain',
+  dal: 'legume', chana: 'legume', rajma: 'legume', peanut: 'legume', sprouts: 'legume',
+  carrot: 'veg', spinach: 'veg', beans: 'veg', bottlegourd: 'veg', beetroot: 'veg', pumpkin: 'veg', sweetpotato: 'veg', potato: 'veg', broccoli: 'veg', cauliflower: 'veg', tomato: 'veg', peas: 'veg', drumstick: 'veg', zucchini: 'veg', okra: 'veg', cabbage: 'veg', brinjal: 'veg', mushroom: 'veg', onion: 'veg',
+  banana: 'fruit', pear: 'fruit', apple: 'fruit', mango: 'fruit', avocado: 'fruit', blueberry: 'fruit', strawberry: 'fruit', grapes: 'fruit', date: 'fruit', papaya: 'fruit', orange: 'fruit', pomegranate: 'fruit', coconut: 'fruit',
+  paneer: 'dairy', milk: 'dairy', curd: 'dairy', cheese: 'dairy', butter: 'dairy', buttermilk: 'dairy',
+  almond: 'nuts', walnut: 'nuts', cashew: 'nuts', pistachio: 'nuts', sesame: 'nuts', chia: 'nuts', flaxseed: 'nuts', pumpkinseed: 'nuts',
+  egg: 'protein', fish: 'protein', chicken: 'protein', prawn: 'protein', mutton: 'protein', tofu: 'protein',
+};
+// Trace ingredients — excluded from the fingerprint + the tagline (fats,
+// spices, sweeteners; matched as substrings so "cow ghee" / "black pepper" hit).
+const _RECIPE_TRACE = ['ghee', 'oil', 'turmeric', 'cinnamon', 'cumin', 'coriander', 'mint', 'jaggery', 'honey', 'salt', 'sugar', 'cardamom', 'pepper', 'ginger', 'garlic', 'lemon'];
+function _recipeIsTrace(name) {
+  const n = String(name).toLowerCase();
+  return _RECIPE_TRACE.some(t => n.indexOf(t) !== -1);
+}
+function _recipeFpDomain(name) {
+  const ic = (typeof recipeFoodIcon === 'function') ? recipeFoodIcon(name) : null;
+  return (ic && _RECIPE_FP_BY_ICON[ic.icon]) ? _RECIPE_FP_BY_ICON[ic.icon] : null;
+}
+// Build the weighted fingerprint: { stripe, fadeL, fadeD, ranked } or null.
+function _recipeFingerprint(r) {
+  const prim = (r.ingredients || []).filter(i => !_recipeIsTrace(i.name) && _recipeFpDomain(i.name));
+  if (!prim.length) return null;
+  const byDom = {};
+  for (const i of prim) { const d = _recipeFpDomain(i.name); byDom[d] = (byDom[d] || 0) + (i.g || 10); }
+  let doms = Object.entries(byDom).map(([d, g]) => ({ d, g, ...RECIPE_FP_DOM[d] })).sort((a, b) => a.o - b.o);
+  if (doms.length > 4) doms = doms.slice().sort((a, b) => b.g - a.g).slice(0, 4).sort((a, b) => a.o - b.o);
+  const total = doms.reduce((s, x) => s + x.g, 0) || 1;
+  doms.forEach(x => { x.frac = x.g / total; });
+  const r2 = n => Math.round(n * 10) / 10;
+  const stopsAt = key => { let cum = 0; const s = []; for (const x of doms) { const mid = cum + x.frac / 2; s.push(`${x[key]} ${r2(mid * 100)}%`); cum += x.frac; } return s; };
+  const stripe = `linear-gradient(90deg, ${doms[0].sat} 0%, ${stopsAt('sat').join(', ')}, ${doms.at(-1).sat} 100%)`;
+  const fadeL = `linear-gradient(135deg, ${doms[0].light} 0%, ${stopsAt('light').join(', ')}, ${doms.at(-1).light} 100%)`;
+  const fadeD = `linear-gradient(135deg, ${doms[0].dark} 0%, ${stopsAt('dark').join(', ')}, ${doms.at(-1).dark} 100%)`;
+  const ranked = prim.slice().sort((a, b) => (b.g || 0) - (a.g || 0)).slice(0, 3);
+  return { stripe, fadeL, fadeD, ranked };
+}
+
+// Day-of-year seed — rotates the tagline epithets daily (deterministic within a
+// day). Cosmetic only; local date, timezone-safe construction (HR-12).
+function _recipeDaySeed() {
+  const d = new Date();
+  return Math.floor((d - new Date(d.getFullYear(), 0, 0)) / 864e5);
+}
+
+// Relevance tag for a catalog row (the LOCKED "uses banana"/"vitamin-A" meta) —
+// a nutrient highlight scanned from the recipe's own dos/steps, else cuisine.
+const _RECIPE_NUTRIENT_HINTS = [
+  [/\biron\b/i, 'iron-rich'], [/calcium/i, 'calcium'], [/protein/i, 'protein'],
+  [/vitamin a|beta-?carotene/i, 'vitamin A'], [/vitamin c/i, 'vitamin C'],
+  [/omega|brain-health/i, 'omega-3'], [/probiotic/i, 'probiotic'],
+  [/fibre|fiber/i, 'fibre'], [/healthy fat|brain-healthy fat/i, 'healthy fats'],
+];
+function _recipeRelevanceTag(r) {
+  const hay = ((r.dos || []).join(' ') + ' ' + (r.steps || []).join(' '));
+  for (const [re, label] of _RECIPE_NUTRIENT_HINTS) if (re.test(hay)) return label;
+  return r.cuisine || '';
+}
 
 // Pass A — surfacing gate. Every ingredient must pass the household diet
 // preference; any fail withholds the recipe (fail-OPEN if the gate is absent).
@@ -689,18 +756,16 @@ function _recipeRailColor(group) {
   return 'var(--tc-sage)';
 }
 
-// The italic "voice" descriptor — epithet + the two dominant ingredients.
+// The italic "voice" descriptor (§9.5/§9.6) — the ported tagline composer,
+// quantity-weighted from the non-trace ingredients, epithets day-seed-rotated.
+// Returns { strict:[lead clauses], body } — render strict first (prominent),
+// then the italic body. Reserved for the hero (Typography C: italic = voice).
 function _recipeTagline(r) {
-  const grp = _recipePrimaryGroup(r);
-  const ep = _RECIPE_GROUP_EPITHET[grp] || 'soft';
-  const names = (r.ingredients || [])
-    .map(i => i.name)
-    .filter(n => !/ghee|oil|turmeric|cinnamon|cumin|coriander|pinch/i.test(n))
-    .slice(0, 2)
-    .map(n => n.replace(/\b(dal|fish)\b/i, m => m.toLowerCase()));
-  if (!names.length) return ep;
-  if (names.length === 1) return ep + ' ' + names[0];
-  return ep + ' ' + names[0] + ' & ' + names[1];
+  if (typeof _recipeComposeTagline !== 'function') return { strict: [], body: '' };
+  const parts = (r.ingredients || [])
+    .filter(i => !_recipeIsTrace(i.name) && typeof recipeFoodIcon === 'function' && recipeFoodIcon(i.name))
+    .map(i => ({ id: recipeFoodIcon(i.name).icon, w: i.g || 10 }));
+  return _recipeComposeTagline(parts, _recipeDaySeed());
 }
 
 // The highest ingredient age-gate (months) — recipe-level age floor (§5).
@@ -787,7 +852,10 @@ function _recipeDetailHtml(r, ageMonths) {
   return h;
 }
 
-// One catalog/suggested row (full-width .recipe-row, expand-in-place).
+// One catalog/suggested row (full-width .recipe-row, expand-in-place). Per the
+// LOCKED 05-meal-rows: food icon + Fraunces title + a factual meta line
+// (prep · age · slot · relevance). The italic "voice" is reserved for the hero
+// (§9.6: italic = descriptor only), so rows carry facts, not voice.
 function _recipeRowHtml(r, uidPrefix, ageMonths, opts) {
   opts = opts || {};
   const uid = uidPrefix + '-' + r.id;
@@ -797,20 +865,20 @@ function _recipeRowHtml(r, uidPrefix, ageMonths, opts) {
   const glyph = ic ? `<svg class="zif" style="--zif-c:${ic.c}"><use href="#zif-${ic.icon}"/></svg>` : zi('bowl');
   const effMin = _recipeEffectiveMinAge(r);
   const withheld = effMin > ageMonths;
-  // V-R-1: one age statement per row. When the recipe is withheld (the amber
-  // age-gate badge shows), suppress the plain meta age span — the badge IS the
-  // age signal, and a duplicate "Xm+" twin dilutes its caution weight.
+  // V-R-1: one age statement per row — the badge IS the age signal when withheld.
   const ageBadge = withheld ? `<span class="recipe-age-badge">${zi('baby')} ${effMin}m+</span>` : '';
   const ageMeta = withheld ? '' : `<span>${zi('baby')} ${effMin}m+</span>`;
   const slot = RECIPE_SLOT_META[r.slot];
   const slotMeta = (opts.showSlot && slot) ? `<span>${zi(slot.icon)} ${escHtml(slot.label)}</span>` : '';
+  const prepMeta = r.prepMinutes ? `<span>${zi('clock')} ${r.prepMinutes} min</span>` : '';
+  const relRaw = (opts.relevance != null) ? opts.relevance : _recipeRelevanceTag(r);
+  const relMeta = relRaw ? `<span class="recipe-row-rel">${escHtml(relRaw)}</span>` : '';
   return `<div class="recipe-row dt-${grp}" id="rrow-${escAttr(uid)}" style="--rc-rail:${rail}" role="button" tabindex="0" aria-expanded="false" data-action="toggleRecipeRow" data-arg="${escAttr(uid)}">
     <div class="recipe-row-top">
       <span class="recipe-row-icon">${glyph}</span>
       <span class="recipe-row-main">
         <span class="recipe-row-title">${escHtml(r.title)}</span>
-        <span class="recipe-row-tag">${escHtml(_recipeTagline(r))}</span>
-        <span class="recipe-row-meta">${slotMeta}${ageMeta}${ageBadge}</span>
+        <span class="recipe-row-meta">${prepMeta}${ageMeta}${slotMeta}${relMeta}${ageBadge}</span>
       </span>
       <span class="recipe-row-chev">${zi('chevron-down')}</span>
     </div>
@@ -818,17 +886,46 @@ function _recipeRowHtml(r, uidPrefix, ageMonths, opts) {
   </div>`;
 }
 
-// The featured "Suggested for Ziva" hero card (top pick), expand-in-place.
+// The featured "Suggested for Ziva" hero (top pick) — the GENERATIVE card
+// (§9.3/§9.4): a grams-weighted wavelength fingerprint stripe + warm-wave sheen
+// + corner zif watermark, the Fraunces-italic composed voice (strict no's lead),
+// the data-driven why, a prep·age·slot meta line, and a "See recipe →" CTA.
+// Expand-in-place like the rows.
 function _recipeHeroHtml(r, whyText, ageMonths) {
   const uid = 'h-' + r.id;
   const grp = _recipePrimaryGroup(r);
   const rail = _recipeRailColor(grp);
-  return `<div class="recipe-hero dt-${grp}" id="rrow-${escAttr(uid)}" style="--rc-rail:${rail}" role="button" tabindex="0" aria-expanded="false" data-action="toggleRecipeRow" data-arg="${escAttr(uid)}">
-    <span class="recipe-hero-eyebrow">${zi('sparkle')} Suggested for Ziva</span>
+  const fp = _recipeFingerprint(r);
+  const slot = RECIPE_SLOT_META[r.slot];
+  const effMin = _recipeEffectiveMinAge(r);
+  const tag = _recipeTagline(r);
+  let wm = '';
+  if (fp && fp.ranked && fp.ranked.length) {
+    const slots = ['wm-1', 'wm-2', 'wm-3'];
+    wm = '<div class="recipe-hero-wm" aria-hidden="true">' + fp.ranked.map((ing, k) => {
+      const ic = recipeFoodIcon(ing.name);
+      return ic ? `<span class="recipe-wm ${slots[k]}"><svg class="zif" style="--zif-c:${ic.c}"><use href="#zif-${ic.icon}"/></svg></span>` : '';
+    }).join('') + '</div>';
+  }
+  const fpStyle = fp ? `--rc-stripe:${fp.stripe};--rc-fl:${fp.fadeL};--rc-fd:${fp.fadeD};` : '';
+  const strictLead = (tag.strict && tag.strict.length) ? `<span class="recipe-strict">${escHtml(tag.strict.join('; '))}</span> ` : '';
+  const meta = [];
+  if (r.prepMinutes) meta.push(`<span>${zi('clock')} ${r.prepMinutes} min</span>`);
+  meta.push(`<span>${zi('baby')} ${effMin}m+</span>`);
+  if (slot) meta.push(`<span>${zi(slot.icon)} ${escHtml(slot.label)}</span>`);
+  return `<div class="recipe-hero recipe-hero-gen dt-${grp}" id="rrow-${escAttr(uid)}" style="${fpStyle}--rc-rail:${rail}" role="button" tabindex="0" aria-expanded="false" data-action="toggleRecipeRow" data-arg="${escAttr(uid)}">
+    ${wm}
+    <div class="recipe-hero-head">
+      <span class="recipe-hero-eyebrow">${zi('sparkle')} Suggested for Ziva</span>
+      ${slot ? `<span class="recipe-hero-badge">${escHtml(slot.label)}</span>` : ''}
+    </div>
     <h3 class="recipe-hero-title">${escHtml(r.title)}</h3>
-    <p class="recipe-hero-tag">${escHtml(_recipeTagline(r))}</p>
+    <p class="recipe-hero-tag">${strictLead}${escHtml(tag.body)}</p>
     <p class="recipe-hero-why">${escHtml(whyText || '')}</p>
-    <span class="recipe-hero-more">${zi('chevron-down')} Tap for steps &amp; safety</span>
+    <div class="recipe-hero-foot">
+      <span class="recipe-hero-meta">${meta.join('')}</span>
+      <span class="recipe-hero-cta">See recipe ${zi('arrow-right')}</span>
+    </div>
     <div class="recipe-detail" id="rdet-${escAttr(uid)}" style="display:none;">${_recipeDetailHtml(r, ageMonths)}</div>
   </div>`;
 }
@@ -882,15 +979,20 @@ function renderDietRecipes() {
 
   let html = '';
 
-  // ── (a) Suggested for Ziva ──
+  // Panel header (LOCKED 05-meal-rows): "Recipes" + the sourced-from-logs subtitle.
+  html += `<div class="col-full recipes-header"><h2 class="recipes-h1">Recipes</h2><p class="recipes-subtitle">Sourced for Ziva's stage · cooked from what you log.</p></div>`;
+
+  // ── (a) Suggested for Ziva — featured generative hero + "More for Ziva" rows ──
   const suggested = _recipeSuggestForZiva(surfaced, ageMonths);
-  html += `<div class="col-full"><div class="recipes-sec-label">Suggested for Ziva</div>`;
+  html += `<div class="col-full">`;
   if (suggested.length) {
     const top = suggested[0];
     const topWhy = top.why || (top.r.dos && top.r.dos[0]) || 'A wholesome, age-appropriate pick for today.';
     html += _recipeHeroHtml(top.r, topWhy, ageMonths);
-    for (const s of suggested.slice(1)) {
-      html += _recipeRowHtml(s.r, 's', ageMonths, { showSlot: true });
+    const more = suggested.slice(1);
+    if (more.length) {
+      html += `<div class="recipe-group-head recipe-more-head">${zi('sprout')}<span class="recipe-group-title">More for Ziva</span><span class="recipe-group-count">${more.length}</span></div>`;
+      for (const s of more) html += _recipeRowHtml(s.r, 's', ageMonths, { showSlot: true });
     }
   } else {
     html += `<div class="recipe-empty">${zi('spoon')} Keep logging meals for a few days and personalised recipe ideas will appear here. Meanwhile, browse the catalog below.</div>`;

--- a/split/recipes.js
+++ b/split/recipes.js
@@ -540,6 +540,15 @@ const RECIPE_EP = {
   turmeric:{eps:['golden','earthy'],noun:'turmeric'}, cinnamon:{eps:['warm','sweet'],noun:'cinnamon'},
   cumin:{eps:['warm','earthy'],noun:'cumin'}, coriander:{eps:['fresh','herby'],noun:'coriander'},
   mint:{eps:['cool','fresh'],noun:'mint'}, ginger:{eps:['warming','zingy'],noun:'ginger'},
+  // fold-completeness (K-T-2): keys present in the fingerprint icon map must also
+  // carry a voice, or a recipe paints a colour band for an unnamed ingredient.
+  poha:{eps:['light','flaky'],noun:'poha'}, okra:{eps:['tender','green'],noun:'okra'},
+  cabbage:{eps:['crisp','leafy'],noun:'cabbage'}, brinjal:{eps:['silky','mellow'],noun:'brinjal'},
+  mushroom:{eps:['earthy','tender'],noun:'mushroom'}, onion:{eps:['sweet','mellow'],noun:'onion'},
+  strawberry:{eps:['sweet','fragrant'],noun:'strawberry'}, grapes:{eps:['juicy','sweet'],noun:'grape',fold:'halved'},
+  papaya:{eps:['soft','sweet'],noun:'papaya'}, orange:{eps:['juicy','bright'],noun:'orange'},
+  pistachio:{eps:['nutty','green'],noun:'pistachio',fold:'ground'}, pumpkinseed:{eps:['nutty','crunchy'],noun:'pumpkin seed',fold:'ground'},
+  tofu:{eps:['silky','mild'],noun:'tofu'},
 };
 const _recipeConnector = s =>
   s < 0.12 ? 'with just a hint of' : s < 0.22 ? 'with a touch of' :

--- a/split/recipes.js
+++ b/split/recipes.js
@@ -50,16 +50,19 @@ const RECIPE_SOURCES = {
 };
 
 // Each recipe:
-//   { id, title, slot, minAgeMonths,
-//     ingredients:[{name, qty}],   // name = the LIVE-resolver classifying form
+//   { id, title, slot, minAgeMonths, prepMinutes,
+//     ingredients:[{name, qty, g}], // name = the LIVE-resolver classifying form;
+//                                   // g = grams (drives the quantity-weighted
+//                                   // generative fingerprint §9.3; trace items
+//                                   // ghee/oil/spices excluded at render)
 //     foodGroups:[FOOD_TAX gid],   // gap-fill scoring + card colour
 //     steps:[…], dos:[…], donts:[…],
 //     cuisine, source:[sourceKey…] }
 const RECIPES = [
   // ─────────────────────────── BREAKFAST ───────────────────────────
   {
-    id: 'ragi-banana-porridge', title: 'Ragi Banana Porridge', slot: 'breakfast', minAgeMonths: 7,
-    ingredients: [{ name: 'ragi', qty: '1 tbsp (24 g)' }, { name: 'banana', qty: '¼, mashed (20 g)' }],
+    id: 'ragi-banana-porridge', title: 'Ragi Banana Porridge', slot: 'breakfast', minAgeMonths: 7, prepMinutes: 12,
+    ingredients: [{ name: 'ragi', qty: '1 tbsp (24 g)', g: 24 }, { name: 'banana', qty: '¼, mashed (20 g)', g: 20 }],
     foodGroups: ['grains', 'fruits'], cuisine: 'Indian',
     steps: [
       'Dry-roast 1 tbsp ragi flour on low for 2 min until fragrant.',
@@ -72,8 +75,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'oats-apple-porridge', title: 'Oats & Apple Porridge', slot: 'breakfast', minAgeMonths: 7,
-    ingredients: [{ name: 'oats', qty: '1 tbsp ground (24 g)' }, { name: 'apple', qty: '¼ grated (20 g)' }, { name: 'cinnamon', qty: 'a pinch' }],
+    id: 'oats-apple-porridge', title: 'Oats & Apple Porridge', slot: 'breakfast', minAgeMonths: 7, prepMinutes: 10,
+    ingredients: [{ name: 'oats', qty: '1 tbsp ground (24 g)', g: 24 }, { name: 'apple', qty: '¼ grated (20 g)', g: 20 }, { name: 'cinnamon', qty: 'a pinch', g: 1 }],
     foodGroups: ['grains', 'fruits', 'spices'], cuisine: 'Global',
     steps: [
       'Grind 1 tbsp plain rolled oats to a coarse powder.',
@@ -86,8 +89,8 @@ const RECIPES = [
     source: ['nhs', 'aap'],
   },
   {
-    id: 'almond-ragi-kheer', title: 'Almond Ragi Kheer (12 m+)', slot: 'breakfast', minAgeMonths: 12,
-    ingredients: [{ name: 'milk', qty: '½ cup (in cooking)' }, { name: 'ragi', qty: '1 tbsp (15 g)' }, { name: 'date', qty: '1, deseeded paste' }, { name: 'almond', qty: '¼ tsp ground (3 g)' }],
+    id: 'almond-ragi-kheer', title: 'Almond Ragi Kheer (12 m+)', slot: 'breakfast', minAgeMonths: 12, prepMinutes: 18,
+    ingredients: [{ name: 'milk', qty: '½ cup (in cooking)', g: 60 }, { name: 'ragi', qty: '1 tbsp (15 g)', g: 15 }, { name: 'date', qty: '1, deseeded paste', g: 8 }, { name: 'almond', qty: '¼ tsp ground (3 g)', g: 3 }],
     foodGroups: ['dairy', 'grains', 'fruits', 'nuts'], cuisine: 'Indian',
     steps: [
       'Soak 2 almonds, peel, and grind to an absolutely smooth paste.',
@@ -100,8 +103,8 @@ const RECIPES = [
     source: ['iap', 'aap'],
   },
   {
-    id: 'suji-veg-upma', title: 'Suji & Veg Upma', slot: 'breakfast', minAgeMonths: 8,
-    ingredients: [{ name: 'suji', qty: '2 tbsp (30 g)' }, { name: 'carrot', qty: '2 tbsp grated' }, { name: 'peas', qty: '1 tbsp, mashed' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'suji-veg-upma', title: 'Suji & Veg Upma', slot: 'breakfast', minAgeMonths: 8, prepMinutes: 15,
+    ingredients: [{ name: 'suji', qty: '2 tbsp (30 g)', g: 30 }, { name: 'carrot', qty: '2 tbsp grated', g: 20 }, { name: 'peas', qty: '1 tbsp, mashed', g: 12 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'vegs', 'dairy'], cuisine: 'Indian',
     steps: [
       'Dry-roast 2 tbsp suji on low until aromatic, set aside.',
@@ -114,8 +117,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'poha-peas-potato', title: 'Poha with Peas & Potato', slot: 'breakfast', minAgeMonths: 8,
-    ingredients: [{ name: 'poha', qty: '3 tbsp (30 g)' }, { name: 'potato', qty: '2 tbsp, boiled & mashed' }, { name: 'peas', qty: '1 tbsp, mashed' }, { name: 'turmeric', qty: 'a pinch' }],
+    id: 'poha-peas-potato', title: 'Poha with Peas & Potato', slot: 'breakfast', minAgeMonths: 8, prepMinutes: 12,
+    ingredients: [{ name: 'poha', qty: '3 tbsp (30 g)', g: 30 }, { name: 'potato', qty: '2 tbsp, boiled & mashed', g: 30 }, { name: 'peas', qty: '1 tbsp, mashed', g: 12 }, { name: 'turmeric', qty: 'a pinch', g: 1 }],
     foodGroups: ['grains', 'vegs', 'spices'], cuisine: 'Indian',
     steps: [
       'Rinse 3 tbsp thin poha in a sieve until just soft, drain.',
@@ -128,8 +131,8 @@ const RECIPES = [
     source: ['icmr', 'iap'],
   },
   {
-    id: 'banana-oats-egg-pancake', title: 'Banana Oats Egg Pancake', slot: 'breakfast', minAgeMonths: 8,
-    ingredients: [{ name: 'banana', qty: '½, mashed' }, { name: 'oats', qty: '1 tbsp ground' }, { name: 'egg', qty: '1, well beaten' }],
+    id: 'banana-oats-egg-pancake', title: 'Banana Oats Egg Pancake', slot: 'breakfast', minAgeMonths: 8, prepMinutes: 10,
+    ingredients: [{ name: 'banana', qty: '½, mashed', g: 25 }, { name: 'oats', qty: '1 tbsp ground', g: 20 }, { name: 'egg', qty: '1, well beaten', g: 50 }],
     foodGroups: ['fruits', 'grains', 'nonveg'], cuisine: 'Global',
     steps: [
       'Mash ½ ripe banana smooth.',
@@ -142,8 +145,8 @@ const RECIPES = [
     source: ['nhs', 'aap'],
   },
   {
-    id: 'dalia-porridge', title: 'Broken-Wheat Dalia Porridge', slot: 'breakfast', minAgeMonths: 8,
-    ingredients: [{ name: 'dalia', qty: '2 tbsp (30 g)' }, { name: 'date', qty: '1, paste' }],
+    id: 'dalia-porridge', title: 'Broken-Wheat Dalia Porridge', slot: 'breakfast', minAgeMonths: 8, prepMinutes: 15,
+    ingredients: [{ name: 'dalia', qty: '2 tbsp (30 g)', g: 30 }, { name: 'date', qty: '1, paste', g: 8 }],
     foodGroups: ['grains', 'fruits'], cuisine: 'Indian',
     steps: [
       'Dry-roast 2 tbsp dalia (broken wheat) 2 min.',
@@ -158,8 +161,8 @@ const RECIPES = [
 
   // ─────────────────────────── LUNCH ───────────────────────────
   {
-    id: 'moong-dal-khichdi', title: 'Moong Dal Khichdi', slot: 'lunch', minAgeMonths: 7,
-    ingredients: [{ name: 'rice', qty: '1 tbsp (12 g)' }, { name: 'moong dal', qty: '½ tbsp (8 g)' }, { name: 'ghee', qty: '½ tsp' }, { name: 'turmeric', qty: 'a pinch' }],
+    id: 'moong-dal-khichdi', title: 'Moong Dal Khichdi', slot: 'lunch', minAgeMonths: 7, prepMinutes: 20,
+    ingredients: [{ name: 'rice', qty: '1 tbsp (12 g)', g: 12 }, { name: 'moong dal', qty: '½ tbsp (8 g)', g: 8 }, { name: 'ghee', qty: '½ tsp', g: 3 }, { name: 'turmeric', qty: 'a pinch', g: 1 }],
     foodGroups: ['grains', 'dairy', 'spices'], cuisine: 'Indian',
     steps: [
       'Wash 1 tbsp rice and ½ tbsp moong dal, soak 20 min.',
@@ -172,8 +175,8 @@ const RECIPES = [
     source: ['iap', 'whopaho'],
   },
   {
-    id: 'veg-moong-khichdi', title: 'Veg & Moong Khichdi', slot: 'lunch', minAgeMonths: 8,
-    ingredients: [{ name: 'rice', qty: '1 tbsp (15 g)' }, { name: 'moong dal', qty: '½ tbsp (10 g)' }, { name: 'carrot', qty: '2 tbsp (20 g)' }, { name: 'pumpkin', qty: '2 tbsp (20 g)' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'veg-moong-khichdi', title: 'Veg & Moong Khichdi', slot: 'lunch', minAgeMonths: 8, prepMinutes: 25,
+    ingredients: [{ name: 'rice', qty: '1 tbsp (15 g)', g: 15 }, { name: 'moong dal', qty: '½ tbsp (10 g)', g: 10 }, { name: 'carrot', qty: '2 tbsp (20 g)', g: 20 }, { name: 'pumpkin', qty: '2 tbsp (20 g)', g: 20 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'vegs', 'dairy'], cuisine: 'Indian',
     steps: [
       'Wash rice and moong dal, soak 20 min.',
@@ -186,8 +189,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'dal-rice-palak', title: 'Dal–Rice with Palak', slot: 'lunch', minAgeMonths: 8,
-    ingredients: [{ name: 'rice', qty: '3 tbsp (45 g)' }, { name: 'toor dal', qty: '1½ tbsp (25 g)' }, { name: 'spinach', qty: '1 tbsp, blanched (15 g)' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'dal-rice-palak', title: 'Dal–Rice with Palak', slot: 'lunch', minAgeMonths: 8, prepMinutes: 25,
+    ingredients: [{ name: 'rice', qty: '3 tbsp (45 g)', g: 45 }, { name: 'toor dal', qty: '1½ tbsp (25 g)', g: 25 }, { name: 'spinach', qty: '1 tbsp, blanched (15 g)', g: 15 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'vegs', 'dairy'], cuisine: 'Indian',
     steps: [
       'Blanch a few spinach (palak) leaves 2 min, chop fine or puree.',
@@ -200,8 +203,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'masoor-lauki-rice', title: 'Masoor Dal & Bottle Gourd Rice', slot: 'lunch', minAgeMonths: 7,
-    ingredients: [{ name: 'rice', qty: '2 tbsp' }, { name: 'masoor dal', qty: '1 tbsp' }, { name: 'bottle gourd', qty: '2 tbsp, diced' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'masoor-lauki-rice', title: 'Masoor Dal & Bottle Gourd Rice', slot: 'lunch', minAgeMonths: 7, prepMinutes: 20,
+    ingredients: [{ name: 'rice', qty: '2 tbsp', g: 30 }, { name: 'masoor dal', qty: '1 tbsp', g: 15 }, { name: 'bottle gourd', qty: '2 tbsp, diced', g: 25 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'vegs', 'dairy'], cuisine: 'Indian',
     steps: [
       'Wash rice and masoor dal, soak 20 min.',
@@ -214,8 +217,8 @@ const RECIPES = [
     source: ['icmr', 'iap'],
   },
   {
-    id: 'soft-curd-rice', title: 'Soft Curd Rice', slot: 'lunch', minAgeMonths: 8,
-    ingredients: [{ name: 'rice', qty: '2 tbsp, very soft' }, { name: 'curd', qty: '1 tbsp, fresh' }],
+    id: 'soft-curd-rice', title: 'Soft Curd Rice', slot: 'lunch', minAgeMonths: 8, prepMinutes: 10,
+    ingredients: [{ name: 'rice', qty: '2 tbsp, very soft', g: 30 }, { name: 'curd', qty: '1 tbsp, fresh', g: 40 }],
     foodGroups: ['grains', 'dairy'], cuisine: 'Indian',
     steps: [
       'Cook 2 tbsp rice until very soft and mashable.',
@@ -228,8 +231,8 @@ const RECIPES = [
     source: ['icmr', 'iap'],
   },
   {
-    id: 'paneer-veg-pulao', title: 'Paneer & Veg Soft Pulao', slot: 'lunch', minAgeMonths: 9,
-    ingredients: [{ name: 'rice', qty: '3 tbsp' }, { name: 'paneer', qty: '1 tbsp, crumbled' }, { name: 'carrot', qty: '1 tbsp, grated' }, { name: 'peas', qty: '1 tbsp, mashed' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'paneer-veg-pulao', title: 'Paneer & Veg Soft Pulao', slot: 'lunch', minAgeMonths: 9, prepMinutes: 20,
+    ingredients: [{ name: 'rice', qty: '3 tbsp', g: 30 }, { name: 'paneer', qty: '1 tbsp, crumbled', g: 15 }, { name: 'carrot', qty: '1 tbsp, grated', g: 20 }, { name: 'peas', qty: '1 tbsp, mashed', g: 12 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'dairy', 'vegs'], cuisine: 'Indian',
     steps: [
       'Soften grated carrot and mashed peas in ½ tsp ghee for 2 min.',
@@ -242,8 +245,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'rohu-fish-rice', title: 'Rohu Fish & Rice Mash', slot: 'lunch', minAgeMonths: 8,
-    ingredients: [{ name: 'rice', qty: '3 tbsp' }, { name: 'rohu fish', qty: '1 tbsp, cooked & deboned' }, { name: 'ghee', qty: '½ tsp' }, { name: 'turmeric', qty: 'a pinch' }],
+    id: 'rohu-fish-rice', title: 'Rohu Fish & Rice Mash', slot: 'lunch', minAgeMonths: 8, prepMinutes: 18,
+    ingredients: [{ name: 'rice', qty: '3 tbsp', g: 30 }, { name: 'rohu fish', qty: '1 tbsp, cooked & deboned', g: 15 }, { name: 'ghee', qty: '½ tsp', g: 3 }, { name: 'turmeric', qty: 'a pinch', g: 1 }],
     foodGroups: ['grains', 'nonveg', 'dairy'], cuisine: 'Indian',
     steps: [
       'Steam a small piece of rohu with a pinch of turmeric until flaky.',
@@ -258,8 +261,8 @@ const RECIPES = [
 
   // ─────────────────────────── DINNER ───────────────────────────
   {
-    id: 'carrot-beet-potato-mash', title: 'Carrot Beetroot Potato Mash', slot: 'dinner', minAgeMonths: 7,
-    ingredients: [{ name: 'carrot', qty: '3 tbsp (40 g)' }, { name: 'beetroot', qty: '2 tbsp (30 g)' }, { name: 'potato', qty: '3 tbsp (40 g)' }, { name: 'ghee', qty: '¼ tsp' }],
+    id: 'carrot-beet-potato-mash', title: 'Carrot Beetroot Potato Mash', slot: 'dinner', minAgeMonths: 7, prepMinutes: 20,
+    ingredients: [{ name: 'carrot', qty: '3 tbsp (40 g)', g: 40 }, { name: 'beetroot', qty: '2 tbsp (30 g)', g: 30 }, { name: 'potato', qty: '3 tbsp (40 g)', g: 40 }, { name: 'ghee', qty: '¼ tsp', g: 3 }],
     foodGroups: ['vegs', 'dairy'], cuisine: 'Indian',
     steps: [
       'Peel and dice carrot, beetroot and potato.',
@@ -272,8 +275,8 @@ const RECIPES = [
     source: ['icmr', 'nhs'],
   },
   {
-    id: 'sweet-potato-moong-mash', title: 'Sweet Potato & Moong Mash', slot: 'dinner', minAgeMonths: 7,
-    ingredients: [{ name: 'sweet potato', qty: '½ small (50 g)' }, { name: 'moong dal', qty: '1 tbsp' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'sweet-potato-moong-mash', title: 'Sweet Potato & Moong Mash', slot: 'dinner', minAgeMonths: 7, prepMinutes: 18,
+    ingredients: [{ name: 'sweet potato', qty: '½ small (50 g)', g: 50 }, { name: 'moong dal', qty: '1 tbsp', g: 12 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['vegs', 'grains', 'dairy'], cuisine: 'Indian',
     steps: [
       'Steam cubed sweet potato 10 min until very soft.',
@@ -286,8 +289,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'palak-paneer-rice', title: 'Palak Paneer Rice', slot: 'dinner', minAgeMonths: 9,
-    ingredients: [{ name: 'rice', qty: '3 tbsp' }, { name: 'paneer', qty: '1 tbsp, crumbled' }, { name: 'spinach', qty: '1 tbsp, blanched' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'palak-paneer-rice', title: 'Palak Paneer Rice', slot: 'dinner', minAgeMonths: 9, prepMinutes: 18,
+    ingredients: [{ name: 'rice', qty: '3 tbsp', g: 30 }, { name: 'paneer', qty: '1 tbsp, crumbled', g: 15 }, { name: 'spinach', qty: '1 tbsp, blanched', g: 15 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'dairy', 'vegs'], cuisine: 'Indian',
     steps: [
       'Blanch spinach 2 min, puree smooth.',
@@ -300,8 +303,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'chicken-rice-bowl', title: 'Soft Chicken & Rice Bowl', slot: 'dinner', minAgeMonths: 9,
-    ingredients: [{ name: 'rice', qty: '3 tbsp' }, { name: 'chicken', qty: '1 tbsp, shredded' }, { name: 'carrot', qty: '1 tbsp, grated' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'chicken-rice-bowl', title: 'Soft Chicken & Rice Bowl', slot: 'dinner', minAgeMonths: 9, prepMinutes: 25,
+    ingredients: [{ name: 'rice', qty: '3 tbsp', g: 30 }, { name: 'chicken', qty: '1 tbsp, shredded', g: 15 }, { name: 'carrot', qty: '1 tbsp, grated', g: 20 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'nonveg', 'vegs'], cuisine: 'Global',
     steps: [
       'Boil a small piece of boneless chicken until fully cooked and tender.',
@@ -314,8 +317,8 @@ const RECIPES = [
     source: ['aap', 'nhs'],
   },
   {
-    id: 'mixed-veg-dal-soup', title: 'Mixed Veg & Dal Soup', slot: 'dinner', minAgeMonths: 8,
-    ingredients: [{ name: 'moong dal', qty: '1 tbsp' }, { name: 'carrot', qty: '1 tbsp' }, { name: 'tomato', qty: '1 tbsp' }, { name: 'bottle gourd', qty: '1 tbsp' }],
+    id: 'mixed-veg-dal-soup', title: 'Mixed Veg & Dal Soup', slot: 'dinner', minAgeMonths: 8, prepMinutes: 20,
+    ingredients: [{ name: 'moong dal', qty: '1 tbsp', g: 12 }, { name: 'carrot', qty: '1 tbsp', g: 20 }, { name: 'tomato', qty: '1 tbsp', g: 15 }, { name: 'bottle gourd', qty: '1 tbsp', g: 25 }],
     foodGroups: ['grains', 'vegs'], cuisine: 'Indian',
     steps: [
       'Pressure-cook moong dal with diced carrot, tomato and bottle gourd until very soft.',
@@ -330,8 +333,8 @@ const RECIPES = [
 
   // ─────────────────────────── SNACK ───────────────────────────
   {
-    id: 'curd-banana-bowl', title: 'Curd & Banana Bowl', slot: 'snack', minAgeMonths: 8,
-    ingredients: [{ name: 'curd', qty: '3 tbsp (60 g)' }, { name: 'banana', qty: '¼, mashed (25 g)' }],
+    id: 'curd-banana-bowl', title: 'Curd & Banana Bowl', slot: 'snack', minAgeMonths: 8, prepMinutes: 3,
+    ingredients: [{ name: 'curd', qty: '3 tbsp (60 g)', g: 60 }, { name: 'banana', qty: '¼, mashed (25 g)', g: 25 }],
     foodGroups: ['dairy', 'fruits'], cuisine: 'Indian',
     steps: [
       'Whisk 3 tbsp fresh full-fat curd smooth.',
@@ -343,8 +346,8 @@ const RECIPES = [
     source: ['icmr', 'nhs'],
   },
   {
-    id: 'carrot-moong-mash', title: 'Carrot Moong Mash', slot: 'snack', minAgeMonths: 6,
-    ingredients: [{ name: 'carrot', qty: '3 tbsp, grated' }, { name: 'moong dal', qty: '2 tbsp' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'carrot-moong-mash', title: 'Carrot Moong Mash', slot: 'snack', minAgeMonths: 6, prepMinutes: 18,
+    ingredients: [{ name: 'carrot', qty: '3 tbsp, grated', g: 20 }, { name: 'moong dal', qty: '2 tbsp', g: 12 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['vegs', 'grains', 'dairy'], cuisine: 'Indian',
     steps: [
       'Grate carrot and wash moong dal.',
@@ -357,8 +360,8 @@ const RECIPES = [
     source: ['whopaho', 'iap'],
   },
   {
-    id: 'avocado-banana-mash', title: 'Avocado & Banana Mash', slot: 'snack', minAgeMonths: 6,
-    ingredients: [{ name: 'avocado', qty: '2 tbsp' }, { name: 'banana', qty: '¼, mashed' }],
+    id: 'avocado-banana-mash', title: 'Avocado & Banana Mash', slot: 'snack', minAgeMonths: 6, prepMinutes: 3,
+    ingredients: [{ name: 'avocado', qty: '2 tbsp', g: 30 }, { name: 'banana', qty: '¼, mashed', g: 25 }],
     foodGroups: ['fruits'], cuisine: 'Global',
     steps: [
       'Scoop 2 tbsp ripe avocado.',
@@ -370,8 +373,8 @@ const RECIPES = [
     source: ['aap', 'nhs'],
   },
   {
-    id: 'stewed-apple-date', title: 'Stewed Apple & Date', slot: 'snack', minAgeMonths: 6,
-    ingredients: [{ name: 'apple', qty: '½, peeled & diced' }, { name: 'date', qty: '1, deseeded' }],
+    id: 'stewed-apple-date', title: 'Stewed Apple & Date', slot: 'snack', minAgeMonths: 6, prepMinutes: 10,
+    ingredients: [{ name: 'apple', qty: '½, peeled & diced', g: 40 }, { name: 'date', qty: '1, deseeded', g: 8 }],
     foodGroups: ['fruits'], cuisine: 'Global',
     steps: [
       'Peel, core and dice ½ apple.',
@@ -384,8 +387,8 @@ const RECIPES = [
     source: ['nhs', 'iap'],
   },
   {
-    id: 'mango-curd-bowl', title: 'Mango & Curd Bowl', slot: 'snack', minAgeMonths: 8,
-    ingredients: [{ name: 'mango', qty: '2 tbsp, ripe' }, { name: 'curd', qty: '1 tbsp, fresh' }],
+    id: 'mango-curd-bowl', title: 'Mango & Curd Bowl', slot: 'snack', minAgeMonths: 8, prepMinutes: 3,
+    ingredients: [{ name: 'mango', qty: '2 tbsp, ripe', g: 30 }, { name: 'curd', qty: '1 tbsp, fresh', g: 40 }],
     foodGroups: ['fruits', 'dairy'], cuisine: 'Indian',
     steps: [
       'Mash 2 tbsp ripe mango smooth.',
@@ -399,8 +402,8 @@ const RECIPES = [
 
   // ─── 12 m+ catalog item — age-gated, never suggested for an under-1 (honey) ───
   {
-    id: 'banana-honey-toast', title: 'Banana & Honey Toast (12 m+)', slot: 'snack', minAgeMonths: 12,
-    ingredients: [{ name: 'bread', qty: '1 slice, soft' }, { name: 'banana', qty: '½, mashed' }, { name: 'honey', qty: '½ tsp (12 m+ only)' }],
+    id: 'banana-honey-toast', title: 'Banana & Honey Toast (12 m+)', slot: 'snack', minAgeMonths: 12, prepMinutes: 5,
+    ingredients: [{ name: 'bread', qty: '1 slice, soft', g: 25 }, { name: 'banana', qty: '½, mashed', g: 25 }, { name: 'honey', qty: '½ tsp (12 m+ only)', g: 5 }],
     foodGroups: ['grains', 'fruits'], cuisine: 'Global',
     steps: [
       'Lightly toast a soft slice of whole-wheat bread, remove crusts, cut into soft fingers.',
@@ -485,6 +488,90 @@ function recipeFoodIcon(name) {
   return null;
 }
 
+// ── §9.5 Tagline composer (ported from docs/design/taglines.mjs) ─────────
+// The generative "voice" line for any recipe/combo: each ingredient
+// contributes an epithet + noun; the minor-share ratio picks the connector so
+// quantity shows in the words. Soft prep-cautions FOLD into the phrase (ground
+// almond / halved grape); STRICT no's (honey / added sugar) keep a prominent
+// LEADING clause. Epithets rotate by a day-seed (fresh daily, deterministic
+// within a day). Adapted to the app's global-script style (no ES exports);
+// keyed by zif icon id (recipeFoodIcon(name).icon) so it shares one vocabulary.
+const RECIPE_EP = {
+  // grains & cereals
+  rice:{eps:['soft','gentle','silky'],noun:'rice'}, millet:{eps:['earthy','iron-rich','nutty'],noun:'ragi'},
+  oats:{eps:['wholesome','warm','hearty'],noun:'oats'}, wheat:{eps:['hearty','wholesome'],noun:'wheat'},
+  suji:{eps:['smooth','light'],noun:'suji'}, corn:{eps:['sweet','sunny'],noun:'corn'},
+  dalia:{eps:['hearty','nutty'],noun:'dalia'}, barley:{eps:['nutty','wholesome'],noun:'barley'},
+  quinoa:{eps:['nutty','light'],noun:'quinoa'},
+  // legumes & pulses
+  dal:{eps:['savoury','soupy','hearty'],noun:'dal'}, chana:{eps:['nutty','hearty'],noun:'chana'},
+  rajma:{eps:['hearty','earthy'],noun:'rajma'}, peanut:{eps:['nutty','rich'],noun:'peanut',fold:'ground'},
+  sprouts:{eps:['fresh','green'],noun:'sprouts'},
+  // vegetables
+  carrot:{eps:['sweet','bright','sunny'],noun:'carrot'}, spinach:{eps:['leafy','green','iron-rich'],noun:'spinach'},
+  beans:{eps:['crisp','green'],noun:'green beans'}, bottlegourd:{eps:['light','soothing'],noun:'bottle gourd'},
+  beetroot:{eps:['earthy','ruby','sweet'],noun:'beetroot'}, pumpkin:{eps:['silky','golden','sweet'],noun:'pumpkin'},
+  sweetpotato:{eps:['velvety','golden','creamy'],noun:'sweet potato'}, potato:{eps:['soft','comforting'],noun:'potato'},
+  broccoli:{eps:['green','tender'],noun:'broccoli'}, cauliflower:{eps:['mild','tender'],noun:'cauliflower'},
+  tomato:{eps:['tangy','bright'],noun:'tomato'}, peas:{eps:['sweet','green'],noun:'peas'},
+  drumstick:{eps:['earthy','green'],noun:'drumstick'}, zucchini:{eps:['soft','mild'],noun:'zucchini'},
+  // fruits
+  banana:{eps:['creamy','sweet','soft'],noun:'banana'}, pear:{eps:['juicy','gentle'],noun:'pear'},
+  apple:{eps:['sweet','stewed','crisp'],noun:'apple'}, mango:{eps:['golden','silky','sweet'],noun:'mango'},
+  avocado:{eps:['buttery','creamy'],noun:'avocado'}, blueberry:{eps:['sweet','jewel-like'],noun:'blueberry'},
+  date:{eps:['caramel-sweet','rich'],noun:'date'}, coconut:{eps:['creamy','rich'],noun:'coconut'},
+  pomegranate:{eps:['ruby','jewel-like'],noun:'pomegranate'},
+  // dairy & eggs
+  paneer:{eps:['mild','soft','milky'],noun:'paneer'}, milk:{eps:['creamy','gentle'],noun:'milk'},
+  ghee:{eps:['rich','golden'],noun:'ghee'}, curd:{eps:['cooling','tangy','creamy'],noun:'curd'},
+  cheese:{eps:['savoury','melty'],noun:'cheese'}, butter:{eps:['rich','soft'],noun:'butter'},
+  buttermilk:{eps:['cooling','tangy'],noun:'buttermilk'}, egg:{eps:['protein-rich','soft'],noun:'egg',fold:'cooked'},
+  // nuts & seeds
+  almond:{eps:['nutty','buttery'],noun:'almond',fold:'ground'}, walnut:{eps:['earthy','rich'],noun:'walnut',fold:'ground'},
+  cashew:{eps:['buttery','mild'],noun:'cashew',fold:'ground'}, sesame:{eps:['nutty','toasty'],noun:'sesame',fold:'ground'},
+  chia:{eps:['tiny','nutty'],noun:'chia',fold:'soaked'}, flaxseed:{eps:['nutty','wholesome'],noun:'flaxseed',fold:'ground'},
+  // proteins
+  fish:{eps:['tender','omega-rich'],noun:'fish',fold:'boneless'}, chicken:{eps:['lean','tender'],noun:'chicken',fold:'shredded'},
+  prawn:{eps:['tender','sweet'],noun:'prawn'}, mutton:{eps:['rich','tender'],noun:'mutton',fold:'soft-cooked'},
+  // fats & sweeteners
+  jaggery:{eps:['caramel-sweet'],noun:'jaggery',strict:'go easy — added sugar'},
+  honey:{eps:['golden'],noun:'honey',strict:'honey — only from age 1'}, oil:{eps:['light'],noun:'oil'},
+  // spices & herbs
+  turmeric:{eps:['golden','earthy'],noun:'turmeric'}, cinnamon:{eps:['warm','sweet'],noun:'cinnamon'},
+  cumin:{eps:['warm','earthy'],noun:'cumin'}, coriander:{eps:['fresh','herby'],noun:'coriander'},
+  mint:{eps:['cool','fresh'],noun:'mint'}, ginger:{eps:['warming','zingy'],noun:'ginger'},
+};
+const _recipeConnector = s =>
+  s < 0.12 ? 'with just a hint of' : s < 0.22 ? 'with a touch of' :
+  s < 0.33 ? 'with a little' : s < 0.45 ? 'balanced with' : 'meets';
+const _recEpOf = (it, seed) => it.eps[seed % it.eps.length];
+const _recNounOf = it => it.fold ? `${it.fold} ${it.noun}` : it.noun;
+
+// parts: [{id, w}] (id = a RECIPE_EP key; w = grams) · seed: day-seed.
+// Returns { strict:[lead clauses], body }. Render strict first (prominent).
+function _recipeComposeTagline(parts, seed) {
+  seed = seed || 0;
+  const items = parts.map(p => ({ ...RECIPE_EP[p.id], w: p.w })).filter(i => i.noun).sort((a, b) => b.w - a.w);
+  if (!items.length) return { strict: [], body: '' };
+  const total = items.reduce((s, i) => s + i.w, 0) || 1;
+  const strict = [...new Set(items.filter(i => i.strict).map(i => i.strict))];
+  const dom = items[0];
+  let body;
+  if (items.length === 1) {
+    body = `${_recEpOf(dom, seed)} ${_recNounOf(dom)}`;
+  } else if (items.length === 2) {
+    const m = items[1], con = _recipeConnector(m.w / total);
+    body = con === 'meets'
+      ? `${_recEpOf(dom, seed)} ${_recNounOf(dom)} meets ${_recEpOf(m, seed)} ${_recNounOf(m)}`
+      : `${_recEpOf(dom, seed)} ${_recNounOf(dom)}, ${con} ${_recNounOf(m)}`;
+  } else {
+    const mids = items.slice(1, -1).map(_recNounOf);
+    const last = items.at(-1), lastCon = (last.w / total) < 0.15 ? 'a touch of' : 'a little';
+    body = `${_recEpOf(dom, seed)} ${_recNounOf(dom)}, with ${mids.join(', ')} and ${lastCon} ${_recNounOf(last)}`;
+  }
+  return { strict, body };
+}
+
 // O(1) lookup for the tap-through dispatcher (openRecipeInTab) + render helpers.
 const RECIPES_BY_ID = RECIPES.reduce((m, r) => { m[r.id] = r; return m; }, {});
 
@@ -494,3 +581,4 @@ window.RECIPES = RECIPES;
 window.RECIPES_BY_ID = RECIPES_BY_ID;
 window.RECIPE_SOURCES = RECIPE_SOURCES;
 window.recipeFoodIcon = recipeFoodIcon;
+window._recipeComposeTagline = _recipeComposeTagline;

--- a/split/styles.css
+++ b/split/styles.css
@@ -11140,9 +11140,46 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 .recipe-hero-title { font-family:'Fraunces', serif; font-weight:700; font-size:var(--fs-2xl); line-height:1.08; color:var(--text); margin:0 0 2px; text-wrap:balance; }
 .recipe-hero-tag { font-family:'Fraunces', serif; font-style:italic; font-weight:400; font-size:var(--fs-lg); line-height:1.25; color:var(--mid); margin:0 0 var(--sp-8); }
 .recipe-hero-why { font-size:var(--fs-sm); color:var(--mid); line-height:var(--lh-relaxed); margin:0 0 var(--sp-8); }
-.recipe-hero-more { display:inline-flex; align-items:center; gap:var(--sp-4); font-size:var(--fs-xs); font-weight:700; color:var(--tc-sage); }
-.recipe-hero-more .zi { width:14px; height:14px; transition:transform var(--ease-med); }
-.recipe-hero[aria-expanded="true"] .recipe-hero-more .zi { transform:rotate(180deg); }
+/* Panel header (LOCKED 05-meal-rows) */
+.recipes-header { margin-bottom:var(--sp-8); }
+.recipes-h1 { font-family:'Fraunces', serif; font-weight:600; font-size:var(--fs-2xl); color:var(--text); margin:0 0 2px; }
+.recipes-subtitle { font-size:var(--fs-sm); color:var(--mid); margin:0; line-height:var(--lh-relaxed); }
+
+/* ── Generative "Suggested for Ziva" hero (§9.3/§9.4) ──
+   grams-weighted wavelength FADE body (--rc-fl light / --rc-fd dark) + a 4px
+   warm-wave STRIPE (--rc-stripe) with a sheen sweep (reuses @keyframes ld-wave)
+   + a corner zif watermark. Two-channel colour: the domain left-rail leads,
+   the fingerprint fade rides under. */
+.recipe-hero-gen { background:var(--rc-fl, var(--card-bg)); }
+[data-theme="dark"] .recipe-hero-gen { background:var(--rc-fd, var(--surface)); }
+.recipe-hero-gen > * { position:relative; z-index:1; }
+.recipe-hero-gen::before {
+  content:''; position:absolute; top:0; left:0; right:0; height:4px; z-index:2; border-radius:var(--r-2xl) var(--r-2xl) 0 0;
+  background-image:linear-gradient(100deg, transparent 35%, rgba(255,255,255,0.5) 50%, transparent 65%), var(--rc-stripe, var(--tc-sage));
+  background-size:35% 100%, 100% 100%; background-repeat:no-repeat; background-position:-35% 0, 0 0;
+  animation:ld-wave 4.4s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) { .recipe-hero-gen::before { animation:none; background-position:0 0, 0 0; } }
+/* corner watermark — dominant ingredient gets the big slot, non-overlapping */
+.recipe-hero-wm { position:absolute; right:0; bottom:0; width:200px; height:100px; pointer-events:none; z-index:0; }
+.recipe-hero-wm .recipe-wm { position:absolute; }
+.recipe-hero-wm .recipe-wm svg.zif { width:100%; height:100%; opacity:0.30; }
+[data-theme="dark"] .recipe-hero-wm .recipe-wm svg.zif { opacity:0.40; }
+.recipe-hero-wm .wm-1 { width:78px; height:78px; right:-4px; bottom:-6px; }
+.recipe-hero-wm .wm-2 { width:46px; height:46px; right:78px; bottom:6px; }
+.recipe-hero-wm .wm-3 { width:34px; height:34px; right:140px; bottom:-2px; }
+.recipe-hero-head { display:flex; align-items:center; justify-content:space-between; gap:var(--sp-8); margin-bottom:var(--sp-6); }
+.recipe-hero-head .recipe-hero-eyebrow { margin-bottom:0; }
+.recipe-hero-badge { flex:0 0 auto; display:inline-flex; align-items:center; background:var(--tc-sage); color:var(--card-bg); border-radius:var(--r-full); padding:var(--sp-4) var(--sp-10); font-size:var(--fs-2xs); font-weight:800; }
+/* strict no's lead the tagline (rose, never folded) */
+.recipe-strict { font-family:'Nunito', sans-serif; font-style:normal; font-weight:800; font-size:var(--fs-2xs); text-transform:uppercase; letter-spacing:0.04em; color:var(--tc-rose); }
+.recipe-hero-foot { display:flex; align-items:center; justify-content:space-between; gap:var(--sp-8); flex-wrap:wrap; }
+.recipe-hero-meta { display:flex; align-items:center; gap:var(--sp-8); flex-wrap:wrap; }
+.recipe-hero-meta span { display:inline-flex; align-items:center; gap:var(--sp-4); font-size:var(--fs-xs); color:var(--mid); }
+.recipe-hero-meta .zi { width:13px; height:13px; }
+.recipe-hero-cta { display:inline-flex; align-items:center; gap:var(--sp-4); min-height:36px; background:var(--tc-sage); color:var(--card-bg); border-radius:var(--r-full); padding:var(--sp-6) var(--sp-12); font-size:var(--fs-xs); font-weight:700; }
+.recipe-hero-cta .zi { width:14px; height:14px; transition:transform var(--ease-med); }
+.recipe-hero[aria-expanded="true"] .recipe-hero-cta .zi { transform:rotate(90deg); }
 
 /* Meal-slot groups + full-width recipe rows (.lib-book idiom) */
 .recipe-group { margin-bottom:var(--sp-16); }
@@ -11159,10 +11196,11 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 .recipe-row-icon .zif { width:30px; height:30px; }
 .recipe-row-main { flex:1; min-width:0; }
 .recipe-row-title { font-family:'Fraunces', serif; font-weight:600; font-size:var(--fs-base); color:var(--text); line-height:1.15; }
-.recipe-row-tag { font-family:'Fraunces', serif; font-style:italic; font-weight:400; font-size:var(--fs-sm); color:var(--mid); line-height:1.2; margin-top:1px; }
-.recipe-row-meta { display:flex; align-items:center; gap:var(--sp-10); margin-top:var(--sp-4); }
+.recipe-row-meta { display:flex; align-items:center; gap:var(--sp-8); margin-top:var(--sp-4); flex-wrap:wrap; }
 .recipe-row-meta span { display:inline-flex; align-items:center; gap:var(--sp-4); font-size:var(--fs-xs); color:var(--mid); }
+.recipe-row-meta span:not(:first-child)::before { content:'·'; margin-right:var(--sp-4); color:var(--light); }
 .recipe-row-meta .zi { width:13px; height:13px; }
+.recipe-row-rel { color:var(--tc-sage); font-weight:700; }
 .recipe-row-chev { flex:0 0 auto; color:var(--light); transition:transform var(--ease-med); }
 .recipe-row[aria-expanded="true"] .recipe-row-chev { transform:rotate(180deg); }
 

--- a/split/styles.css
+++ b/split/styles.css
@@ -11172,10 +11172,11 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 .recipe-hero-head .recipe-hero-eyebrow { margin-bottom:0; }
 .recipe-hero-badge { flex:0 0 auto; display:inline-flex; align-items:center; background:var(--tc-sage); color:var(--card-bg); border-radius:var(--r-full); padding:var(--sp-4) var(--sp-10); font-size:var(--fs-2xs); font-weight:800; }
 /* strict no's lead the tagline (rose, never folded) */
-.recipe-strict { font-family:'Nunito', sans-serif; font-style:normal; font-weight:800; font-size:var(--fs-2xs); text-transform:uppercase; letter-spacing:0.04em; color:var(--tc-rose); }
+.recipe-strict { font-family:'Nunito', sans-serif; font-style:normal; font-weight:800; font-size:var(--fs-2xs); text-transform:uppercase; letter-spacing:var(--ls-normal); color:var(--tc-rose); }
 .recipe-hero-foot { display:flex; align-items:center; justify-content:space-between; gap:var(--sp-8); flex-wrap:wrap; }
 .recipe-hero-meta { display:flex; align-items:center; gap:var(--sp-8); flex-wrap:wrap; }
 .recipe-hero-meta span { display:inline-flex; align-items:center; gap:var(--sp-4); font-size:var(--fs-xs); color:var(--mid); }
+.recipe-hero-meta span:not(:first-child)::before { content:'·'; margin-right:var(--sp-4); color:var(--light); }
 .recipe-hero-meta .zi { width:13px; height:13px; }
 .recipe-hero-cta { display:inline-flex; align-items:center; gap:var(--sp-4); min-height:36px; background:var(--tc-sage); color:var(--card-bg); border-radius:var(--r-full); padding:var(--sp-6) var(--sp-12); font-size:var(--fs-xs); font-weight:700; }
 .recipe-hero-cta .zi { width:14px; height:14px; transition:transform var(--ease-med); }

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -11147,9 +11147,46 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 .recipe-hero-title { font-family:'Fraunces', serif; font-weight:700; font-size:var(--fs-2xl); line-height:1.08; color:var(--text); margin:0 0 2px; text-wrap:balance; }
 .recipe-hero-tag { font-family:'Fraunces', serif; font-style:italic; font-weight:400; font-size:var(--fs-lg); line-height:1.25; color:var(--mid); margin:0 0 var(--sp-8); }
 .recipe-hero-why { font-size:var(--fs-sm); color:var(--mid); line-height:var(--lh-relaxed); margin:0 0 var(--sp-8); }
-.recipe-hero-more { display:inline-flex; align-items:center; gap:var(--sp-4); font-size:var(--fs-xs); font-weight:700; color:var(--tc-sage); }
-.recipe-hero-more .zi { width:14px; height:14px; transition:transform var(--ease-med); }
-.recipe-hero[aria-expanded="true"] .recipe-hero-more .zi { transform:rotate(180deg); }
+/* Panel header (LOCKED 05-meal-rows) */
+.recipes-header { margin-bottom:var(--sp-8); }
+.recipes-h1 { font-family:'Fraunces', serif; font-weight:600; font-size:var(--fs-2xl); color:var(--text); margin:0 0 2px; }
+.recipes-subtitle { font-size:var(--fs-sm); color:var(--mid); margin:0; line-height:var(--lh-relaxed); }
+
+/* ── Generative "Suggested for Ziva" hero (§9.3/§9.4) ──
+   grams-weighted wavelength FADE body (--rc-fl light / --rc-fd dark) + a 4px
+   warm-wave STRIPE (--rc-stripe) with a sheen sweep (reuses @keyframes ld-wave)
+   + a corner zif watermark. Two-channel colour: the domain left-rail leads,
+   the fingerprint fade rides under. */
+.recipe-hero-gen { background:var(--rc-fl, var(--card-bg)); }
+[data-theme="dark"] .recipe-hero-gen { background:var(--rc-fd, var(--surface)); }
+.recipe-hero-gen > * { position:relative; z-index:1; }
+.recipe-hero-gen::before {
+  content:''; position:absolute; top:0; left:0; right:0; height:4px; z-index:2; border-radius:var(--r-2xl) var(--r-2xl) 0 0;
+  background-image:linear-gradient(100deg, transparent 35%, rgba(255,255,255,0.5) 50%, transparent 65%), var(--rc-stripe, var(--tc-sage));
+  background-size:35% 100%, 100% 100%; background-repeat:no-repeat; background-position:-35% 0, 0 0;
+  animation:ld-wave 4.4s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) { .recipe-hero-gen::before { animation:none; background-position:0 0, 0 0; } }
+/* corner watermark — dominant ingredient gets the big slot, non-overlapping */
+.recipe-hero-wm { position:absolute; right:0; bottom:0; width:200px; height:100px; pointer-events:none; z-index:0; }
+.recipe-hero-wm .recipe-wm { position:absolute; }
+.recipe-hero-wm .recipe-wm svg.zif { width:100%; height:100%; opacity:0.30; }
+[data-theme="dark"] .recipe-hero-wm .recipe-wm svg.zif { opacity:0.40; }
+.recipe-hero-wm .wm-1 { width:78px; height:78px; right:-4px; bottom:-6px; }
+.recipe-hero-wm .wm-2 { width:46px; height:46px; right:78px; bottom:6px; }
+.recipe-hero-wm .wm-3 { width:34px; height:34px; right:140px; bottom:-2px; }
+.recipe-hero-head { display:flex; align-items:center; justify-content:space-between; gap:var(--sp-8); margin-bottom:var(--sp-6); }
+.recipe-hero-head .recipe-hero-eyebrow { margin-bottom:0; }
+.recipe-hero-badge { flex:0 0 auto; display:inline-flex; align-items:center; background:var(--tc-sage); color:var(--card-bg); border-radius:var(--r-full); padding:var(--sp-4) var(--sp-10); font-size:var(--fs-2xs); font-weight:800; }
+/* strict no's lead the tagline (rose, never folded) */
+.recipe-strict { font-family:'Nunito', sans-serif; font-style:normal; font-weight:800; font-size:var(--fs-2xs); text-transform:uppercase; letter-spacing:0.04em; color:var(--tc-rose); }
+.recipe-hero-foot { display:flex; align-items:center; justify-content:space-between; gap:var(--sp-8); flex-wrap:wrap; }
+.recipe-hero-meta { display:flex; align-items:center; gap:var(--sp-8); flex-wrap:wrap; }
+.recipe-hero-meta span { display:inline-flex; align-items:center; gap:var(--sp-4); font-size:var(--fs-xs); color:var(--mid); }
+.recipe-hero-meta .zi { width:13px; height:13px; }
+.recipe-hero-cta { display:inline-flex; align-items:center; gap:var(--sp-4); min-height:36px; background:var(--tc-sage); color:var(--card-bg); border-radius:var(--r-full); padding:var(--sp-6) var(--sp-12); font-size:var(--fs-xs); font-weight:700; }
+.recipe-hero-cta .zi { width:14px; height:14px; transition:transform var(--ease-med); }
+.recipe-hero[aria-expanded="true"] .recipe-hero-cta .zi { transform:rotate(90deg); }
 
 /* Meal-slot groups + full-width recipe rows (.lib-book idiom) */
 .recipe-group { margin-bottom:var(--sp-16); }
@@ -11166,10 +11203,11 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 .recipe-row-icon .zif { width:30px; height:30px; }
 .recipe-row-main { flex:1; min-width:0; }
 .recipe-row-title { font-family:'Fraunces', serif; font-weight:600; font-size:var(--fs-base); color:var(--text); line-height:1.15; }
-.recipe-row-tag { font-family:'Fraunces', serif; font-style:italic; font-weight:400; font-size:var(--fs-sm); color:var(--mid); line-height:1.2; margin-top:1px; }
-.recipe-row-meta { display:flex; align-items:center; gap:var(--sp-10); margin-top:var(--sp-4); }
+.recipe-row-meta { display:flex; align-items:center; gap:var(--sp-8); margin-top:var(--sp-4); flex-wrap:wrap; }
 .recipe-row-meta span { display:inline-flex; align-items:center; gap:var(--sp-4); font-size:var(--fs-xs); color:var(--mid); }
+.recipe-row-meta span:not(:first-child)::before { content:'·'; margin-right:var(--sp-4); color:var(--light); }
 .recipe-row-meta .zi { width:13px; height:13px; }
+.recipe-row-rel { color:var(--tc-sage); font-weight:700; }
 .recipe-row-chev { flex:0 0 auto; color:var(--light); transition:transform var(--ease-med); }
 .recipe-row[aria-expanded="true"] .recipe-row-chev { transform:rotate(180deg); }
 
@@ -20389,16 +20427,19 @@ const RECIPE_SOURCES = {
 };
 
 // Each recipe:
-//   { id, title, slot, minAgeMonths,
-//     ingredients:[{name, qty}],   // name = the LIVE-resolver classifying form
+//   { id, title, slot, minAgeMonths, prepMinutes,
+//     ingredients:[{name, qty, g}], // name = the LIVE-resolver classifying form;
+//                                   // g = grams (drives the quantity-weighted
+//                                   // generative fingerprint §9.3; trace items
+//                                   // ghee/oil/spices excluded at render)
 //     foodGroups:[FOOD_TAX gid],   // gap-fill scoring + card colour
 //     steps:[…], dos:[…], donts:[…],
 //     cuisine, source:[sourceKey…] }
 const RECIPES = [
   // ─────────────────────────── BREAKFAST ───────────────────────────
   {
-    id: 'ragi-banana-porridge', title: 'Ragi Banana Porridge', slot: 'breakfast', minAgeMonths: 7,
-    ingredients: [{ name: 'ragi', qty: '1 tbsp (24 g)' }, { name: 'banana', qty: '¼, mashed (20 g)' }],
+    id: 'ragi-banana-porridge', title: 'Ragi Banana Porridge', slot: 'breakfast', minAgeMonths: 7, prepMinutes: 12,
+    ingredients: [{ name: 'ragi', qty: '1 tbsp (24 g)', g: 24 }, { name: 'banana', qty: '¼, mashed (20 g)', g: 20 }],
     foodGroups: ['grains', 'fruits'], cuisine: 'Indian',
     steps: [
       'Dry-roast 1 tbsp ragi flour on low for 2 min until fragrant.',
@@ -20411,8 +20452,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'oats-apple-porridge', title: 'Oats & Apple Porridge', slot: 'breakfast', minAgeMonths: 7,
-    ingredients: [{ name: 'oats', qty: '1 tbsp ground (24 g)' }, { name: 'apple', qty: '¼ grated (20 g)' }, { name: 'cinnamon', qty: 'a pinch' }],
+    id: 'oats-apple-porridge', title: 'Oats & Apple Porridge', slot: 'breakfast', minAgeMonths: 7, prepMinutes: 10,
+    ingredients: [{ name: 'oats', qty: '1 tbsp ground (24 g)', g: 24 }, { name: 'apple', qty: '¼ grated (20 g)', g: 20 }, { name: 'cinnamon', qty: 'a pinch', g: 1 }],
     foodGroups: ['grains', 'fruits', 'spices'], cuisine: 'Global',
     steps: [
       'Grind 1 tbsp plain rolled oats to a coarse powder.',
@@ -20425,8 +20466,8 @@ const RECIPES = [
     source: ['nhs', 'aap'],
   },
   {
-    id: 'almond-ragi-kheer', title: 'Almond Ragi Kheer (12 m+)', slot: 'breakfast', minAgeMonths: 12,
-    ingredients: [{ name: 'milk', qty: '½ cup (in cooking)' }, { name: 'ragi', qty: '1 tbsp (15 g)' }, { name: 'date', qty: '1, deseeded paste' }, { name: 'almond', qty: '¼ tsp ground (3 g)' }],
+    id: 'almond-ragi-kheer', title: 'Almond Ragi Kheer (12 m+)', slot: 'breakfast', minAgeMonths: 12, prepMinutes: 18,
+    ingredients: [{ name: 'milk', qty: '½ cup (in cooking)', g: 60 }, { name: 'ragi', qty: '1 tbsp (15 g)', g: 15 }, { name: 'date', qty: '1, deseeded paste', g: 8 }, { name: 'almond', qty: '¼ tsp ground (3 g)', g: 3 }],
     foodGroups: ['dairy', 'grains', 'fruits', 'nuts'], cuisine: 'Indian',
     steps: [
       'Soak 2 almonds, peel, and grind to an absolutely smooth paste.',
@@ -20439,8 +20480,8 @@ const RECIPES = [
     source: ['iap', 'aap'],
   },
   {
-    id: 'suji-veg-upma', title: 'Suji & Veg Upma', slot: 'breakfast', minAgeMonths: 8,
-    ingredients: [{ name: 'suji', qty: '2 tbsp (30 g)' }, { name: 'carrot', qty: '2 tbsp grated' }, { name: 'peas', qty: '1 tbsp, mashed' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'suji-veg-upma', title: 'Suji & Veg Upma', slot: 'breakfast', minAgeMonths: 8, prepMinutes: 15,
+    ingredients: [{ name: 'suji', qty: '2 tbsp (30 g)', g: 30 }, { name: 'carrot', qty: '2 tbsp grated', g: 20 }, { name: 'peas', qty: '1 tbsp, mashed', g: 12 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'vegs', 'dairy'], cuisine: 'Indian',
     steps: [
       'Dry-roast 2 tbsp suji on low until aromatic, set aside.',
@@ -20453,8 +20494,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'poha-peas-potato', title: 'Poha with Peas & Potato', slot: 'breakfast', minAgeMonths: 8,
-    ingredients: [{ name: 'poha', qty: '3 tbsp (30 g)' }, { name: 'potato', qty: '2 tbsp, boiled & mashed' }, { name: 'peas', qty: '1 tbsp, mashed' }, { name: 'turmeric', qty: 'a pinch' }],
+    id: 'poha-peas-potato', title: 'Poha with Peas & Potato', slot: 'breakfast', minAgeMonths: 8, prepMinutes: 12,
+    ingredients: [{ name: 'poha', qty: '3 tbsp (30 g)', g: 30 }, { name: 'potato', qty: '2 tbsp, boiled & mashed', g: 30 }, { name: 'peas', qty: '1 tbsp, mashed', g: 12 }, { name: 'turmeric', qty: 'a pinch', g: 1 }],
     foodGroups: ['grains', 'vegs', 'spices'], cuisine: 'Indian',
     steps: [
       'Rinse 3 tbsp thin poha in a sieve until just soft, drain.',
@@ -20467,8 +20508,8 @@ const RECIPES = [
     source: ['icmr', 'iap'],
   },
   {
-    id: 'banana-oats-egg-pancake', title: 'Banana Oats Egg Pancake', slot: 'breakfast', minAgeMonths: 8,
-    ingredients: [{ name: 'banana', qty: '½, mashed' }, { name: 'oats', qty: '1 tbsp ground' }, { name: 'egg', qty: '1, well beaten' }],
+    id: 'banana-oats-egg-pancake', title: 'Banana Oats Egg Pancake', slot: 'breakfast', minAgeMonths: 8, prepMinutes: 10,
+    ingredients: [{ name: 'banana', qty: '½, mashed', g: 25 }, { name: 'oats', qty: '1 tbsp ground', g: 20 }, { name: 'egg', qty: '1, well beaten', g: 50 }],
     foodGroups: ['fruits', 'grains', 'nonveg'], cuisine: 'Global',
     steps: [
       'Mash ½ ripe banana smooth.',
@@ -20481,8 +20522,8 @@ const RECIPES = [
     source: ['nhs', 'aap'],
   },
   {
-    id: 'dalia-porridge', title: 'Broken-Wheat Dalia Porridge', slot: 'breakfast', minAgeMonths: 8,
-    ingredients: [{ name: 'dalia', qty: '2 tbsp (30 g)' }, { name: 'date', qty: '1, paste' }],
+    id: 'dalia-porridge', title: 'Broken-Wheat Dalia Porridge', slot: 'breakfast', minAgeMonths: 8, prepMinutes: 15,
+    ingredients: [{ name: 'dalia', qty: '2 tbsp (30 g)', g: 30 }, { name: 'date', qty: '1, paste', g: 8 }],
     foodGroups: ['grains', 'fruits'], cuisine: 'Indian',
     steps: [
       'Dry-roast 2 tbsp dalia (broken wheat) 2 min.',
@@ -20497,8 +20538,8 @@ const RECIPES = [
 
   // ─────────────────────────── LUNCH ───────────────────────────
   {
-    id: 'moong-dal-khichdi', title: 'Moong Dal Khichdi', slot: 'lunch', minAgeMonths: 7,
-    ingredients: [{ name: 'rice', qty: '1 tbsp (12 g)' }, { name: 'moong dal', qty: '½ tbsp (8 g)' }, { name: 'ghee', qty: '½ tsp' }, { name: 'turmeric', qty: 'a pinch' }],
+    id: 'moong-dal-khichdi', title: 'Moong Dal Khichdi', slot: 'lunch', minAgeMonths: 7, prepMinutes: 20,
+    ingredients: [{ name: 'rice', qty: '1 tbsp (12 g)', g: 12 }, { name: 'moong dal', qty: '½ tbsp (8 g)', g: 8 }, { name: 'ghee', qty: '½ tsp', g: 3 }, { name: 'turmeric', qty: 'a pinch', g: 1 }],
     foodGroups: ['grains', 'dairy', 'spices'], cuisine: 'Indian',
     steps: [
       'Wash 1 tbsp rice and ½ tbsp moong dal, soak 20 min.',
@@ -20511,8 +20552,8 @@ const RECIPES = [
     source: ['iap', 'whopaho'],
   },
   {
-    id: 'veg-moong-khichdi', title: 'Veg & Moong Khichdi', slot: 'lunch', minAgeMonths: 8,
-    ingredients: [{ name: 'rice', qty: '1 tbsp (15 g)' }, { name: 'moong dal', qty: '½ tbsp (10 g)' }, { name: 'carrot', qty: '2 tbsp (20 g)' }, { name: 'pumpkin', qty: '2 tbsp (20 g)' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'veg-moong-khichdi', title: 'Veg & Moong Khichdi', slot: 'lunch', minAgeMonths: 8, prepMinutes: 25,
+    ingredients: [{ name: 'rice', qty: '1 tbsp (15 g)', g: 15 }, { name: 'moong dal', qty: '½ tbsp (10 g)', g: 10 }, { name: 'carrot', qty: '2 tbsp (20 g)', g: 20 }, { name: 'pumpkin', qty: '2 tbsp (20 g)', g: 20 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'vegs', 'dairy'], cuisine: 'Indian',
     steps: [
       'Wash rice and moong dal, soak 20 min.',
@@ -20525,8 +20566,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'dal-rice-palak', title: 'Dal–Rice with Palak', slot: 'lunch', minAgeMonths: 8,
-    ingredients: [{ name: 'rice', qty: '3 tbsp (45 g)' }, { name: 'toor dal', qty: '1½ tbsp (25 g)' }, { name: 'spinach', qty: '1 tbsp, blanched (15 g)' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'dal-rice-palak', title: 'Dal–Rice with Palak', slot: 'lunch', minAgeMonths: 8, prepMinutes: 25,
+    ingredients: [{ name: 'rice', qty: '3 tbsp (45 g)', g: 45 }, { name: 'toor dal', qty: '1½ tbsp (25 g)', g: 25 }, { name: 'spinach', qty: '1 tbsp, blanched (15 g)', g: 15 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'vegs', 'dairy'], cuisine: 'Indian',
     steps: [
       'Blanch a few spinach (palak) leaves 2 min, chop fine or puree.',
@@ -20539,8 +20580,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'masoor-lauki-rice', title: 'Masoor Dal & Bottle Gourd Rice', slot: 'lunch', minAgeMonths: 7,
-    ingredients: [{ name: 'rice', qty: '2 tbsp' }, { name: 'masoor dal', qty: '1 tbsp' }, { name: 'bottle gourd', qty: '2 tbsp, diced' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'masoor-lauki-rice', title: 'Masoor Dal & Bottle Gourd Rice', slot: 'lunch', minAgeMonths: 7, prepMinutes: 20,
+    ingredients: [{ name: 'rice', qty: '2 tbsp', g: 30 }, { name: 'masoor dal', qty: '1 tbsp', g: 15 }, { name: 'bottle gourd', qty: '2 tbsp, diced', g: 25 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'vegs', 'dairy'], cuisine: 'Indian',
     steps: [
       'Wash rice and masoor dal, soak 20 min.',
@@ -20553,8 +20594,8 @@ const RECIPES = [
     source: ['icmr', 'iap'],
   },
   {
-    id: 'soft-curd-rice', title: 'Soft Curd Rice', slot: 'lunch', minAgeMonths: 8,
-    ingredients: [{ name: 'rice', qty: '2 tbsp, very soft' }, { name: 'curd', qty: '1 tbsp, fresh' }],
+    id: 'soft-curd-rice', title: 'Soft Curd Rice', slot: 'lunch', minAgeMonths: 8, prepMinutes: 10,
+    ingredients: [{ name: 'rice', qty: '2 tbsp, very soft', g: 30 }, { name: 'curd', qty: '1 tbsp, fresh', g: 40 }],
     foodGroups: ['grains', 'dairy'], cuisine: 'Indian',
     steps: [
       'Cook 2 tbsp rice until very soft and mashable.',
@@ -20567,8 +20608,8 @@ const RECIPES = [
     source: ['icmr', 'iap'],
   },
   {
-    id: 'paneer-veg-pulao', title: 'Paneer & Veg Soft Pulao', slot: 'lunch', minAgeMonths: 9,
-    ingredients: [{ name: 'rice', qty: '3 tbsp' }, { name: 'paneer', qty: '1 tbsp, crumbled' }, { name: 'carrot', qty: '1 tbsp, grated' }, { name: 'peas', qty: '1 tbsp, mashed' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'paneer-veg-pulao', title: 'Paneer & Veg Soft Pulao', slot: 'lunch', minAgeMonths: 9, prepMinutes: 20,
+    ingredients: [{ name: 'rice', qty: '3 tbsp', g: 30 }, { name: 'paneer', qty: '1 tbsp, crumbled', g: 15 }, { name: 'carrot', qty: '1 tbsp, grated', g: 20 }, { name: 'peas', qty: '1 tbsp, mashed', g: 12 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'dairy', 'vegs'], cuisine: 'Indian',
     steps: [
       'Soften grated carrot and mashed peas in ½ tsp ghee for 2 min.',
@@ -20581,8 +20622,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'rohu-fish-rice', title: 'Rohu Fish & Rice Mash', slot: 'lunch', minAgeMonths: 8,
-    ingredients: [{ name: 'rice', qty: '3 tbsp' }, { name: 'rohu fish', qty: '1 tbsp, cooked & deboned' }, { name: 'ghee', qty: '½ tsp' }, { name: 'turmeric', qty: 'a pinch' }],
+    id: 'rohu-fish-rice', title: 'Rohu Fish & Rice Mash', slot: 'lunch', minAgeMonths: 8, prepMinutes: 18,
+    ingredients: [{ name: 'rice', qty: '3 tbsp', g: 30 }, { name: 'rohu fish', qty: '1 tbsp, cooked & deboned', g: 15 }, { name: 'ghee', qty: '½ tsp', g: 3 }, { name: 'turmeric', qty: 'a pinch', g: 1 }],
     foodGroups: ['grains', 'nonveg', 'dairy'], cuisine: 'Indian',
     steps: [
       'Steam a small piece of rohu with a pinch of turmeric until flaky.',
@@ -20597,8 +20638,8 @@ const RECIPES = [
 
   // ─────────────────────────── DINNER ───────────────────────────
   {
-    id: 'carrot-beet-potato-mash', title: 'Carrot Beetroot Potato Mash', slot: 'dinner', minAgeMonths: 7,
-    ingredients: [{ name: 'carrot', qty: '3 tbsp (40 g)' }, { name: 'beetroot', qty: '2 tbsp (30 g)' }, { name: 'potato', qty: '3 tbsp (40 g)' }, { name: 'ghee', qty: '¼ tsp' }],
+    id: 'carrot-beet-potato-mash', title: 'Carrot Beetroot Potato Mash', slot: 'dinner', minAgeMonths: 7, prepMinutes: 20,
+    ingredients: [{ name: 'carrot', qty: '3 tbsp (40 g)', g: 40 }, { name: 'beetroot', qty: '2 tbsp (30 g)', g: 30 }, { name: 'potato', qty: '3 tbsp (40 g)', g: 40 }, { name: 'ghee', qty: '¼ tsp', g: 3 }],
     foodGroups: ['vegs', 'dairy'], cuisine: 'Indian',
     steps: [
       'Peel and dice carrot, beetroot and potato.',
@@ -20611,8 +20652,8 @@ const RECIPES = [
     source: ['icmr', 'nhs'],
   },
   {
-    id: 'sweet-potato-moong-mash', title: 'Sweet Potato & Moong Mash', slot: 'dinner', minAgeMonths: 7,
-    ingredients: [{ name: 'sweet potato', qty: '½ small (50 g)' }, { name: 'moong dal', qty: '1 tbsp' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'sweet-potato-moong-mash', title: 'Sweet Potato & Moong Mash', slot: 'dinner', minAgeMonths: 7, prepMinutes: 18,
+    ingredients: [{ name: 'sweet potato', qty: '½ small (50 g)', g: 50 }, { name: 'moong dal', qty: '1 tbsp', g: 12 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['vegs', 'grains', 'dairy'], cuisine: 'Indian',
     steps: [
       'Steam cubed sweet potato 10 min until very soft.',
@@ -20625,8 +20666,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'palak-paneer-rice', title: 'Palak Paneer Rice', slot: 'dinner', minAgeMonths: 9,
-    ingredients: [{ name: 'rice', qty: '3 tbsp' }, { name: 'paneer', qty: '1 tbsp, crumbled' }, { name: 'spinach', qty: '1 tbsp, blanched' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'palak-paneer-rice', title: 'Palak Paneer Rice', slot: 'dinner', minAgeMonths: 9, prepMinutes: 18,
+    ingredients: [{ name: 'rice', qty: '3 tbsp', g: 30 }, { name: 'paneer', qty: '1 tbsp, crumbled', g: 15 }, { name: 'spinach', qty: '1 tbsp, blanched', g: 15 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'dairy', 'vegs'], cuisine: 'Indian',
     steps: [
       'Blanch spinach 2 min, puree smooth.',
@@ -20639,8 +20680,8 @@ const RECIPES = [
     source: ['iap', 'icmr'],
   },
   {
-    id: 'chicken-rice-bowl', title: 'Soft Chicken & Rice Bowl', slot: 'dinner', minAgeMonths: 9,
-    ingredients: [{ name: 'rice', qty: '3 tbsp' }, { name: 'chicken', qty: '1 tbsp, shredded' }, { name: 'carrot', qty: '1 tbsp, grated' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'chicken-rice-bowl', title: 'Soft Chicken & Rice Bowl', slot: 'dinner', minAgeMonths: 9, prepMinutes: 25,
+    ingredients: [{ name: 'rice', qty: '3 tbsp', g: 30 }, { name: 'chicken', qty: '1 tbsp, shredded', g: 15 }, { name: 'carrot', qty: '1 tbsp, grated', g: 20 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['grains', 'nonveg', 'vegs'], cuisine: 'Global',
     steps: [
       'Boil a small piece of boneless chicken until fully cooked and tender.',
@@ -20653,8 +20694,8 @@ const RECIPES = [
     source: ['aap', 'nhs'],
   },
   {
-    id: 'mixed-veg-dal-soup', title: 'Mixed Veg & Dal Soup', slot: 'dinner', minAgeMonths: 8,
-    ingredients: [{ name: 'moong dal', qty: '1 tbsp' }, { name: 'carrot', qty: '1 tbsp' }, { name: 'tomato', qty: '1 tbsp' }, { name: 'bottle gourd', qty: '1 tbsp' }],
+    id: 'mixed-veg-dal-soup', title: 'Mixed Veg & Dal Soup', slot: 'dinner', minAgeMonths: 8, prepMinutes: 20,
+    ingredients: [{ name: 'moong dal', qty: '1 tbsp', g: 12 }, { name: 'carrot', qty: '1 tbsp', g: 20 }, { name: 'tomato', qty: '1 tbsp', g: 15 }, { name: 'bottle gourd', qty: '1 tbsp', g: 25 }],
     foodGroups: ['grains', 'vegs'], cuisine: 'Indian',
     steps: [
       'Pressure-cook moong dal with diced carrot, tomato and bottle gourd until very soft.',
@@ -20669,8 +20710,8 @@ const RECIPES = [
 
   // ─────────────────────────── SNACK ───────────────────────────
   {
-    id: 'curd-banana-bowl', title: 'Curd & Banana Bowl', slot: 'snack', minAgeMonths: 8,
-    ingredients: [{ name: 'curd', qty: '3 tbsp (60 g)' }, { name: 'banana', qty: '¼, mashed (25 g)' }],
+    id: 'curd-banana-bowl', title: 'Curd & Banana Bowl', slot: 'snack', minAgeMonths: 8, prepMinutes: 3,
+    ingredients: [{ name: 'curd', qty: '3 tbsp (60 g)', g: 60 }, { name: 'banana', qty: '¼, mashed (25 g)', g: 25 }],
     foodGroups: ['dairy', 'fruits'], cuisine: 'Indian',
     steps: [
       'Whisk 3 tbsp fresh full-fat curd smooth.',
@@ -20682,8 +20723,8 @@ const RECIPES = [
     source: ['icmr', 'nhs'],
   },
   {
-    id: 'carrot-moong-mash', title: 'Carrot Moong Mash', slot: 'snack', minAgeMonths: 6,
-    ingredients: [{ name: 'carrot', qty: '3 tbsp, grated' }, { name: 'moong dal', qty: '2 tbsp' }, { name: 'ghee', qty: '½ tsp' }],
+    id: 'carrot-moong-mash', title: 'Carrot Moong Mash', slot: 'snack', minAgeMonths: 6, prepMinutes: 18,
+    ingredients: [{ name: 'carrot', qty: '3 tbsp, grated', g: 20 }, { name: 'moong dal', qty: '2 tbsp', g: 12 }, { name: 'ghee', qty: '½ tsp', g: 3 }],
     foodGroups: ['vegs', 'grains', 'dairy'], cuisine: 'Indian',
     steps: [
       'Grate carrot and wash moong dal.',
@@ -20696,8 +20737,8 @@ const RECIPES = [
     source: ['whopaho', 'iap'],
   },
   {
-    id: 'avocado-banana-mash', title: 'Avocado & Banana Mash', slot: 'snack', minAgeMonths: 6,
-    ingredients: [{ name: 'avocado', qty: '2 tbsp' }, { name: 'banana', qty: '¼, mashed' }],
+    id: 'avocado-banana-mash', title: 'Avocado & Banana Mash', slot: 'snack', minAgeMonths: 6, prepMinutes: 3,
+    ingredients: [{ name: 'avocado', qty: '2 tbsp', g: 30 }, { name: 'banana', qty: '¼, mashed', g: 25 }],
     foodGroups: ['fruits'], cuisine: 'Global',
     steps: [
       'Scoop 2 tbsp ripe avocado.',
@@ -20709,8 +20750,8 @@ const RECIPES = [
     source: ['aap', 'nhs'],
   },
   {
-    id: 'stewed-apple-date', title: 'Stewed Apple & Date', slot: 'snack', minAgeMonths: 6,
-    ingredients: [{ name: 'apple', qty: '½, peeled & diced' }, { name: 'date', qty: '1, deseeded' }],
+    id: 'stewed-apple-date', title: 'Stewed Apple & Date', slot: 'snack', minAgeMonths: 6, prepMinutes: 10,
+    ingredients: [{ name: 'apple', qty: '½, peeled & diced', g: 40 }, { name: 'date', qty: '1, deseeded', g: 8 }],
     foodGroups: ['fruits'], cuisine: 'Global',
     steps: [
       'Peel, core and dice ½ apple.',
@@ -20723,8 +20764,8 @@ const RECIPES = [
     source: ['nhs', 'iap'],
   },
   {
-    id: 'mango-curd-bowl', title: 'Mango & Curd Bowl', slot: 'snack', minAgeMonths: 8,
-    ingredients: [{ name: 'mango', qty: '2 tbsp, ripe' }, { name: 'curd', qty: '1 tbsp, fresh' }],
+    id: 'mango-curd-bowl', title: 'Mango & Curd Bowl', slot: 'snack', minAgeMonths: 8, prepMinutes: 3,
+    ingredients: [{ name: 'mango', qty: '2 tbsp, ripe', g: 30 }, { name: 'curd', qty: '1 tbsp, fresh', g: 40 }],
     foodGroups: ['fruits', 'dairy'], cuisine: 'Indian',
     steps: [
       'Mash 2 tbsp ripe mango smooth.',
@@ -20738,8 +20779,8 @@ const RECIPES = [
 
   // ─── 12 m+ catalog item — age-gated, never suggested for an under-1 (honey) ───
   {
-    id: 'banana-honey-toast', title: 'Banana & Honey Toast (12 m+)', slot: 'snack', minAgeMonths: 12,
-    ingredients: [{ name: 'bread', qty: '1 slice, soft' }, { name: 'banana', qty: '½, mashed' }, { name: 'honey', qty: '½ tsp (12 m+ only)' }],
+    id: 'banana-honey-toast', title: 'Banana & Honey Toast (12 m+)', slot: 'snack', minAgeMonths: 12, prepMinutes: 5,
+    ingredients: [{ name: 'bread', qty: '1 slice, soft', g: 25 }, { name: 'banana', qty: '½, mashed', g: 25 }, { name: 'honey', qty: '½ tsp (12 m+ only)', g: 5 }],
     foodGroups: ['grains', 'fruits'], cuisine: 'Global',
     steps: [
       'Lightly toast a soft slice of whole-wheat bread, remove crusts, cut into soft fingers.',
@@ -20824,6 +20865,90 @@ function recipeFoodIcon(name) {
   return null;
 }
 
+// ── §9.5 Tagline composer (ported from docs/design/taglines.mjs) ─────────
+// The generative "voice" line for any recipe/combo: each ingredient
+// contributes an epithet + noun; the minor-share ratio picks the connector so
+// quantity shows in the words. Soft prep-cautions FOLD into the phrase (ground
+// almond / halved grape); STRICT no's (honey / added sugar) keep a prominent
+// LEADING clause. Epithets rotate by a day-seed (fresh daily, deterministic
+// within a day). Adapted to the app's global-script style (no ES exports);
+// keyed by zif icon id (recipeFoodIcon(name).icon) so it shares one vocabulary.
+const RECIPE_EP = {
+  // grains & cereals
+  rice:{eps:['soft','gentle','silky'],noun:'rice'}, millet:{eps:['earthy','iron-rich','nutty'],noun:'ragi'},
+  oats:{eps:['wholesome','warm','hearty'],noun:'oats'}, wheat:{eps:['hearty','wholesome'],noun:'wheat'},
+  suji:{eps:['smooth','light'],noun:'suji'}, corn:{eps:['sweet','sunny'],noun:'corn'},
+  dalia:{eps:['hearty','nutty'],noun:'dalia'}, barley:{eps:['nutty','wholesome'],noun:'barley'},
+  quinoa:{eps:['nutty','light'],noun:'quinoa'},
+  // legumes & pulses
+  dal:{eps:['savoury','soupy','hearty'],noun:'dal'}, chana:{eps:['nutty','hearty'],noun:'chana'},
+  rajma:{eps:['hearty','earthy'],noun:'rajma'}, peanut:{eps:['nutty','rich'],noun:'peanut',fold:'ground'},
+  sprouts:{eps:['fresh','green'],noun:'sprouts'},
+  // vegetables
+  carrot:{eps:['sweet','bright','sunny'],noun:'carrot'}, spinach:{eps:['leafy','green','iron-rich'],noun:'spinach'},
+  beans:{eps:['crisp','green'],noun:'green beans'}, bottlegourd:{eps:['light','soothing'],noun:'bottle gourd'},
+  beetroot:{eps:['earthy','ruby','sweet'],noun:'beetroot'}, pumpkin:{eps:['silky','golden','sweet'],noun:'pumpkin'},
+  sweetpotato:{eps:['velvety','golden','creamy'],noun:'sweet potato'}, potato:{eps:['soft','comforting'],noun:'potato'},
+  broccoli:{eps:['green','tender'],noun:'broccoli'}, cauliflower:{eps:['mild','tender'],noun:'cauliflower'},
+  tomato:{eps:['tangy','bright'],noun:'tomato'}, peas:{eps:['sweet','green'],noun:'peas'},
+  drumstick:{eps:['earthy','green'],noun:'drumstick'}, zucchini:{eps:['soft','mild'],noun:'zucchini'},
+  // fruits
+  banana:{eps:['creamy','sweet','soft'],noun:'banana'}, pear:{eps:['juicy','gentle'],noun:'pear'},
+  apple:{eps:['sweet','stewed','crisp'],noun:'apple'}, mango:{eps:['golden','silky','sweet'],noun:'mango'},
+  avocado:{eps:['buttery','creamy'],noun:'avocado'}, blueberry:{eps:['sweet','jewel-like'],noun:'blueberry'},
+  date:{eps:['caramel-sweet','rich'],noun:'date'}, coconut:{eps:['creamy','rich'],noun:'coconut'},
+  pomegranate:{eps:['ruby','jewel-like'],noun:'pomegranate'},
+  // dairy & eggs
+  paneer:{eps:['mild','soft','milky'],noun:'paneer'}, milk:{eps:['creamy','gentle'],noun:'milk'},
+  ghee:{eps:['rich','golden'],noun:'ghee'}, curd:{eps:['cooling','tangy','creamy'],noun:'curd'},
+  cheese:{eps:['savoury','melty'],noun:'cheese'}, butter:{eps:['rich','soft'],noun:'butter'},
+  buttermilk:{eps:['cooling','tangy'],noun:'buttermilk'}, egg:{eps:['protein-rich','soft'],noun:'egg',fold:'cooked'},
+  // nuts & seeds
+  almond:{eps:['nutty','buttery'],noun:'almond',fold:'ground'}, walnut:{eps:['earthy','rich'],noun:'walnut',fold:'ground'},
+  cashew:{eps:['buttery','mild'],noun:'cashew',fold:'ground'}, sesame:{eps:['nutty','toasty'],noun:'sesame',fold:'ground'},
+  chia:{eps:['tiny','nutty'],noun:'chia',fold:'soaked'}, flaxseed:{eps:['nutty','wholesome'],noun:'flaxseed',fold:'ground'},
+  // proteins
+  fish:{eps:['tender','omega-rich'],noun:'fish',fold:'boneless'}, chicken:{eps:['lean','tender'],noun:'chicken',fold:'shredded'},
+  prawn:{eps:['tender','sweet'],noun:'prawn'}, mutton:{eps:['rich','tender'],noun:'mutton',fold:'soft-cooked'},
+  // fats & sweeteners
+  jaggery:{eps:['caramel-sweet'],noun:'jaggery',strict:'go easy — added sugar'},
+  honey:{eps:['golden'],noun:'honey',strict:'honey — only from age 1'}, oil:{eps:['light'],noun:'oil'},
+  // spices & herbs
+  turmeric:{eps:['golden','earthy'],noun:'turmeric'}, cinnamon:{eps:['warm','sweet'],noun:'cinnamon'},
+  cumin:{eps:['warm','earthy'],noun:'cumin'}, coriander:{eps:['fresh','herby'],noun:'coriander'},
+  mint:{eps:['cool','fresh'],noun:'mint'}, ginger:{eps:['warming','zingy'],noun:'ginger'},
+};
+const _recipeConnector = s =>
+  s < 0.12 ? 'with just a hint of' : s < 0.22 ? 'with a touch of' :
+  s < 0.33 ? 'with a little' : s < 0.45 ? 'balanced with' : 'meets';
+const _recEpOf = (it, seed) => it.eps[seed % it.eps.length];
+const _recNounOf = it => it.fold ? `${it.fold} ${it.noun}` : it.noun;
+
+// parts: [{id, w}] (id = a RECIPE_EP key; w = grams) · seed: day-seed.
+// Returns { strict:[lead clauses], body }. Render strict first (prominent).
+function _recipeComposeTagline(parts, seed) {
+  seed = seed || 0;
+  const items = parts.map(p => ({ ...RECIPE_EP[p.id], w: p.w })).filter(i => i.noun).sort((a, b) => b.w - a.w);
+  if (!items.length) return { strict: [], body: '' };
+  const total = items.reduce((s, i) => s + i.w, 0) || 1;
+  const strict = [...new Set(items.filter(i => i.strict).map(i => i.strict))];
+  const dom = items[0];
+  let body;
+  if (items.length === 1) {
+    body = `${_recEpOf(dom, seed)} ${_recNounOf(dom)}`;
+  } else if (items.length === 2) {
+    const m = items[1], con = _recipeConnector(m.w / total);
+    body = con === 'meets'
+      ? `${_recEpOf(dom, seed)} ${_recNounOf(dom)} meets ${_recEpOf(m, seed)} ${_recNounOf(m)}`
+      : `${_recEpOf(dom, seed)} ${_recNounOf(dom)}, ${con} ${_recNounOf(m)}`;
+  } else {
+    const mids = items.slice(1, -1).map(_recNounOf);
+    const last = items.at(-1), lastCon = (last.w / total) < 0.15 ? 'a touch of' : 'a little';
+    body = `${_recEpOf(dom, seed)} ${_recNounOf(dom)}, with ${mids.join(', ')} and ${lastCon} ${_recNounOf(last)}`;
+  }
+  return { strict, body };
+}
+
 // O(1) lookup for the tap-through dispatcher (openRecipeInTab) + render helpers.
 const RECIPES_BY_ID = RECIPES.reduce((m, r) => { m[r.id] = r; return m; }, {});
 
@@ -20833,6 +20958,7 @@ window.RECIPES = RECIPES;
 window.RECIPES_BY_ID = RECIPES_BY_ID;
 window.RECIPE_SOURCES = RECIPE_SOURCES;
 window.recipeFoodIcon = recipeFoodIcon;
+window._recipeComposeTagline = _recipeComposeTagline;
 // ─────────────────────────────────────────
 // SVG ICON HELPER — Ziva Sketch icon set
 // ─────────────────────────────────────────
@@ -40296,14 +40422,81 @@ const _RECIPE_FD_POLARITY = {
   conditional: { cls: 'fd-flag-conditional', ic: 'clock'  },
   inform:      { cls: 'fd-flag-inform',      ic: 'info'   },
 };
-// A small group → epithet bank for the italic "voice" descriptor (typography C).
-// The full ratified tagline composer (docs/design/taglines.mjs, 126-tagline
-// bank) is a follow-up port flagged in recipes-tab/SESSION_HANDOFF.md; this is
-// the in-scope minimal voice.
-const _RECIPE_GROUP_EPITHET = {
-  grains: 'wholesome', fruits: 'naturally sweet', vegs: 'garden-soft',
-  dairy: 'creamy', nuts: 'nutty', spices: 'gently spiced', nonveg: 'protein-rich',
+// ── Generative fingerprint (§9.3) — quantity-weighted, wavelength-ordered ──
+// Each recipe's hero renders a deterministic colour fingerprint from its
+// ingredients: a STRIPE (top ribbon) + a FADE (body wash), band-widths weighted
+// by grams, wavelength-ordered (rose→peach→amber→sage→sky→lav). Trace items
+// (ghee/oil/spices) are excluded so the fingerprint never muds; cap ≤4 domains.
+const RECIPE_FP_DOM = {
+  fruit:   { o: 0,   sat: '#e59cb0', light: 'var(--rose-light)',  dark: 'rgba(158,62,82,0.20)' },
+  protein: { o: 0.6, sat: '#e0a285', light: 'var(--rose-light)',  dark: 'rgba(150,72,60,0.20)' },
+  veg:     { o: 1,   sat: '#ecae7e', light: 'var(--peach-light)', dark: 'rgba(138,101,32,0.18)' },
+  legume:  { o: 2,   sat: '#e6c078', light: 'var(--amber-light)', dark: 'rgba(150,110,40,0.18)' },
+  grain:   { o: 3,   sat: '#9fcdb5', light: 'var(--sage-light)',  dark: 'rgba(58,112,96,0.17)' },
+  dairy:   { o: 4,   sat: '#a0cce0', light: 'var(--sky-light)',   dark: 'rgba(58,112,144,0.18)' },
+  nuts:    { o: 6,   sat: '#c4b4e6', light: 'var(--lav-light)',   dark: 'rgba(110,94,154,0.18)' },
 };
+// zif icon id → fingerprint domain (distinguishes legumes from grains, which
+// FOOD_TAX folds together — the fingerprint wants the dal/rice colour split).
+const _RECIPE_FP_BY_ICON = {
+  rice: 'grain', millet: 'grain', oats: 'grain', wheat: 'grain', suji: 'grain', dalia: 'grain', barley: 'grain', quinoa: 'grain', corn: 'grain',
+  dal: 'legume', chana: 'legume', rajma: 'legume', peanut: 'legume', sprouts: 'legume',
+  carrot: 'veg', spinach: 'veg', beans: 'veg', bottlegourd: 'veg', beetroot: 'veg', pumpkin: 'veg', sweetpotato: 'veg', potato: 'veg', broccoli: 'veg', cauliflower: 'veg', tomato: 'veg', peas: 'veg', drumstick: 'veg', zucchini: 'veg', okra: 'veg', cabbage: 'veg', brinjal: 'veg', mushroom: 'veg', onion: 'veg',
+  banana: 'fruit', pear: 'fruit', apple: 'fruit', mango: 'fruit', avocado: 'fruit', blueberry: 'fruit', strawberry: 'fruit', grapes: 'fruit', date: 'fruit', papaya: 'fruit', orange: 'fruit', pomegranate: 'fruit', coconut: 'fruit',
+  paneer: 'dairy', milk: 'dairy', curd: 'dairy', cheese: 'dairy', butter: 'dairy', buttermilk: 'dairy',
+  almond: 'nuts', walnut: 'nuts', cashew: 'nuts', pistachio: 'nuts', sesame: 'nuts', chia: 'nuts', flaxseed: 'nuts', pumpkinseed: 'nuts',
+  egg: 'protein', fish: 'protein', chicken: 'protein', prawn: 'protein', mutton: 'protein', tofu: 'protein',
+};
+// Trace ingredients — excluded from the fingerprint + the tagline (fats,
+// spices, sweeteners; matched as substrings so "cow ghee" / "black pepper" hit).
+const _RECIPE_TRACE = ['ghee', 'oil', 'turmeric', 'cinnamon', 'cumin', 'coriander', 'mint', 'jaggery', 'honey', 'salt', 'sugar', 'cardamom', 'pepper', 'ginger', 'garlic', 'lemon'];
+function _recipeIsTrace(name) {
+  const n = String(name).toLowerCase();
+  return _RECIPE_TRACE.some(t => n.indexOf(t) !== -1);
+}
+function _recipeFpDomain(name) {
+  const ic = (typeof recipeFoodIcon === 'function') ? recipeFoodIcon(name) : null;
+  return (ic && _RECIPE_FP_BY_ICON[ic.icon]) ? _RECIPE_FP_BY_ICON[ic.icon] : null;
+}
+// Build the weighted fingerprint: { stripe, fadeL, fadeD, ranked } or null.
+function _recipeFingerprint(r) {
+  const prim = (r.ingredients || []).filter(i => !_recipeIsTrace(i.name) && _recipeFpDomain(i.name));
+  if (!prim.length) return null;
+  const byDom = {};
+  for (const i of prim) { const d = _recipeFpDomain(i.name); byDom[d] = (byDom[d] || 0) + (i.g || 10); }
+  let doms = Object.entries(byDom).map(([d, g]) => ({ d, g, ...RECIPE_FP_DOM[d] })).sort((a, b) => a.o - b.o);
+  if (doms.length > 4) doms = doms.slice().sort((a, b) => b.g - a.g).slice(0, 4).sort((a, b) => a.o - b.o);
+  const total = doms.reduce((s, x) => s + x.g, 0) || 1;
+  doms.forEach(x => { x.frac = x.g / total; });
+  const r2 = n => Math.round(n * 10) / 10;
+  const stopsAt = key => { let cum = 0; const s = []; for (const x of doms) { const mid = cum + x.frac / 2; s.push(`${x[key]} ${r2(mid * 100)}%`); cum += x.frac; } return s; };
+  const stripe = `linear-gradient(90deg, ${doms[0].sat} 0%, ${stopsAt('sat').join(', ')}, ${doms.at(-1).sat} 100%)`;
+  const fadeL = `linear-gradient(135deg, ${doms[0].light} 0%, ${stopsAt('light').join(', ')}, ${doms.at(-1).light} 100%)`;
+  const fadeD = `linear-gradient(135deg, ${doms[0].dark} 0%, ${stopsAt('dark').join(', ')}, ${doms.at(-1).dark} 100%)`;
+  const ranked = prim.slice().sort((a, b) => (b.g || 0) - (a.g || 0)).slice(0, 3);
+  return { stripe, fadeL, fadeD, ranked };
+}
+
+// Day-of-year seed — rotates the tagline epithets daily (deterministic within a
+// day). Cosmetic only; local date, timezone-safe construction (HR-12).
+function _recipeDaySeed() {
+  const d = new Date();
+  return Math.floor((d - new Date(d.getFullYear(), 0, 0)) / 864e5);
+}
+
+// Relevance tag for a catalog row (the LOCKED "uses banana"/"vitamin-A" meta) —
+// a nutrient highlight scanned from the recipe's own dos/steps, else cuisine.
+const _RECIPE_NUTRIENT_HINTS = [
+  [/\biron\b/i, 'iron-rich'], [/calcium/i, 'calcium'], [/protein/i, 'protein'],
+  [/vitamin a|beta-?carotene/i, 'vitamin A'], [/vitamin c/i, 'vitamin C'],
+  [/omega|brain-health/i, 'omega-3'], [/probiotic/i, 'probiotic'],
+  [/fibre|fiber/i, 'fibre'], [/healthy fat|brain-healthy fat/i, 'healthy fats'],
+];
+function _recipeRelevanceTag(r) {
+  const hay = ((r.dos || []).join(' ') + ' ' + (r.steps || []).join(' '));
+  for (const [re, label] of _RECIPE_NUTRIENT_HINTS) if (re.test(hay)) return label;
+  return r.cuisine || '';
+}
 
 // Pass A — surfacing gate. Every ingredient must pass the household diet
 // preference; any fail withholds the recipe (fail-OPEN if the gate is absent).
@@ -40331,18 +40524,16 @@ function _recipeRailColor(group) {
   return 'var(--tc-sage)';
 }
 
-// The italic "voice" descriptor — epithet + the two dominant ingredients.
+// The italic "voice" descriptor (§9.5/§9.6) — the ported tagline composer,
+// quantity-weighted from the non-trace ingredients, epithets day-seed-rotated.
+// Returns { strict:[lead clauses], body } — render strict first (prominent),
+// then the italic body. Reserved for the hero (Typography C: italic = voice).
 function _recipeTagline(r) {
-  const grp = _recipePrimaryGroup(r);
-  const ep = _RECIPE_GROUP_EPITHET[grp] || 'soft';
-  const names = (r.ingredients || [])
-    .map(i => i.name)
-    .filter(n => !/ghee|oil|turmeric|cinnamon|cumin|coriander|pinch/i.test(n))
-    .slice(0, 2)
-    .map(n => n.replace(/\b(dal|fish)\b/i, m => m.toLowerCase()));
-  if (!names.length) return ep;
-  if (names.length === 1) return ep + ' ' + names[0];
-  return ep + ' ' + names[0] + ' & ' + names[1];
+  if (typeof _recipeComposeTagline !== 'function') return { strict: [], body: '' };
+  const parts = (r.ingredients || [])
+    .filter(i => !_recipeIsTrace(i.name) && typeof recipeFoodIcon === 'function' && recipeFoodIcon(i.name))
+    .map(i => ({ id: recipeFoodIcon(i.name).icon, w: i.g || 10 }));
+  return _recipeComposeTagline(parts, _recipeDaySeed());
 }
 
 // The highest ingredient age-gate (months) — recipe-level age floor (§5).
@@ -40429,7 +40620,10 @@ function _recipeDetailHtml(r, ageMonths) {
   return h;
 }
 
-// One catalog/suggested row (full-width .recipe-row, expand-in-place).
+// One catalog/suggested row (full-width .recipe-row, expand-in-place). Per the
+// LOCKED 05-meal-rows: food icon + Fraunces title + a factual meta line
+// (prep · age · slot · relevance). The italic "voice" is reserved for the hero
+// (§9.6: italic = descriptor only), so rows carry facts, not voice.
 function _recipeRowHtml(r, uidPrefix, ageMonths, opts) {
   opts = opts || {};
   const uid = uidPrefix + '-' + r.id;
@@ -40439,20 +40633,20 @@ function _recipeRowHtml(r, uidPrefix, ageMonths, opts) {
   const glyph = ic ? `<svg class="zif" style="--zif-c:${ic.c}"><use href="#zif-${ic.icon}"/></svg>` : zi('bowl');
   const effMin = _recipeEffectiveMinAge(r);
   const withheld = effMin > ageMonths;
-  // V-R-1: one age statement per row. When the recipe is withheld (the amber
-  // age-gate badge shows), suppress the plain meta age span — the badge IS the
-  // age signal, and a duplicate "Xm+" twin dilutes its caution weight.
+  // V-R-1: one age statement per row — the badge IS the age signal when withheld.
   const ageBadge = withheld ? `<span class="recipe-age-badge">${zi('baby')} ${effMin}m+</span>` : '';
   const ageMeta = withheld ? '' : `<span>${zi('baby')} ${effMin}m+</span>`;
   const slot = RECIPE_SLOT_META[r.slot];
   const slotMeta = (opts.showSlot && slot) ? `<span>${zi(slot.icon)} ${escHtml(slot.label)}</span>` : '';
+  const prepMeta = r.prepMinutes ? `<span>${zi('clock')} ${r.prepMinutes} min</span>` : '';
+  const relRaw = (opts.relevance != null) ? opts.relevance : _recipeRelevanceTag(r);
+  const relMeta = relRaw ? `<span class="recipe-row-rel">${escHtml(relRaw)}</span>` : '';
   return `<div class="recipe-row dt-${grp}" id="rrow-${escAttr(uid)}" style="--rc-rail:${rail}" role="button" tabindex="0" aria-expanded="false" data-action="toggleRecipeRow" data-arg="${escAttr(uid)}">
     <div class="recipe-row-top">
       <span class="recipe-row-icon">${glyph}</span>
       <span class="recipe-row-main">
         <span class="recipe-row-title">${escHtml(r.title)}</span>
-        <span class="recipe-row-tag">${escHtml(_recipeTagline(r))}</span>
-        <span class="recipe-row-meta">${slotMeta}${ageMeta}${ageBadge}</span>
+        <span class="recipe-row-meta">${prepMeta}${ageMeta}${slotMeta}${relMeta}${ageBadge}</span>
       </span>
       <span class="recipe-row-chev">${zi('chevron-down')}</span>
     </div>
@@ -40460,17 +40654,46 @@ function _recipeRowHtml(r, uidPrefix, ageMonths, opts) {
   </div>`;
 }
 
-// The featured "Suggested for Ziva" hero card (top pick), expand-in-place.
+// The featured "Suggested for Ziva" hero (top pick) — the GENERATIVE card
+// (§9.3/§9.4): a grams-weighted wavelength fingerprint stripe + warm-wave sheen
+// + corner zif watermark, the Fraunces-italic composed voice (strict no's lead),
+// the data-driven why, a prep·age·slot meta line, and a "See recipe →" CTA.
+// Expand-in-place like the rows.
 function _recipeHeroHtml(r, whyText, ageMonths) {
   const uid = 'h-' + r.id;
   const grp = _recipePrimaryGroup(r);
   const rail = _recipeRailColor(grp);
-  return `<div class="recipe-hero dt-${grp}" id="rrow-${escAttr(uid)}" style="--rc-rail:${rail}" role="button" tabindex="0" aria-expanded="false" data-action="toggleRecipeRow" data-arg="${escAttr(uid)}">
-    <span class="recipe-hero-eyebrow">${zi('sparkle')} Suggested for Ziva</span>
+  const fp = _recipeFingerprint(r);
+  const slot = RECIPE_SLOT_META[r.slot];
+  const effMin = _recipeEffectiveMinAge(r);
+  const tag = _recipeTagline(r);
+  let wm = '';
+  if (fp && fp.ranked && fp.ranked.length) {
+    const slots = ['wm-1', 'wm-2', 'wm-3'];
+    wm = '<div class="recipe-hero-wm" aria-hidden="true">' + fp.ranked.map((ing, k) => {
+      const ic = recipeFoodIcon(ing.name);
+      return ic ? `<span class="recipe-wm ${slots[k]}"><svg class="zif" style="--zif-c:${ic.c}"><use href="#zif-${ic.icon}"/></svg></span>` : '';
+    }).join('') + '</div>';
+  }
+  const fpStyle = fp ? `--rc-stripe:${fp.stripe};--rc-fl:${fp.fadeL};--rc-fd:${fp.fadeD};` : '';
+  const strictLead = (tag.strict && tag.strict.length) ? `<span class="recipe-strict">${escHtml(tag.strict.join('; '))}</span> ` : '';
+  const meta = [];
+  if (r.prepMinutes) meta.push(`<span>${zi('clock')} ${r.prepMinutes} min</span>`);
+  meta.push(`<span>${zi('baby')} ${effMin}m+</span>`);
+  if (slot) meta.push(`<span>${zi(slot.icon)} ${escHtml(slot.label)}</span>`);
+  return `<div class="recipe-hero recipe-hero-gen dt-${grp}" id="rrow-${escAttr(uid)}" style="${fpStyle}--rc-rail:${rail}" role="button" tabindex="0" aria-expanded="false" data-action="toggleRecipeRow" data-arg="${escAttr(uid)}">
+    ${wm}
+    <div class="recipe-hero-head">
+      <span class="recipe-hero-eyebrow">${zi('sparkle')} Suggested for Ziva</span>
+      ${slot ? `<span class="recipe-hero-badge">${escHtml(slot.label)}</span>` : ''}
+    </div>
     <h3 class="recipe-hero-title">${escHtml(r.title)}</h3>
-    <p class="recipe-hero-tag">${escHtml(_recipeTagline(r))}</p>
+    <p class="recipe-hero-tag">${strictLead}${escHtml(tag.body)}</p>
     <p class="recipe-hero-why">${escHtml(whyText || '')}</p>
-    <span class="recipe-hero-more">${zi('chevron-down')} Tap for steps &amp; safety</span>
+    <div class="recipe-hero-foot">
+      <span class="recipe-hero-meta">${meta.join('')}</span>
+      <span class="recipe-hero-cta">See recipe ${zi('arrow-right')}</span>
+    </div>
     <div class="recipe-detail" id="rdet-${escAttr(uid)}" style="display:none;">${_recipeDetailHtml(r, ageMonths)}</div>
   </div>`;
 }
@@ -40524,15 +40747,20 @@ function renderDietRecipes() {
 
   let html = '';
 
-  // ── (a) Suggested for Ziva ──
+  // Panel header (LOCKED 05-meal-rows): "Recipes" + the sourced-from-logs subtitle.
+  html += `<div class="col-full recipes-header"><h2 class="recipes-h1">Recipes</h2><p class="recipes-subtitle">Sourced for Ziva's stage · cooked from what you log.</p></div>`;
+
+  // ── (a) Suggested for Ziva — featured generative hero + "More for Ziva" rows ──
   const suggested = _recipeSuggestForZiva(surfaced, ageMonths);
-  html += `<div class="col-full"><div class="recipes-sec-label">Suggested for Ziva</div>`;
+  html += `<div class="col-full">`;
   if (suggested.length) {
     const top = suggested[0];
     const topWhy = top.why || (top.r.dos && top.r.dos[0]) || 'A wholesome, age-appropriate pick for today.';
     html += _recipeHeroHtml(top.r, topWhy, ageMonths);
-    for (const s of suggested.slice(1)) {
-      html += _recipeRowHtml(s.r, 's', ageMonths, { showSlot: true });
+    const more = suggested.slice(1);
+    if (more.length) {
+      html += `<div class="recipe-group-head recipe-more-head">${zi('sprout')}<span class="recipe-group-title">More for Ziva</span><span class="recipe-group-count">${more.length}</span></div>`;
+      for (const s of more) html += _recipeRowHtml(s.r, 's', ageMonths, { showSlot: true });
     }
   } else {
     html += `<div class="recipe-empty">${zi('spoon')} Keep logging meals for a few days and personalised recipe ideas will appear here. Meanwhile, browse the catalog below.</div>`;

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -11179,10 +11179,11 @@ details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
 .recipe-hero-head .recipe-hero-eyebrow { margin-bottom:0; }
 .recipe-hero-badge { flex:0 0 auto; display:inline-flex; align-items:center; background:var(--tc-sage); color:var(--card-bg); border-radius:var(--r-full); padding:var(--sp-4) var(--sp-10); font-size:var(--fs-2xs); font-weight:800; }
 /* strict no's lead the tagline (rose, never folded) */
-.recipe-strict { font-family:'Nunito', sans-serif; font-style:normal; font-weight:800; font-size:var(--fs-2xs); text-transform:uppercase; letter-spacing:0.04em; color:var(--tc-rose); }
+.recipe-strict { font-family:'Nunito', sans-serif; font-style:normal; font-weight:800; font-size:var(--fs-2xs); text-transform:uppercase; letter-spacing:var(--ls-normal); color:var(--tc-rose); }
 .recipe-hero-foot { display:flex; align-items:center; justify-content:space-between; gap:var(--sp-8); flex-wrap:wrap; }
 .recipe-hero-meta { display:flex; align-items:center; gap:var(--sp-8); flex-wrap:wrap; }
 .recipe-hero-meta span { display:inline-flex; align-items:center; gap:var(--sp-4); font-size:var(--fs-xs); color:var(--mid); }
+.recipe-hero-meta span:not(:first-child)::before { content:'·'; margin-right:var(--sp-4); color:var(--light); }
 .recipe-hero-meta .zi { width:13px; height:13px; }
 .recipe-hero-cta { display:inline-flex; align-items:center; gap:var(--sp-4); min-height:36px; background:var(--tc-sage); color:var(--card-bg); border-radius:var(--r-full); padding:var(--sp-6) var(--sp-12); font-size:var(--fs-xs); font-weight:700; }
 .recipe-hero-cta .zi { width:14px; height:14px; transition:transform var(--ease-med); }
@@ -20917,6 +20918,15 @@ const RECIPE_EP = {
   turmeric:{eps:['golden','earthy'],noun:'turmeric'}, cinnamon:{eps:['warm','sweet'],noun:'cinnamon'},
   cumin:{eps:['warm','earthy'],noun:'cumin'}, coriander:{eps:['fresh','herby'],noun:'coriander'},
   mint:{eps:['cool','fresh'],noun:'mint'}, ginger:{eps:['warming','zingy'],noun:'ginger'},
+  // fold-completeness (K-T-2): keys present in the fingerprint icon map must also
+  // carry a voice, or a recipe paints a colour band for an unnamed ingredient.
+  poha:{eps:['light','flaky'],noun:'poha'}, okra:{eps:['tender','green'],noun:'okra'},
+  cabbage:{eps:['crisp','leafy'],noun:'cabbage'}, brinjal:{eps:['silky','mellow'],noun:'brinjal'},
+  mushroom:{eps:['earthy','tender'],noun:'mushroom'}, onion:{eps:['sweet','mellow'],noun:'onion'},
+  strawberry:{eps:['sweet','fragrant'],noun:'strawberry'}, grapes:{eps:['juicy','sweet'],noun:'grape',fold:'halved'},
+  papaya:{eps:['soft','sweet'],noun:'papaya'}, orange:{eps:['juicy','bright'],noun:'orange'},
+  pistachio:{eps:['nutty','green'],noun:'pistachio',fold:'ground'}, pumpkinseed:{eps:['nutty','crunchy'],noun:'pumpkin seed',fold:'ground'},
+  tofu:{eps:['silky','mild'],noun:'tofu'},
 };
 const _recipeConnector = s =>
   s < 0.12 ? 'with just a hint of' : s < 0.22 ? 'with a touch of' :
@@ -40447,13 +40457,13 @@ const _RECIPE_FP_BY_ICON = {
   almond: 'nuts', walnut: 'nuts', cashew: 'nuts', pistachio: 'nuts', sesame: 'nuts', chia: 'nuts', flaxseed: 'nuts', pumpkinseed: 'nuts',
   egg: 'protein', fish: 'protein', chicken: 'protein', prawn: 'protein', mutton: 'protein', tofu: 'protein',
 };
-// Trace ingredients — excluded from the fingerprint + the tagline (fats,
-// spices, sweeteners; matched as substrings so "cow ghee" / "black pepper" hit).
+// Trace ingredients — excluded from the fingerprint + the tagline BODY (fats,
+// spices, sweeteners). Word-boundary matched (K-T-3) so "oil" doesn't catch an
+// unrelated word; the corpus is curated, so the documented edge ("pepper" would
+// match a future "bell pepper") is a known invariant, not a live collision.
 const _RECIPE_TRACE = ['ghee', 'oil', 'turmeric', 'cinnamon', 'cumin', 'coriander', 'mint', 'jaggery', 'honey', 'salt', 'sugar', 'cardamom', 'pepper', 'ginger', 'garlic', 'lemon'];
-function _recipeIsTrace(name) {
-  const n = String(name).toLowerCase();
-  return _RECIPE_TRACE.some(t => n.indexOf(t) !== -1);
-}
+const _RECIPE_TRACE_RE = new RegExp('\\b(' + _RECIPE_TRACE.join('|') + ')\\b', 'i');
+function _recipeIsTrace(name) { return _RECIPE_TRACE_RE.test(String(name)); }
 function _recipeFpDomain(name) {
   const ic = (typeof recipeFoodIcon === 'function') ? recipeFoodIcon(name) : null;
   return (ic && _RECIPE_FP_BY_ICON[ic.icon]) ? _RECIPE_FP_BY_ICON[ic.icon] : null;
@@ -40524,15 +40534,35 @@ function _recipeRailColor(group) {
   return 'var(--tc-sage)';
 }
 
+// When an ingredient shares a zif icon with a differently-named food, the
+// composer would voice the wrong noun (M-T-2: poha shares the 'suji' icon →
+// voiced "suji"). Resolve the tagline EP key from the name first, then the icon.
+const _RECIPE_EP_KEY_OVERRIDE = { poha: 'poha' };
+function _recipeEpKey(name) {
+  const n = String(name).toLowerCase();
+  for (const k in _RECIPE_EP_KEY_OVERRIDE) if (n.indexOf(k) !== -1) return _RECIPE_EP_KEY_OVERRIDE[k];
+  const ic = (typeof recipeFoodIcon === 'function') ? recipeFoodIcon(name) : null;
+  return ic ? ic.icon : null;
+}
 // The italic "voice" descriptor (§9.5/§9.6) — the ported tagline composer,
-// quantity-weighted from the non-trace ingredients, epithets day-seed-rotated.
-// Returns { strict:[lead clauses], body } — render strict first (prominent),
-// then the italic body. Reserved for the hero (Typography C: italic = voice).
+// quantity-weighted, epithets day-seed-rotated. Returns { strict:[lead clauses],
+// body } — render strict FIRST (prominent), then the italic body. Reserved for
+// the hero (Typography C: italic = voice).
+//
+// M-T-1 / K-T-1 (BLOCKING fold): trace items are dropped from the BODY, but an
+// ingredient carrying a STRICT safety clause (honey/jaggery → RECIPE_EP[].strict)
+// is kept so the composer surfaces it as the rose lead (§9.7: strict no's lead,
+// never folded). Its tiny gram weight keeps it a "touch of" in the body while the
+// strict clause leads. (The fingerprint path excludes it separately, unchanged.)
 function _recipeTagline(r) {
-  if (typeof _recipeComposeTagline !== 'function') return { strict: [], body: '' };
-  const parts = (r.ingredients || [])
-    .filter(i => !_recipeIsTrace(i.name) && typeof recipeFoodIcon === 'function' && recipeFoodIcon(i.name))
-    .map(i => ({ id: recipeFoodIcon(i.name).icon, w: i.g || 10 }));
+  if (typeof _recipeComposeTagline !== 'function' || typeof RECIPE_EP === 'undefined') return { strict: [], body: '' };
+  const parts = [];
+  for (const i of (r.ingredients || [])) {
+    const key = _recipeEpKey(i.name);
+    if (!key || !RECIPE_EP[key]) continue;
+    if (_recipeIsTrace(i.name) && !RECIPE_EP[key].strict) continue;
+    parts.push({ id: key, w: i.g || 10 });
+  }
   return _recipeComposeTagline(parts, _recipeDaySeed());
 }
 

--- a/tests/e2e/diet-recipes.spec.ts
+++ b/tests/e2e/diet-recipes.spec.ts
@@ -98,6 +98,20 @@ test.describe('Diet → Recipes sub-tab', () => {
     expect(html).toContain('Dal');   // a dal/leafy recipe is present in the corpus
   });
 
+  // 5b — §9.7 strict-lead floor: a honey recipe's composed voice must LEAD with
+  // the honey caution (M-T-1/K-T-1 fold — the strict clause must reach the
+  // composer, not be filtered out as a trace ingredient).
+  test('strict safety lead surfaces for a honey recipe (§9.7 floor)', async ({ page }) => {
+    const strict = await page.evaluate(() => {
+      const rec = (window as any).RECIPES_BY_ID['banana-honey-toast'];
+      const fn = (window as any)._recipeTagline;
+      const t = typeof fn === 'function' ? fn(rec) : null;
+      return t ? t.strict : null;
+    });
+    expect(Array.isArray(strict)).toBe(true);
+    expect((strict as string[]).join(' ').toLowerCase()).toContain('honey');
+  });
+
   // 6 — ingredient names resolve through the LIVE resolver (alias-precedence)
   test('corpus ingredient forms resolve correctly through the live resolver', async ({ page }) => {
     const r = await page.evaluate(() => ({


### PR DESCRIPTION
## Recipes Tier C — generative warm-wave hero + tagline composer + LOCKED polish

**Render-first — this is a DRAFT for your Vercel-preview sign-off before the canon-cc-008 gate.** Open the preview, view the **Track → Diet → Recipes** tab (light + dark).

Upgrades the live Recipes tab (PR #223) to the full **§9 generative food system**, aligning it with the now-live lean-landing warm-wave aesthetic and closing the LOCKED `05-meal-rows` gaps.

### What changed
- **Corpus** — `prepMinutes` on all 25 recipes + per-ingredient grams `g` (drives the quantity-weighted fingerprint). Ported the **§9.5 three-layer tagline composer** (EP bank + `compose`) — quantity-weighted voice, strict no's lead, soft prep folds, day-seed rotation.
- **Generative hero (§9.3/§9.4)** — a grams-weighted, wavelength-ordered multi-domain **fingerprint stripe + fade** (legumes split from grains, ≤4 domains), the **4px warm-wave sheen sweep** (reuses `@keyframes ld-wave`; reduced-motion floor), a **corner zif watermark** (dominant ingredient = big slot), the Fraunces-italic composed voice, a data-driven *why*, a `prep · age · slot` meta, and a **"See recipe →"** CTA.
- **LOCKED 05-meal-rows polish** — panel **"Recipes"** header + *"Sourced for Ziva's stage · cooked from what you log."*; rows now carry a **factual meta** (prep · age · slot · relevance nutrient tag), with the italic voice **reserved for the hero** (§9.6); a **"More for Ziva"** group label.

### Verification
- `pnpm build` clean — 12/12 audit gates.
- Recipe + §10 e2e: **10/10 pass** (structure-agnostic assertions held through the rewrite).
- Verified light + dark locally (warm-wave stripe + fade hue-swap, watermark, rails, age badge).

### Not yet run — canon-cc-008
Holding the Governor gate until your render sign-off. On approval: Maren (corpus `prepMinutes`/grams content + safety), Kael (composer engine + fingerprint), Vela (warm-wave render + watermark + half-awake + reduced-motion), shared `styles.css` triple-Gov, Cipher Edict V.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
