### PR TITLE
build(province-map): write only on substantive change, kill regeneration churn

### DIFF
--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-06-05 &middot; graph @ <code>6830d0d7d072</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-05 &middot; graph @ <code>7eb64dce4d44</code></div>
   <div class="sub" style="margin-top:8px">
-    <span class="stat"><b>1,881</b> symbols</span>
+    <span class="stat"><b>1,882</b> symbols</span>
     <span class="stat"><b>5,533</b> relations</span>
-    <span class="stat"><b>85,928</b> LOC</span>
+    <span class="stat"><b>85,948</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -127,8 +127,8 @@
       <div class="cgov">Governor: <b>(tooling)</b></div>
       <div class="nums">
         <span><b>26</b> modules</span>
-        <span><b>171</b> symbols</span>
-        <span><b>4,867</b> LOC</span>
+        <span><b>172</b> symbols</span>
+        <span><b>4,887</b> LOC</span>
       </div>
       
       <div class="mods">build-province-map.mjs, build-poop-reference.mjs, QA_GATE_SPEC.md, build-careticket-state-machine.mjs, build-design-principles.mjs, recipes.js, audit-food-library-wiring-v1.sh, bump-version.mjs, build-graph.sh, audit-activity-categories-v1.sh, audit-card-priority-v3-6.sh, audit-chip-taxonomy-v3-5.sh, audit-emergency-floor-v1.sh, audit-emoji.sh, audit-feed-sheet-wiring-v1.sh, audit-floor-fidelity-v1.sh, audit-food-effects-sync-v1.sh, audit-hr12-v3-3.sh, audit-icon-text.sh, audit-no-personalised-prediction-v1.sh, audit-resolve-shield.sh, audit-shelf-totality-v1.sh, audit-viz-smoke.sh, build-safe.sh, build.sh, qa-route.sh</div>

--- a/split/build-province-map.mjs
+++ b/split/build-province-map.mjs
@@ -269,5 +269,25 @@ const html = `<!DOCTYPE html>
 </body></html>
 `;
 
+// ── write only when the SUBSTANTIVE content changed (kill regeneration churn) ──
+// PROVINCE_MAP.html is the one committed graph-derived artifact, so every rewrite
+// is a git diff that trips the stop-hook. Three header fields wobble on every
+// rebuild with no real change behind them:
+//   - builtAt   — a hash of the graph's internals, not the repo commit
+//   - now       — the generated date, which flips daily
+//   - totalEdges — graphify's extraction jitters the relation count +/-1 run-to-run
+// Normalize those three out and compare against the committed file; if only they
+// differ, leave it untouched. A genuine content change (LOC, symbols, the
+// coupling table, the hub degrees) still lands in the body and forces a rewrite.
+const normalize = (s) => s
+  .replace(/generated \d{4}-\d{2}-\d{2}/, 'generated <DATE>')
+  .replace(/graph @ <code>[^<]*<\/code>/, 'graph @ <code><HASH></code>')
+  .replace(/<b>[\d,]+<\/b> relations/, '<b><RELATIONS></b> relations');
+
+if (existsSync(outPath) && normalize(readFileSync(outPath, 'utf8')) === normalize(html)) {
+  console.error(`[province-map] no substantive change (graph-hash/date/relation-jitter only); left ${outPath} untouched.`);
+  process.exit(0);
+}
+
 writeFileSync(outPath, html, 'utf8');
 console.error(`[province-map] wrote ${outPath} (${(html.length / 1024).toFixed(1)} KB; ${totalNodes} symbols, ${crossRoads.length} cross-province couplings, extraction=${sharedSurveyed ? 'thorough' : 'code-only'}).`);


### PR DESCRIPTION
## What

`docs/PROVINCE_MAP.html` is the **one committed graph-derived artifact**, so every `pnpm build` that flipped one of three volatile header fields produced a git diff with no real change behind it — repeatedly tripping the stop-hook between sessions.

The three churn sources:
- **graph content-hash** (`built_at_commit`) — a hash of the graph's internals, flips every extraction
- **generated date** — flips daily even with no code change
- **relation count** — graphify's code-only extraction jitters it ±1 run-to-run (observed `5,533 ⇄ 5,532`)

## How

`split/build-province-map.mjs` now **writes only when the substantive content changed.** It generates the HTML as before, then normalizes those three volatile fields out and compares against the committed file. If only they differ, it leaves the file untouched (`process.exit(0)`, non-fatal). A genuine change — LOC, symbol counts, the cross-province coupling table, hub degrees — still lands in the page body and forces a rewrite.

Verified idempotent: a second generator run on unchanged content is a no-op (`left … untouched`).

## Why the map still changed in this PR

The diff is honest, not churn: this very edit added **+20 LOC** and **+1 symbol** (the new `normalize` function) to `build-province-map.mjs` — a Public Works / build-tooling file the map counts — so the regenerated map correctly reflects `171→172` symbols and `4,867→4,887` LOC in the Public Works province. The hash flip rode along because we were writing anyway.

## Scope chosen

Considered fully gitignoring the artifact, but it's documented as the authoritative committed Province Map in CLAUDE.md (×3) + `GRAPHIFY_INTEGRATION.md` (×2) and is served on the live Pages site — root-causing the churn keeps the page published and the docs accurate.

## canon-cc-008

Touches only `split/build-province-map.mjs` (Public Works / build tooling — no Governor jurisdiction) and a regenerated `docs/` artifact. No Care / Intelligence-engine / Surfacing-render / Shared region touched → **Governor audit waived** (build-tooling + docs-only, Gate 2.5). Pre-commit audit gates (HR-1, HR-12, icon-text) pass.

https://claude.ai/code/session_018ta3zcZFC8Kz91ue7aHmK7

---
_Generated by [Claude Code](https://claude.ai/code/session_018ta3zcZFC8Kz91ue7aHmK7)_