### PR TITLE
docs(CLAUDE): reference /sproutlab-compact and /session-close skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,15 @@ Cipher's Province mirror is a byte-identical deploy of the Codex canon (`Codex/d
 
 **Full invocation procedure:** `invocation.md` — per-Companion modes, brief shape, the Scribe Worker Tier, the canon-cc-008 invocation sequence, and a routing quick reference.
 
+### Session-lifecycle skills (operational, not Companion mirrors)
+
+Two utility slash-skills bookend a session. They are Codex-canon-homed (`docs/specs/skills/`) and deploy byte-identical to the loadable `SKILL.md` directory shape per canon-cc-026 — invocable, not persona mirrors:
+
+| Skill | When | What it does |
+|-------|------|--------------|
+| **`/sproutlab-compact`** (`.claude/skills/sproutlab-compact/SKILL.md`) | BEFORE `/compact` on a long session | Writes a graph-anchored, ephemeral `/tmp` resume handoff (PR/branch state, next action, the canon-cc-008 summon-set, file→symbol anchors) so post-compact work resumes precisely, then hands back to `/compact`. A convenience ritual — does **not** discharge canon-cc-008. |
+| **`/session-close`** (`.claude/skills/session-close/SKILL.md`) | At the END of a session, after work is merged | Runs the close sequence — pre-close gate → five close artifacts (handoff + next-session target, synthesis-if-warranted, governance/facts refresh, copiable opening prompt) → lands them as a docs-only PR. Portable skeleton that **defers to [`docs/SESSION_CLOSE_SEQUENCE.md`](docs/SESSION_CLOSE_SEQUENCE.md)** as the authoritative local floor. |
+
 ## QA Chain — Mandatory Pre-Merge Gate (canon-cc-008)
 
 **NON-NEGOTIABLE. This is a release gate, not a guideline.** Every SproutLab


### PR DESCRIPTION
Documents the two session-lifecycle slash-skills in `CLAUDE.md`, as the prior PRs left them unreferenced in the policy floor.

## Change
Adds a **"Session-lifecycle skills (operational, not Companion mirrors)"** subsection to the Companion-Set Invocation Surface, with a two-row table:
- **`/sproutlab-compact`** — pre-`/compact` graph-anchored resume handoff (convenience ritual; does not discharge canon-cc-008).
- **`/session-close`** — the end-of-session close sequence; portable skeleton that defers to `docs/SESSION_CLOSE_SEQUENCE.md` as the authoritative local floor.

Both noted as Codex-canon-homed, byte-identical `SKILL.md` deploys per canon-cc-026 — distinct from the Companion persona mirrors and the design tooling (`/design-principles`, `/doc-render`).

Docs-only (`CLAUDE.md`); no `split/` touch → Governor audit waivable. SproutLab pre-commit audits passed.

https://claude.ai/code/session_011C34ei6PorU5gme7NYN2xF

---
_Generated by [Claude Code](https://claude.ai/code/session_011C34ei6PorU5gme7NYN2xF)_