### PR TITLE
docs(gov): provenance sweep — Companion mirror headers Province-first (follow-up to #247)

### DIFF
--- a/.claude/agents/ceres.md
+++ b/.claude/agents/ceres.md
@@ -5,8 +5,11 @@ tools: Read, Grep, Glob, Bash
 ---
 
 <!--
-Canonical spec — authored and maintained in Codex per canon-cc-026.
-Deploys byte-identical to sproutlab/.claude/agents/ceres.md per canon-cc-026
+Province-authoritative spec — SproutLab governs this copy (canon-cc-026
+amended 2026-06-10, Province self-governance). Codex keeps a reference copy
+under docs/specs/subagents/ceres.md for record-keeping, not routing; the
+session-start overlay gap-fills from Codex and never clobbers this Province-
+owned copy. Per canon-cc-026
 §Per-Province-Layout and canon-cc-027 Rung 5. Province-Governor spec —
 single-Province deployment. Governor jurisdiction bound by the 30K Rule;
 Ceres is seated Governor of Nutrition for SproutLab.

--- a/.claude/agents/chronicler.md
+++ b/.claude/agents/chronicler.md
@@ -5,7 +5,11 @@ tools: Read, Grep, Glob, Bash
 ---
 
 <!--
-Canonical spec — authored and maintained in Codex per canon-cc-026.
+Cross-cluster role spec — the Chronicler (Aurelius) is a cross-cluster visitor;
+Codex holds the canonical record and replicates it to every Province. Per
+canon-cc-026 (amended 2026-06-10) the in-Province copy is Province-editable and
+wins on session-start materialization (gap-fill, no clobber); keep it in sync
+with the Codex record rather than fork it.
 Deploys byte-identical to every Province's .claude/agents/chronicler.md per
 canon-cc-026 §Per-Province-Layout (cross-cluster role replicates everywhere).
 Amendment path: canon-cc-027 signing chain, with the institutional-spec

--- a/.claude/agents/cipher.md
+++ b/.claude/agents/cipher.md
@@ -5,7 +5,11 @@ tools: Read, Grep, Glob, Bash
 ---
 
 <!--
-Canonical spec — authored and maintained in Codex per canon-cc-026.
+Cross-cluster role spec — Cipher is Censor of Cluster A; Codex holds the
+canonical record and replicates it to every cluster. Per canon-cc-026 (amended
+2026-06-10) the in-Province copy is Province-editable and wins on session-start
+materialization (gap-fill, no clobber) — but as a cross-cluster role, keep it in
+sync with the Codex record rather than fork it.
 Deploys byte-identical to Codex/.claude/agents/cipher.md, SproutLab/.claude/agents/cipher.md,
 and MSc/.claude/agents/cipher.md per canon-cc-026 §Per-Province-Layout and canon-cc-027 Rung 5.
 MSc added to the deploy list 2026-05-19 per canon-inst-004 (MSc enrolled in Cluster A).

--- a/.claude/agents/kael.md
+++ b/.claude/agents/kael.md
@@ -5,8 +5,11 @@ tools: Read, Grep, Glob, Bash
 ---
 
 <!--
-Canonical spec — authored and maintained in Codex per canon-cc-026.
-Deploys byte-identical to sproutlab/.claude/agents/kael.md per canon-cc-026
+Province-authoritative spec — SproutLab governs this copy (canon-cc-026
+amended 2026-06-10, Province self-governance). Codex keeps a reference copy
+under docs/specs/subagents/kael.md for record-keeping, not routing; the
+session-start overlay gap-fills from Codex and never clobbers this Province-
+owned copy. Per canon-cc-026
 §Per-Province-Layout and canon-cc-027 Rung 5. Province-Governor spec —
 single-Province deployment. Governor jurisdiction bound by the 30K Rule;
 Kael is seated Governor of Intelligence for SproutLab.

--- a/.claude/agents/maren.md
+++ b/.claude/agents/maren.md
@@ -5,8 +5,11 @@ tools: Read, Grep, Glob, Bash
 ---
 
 <!--
-Canonical spec — authored and maintained in Codex per canon-cc-026.
-Deploys byte-identical to sproutlab/.claude/agents/maren.md per canon-cc-026
+Province-authoritative spec — SproutLab governs this copy (canon-cc-026
+amended 2026-06-10, Province self-governance). Codex keeps a reference copy
+under docs/specs/subagents/maren.md for record-keeping, not routing; the
+session-start overlay gap-fills from Codex and never clobbers this Province-
+owned copy. Per canon-cc-026
 §Per-Province-Layout and canon-cc-027 Rung 5. Province-Governor spec —
 single-Province deployment. Governor jurisdiction bound by the 30K Rule;
 SproutLab crossed 30,000 LOC and split into Care + Intelligence Regions;

--- a/.claude/agents/scribe-draft.md
+++ b/.claude/agents/scribe-draft.md
@@ -5,7 +5,9 @@ tools: Read, Grep, Glob, Write, Edit
 ---
 
 <!--
-Canonical spec — authored and maintained in Codex per canon-cc-026, with the
+Cross-cluster worker-tier spec — Codex holds the canonical record (per
+canon-cc-026, amended 2026-06-10: the in-Province copy is Province-editable and
+wins on materialization), with the
 Scribe-tier carve-out ratified by decree-0019 / canon-proc-006: the body below
 deploys to every Province's .claude/agents/scribe-draft.md byte-identical
 EXCEPT the "Serving voice" section, which each Province's Builder tunes to that

--- a/.claude/agents/scribe-record.md
+++ b/.claude/agents/scribe-record.md
@@ -5,7 +5,9 @@ tools: Read, Grep, Glob, Write, Edit
 ---
 
 <!--
-Canonical spec — authored and maintained in Codex per canon-cc-026, with the
+Cross-cluster worker-tier spec — Codex holds the canonical record (per
+canon-cc-026, amended 2026-06-10: the in-Province copy is Province-editable and
+wins on materialization), with the
 Scribe-tier carve-out ratified by decree-0019 / canon-proc-006: the body below
 deploys to every Province's .claude/agents/scribe-record.md byte-identical
 EXCEPT the "Serving voice" section, which each Province's Builder tunes to that

--- a/.claude/agents/scribe-scout.md
+++ b/.claude/agents/scribe-scout.md
@@ -5,7 +5,9 @@ tools: Read, Grep, Glob, Bash
 ---
 
 <!--
-Canonical spec — authored and maintained in Codex per canon-cc-026, with the
+Cross-cluster worker-tier spec — Codex holds the canonical record (per
+canon-cc-026, amended 2026-06-10: the in-Province copy is Province-editable and
+wins on materialization), with the
 Scribe-tier carve-out ratified by decree-0019 / canon-proc-006: the body below
 deploys to every Province's .claude/agents/scribe-scout.md byte-identical
 EXCEPT the "Serving voice" section, which each Province's Builder tunes to that

--- a/.claude/agents/scribe-verify.md
+++ b/.claude/agents/scribe-verify.md
@@ -5,7 +5,9 @@ tools: Read, Grep, Glob, Bash
 ---
 
 <!--
-Canonical spec — authored and maintained in Codex per canon-cc-026, with the
+Cross-cluster worker-tier spec — Codex holds the canonical record (per
+canon-cc-026, amended 2026-06-10: the in-Province copy is Province-editable and
+wins on materialization), with the
 Scribe-tier carve-out ratified by decree-0019 / canon-proc-006: the body below
 deploys to every Province's .claude/agents/scribe-verify.md byte-identical
 EXCEPT the "Serving voice" section, which each Province's Builder tunes to that

--- a/.claude/agents/vela.md
+++ b/.claude/agents/vela.md
@@ -5,8 +5,11 @@ tools: Read, Grep, Glob, Bash
 ---
 
 <!--
-Canonical spec — authored and maintained in Codex per canon-cc-026.
-Deploys byte-identical to sproutlab/.claude/agents/vela.md per canon-cc-026
+Province-authoritative spec — SproutLab governs this copy (canon-cc-026
+amended 2026-06-10, Province self-governance). Codex keeps a reference copy
+under docs/specs/subagents/vela.md for record-keeping, not routing; the
+session-start overlay gap-fills from Codex and never clobbers this Province-
+owned copy. Per canon-cc-026
 §Per-Province-Layout and canon-cc-027 Rung 5. Province-Governor spec —
 single-Province deployment. Governor jurisdiction bound by the 30K Rule;
 Vela is seated Governor of Surfacing for SproutLab.

--- a/.claude/skills/ceres.md
+++ b/.claude/skills/ceres.md
@@ -4,8 +4,11 @@ description: Use this skill when Lyra (the Builder) wants an in-transcript Nutri
 ---
 
 <!--
-Canonical spec — authored and maintained in Codex per canon-cc-026.
-Deploys byte-identical to sproutlab/.claude/skills/ceres.md per canon-cc-026
+Province-authoritative spec — SproutLab governs this copy (canon-cc-026
+amended 2026-06-10, Province self-governance). Codex keeps a reference copy
+under docs/specs/skills/ceres.md for record-keeping, not routing; the session-
+start overlay gap-fills from Codex and never clobbers this Province-owned
+copy. Per canon-cc-026
 §Per-Province-Layout. Province-Governor skill — single-Province deployment.
 Amendment path: canon-cc-027 signing chain; Governor self-review forbidden
 per canon-gov-002, so Rung 2 falls to Maren under the cross-Governor peer-

--- a/.claude/skills/chronicler.md
+++ b/.claude/skills/chronicler.md
@@ -4,7 +4,11 @@ description: Use this skill when any rank invokes the Chronicler's authoring voi
 ---
 
 <!--
-Canonical spec — authored and maintained in Codex per canon-cc-026.
+Cross-cluster role spec — the Chronicler (Aurelius) is a cross-cluster visitor;
+Codex holds the canonical record and replicates it to every Province. Per
+canon-cc-026 (amended 2026-06-10) the in-Province copy is Province-editable and
+wins on session-start materialization (gap-fill, no clobber); keep it in sync
+with the Codex record rather than fork it.
 Deploys byte-identical to every Province's .claude/skills/chronicler.md per
 canon-cc-026 §Per-Province-Layout (cross-cluster role replicates everywhere).
 Amendment path: canon-cc-027 signing chain, with the institutional-spec

--- a/.claude/skills/cipher.md
+++ b/.claude/skills/cipher.md
@@ -4,7 +4,11 @@ description: Use this skill when a Cluster A Builder wants an in-transcript arch
 ---
 
 <!--
-Canonical spec — authored and maintained in Codex per canon-cc-026.
+Cross-cluster role spec — Cipher is Censor of Cluster A; Codex holds the
+canonical record and replicates it to every cluster. Per canon-cc-026 (amended
+2026-06-10) the in-Province copy is Province-editable and wins on session-start
+materialization (gap-fill, no clobber) — but as a cross-cluster role, keep it in
+sync with the Codex record rather than fork it.
 Deploys byte-identical to Codex/.claude/skills/cipher.md, SproutLab/.claude/skills/cipher.md,
 and MSc/.claude/skills/cipher.md per canon-cc-026 §Per-Province-Layout and canon-cc-027 Rung 5.
 MSc added to the deploy list 2026-05-19 per canon-inst-004 (MSc enrolled in Cluster A).

--- a/.claude/skills/kael.md
+++ b/.claude/skills/kael.md
@@ -4,8 +4,11 @@ description: Use this skill when Lyra (the Builder) wants an in-transcript Intel
 ---
 
 <!--
-Canonical spec — authored and maintained in Codex per canon-cc-026.
-Deploys byte-identical to sproutlab/.claude/skills/kael.md per canon-cc-026
+Province-authoritative spec — SproutLab governs this copy (canon-cc-026
+amended 2026-06-10, Province self-governance). Codex keeps a reference copy
+under docs/specs/skills/kael.md for record-keeping, not routing; the session-
+start overlay gap-fills from Codex and never clobbers this Province-owned
+copy. Per canon-cc-026
 §Per-Province-Layout. Province-Governor skill — single-Province deployment.
 Amendment path: canon-cc-027 signing chain; Governor self-review forbidden
 per canon-gov-002, so Rung 2 falls to Maren under the cross-Governor peer-

--- a/.claude/skills/maren.md
+++ b/.claude/skills/maren.md
@@ -4,8 +4,11 @@ description: Use this skill when Lyra (the Builder) wants an in-transcript Care-
 ---
 
 <!--
-Canonical spec — authored and maintained in Codex per canon-cc-026.
-Deploys byte-identical to sproutlab/.claude/skills/maren.md per canon-cc-026
+Province-authoritative spec — SproutLab governs this copy (canon-cc-026
+amended 2026-06-10, Province self-governance). Codex keeps a reference copy
+under docs/specs/skills/maren.md for record-keeping, not routing; the session-
+start overlay gap-fills from Codex and never clobbers this Province-owned
+copy. Per canon-cc-026
 §Per-Province-Layout. Province-Governor skill — single-Province deployment.
 Amendment path: canon-cc-027 signing chain; Governor self-review forbidden
 per canon-gov-002, so Rung 2 falls to Kael under the cross-Governor peer-

--- a/.claude/skills/session-close/SKILL.md
+++ b/.claude/skills/session-close/SKILL.md
@@ -4,7 +4,9 @@ description: Run the end-of-session close sequence — the repeatable ritual for
 trigger: /session-close
 ---
 
-<!-- Canonical spec — authored and maintained in Codex per canon-cc-026.
+<!-- Province-authoritative portable skill — SproutLab governs its in-Province
+     copy (canon-cc-026 amended 2026-06-10, Province self-governance); Codex keeps a
+     reference copy in docs/specs/skills/ for record-keeping, not routing.
      Portable close ritual — deploys to any Province that runs session closes.
      Deploys byte-identical to <repo>/.claude/skills/session-close/SKILL.md per
      canon-cc-026 §Per-Province-Layout — the loadable SKILL.md directory shape

--- a/.claude/skills/sproutlab-compact/SKILL.md
+++ b/.claude/skills/sproutlab-compact/SKILL.md
@@ -4,7 +4,9 @@ description: Prepare a SproutLab session for /compact. Use BEFORE running /compa
 trigger: /sproutlab-compact
 ---
 
-<!-- Canonical spec — authored and maintained in Codex per canon-cc-026.
+<!-- Province-authoritative utility skill — SproutLab governs this copy
+     (canon-cc-026 amended 2026-06-10, Province self-governance); Codex keeps a
+     reference copy in docs/specs/skills/ for record-keeping, not routing.
      Promoted to the Codex docs/specs/skills/ canonical home 2026-06-04 (PR #85).
      Province-local utility skill — single-Province deployment. Deploys byte-identical
      to sproutlab/.claude/skills/sproutlab-compact/SKILL.md per canon-cc-026

--- a/.claude/skills/vela.md
+++ b/.claude/skills/vela.md
@@ -4,8 +4,11 @@ description: Use this skill when Lyra (the Builder) wants an in-transcript Surfa
 ---
 
 <!--
-Canonical spec — authored and maintained in Codex per canon-cc-026.
-Deploys byte-identical to sproutlab/.claude/skills/vela.md per canon-cc-026
+Province-authoritative spec — SproutLab governs this copy (canon-cc-026
+amended 2026-06-10, Province self-governance). Codex keeps a reference copy
+under docs/specs/skills/vela.md for record-keeping, not routing; the session-
+start overlay gap-fills from Codex and never clobbers this Province-owned
+copy. Per canon-cc-026
 §Per-Province-Layout. Province-Governor skill — single-Province deployment.
 Amendment path: canon-cc-027 signing chain; Governor self-review forbidden
 per canon-gov-002, so Rung 2 falls to Kael or Maren under the cross-Governor

--- a/invocation.md
+++ b/invocation.md
@@ -38,8 +38,8 @@ reference copies (`docs/specs/subagents/`, `docs/specs/skills/`) for record-
 keeping, not routing. The Scribe serving-voice carve-out (decree-0019 /
 canon-proc-006) and the cross-cluster Cipher/Chronicler records remain Codex-
 sourced but Province-editable in their in-Province copy. **Invoke the
-mirrors.** Cipher's mirror is a deploy of the Codex canon: Cipher remains Censor
-of Cluster A, not a Province seat — the mirror exists so the Edict V final-pass
+mirrors.** Cipher's in-Province copy mirrors the cross-cluster Codex record:
+Cipher remains Censor of Cluster A, not a Province seat — the mirror exists so the Edict V final-pass
 can be invoked without leaving Province context.
 
 ## 3. Subagent or skill — the artifact test (canon-cc-022)

--- a/invocation.md
+++ b/invocation.md
@@ -32,10 +32,12 @@ Claude Code harness. Cross-model invocation is out of scope — see §9.
 | scribe-verify | Worker tier — mechanical checks | `.claude/agents/scribe-verify.md` | — |
 | scribe-record | Worker tier — chronicling | `.claude/agents/scribe-record.md` | — |
 
-The canonical spec bodies are authored in Codex (`docs/specs/subagents/`,
-`docs/specs/skills/`); the `.claude/` paths above are the byte-identical
-Province mirrors per canon-cc-026 §Per-Province-Layout — with the Scribe
-serving-voice carve-out ratified by decree-0019 / canon-proc-006. **Invoke the
+The `.claude/` paths above are the **Province-authoritative** spec bodies
+(canon-cc-026 amended 2026-06-10 — Province self-governance); Codex keeps
+reference copies (`docs/specs/subagents/`, `docs/specs/skills/`) for record-
+keeping, not routing. The Scribe serving-voice carve-out (decree-0019 /
+canon-proc-006) and the cross-cluster Cipher/Chronicler records remain Codex-
+sourced but Province-editable in their in-Province copy. **Invoke the
 mirrors.** Cipher's mirror is a deploy of the Codex canon: Cipher remains Censor
 of Cluster A, not a Province seat — the mirror exists so the Edict V final-pass
 can be invoked without leaving Province context.


### PR DESCRIPTION
## Provenance sweep — Companion mirror headers Province-first

Follow-up to **#247** (Province self-governance, canon-cc-026 amendment). #247 made the hook + CLAUDE.md enforce that SproutLab governs its own Companion specs and Codex is record-keeping — but ~28 mirror-header / `invocation.md` lines still asserted *"authored and maintained in Codex"* / *"byte-identical Codex deploy."* This sweep brings the prose in line with the governance. **No behavior change — provenance text only.**

### What changed (19 files)
- **Seats** (`maren`/`kael`/`vela`/`ceres`, agents+skills) → *Province-authoritative; Codex keeps a reference copy for record-keeping, not routing.*
- **Cross-cluster roles** (`cipher`, `chronicler`) → reframed as cross-cluster **records** Codex holds + replicates, with the in-Province copy **Province-editable (A1)** — *"keep in sync rather than fork."* Their cross-cluster deploy descriptions (Codex/SproutLab/MSc; every-Province) are retained, now correctly subordinate.
- **Scribes** (`scout`/`draft`/`verify`/`record`) → worker-tier cross-cluster record; in-Province copy Province-editable; serving-voice carve-out unchanged.
- **Utility skills** (`sproutlab-compact`, `session-close`) → Province-authoritative.
- **`invocation.md`** → ".claude/ paths are byte-identical Codex mirrors" → Province-authoritative bodies; Codex reference-only.

### Verified
- Zero `"authored and maintained in Codex"` left in `.claude/` or `invocation.md`.
- Remaining `byte-identical` strings are only the **deliberately-kept cross-cluster deploy descriptions** (cipher→Codex/SproutLab/MSc, chronicler/scribes→every Province), accurate for those roles.
- Frontmatter intact on all 19 files; pre-commit audits green.

### Out of scope (intentional)
CLAUDE.md's Cipher/Chronicler paragraphs still say "byte-identical Codex deploy" — they're **self-reconciled by the #247 amendment paragraph** in that same section ("read as Codex-originated reference"), so left as-is.

Draft for your review.

https://claude.ai/code/session_01NSTnMqXjQzBVNHXkijG9MG

---
_Generated by [Claude Code](https://claude.ai/code/session_01NSTnMqXjQzBVNHXkijG9MG)_