### PR TITLE
Surface Catalog — living visual contract (heroes)

### DIFF
--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-06-15 &middot; graph @ <code>f0c73f0c8720</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-15 &middot; graph @ <code>10b909a98fe7</code></div>
   <div class="sub" style="margin-top:8px">
     <span class="stat"><b>1,997</b> symbols</span>
     <span class="stat"><b>5,715</b> relations</span>
-    <span class="stat"><b>87,847</b> LOC</span>
+    <span class="stat"><b>87,882</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -99,14 +99,14 @@
       <div class="nums">
         <span><b>2</b> modules</span>
         <span><b>280</b> symbols</span>
-        <span><b>8,350</b> LOC</span>
+        <span><b>8,353</b> LOC</span>
       </div>
       
-      <div class="bar" title="8,350 of 30,000 LOC">
+      <div class="bar" title="8,353 of 30,000 LOC">
         <div class="fill " style="width:28%"></div>
         <span class="barlbl">28% to 30K frontier</span>
       </div>
-      <div class="hd">21,650 LOC headroom</div>
+      <div class="hd">21,647 LOC headroom</div>
       <div class="mods">diet.js, recipes.js</div>
     </div>
     <div class="card" style="border-top:5px solid #c9b8e8">
@@ -133,7 +133,7 @@
       <div class="nums">
         <span><b>2</b> modules</span>
         <span><b>0</b> symbols</span>
-        <span><b>15,393</b> LOC</span>
+        <span><b>15,425</b> LOC</span>
       </div>
       <div class="note">Unsurveyed &mdash; code-only extraction. Set a backend and rebuild for symbols.</div>
       <div class="mods">styles.css, template.html</div>

--- a/docs/PROVINCE_MAP.html
+++ b/docs/PROVINCE_MAP.html
@@ -40,11 +40,11 @@
 <body>
 <header>
   <h1>SPROUTLAB &middot; JURISDICTION OVERVIEW</h1>
-  <div class="sub">graph-derived exec summary &middot; generated 2026-06-15 &middot; graph @ <code>33334f59ca6b</code></div>
+  <div class="sub">graph-derived exec summary &middot; generated 2026-06-15 &middot; graph @ <code>f0c73f0c8720</code></div>
   <div class="sub" style="margin-top:8px">
-    <span class="stat"><b>1,979</b> symbols</span>
-    <span class="stat"><b>5,692</b> relations</span>
-    <span class="stat"><b>87,581</b> LOC</span>
+    <span class="stat"><b>1,997</b> symbols</span>
+    <span class="stat"><b>5,715</b> relations</span>
+    <span class="stat"><b>87,847</b> LOC</span>
     <span class="stat">extraction: <b>code-only</b></span>
   </div>
 </header>
@@ -143,12 +143,12 @@
       <div class="clatin">build + audit corps</div>
       <div class="cgov">Governor: <b>(tooling)</b></div>
       <div class="nums">
-        <span><b>29</b> modules</span>
-        <span><b>221</b> symbols</span>
-        <span><b>4,923</b> LOC</span>
+        <span><b>30</b> modules</span>
+        <span><b>239</b> symbols</span>
+        <span><b>5,189</b> LOC</span>
       </div>
       
-      <div class="mods">build-province-map.mjs, build-poop-reference.mjs, QA_GATE_SPEC.md, build-careticket-state-machine.mjs, build-app-evolution.mjs, build-pr-dashboard.mjs, build-icon-reference.mjs, build-design-principles.mjs, build-doc-views.mjs, audit-food-library-wiring-v1.sh, bump-version.mjs, build-graph.sh, audit-activity-categories-v1.sh, audit-card-priority-v3-6.sh, audit-chip-taxonomy-v3-5.sh, audit-emergency-floor-v1.sh, audit-emoji.sh, audit-feed-sheet-wiring-v1.sh, audit-floor-fidelity-v1.sh, audit-food-effects-sync-v1.sh, audit-hr12-v3-3.sh, audit-icon-text.sh, audit-no-personalised-prediction-v1.sh, audit-resolve-shield.sh, audit-shelf-totality-v1.sh, audit-viz-smoke.sh, build-safe.sh, build.sh, qa-route.sh</div>
+      <div class="mods">build-province-map.mjs, build-poop-reference.mjs, QA_GATE_SPEC.md, build-careticket-state-machine.mjs, build-app-evolution.mjs, build-pr-dashboard.mjs, build-surface-catalog.mjs, build-icon-reference.mjs, build-design-principles.mjs, build-doc-views.mjs, audit-food-library-wiring-v1.sh, bump-version.mjs, build-graph.sh, audit-activity-categories-v1.sh, audit-card-priority-v3-6.sh, audit-chip-taxonomy-v3-5.sh, audit-emergency-floor-v1.sh, audit-emoji.sh, audit-feed-sheet-wiring-v1.sh, audit-floor-fidelity-v1.sh, audit-food-effects-sync-v1.sh, audit-hr12-v3-3.sh, audit-icon-text.sh, audit-no-personalised-prediction-v1.sh, audit-resolve-shield.sh, audit-shelf-totality-v1.sh, audit-viz-smoke.sh, build-safe.sh, build.sh, qa-route.sh</div>
     </div></div>
 
   <h2>Cross-province coupling (highest-traffic calls across jurisdiction borders)</h2>

--- a/docs/SURFACE_CATALOG.html
+++ b/docs/SURFACE_CATALOG.html
@@ -1,0 +1,12765 @@
+<!DOCTYPE html>
+<html lang="en" data-zoom="default">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SproutLab — Surface Catalog</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&family=Nunito:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+/* ── the LIVE app stylesheet (inlined; do not edit here — edit split/styles.css) ── */
+/* ──────────────────────────────────────────────────────────────────────────
+ * Responsive Breakpoint Conventions (Polish-7; canonical 4-value system)
+ * ──────────────────────────────────────────────────────────────────────────
+ * @media queries in this file use 4 canonical pixel breakpoints uniformly:
+ *
+ *   --bp-xs : 360px  — narrowest phones (rare; specific quad-grid affordances)
+ *   --bp-sm : 400px  — standard small phone (collapse-to-1col threshold)
+ *   --bp-md : 500px  — large phone / portrait tablet (intermediate layouts)
+ *   --bp-lg : 700px  — landscape tablet / small desktop (multi-col / sidebar)
+ *
+ * NOTE: CSS custom properties cannot be consumed inside @media query
+ * conditions in current browsers (no @custom-media support yet); these
+ * values are therefore inlined at each @media declaration. The convention
+ * is enforced by Polish-7 R-7 regression-guard (no @media uses a non-
+ * canonical pixel value). Future browser support for @custom-media would
+ * allow promoting these to actual CSS variables.
+ *
+ * Care-domain queries (`.food-cats`, `.ms-cats`, `.activity-cats`,
+ * `.upcoming-cats`, `.tip-cats`) at 700/400 are left untouched verbatim
+ * per Maren-charter coherence finding (5 cat-grids × 2 queries = 10
+ * queries; uniform 700px collapse + 400px sub-collapse pattern).
+ *
+ * Special-feature queries (`@media print`, `@media (prefers-reduced-motion:
+ * reduce)`) are not pixel-based and are excluded from the canonical-value
+ * convention.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ── Colour Palette ── */
+  --rose:     #f2a8b8;
+  --rose-light: #fde8ed;
+  --blush:    #fdf0f3;
+  --peach:    #fad4b4;
+  --peach-light: #fef3ea;
+  --sage:     #b5d5c5;
+  --sage-light: #e8f5ef;
+  --lavender: #c9b8e8;
+  --lav-light: #f0ebfb;
+  --sky:      #a8cfe0;
+  --sky-light:#e8f4fa;
+  --cream:    #fffaf7;
+  --warm:     #fef6f0;
+  --text:     #3d2e2e;
+  --mid:      #6e5858;
+  --light:    #806c6c;
+  --white:    #ffffff;
+  --shadow:   rgba(180,120,120,0.10);
+  /* Semantic text colors */
+  --tc-sage:    #3a7060;
+  --tc-sage-light: #5a9080;
+  --tc-rose:    #9e3e52;
+  --rose-deep:  #7a2c3e;   /* D2 phase-spec §2.3 — DO-NOT callout border. Deeper than --tc-rose for visual amplification of contraindications (SG-D2-DONOT-BORDER ratified). */
+  --tc-lav:     #6e5e9a;
+  --tc-sky:     #336580;
+  --tc-warn:    #856404;
+  --tc-danger:  #c44040;
+  --tc-caution: #875a20;
+  /* Sleep / Indigo */
+  --indigo:     #9ba8d8;
+  --indigo-light: #edf0fa;
+  --amber:      #e8b86d;
+  --amber-light:#fef6e8;
+  --tc-amber:   #8a6520;
+  --tc-indigo:  #4a5080;
+  --tc-peach:   #9a5f30;   /* v1.4 — peach text-on-wash, defined for the food-domain vegetables chip (.fdom-chip--vegs, §10.5). Retires the long-standing dangling reference. */
+  /* Polish-4: tonal variants + border-accents (token-family naming rule per
+     DESIGN_PRINCIPLES.md). 9 tokens introduced; substitution sweep ships
+     in same PR per spec-amendment-in-substitution-PR doctrine candidate. */
+  --border-warn:        #ffc107;
+  --border-warn-soft:   #ffd166;
+  --sage-deepest:       #1a7a42;
+  --sage-mid:           #5a9a6a;
+  --accent-sage-deep:   #3d7a60;
+  --amber-deepest:      #b8904a;
+  --amber-deep:         #d4a04a;
+  --amber-mid:          #e8a840;
+  --amber-text-deep:    #886520;
+  --surface-danger:  #fef5f5;
+  --surface-warn:    #fffdf5;
+  --surface-warn-grad: linear-gradient(135deg, #fff8e1, #fffdf5);
+  --surface-neutral: #fffdf8;
+  --surface-sage:    rgba(61,122,96,0.12);
+  --surface-rose:    rgba(224,112,112,0.10);
+  --surface-amber:   rgba(138,100,24,0.12);
+  --surface-lav:     rgba(201,184,232,0.10);
+  --surface-caution: rgba(240,180,80,0.08);
+  --surface-sky:     rgba(58,112,144,0.08);
+  --glass: rgba(255,255,255,0.5);
+  --glass-strong: rgba(255,255,255,0.6);
+  --card-bg: #ffffff;
+  --card-border: rgba(200,180,190,0.2);
+
+  /* ── Design Tokens: Spacing Scale ── */
+  --sp-2: 2px; --sp-4: 4px; --sp-6: 6px; --sp-8: 8px; --sp-10: 10px; --sp-12: 12px;
+  --sp-16: 16px;  --sp-20: 20px;  --sp-24: 24px;  --sp-32: 32px;
+  /* Section spacing */
+  --section-gap-hero: var(--sp-16);
+  --section-gap-zone: var(--sp-8);
+  --card-gap-paired: var(--sp-12);
+
+  /* ── Design Tokens: Type Scale (v2.5 — full hierarchy) ── */
+  --fs-2xs:  0.56rem;  --fs-xs:   0.65rem;  --fs-sm:   0.75rem;
+  --fs-base: 0.85rem;  --fs-md:   0.95rem;  --fs-lg:   1.1rem;
+  --fs-xl:   1.35rem;  --fs-2xl:  1.6rem;   --fs-3xl:  2.0rem;
+  /* Icon size tokens */
+  --icon-xs: 12px;  --icon-sm: 14px;  --icon-base: 16px;  --icon-md: 18px;  --icon-lg: 22px;
+  /* Letter-spacing tokens */
+  --ls-tight: 0.02em;  --ls-normal: 0.04em;  --ls-wide: 0.08em;
+
+  /* ── Design Tokens: Radius Scale ── */
+  --r-sm: 4px;  --r-md: 8px;  --r-lg: 12px;  --r-xl: 14px;  --r-2xl: 20px;  --r-full: 9999px;
+
+  /* ── Design Tokens: Transitions ── */
+  --ease-fast: 0.15s ease;
+  --ease-med:  0.22s ease;
+  --ease-slow: 0.35s ease;
+
+  /* ── Design Tokens: Line Heights ── */
+  --lh-none: 1;  --lh-tight: 1.2;  --lh-snug: 1.3;  --lh-normal: 1.4;  --lh-relaxed: 1.5;
+
+  /* ── Design Tokens: Border Accents ── */
+  --accent-w: 3px;
+
+  /* ── Dark Mode Surface Colours (inactive by default) ── */
+  --surface:       var(--white);
+  --surface-alt:   var(--warm);
+  --body-bg:       var(--cream);
+  --card-shadow:   var(--shadow);
+  --border-subtle: rgba(200,180,180,0.2);
+  --overlay-bg:    rgba(60,40,40,0.5);
+
+  /* Poop-color reference palette (anatomical, NOT domain).
+     Single source of truth for the picker, legend, timeline, anomaly cards,
+     and Color Guide. The core.js POOP_COLOR_HEX mirror must stay in sync. */
+  --poop-c-yellow: #e8c84a;
+  --poop-c-green:  #6aa84f;
+  --poop-c-brown:  #8B6914;
+  --poop-c-dark:   #5a4a2a;
+  --poop-c-orange: #e8913a;
+  --poop-c-red:    #d04040;
+  --poop-c-white:  #e0ddd4;
+  --poop-c-black:  #2a2a2a;
+
+  /* ── PR-EF Viz tokens ── */
+  /* Viz #1 — sleep calendar heatmap bands (semantic aliases) */
+  --cal-poor:       var(--tc-danger);
+  --cal-short:      var(--tc-amber);
+  --cal-target:     var(--tc-sage);
+  --cal-long:       var(--tc-sky);
+  /* Viz #2 — consistency stream colors (Bristol-band intensity tones) */
+  --con-runny:      rgba(220,180,90,0.7);
+  --con-watery:     rgba(220,180,90,0.9);
+  --con-loose:      rgba(180,200,140,0.7);
+  --con-soft:       rgba(140,190,160,0.7);
+  --con-normal:     var(--tc-sage);
+  --con-hard:       rgba(180,130,80,0.7);
+  --con-pellets:    rgba(140,90,60,0.7);
+  /* Viz #5 — milestone treemap status tiers */
+  --ms-emerging:    var(--surface-sage);
+  --ms-practicing:  var(--tc-sage-light);
+  --ms-consistent:  var(--tc-sage);
+  --ms-mastered:    var(--tc-indigo);
+}
+
+/* PR-EF Viz container chrome — light defaults; cards add their own padding */
+.viz-cal-grid, .viz-stream, .viz-treemap, .viz-gantt, .viz-intake-bar,
+.viz-food-timeline {
+  background: transparent;
+  margin-top: var(--sp-4);
+}
+.viz-chart-mount {
+  width: 100%;
+  position: relative;
+}
+
+/* ── Text Zoom ── */
+:root[data-zoom="med"] {
+  --fs-2xs:0.644rem; --fs-xs:0.748rem; --fs-sm:0.863rem;
+  --fs-base:0.978rem; --fs-md:1.093rem; --fs-lg:1.265rem;
+  --fs-xl:1.553rem; --fs-2xl:1.840rem; --fs-3xl:2.300rem;
+}
+:root[data-zoom="high"] {
+  --fs-2xs:0.728rem; --fs-xs:0.845rem; --fs-sm:0.975rem;
+  --fs-base:1.105rem; --fs-md:1.235rem; --fs-lg:1.430rem;
+  --fs-xl:1.755rem; --fs-2xl:2.080rem; --fs-3xl:2.600rem;
+}
+
+/* Greeting card exemption — always Low */
+.header {
+  --fs-2xs:0.56rem; --fs-xs:0.65rem; --fs-sm:0.75rem;
+  --fs-base:0.85rem; --fs-md:0.95rem; --fs-lg:1.1rem;
+  --fs-xl:1.35rem; --fs-2xl:1.6rem; --fs-3xl:2.0rem;
+}
+
+* { margin:0; padding:0; box-sizing:border-box; -webkit-tap-highlight-color:transparent; }
+
+/* ── Accessibility ── */
+:focus-visible { outline:2px solid var(--rose); outline-offset:2px; border-radius:var(--r-sm); }
+button, [onclick] { cursor:pointer; }
+button:focus-visible, .tab-btn:focus-visible { outline:2px solid var(--rose); outline-offset:2px; }
+/* Minimum touch target */
+button, .tab-btn, .ms-action-btn, .chip, .rtog, .food-cat-card, .tip-cat-card,
+.activity-cat-card, .ms-cat-card, .upcoming-cat-card, .history-month-header,
+.history-day-header, .upc-subcat-header { min-height:36px; }
+/* Prevent iOS Safari zoom on input focus (requires ≥16px) */
+input, textarea, select { font-size:16px !important; }
+
+body {
+  font-family: 'Nunito', sans-serif;
+  background: var(--cream);
+  color: var(--text);
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+/* ── Background blobs ── */
+body::before {
+  content:'';
+  position:fixed; inset:0; z-index:0; pointer-events:none;
+  background:
+    radial-gradient(ellipse 600px 400px at 10% 20%, rgba(242,168,184,0.18) 0%, transparent 70%),
+    radial-gradient(ellipse 500px 350px at 85% 70%, rgba(181,213,197,0.14) 0%, transparent 70%),
+    radial-gradient(ellipse 400px 300px at 50% 50%, rgba(201,184,232,0.10) 0%, transparent 70%);
+}
+
+.app { position:relative; z-index:1; max-width:1100px; margin:0 auto; padding:var(--sp-16) var(--sp-20) 60px; overflow-x:hidden; }
+
+/* ── Header ── */
+.header {
+  display:flex; align-items:center; gap:var(--sp-24);
+  background:var(--white); border-radius:var(--r-2xl);
+  padding:var(--sp-16) var(--sp-24); margin-bottom:var(--sp-12);
+  box-shadow:0 4px 24px var(--shadow);
+  position:relative; overflow:hidden;
+}
+.header::before {
+  content:'';
+  position:absolute; top:0; left:0; right:0; height:4px;
+  background: linear-gradient(90deg, var(--rose), var(--peach), var(--sage), var(--lavender));
+}
+
+.avatar-wrap { position:relative; flex-shrink:0; cursor:pointer; }
+.avatar {
+  width:72px; height:88px; border-radius:var(--r-xl);
+  object-fit:cover;
+  border:2.5px solid var(--rose-light);
+  box-shadow:0 4px 16px rgba(242,168,184,0.3);
+  background: linear-gradient(135deg, var(--rose-light), var(--peach-light));
+  display:flex; align-items:center; justify-content:center;
+  font-size:var(--fs-3xl); overflow:hidden;
+}
+.avatar img { width:100%; height:100%; object-fit:cover; border-radius:var(--r-xl); }
+.avatar-edit {
+  position:absolute; bottom:-2px; right:-2px;
+  width:24px; height:24px; border-radius:50%;
+  background:#b0485e; color:white;
+  display:flex; align-items:center; justify-content:center;
+  font-size:var(--icon-xs); box-shadow:0 2px 6px rgba(0,0,0,0.15);
+  cursor:pointer;
+}
+#avatarInput { display:none; }
+
+.header-info { flex:1; }
+
+.header-info h1 {
+  font-family:'Fraunces', serif;
+  font-size:var(--fs-3xl); font-weight:600; color:var(--text);
+  letter-spacing:-0.02em;
+}
+.header-info h1 span { font-style:italic; color:var(--tc-rose); }
+.header-info p { color:var(--mid); font-size:var(--fs-base); margin-top:var(--sp-2); }
+
+/* ── Grid ── */
+.grid { display:grid; grid-template-columns:1fr 1fr; gap:var(--sp-20); min-width:0; }
+.col-full { grid-column:1/-1; min-width:0; }
+.col-half { min-width:0; }
+/* Section spacing: hero breathing room */
+.card-hero { margin-bottom:var(--section-gap-hero); }
+/* Section spacing: zone labels get extra top margin */
+.home-section-label.sec-t1 + .home-section-label,
+.home-section-label.sec-t2 + .home-section-label,
+.home-section-label.sec-t3 + .home-section-label { margin-top:var(--section-gap-zone); }
+
+/* ── Cards ── */
+.card {
+  background:var(--white); border-radius:var(--r-2xl);
+  padding:var(--sp-16);
+  box-shadow:0 4px 20px var(--shadow);
+  animation: fadeUp 0.5s ease both;
+  min-width:0; overflow:hidden;
+}
+.card.card-overflow-visible { overflow:visible; }
+@media(min-width:500px) {
+  .card { padding:var(--sp-20) var(--sp-24); }
+}
+@keyframes fadeUp {
+  from { opacity:0; transform:translateY(16px); }
+  to   { opacity:1; transform:translateY(0); }
+}
+.card:nth-child(1) { animation-delay:0.05s; }
+.card:nth-child(2) { animation-delay:0.10s; }
+.card:nth-child(3) { animation-delay:0.15s; }
+.card:nth-child(4) { animation-delay:0.20s; }
+.card:nth-child(5) { animation-delay:0.25s; }
+
+.card-header {
+  display:flex; align-items:center; justify-content:space-between;
+  margin-bottom:var(--sp-12); flex-wrap:wrap; gap:var(--sp-8);
+}
+.card-title {
+  font-family:'Fraunces', serif;
+  font-size:var(--fs-md); font-weight:600; color:var(--text);
+  display:flex; align-items:center; gap:var(--sp-8);
+}
+.card-title .icon {
+  width:30px; height:30px; border-radius:var(--r-md);
+  display:flex; align-items:center; justify-content:center;
+  font-size:var(--icon-md);
+}
+/* SVG icon inside .icon container — inherits color from parent */
+.card-title .icon svg.zi,
+.icon svg.zi { width:60%; height:60%; }
+.tab-icon svg.zi { width:20px; height:20px; }
+.tsb-icon svg.zi { width:14px; height:14px; }
+/* Category card and large icon contexts */
+.ms-cat-icon svg.zi { width:22px; height:22px; }
+.upc-icon svg.zi { width:22px; height:22px; }
+.fc-icon svg.zi { width:18px; height:18px; }
+.tc-icon svg.zi { width:18px; height:18px; }
+.act-cat-icon svg.zi { width:22px; height:22px; }
+.ql-option-icon svg.zi { width:24px; height:24px; }
+.plan-icon svg.zi { width:18px; height:18px; }
+.reco-icon svg.zi { width:18px; height:18px; }
+.tip-icon svg.zi { width:18px; height:18px; }
+.dark-toggle svg.zi { width:20px; height:20px; }
+.home-fab svg.zi { width:22px; height:22px; }
+/* Inline SVG icons in rendered content */
+svg.zi { width:16px; height:16px; vertical-align:-2px; flex-shrink:0; }
+.icon-rose   { background:var(--rose-light); color:var(--tc-rose); }
+.icon-peach  { background:var(--peach-light); color:var(--tc-caution); }
+.icon-sage   { background:var(--sage-light); color:var(--tc-sage); }
+.icon-lav    { background:var(--lav-light); color:var(--tc-lav); }
+.icon-sky    { background:var(--sky-light); color:var(--tc-sky); }
+.icon-indigo { background:var(--indigo-light); color:var(--tc-indigo); }
+.icon-amber  { background:var(--amber-light); color:var(--tc-amber); }
+.icon-mint   { background:var(--sage-light); color:var(--tc-sage); }
+
+/* ── Buttons ── */
+.btn {
+  font-family:'Nunito', sans-serif;
+  font-size:var(--fs-base); font-weight:700;
+  padding:var(--sp-10) var(--sp-16); border-radius:var(--r-2xl); border:none;
+  cursor:pointer; transition:all var(--ease-fast);
+  letter-spacing:var(--ls-normal); min-height:40px;
+  display:inline-flex; align-items:center; justify-content:center;
+}
+.btn-rose   { background:#b0485e; color:white; }
+.btn-sage   { background:var(--accent-sage-deep); color:white; }
+.btn-peach  { background:#966525; color:white; }
+.btn-lav    { background:#7e66b4; color:white; }
+.btn-sky    { background:#3a7a8a; color:white; }
+.btn-indigo { background:#5a6498; color:white; }
+.btn:hover  { filter:brightness(1.05); transform:translateY(-1px); }
+.btn-ghost  { background:transparent; border:1.5px solid var(--light); color:var(--mid); }
+.btn-ghost:hover { border-color:var(--rose); color:var(--rose); background:var(--rose-light); }
+.btn-compact { font-size:var(--fs-sm); padding:var(--sp-6) var(--sp-12); min-height:32px; border-radius:var(--r-xl); }
+
+/* ── Growth ── */
+.growth-row.growth-row:not(.header-row):hover { background:var(--blush); }
+.growth-row:last-child:not(.header-row) { background:var(--rose-light); font-weight:600; }
+.del-btn { background:none; border:1.5px solid transparent; border-radius:var(--r-md); cursor:pointer; color:var(--light); font-size:var(--icon-base); min-width:44px; min-height:44px; display:flex; align-items:center; justify-content:center; transition:all var(--ease-fast); }
+.del-btn:hover { color:var(--tc-danger); border-color:var(--rose); background:var(--rose-light); }
+
+.chart-wrap { height:200px; margin-top:var(--sp-16); }
+
+.chart-filter-btn {
+  padding:var(--sp-10) var(--sp-16); border-radius:var(--r-2xl); border:1.5px solid var(--light);
+  background:var(--card-bg); color:var(--mid); font-family:'Nunito',sans-serif;
+  font-size:var(--fs-sm); font-weight:700; cursor:pointer; transition:all var(--ease-fast);
+  min-height:40px; display:inline-flex; align-items:center;
+}
+.chart-filter-btn:hover { border-color:var(--rose); color:var(--rose); }
+.chart-filter-btn.active { background:#b0485e; color:white; border-color:#b0485e; }
+.chart-filter-btn.active-india { background:#a85a00; color:white; border-color:#a85a00; }
+.chart-filter-btn.active-both { background:#7e66b4; color:white; border-color:#7e66b4; }
+
+.chart-zoom-row { display:flex; gap:var(--sp-8); margin-bottom:var(--sp-10); flex-wrap:wrap; align-items:center; }
+.chart-zoom-label { font-size:var(--fs-xs); font-weight:600; color:var(--light); text-transform:uppercase; letter-spacing:var(--ls-normal); margin-right:var(--sp-2); }
+.czoom-btn {
+  padding:var(--sp-4) var(--sp-10); border-radius:var(--r-full); border:1.5px solid var(--light);
+  background:var(--card-bg); color:var(--mid); font-family:'Nunito',sans-serif;
+  font-size:var(--fs-xs); font-weight:600; cursor:pointer; transition:all var(--ease-fast);
+}
+.czoom-btn:hover { border-color:var(--rose); color:var(--rose); }
+.czoom-btn.active { background:var(--rose); color:white; border-color:var(--rose); }
+.czoom-btn.active-sky { background:var(--tc-sky); color:white; border-color:var(--tc-sky); }
+[data-theme="dark"] .czoom-btn { background:var(--surface); border-color:var(--light); color:var(--mid); }
+[data-theme="dark"] .czoom-btn.active { background:rgba(224,144,168,0.18); color:var(--tc-rose); border-color:rgba(224,144,168,0.35); }
+[data-theme="dark"] .czoom-btn.active-sky { background:rgba(168,207,224,0.18); color:var(--tc-sky); border-color:rgba(168,207,224,0.35); }
+
+.percentile-badges { display:flex; gap:var(--sp-8); margin-top:var(--sp-12); min-width:0; flex-wrap:wrap;}
+.pbadge {
+  flex:1; text-align:center; padding:var(--sp-10) var(--sp-6);
+  border-radius:var(--r-xl); border:1.5px solid transparent;
+  transition:all var(--ease-fast); min-width:0; overflow:hidden;
+}
+.pbadge-icon { font-size:var(--icon-md); margin-bottom:var(--sp-2); }
+.pbadge-val { font-family:'Fraunces', serif; font-size:var(--fs-md); font-weight:600; word-break:break-word; }
+.pbadge-label { font-size:var(--fs-2xs); color:var(--mid); text-transform:uppercase; letter-spacing:var(--ls-tight); line-height:var(--lh-tight); }
+.pbadge.pb-rose    { background:var(--blush); border-color:rgba(242,168,184,0.3); }
+.pbadge.pb-rose .pbadge-val { color:var(--tc-rose); }
+.pbadge.pb-sky     { background:var(--sky-light); border-color:rgba(168,207,224,0.3); }
+.pbadge.pb-sky .pbadge-val { color:var(--tc-sky); }
+.pbadge.pb-sage    { background:var(--sage-light); border-color:rgba(181,213,197,0.3); }
+.pbadge.pb-sage .pbadge-val { color:var(--tc-sage); }
+.pbadge.pb-lav     { background:var(--lav-light); border-color:rgba(201,184,232,0.3); }
+.pbadge.pb-lav .pbadge-val { color:var(--tc-lav); }
+
+/* ── Growth Hero Card ── */
+.growth-hero { display:flex; flex-direction:column; gap:var(--sp-12); }
+.gh-gauges { display:flex; gap:var(--sp-12); justify-content:center; min-width:0; flex-wrap:wrap;}
+.gh-gauge {
+  display:flex; flex-direction:column; align-items:center; flex:1;
+  position:relative; padding:var(--sp-8) 0;
+}
+.gh-gauge-ring {
+  width:100px; height:100px; border-radius:50%; position:relative;
+  display:flex; align-items:center; justify-content:center;
+  cursor:pointer; transition:transform var(--ease-fast);
+}
+.gh-gauge-ring:active { transform:scale(0.95); }
+.gh-gauge-ring svg { position:absolute; inset:0; width:100%; height:100%; transform:rotate(-90deg); }
+.gh-gauge-ring svg circle { fill:none; stroke-width:6; stroke-linecap:round; }
+.gh-gauge-ring svg .gh-track { stroke:var(--border-subtle); opacity:0.4; }
+.gh-gauge-ring svg .gh-fill { transition:stroke-dashoffset 0.8s ease; }
+.gh-gauge-inner {
+  display:flex; flex-direction:column; align-items:center; justify-content:center;
+  z-index:1; position:relative;
+}
+.gh-gauge-val { font-family:'Fraunces',serif; font-size:var(--fs-xl); font-weight:600; line-height:var(--lh-none); }
+.gh-gauge-unit { font-size:var(--fs-2xs); font-weight:600; color:var(--mid); text-transform:uppercase; letter-spacing:var(--ls-tight); margin-top:1px; }
+.gh-gauge-pct { font-size:var(--fs-sm); font-weight:600; margin-top:var(--sp-2); padding:var(--sp-2) var(--sp-8); border-radius:var(--r-full); }
+.gh-gauge-label { font-size:var(--fs-xs); font-weight:600; color:var(--text); text-transform:uppercase; letter-spacing:var(--ls-tight); margin-top:var(--sp-6); }
+.gh-gauge-sub { font-size:var(--fs-xs); color:var(--mid); margin-top:1px; }
+.gh-meta-row { display:flex; gap:var(--sp-8); min-width:0; flex-wrap:wrap;}
+.gh-meta-pill {
+  flex:1; display:flex; align-items:center; gap:var(--sp-8);
+  padding:var(--sp-8) var(--sp-10); border-radius:var(--r-lg);
+  border:1px solid var(--border-subtle); background:var(--white);
+  cursor:pointer; transition:all var(--ease-fast);
+}
+.gh-meta-pill:active { transform:scale(0.97); }
+.gh-meta-icon { font-size:var(--icon-sm); flex-shrink:0; }
+.gh-meta-text { min-width:0; }
+.gh-meta-val { font-family:'Fraunces',serif; font-size:var(--fs-base); font-weight:600; color:var(--text); }
+.gh-meta-label { font-size:var(--fs-2xs); color:var(--mid); text-transform:uppercase; letter-spacing:var(--ls-tight); }
+
+/* ── Feeding Diary ── */
+.date-nav { display:flex; align-items:center; gap:var(--sp-8); flex-wrap:wrap; }
+.date-nav button { background:none; border:none; cursor:pointer; color:var(--mid); font-size:var(--icon-md); padding:var(--sp-6) var(--sp-10); border-radius:var(--r-md); min-width:44px; min-height:44px; display:flex; align-items:center; justify-content:center; }
+.date-nav button:hover { background:var(--blush); color:var(--tc-rose); }
+.date-nav input[type=date] {
+  font-family:'Nunito', sans-serif; font-size:var(--fs-base);
+  border:1.5px solid var(--rose-light); border-radius:var(--r-lg);
+  padding:var(--sp-6) var(--sp-10); background:var(--blush); color:var(--text); outline:none;
+}
+
+.meal-cards { display:flex; flex-direction:column; gap:var(--sp-8); margin-top:var(--sp-12); }
+.meal-card {
+  border-radius:var(--r-xl); padding:var(--sp-12) var(--sp-12);
+  border:1.5px solid transparent;
+  overflow:visible;
+}
+/* F-6a: the legacy .meal-card markup is retired (replaced by composer
+   .fc-card mounts). These rules are dead; the rgba domain borders are
+   replaced with domain accent tokens (HR-5) in case any reference survives. */
+.meal-card.breakfast { background:var(--peach-light); border-color:var(--peach); }
+.meal-card.lunch     { background:var(--sage-light);  border-color:var(--sage); }
+.meal-card.dinner    { background:var(--lav-light);   border-color:var(--lavender); }
+.meal-card.snack     { background:var(--amber-light); border-color:var(--amber); }
+
+.meal-label { font-size:var(--fs-sm); font-weight:600; text-transform:uppercase; letter-spacing:var(--ls-wide); color:var(--mid); margin-bottom:var(--sp-6); display:flex; align-items:center; gap:var(--sp-8); }
+.meal-time-input {
+  margin-left:auto; width:90px; padding:var(--sp-2) var(--sp-6);
+  border:1px solid var(--border-subtle); border-radius:var(--r-md);
+  font-family:'Nunito',sans-serif; font-size:var(--fs-xs); font-weight:500;
+  color:var(--mid); background:transparent; outline:none;
+  text-transform:none; letter-spacing:0;
+}
+.meal-time-input:focus { border-color:var(--tc-peach); color:var(--text); }
+[data-theme="dark"] .meal-time-input { border-color:rgba(255,255,255,0.1); color:var(--mid); }
+[data-theme="dark"] .meal-time-input:focus { border-color:var(--tc-peach); color:var(--text); }
+.meal-skip-btn { font-size:var(--fs-xs); font-weight:500; color:var(--light); text-transform:none; letter-spacing:normal; cursor:pointer; padding:var(--sp-4) var(--sp-8); border-radius:var(--r-md); background:var(--surface); border:1px solid var(--border-subtle); transition:all var(--ease-fast); margin-left:auto; }
+.meal-skip-btn:hover { background:var(--peach-light); color:var(--tc-caution); }
+.meal-skip-btn.skipped { background:var(--peach-light); color:var(--tc-caution); cursor:pointer; }
+
+/* ── Meal autocomplete ── */
+
+.meal-input-wrap { position:relative; z-index:30; }
+.meal-input-wrap .meal-input {
+  width:100%; padding:var(--sp-8) var(--sp-12); border-radius:var(--r-lg); border:none;
+  font-family:'Nunito',sans-serif; font-size:var(--fs-base);
+  background:var(--glass-strong); color:var(--text); outline:none;
+}
+.meal-input-wrap .meal-input:focus { box-shadow:0 0 0 2px var(--rose-light); }
+.meal-dropdown {
+  position:absolute; left:0; right:0; top:100%; z-index:50;
+  background:var(--card-bg); border-radius:0 0 var(--r-lg) var(--r-lg);
+  border:1.5px solid var(--rose-light); border-top:none;
+  box-shadow:0 8px 24px rgba(180,120,120,0.15);
+  max-height:200px; overflow-y:auto; display:none;
+}
+.meal-dropdown.open { display:block; }
+.meal-card:has(.meal-dropdown.open) { z-index:10; position:relative; }
+.meal-dd-cat {
+  font-size:var(--fs-sm); font-weight:600; text-transform:uppercase;
+  letter-spacing:var(--ls-wide); color:var(--light); padding:var(--sp-6) var(--sp-10) var(--sp-2);
+}
+.meal-dd-item {
+  font-size:var(--fs-base); padding:var(--sp-6) var(--sp-12); cursor:pointer;
+  color:var(--text); transition:background var(--ease-fast);
+}
+.meal-dd-item:hover { background:var(--rose-light); color:var(--tc-rose); }
+.meal-dd-item:last-child { border-radius:0 0 10px 10px; }
+.meal-dd-add {
+  font-size:var(--fs-base); padding:var(--sp-8) var(--sp-12); cursor:pointer;
+  color:var(--sage); font-weight:700; border-top:1px solid var(--rose-light);
+  display:flex; align-items:center; gap:var(--sp-8);
+  transition:background var(--ease-fast);
+}
+.meal-dd-add:hover { background:var(--sage-light); }
+.meal-dd-empty { font-size:var(--fs-base); font-weight:400; color:var(--light); padding:var(--sp-12) var(--sp-12); text-align:center; }
+
+/* ── Feeding History ── */
+.history-entries { display:flex; flex-direction:column; gap:var(--sp-8); }
+.history-month {
+  border-radius:var(--r-xl); overflow:hidden; min-width:0;
+}
+.history-month-header {
+  display:flex; align-items:center; gap:var(--sp-8); cursor:pointer;
+  padding:var(--sp-12) var(--sp-16); border-radius:var(--r-xl);
+  background:linear-gradient(135deg,var(--peach-light),var(--warm));
+  border:1.5px solid rgba(250,212,180,0.4);
+  transition:all var(--ease-fast); min-width:0;
+}
+.history-month-header:hover { filter:brightness(0.97); }
+.history-month.expanded .history-month-header { border-radius:var(--r-xl) var(--r-xl) 0 0; }
+.hm-icon { font-size:var(--icon-md); }
+.hm-info { flex:1; }
+.hm-name { font-weight:600; font-size:var(--fs-md); color:var(--text); }
+.hm-count { font-size:var(--fs-base); font-weight:400; color:var(--mid); }
+.hm-chevron { font-size:var(--icon-xs); color:var(--light); transition:transform var(--ease-fast); }
+.history-month.expanded .hm-chevron { transform:rotate(180deg); }
+.hm-days {
+  display:none; padding:var(--sp-8) var(--sp-10) var(--sp-10);
+  border:1.5px solid rgba(250,212,180,0.4); border-top:none;
+  border-radius:0 0 var(--r-xl) var(--r-xl);
+  background:rgba(254,246,240,0.3);
+  flex-direction:column; gap:var(--sp-8);
+  min-width:0; overflow:hidden;
+}
+.history-month.expanded .hm-days { display:flex; }
+.history-day-header {
+  display:flex; align-items:center; gap:var(--sp-8); cursor:pointer;
+  padding:var(--sp-8) var(--sp-10); border-radius:var(--r-lg);
+  background:var(--warm); border-left:var(--accent-w) solid var(--peach);
+  transition:all var(--ease-fast); min-width:0; overflow:hidden;
+}
+.history-day-header:hover { filter:brightness(0.97); }
+.hd-date { flex-shrink:0; font-weight:600; font-size:var(--fs-md); color:var(--tc-rose); }
+.hd-summary { flex:1; font-size:var(--fs-base); font-weight:400; color:var(--mid); min-width:0; }
+.hd-chevron { flex-shrink:0; font-size:var(--icon-xs); color:var(--light); transition:transform var(--ease-fast); }
+.history-day.expanded .hd-chevron { transform:rotate(180deg); }
+.history-day.expanded .history-day-header { background:var(--peach-light); }
+.hd-content {
+  display:none; padding:var(--sp-8) var(--sp-12); margin-top:-var(--sp-2);
+  border-radius:0 0 10px 10px;
+  background:var(--warm); border-left:var(--accent-w) solid var(--peach);
+  font-size:var(--fs-base); overflow-wrap:break-word; word-break:break-word;
+}
+.history-day.expanded .hd-content { display:block; }
+.history-meal-insight {
+  font-size:var(--fs-base); font-weight:400; color:var(--mid); line-height:var(--lh-normal);
+  padding:var(--sp-4) var(--sp-8); margin-top:var(--sp-4);
+  border-radius:var(--r-md); background:var(--glass);
+  border-left:var(--accent-w) solid var(--peach);
+  display:flex; align-items:flex-start; gap:var(--sp-4);
+  overflow-wrap:break-word; word-break:break-word;
+}
+.history-meal-insight .hmi-icon { flex-shrink:0; font-size:var(--icon-xs); margin-top:1px; }
+
+/* ── Food Categories ── */
+.food-cats { display:grid; grid-template-columns:1fr 1fr 1fr; gap:var(--sp-8); }
+@media(max-width:700px) { .food-cats { grid-template-columns:1fr; } }
+@media(max-width:400px) { .food-cats { grid-template-columns:1fr; } }
+.food-cat-card {
+  border-radius:var(--r-lg); padding:var(--sp-12) var(--sp-12); cursor:pointer;
+  transition:all var(--ease-fast); border:1.5px solid transparent; text-align:center;
+}
+.food-cat-card:hover { filter:brightness(0.96); }
+.food-cat-card.expanded { border-radius:var(--r-lg) var(--r-lg) 0 0; }
+.food-cat-card.fc-grains   { background:rgba(181,213,197,0.2); border-color:rgba(181,213,197,0.4); }
+.food-cat-card.fc-fruits   { background:rgba(242,168,184,0.15); border-color:rgba(242,168,184,0.3); }
+.food-cat-card.fc-vegs     { background:rgba(250,212,180,0.2); border-color:rgba(250,212,180,0.4); }
+.food-cat-card.fc-dairy    { background:rgba(168,207,224,0.2); border-color:rgba(168,207,224,0.4); }
+.food-cat-card.fc-nuts     { background:rgba(201,184,232,0.2); border-color:rgba(201,184,232,0.4); }
+.food-cat-card.fc-spices   { background:rgba(232,184,109,0.15); border-color:rgba(232,184,109,0.3); }
+.food-cat-card.fc-nonveg   { background:rgba(242,168,184,0.25); border-color:rgba(242,168,184,0.4); }
+.fc-icon { font-size:var(--icon-md); }
+.fc-name { font-size:var(--fs-md); font-weight:600; color:var(--text); margin-top:var(--sp-2); }
+.fc-count { font-size:var(--fs-xs); color:var(--mid); }
+.fc-chevron { font-size:var(--icon-xs); color:var(--light); transition:transform var(--ease-fast); display:inline-block; }
+.food-cat-card.expanded .fc-chevron { transform:rotate(180deg); }
+.fc-items {
+  display:none; padding:var(--sp-8) var(--sp-10) var(--sp-10);
+  border-radius:0 0 var(--r-lg) var(--r-lg); border:1.5px solid transparent; border-top:none; margin-top:-1px;
+  overflow:hidden; min-width:0;
+}
+.fc-items.fc-grains { background:rgba(181,213,197,0.08); border-color:rgba(181,213,197,0.4); }
+.fc-items.fc-fruits { background:rgba(242,168,184,0.06); border-color:rgba(242,168,184,0.3); }
+.fc-items.fc-vegs   { background:rgba(250,212,180,0.08); border-color:rgba(250,212,180,0.4); }
+.fc-items.fc-dairy  { background:rgba(168,207,224,0.08); border-color:rgba(168,207,224,0.4); }
+.fc-items.fc-nuts   { background:rgba(201,184,232,0.08); border-color:rgba(201,184,232,0.4); }
+.fc-items.fc-spices { background:rgba(232,184,109,0.06); border-color:rgba(232,184,109,0.3); }
+.fc-items.fc-nonveg { background:rgba(242,168,184,0.1); border-color:rgba(242,168,184,0.4); }
+.fc-items.open { display:block; }
+.fc-items .foods-grid { display:flex; flex-wrap:wrap; gap:var(--sp-4); }
+
+/* ── Food date tag ── */
+.food-tag-name { font-weight:400; font-size:var(--fs-base); white-space:nowrap; }
+.food-tag-date { font-size:var(--fs-xs); opacity:0.6; font-weight:400; display:none; }
+.food-tag-top { display:flex; align-items:center; gap:var(--sp-4); }
+
+/* ── Food frequency badge ── */
+.freq-badge {
+  font-size:var(--fs-sm); font-weight:700; text-transform:uppercase;
+  letter-spacing:var(--ls-normal); padding:var(--sp-2) var(--sp-8); border-radius:var(--r-md);
+  margin-top:var(--sp-4); display:inline-block;
+}
+.freq-high   { background:#d4edda; color:#276138; }
+.freq-medium { background:var(--peach-light); color:var(--tc-warn); }
+.freq-low    { background:var(--rose-light); color:var(--tc-rose); }
+.freq-none   { background:var(--glass); color:var(--light); }
+
+/* ── Meal insights ── */
+.meal-insight {
+  margin-top:var(--sp-6); padding:var(--sp-6) var(--sp-10);
+  border-radius:var(--r-md); background:var(--glass-strong);
+  font-size:var(--fs-base); font-weight:400; color:var(--mid); line-height:var(--lh-relaxed);
+  display:flex; align-items:flex-start; gap:var(--sp-4);
+}
+[data-theme="dark"] .meal-insight { background:rgba(255,255,255,0.06); }
+.meal-insight-icon { flex-shrink:0; font-size:var(--icon-xs); }
+
+/* ── Foods Introduced ── */
+.foods-grid { display:flex; flex-wrap:wrap; gap:var(--sp-8); margin-top:var(--sp-4); }
+.food-tag {
+  display:flex; align-items:center; gap:var(--sp-8);
+  padding:var(--sp-6) var(--sp-12); border-radius:var(--r-2xl);
+  font-size:var(--fs-base); font-weight:600;
+  transition:all var(--ease-fast); cursor:default;
+}
+.food-tag.ok     { background:var(--sage-light);  color:var(--tc-sage); }
+.food-tag.watch  { background:var(--peach-light); color:var(--tc-warn); }
+.food-tag .food-del { background:none; border:none; cursor:pointer; font-size:var(--icon-xs); color:inherit; opacity:0.6; padding:var(--sp-4) var(--sp-6); margin-left:var(--sp-2); min-width:44px; min-height:44px; display:flex; align-items:center; justify-content:center; }
+.food-del:hover { opacity:1; }
+
+.add-food { display:flex; gap:var(--sp-8); margin-top:var(--sp-12); flex-wrap:wrap; align-items:center; }
+.add-food input {
+  flex:1; min-width:120px; padding:var(--sp-8) var(--sp-12); border-radius:var(--r-lg);
+  border:1.5px solid var(--sky-light);
+  font-family:'Nunito', sans-serif; font-size:var(--fs-base);
+  background:var(--sky-light); color:var(--text); outline:none;
+}
+.add-food input:focus { border-color:var(--sky); }
+/* "Can I Give This?" combo card — HR-2 token-driven classes */
+.combo-desc {
+  font-size:var(--fs-base); color:var(--mid);
+  line-height:var(--lh-relaxed); margin-bottom:var(--sp-10);
+}
+.combo-input { flex:1; min-width:180px; }
+.combo-quick-chips {
+  display:flex; flex-wrap:wrap; gap:var(--sp-8);
+  align-items:center; margin-bottom:var(--sp-10);
+}
+.combo-history { margin-top:var(--sp-12); }
+.food-slot-select {
+  padding:var(--sp-8) var(--sp-12); border-radius:var(--r-lg);
+  border:1.5px solid var(--sky-light);
+  font-family:'Nunito', sans-serif; font-size:var(--fs-base);
+  background:var(--sky-light); color:var(--text); outline:none;
+}
+.food-slot-select:focus { border-color:var(--sky); }
+.reaction-toggle { display:flex; gap:var(--sp-4); }
+.rtog { min-height:40px; display:inline-flex; align-items:center; justify-content:center;
+  padding:var(--sp-6) var(--sp-10); border-radius:var(--r-md); border:1.5px solid var(--light);
+  font-size:var(--fs-sm); font-weight:700; cursor:pointer; background:var(--card-bg);
+  transition:all var(--ease-fast);
+}
+.rtog.active-ok    { background:var(--accent-sage-deep); color:white; border-color:var(--accent-sage-deep); }
+.rtog.active-watch { background:var(--border-warn-soft); color:#6b4e00; border-color:var(--border-warn-soft); }
+
+/* ── Vaccination ── */
+.vacc-card {
+  display:flex; align-items:center; gap:var(--sp-16);
+  padding:var(--sp-16); border-radius:var(--r-xl);
+  background: linear-gradient(135deg, var(--lav-light), var(--sky-light));
+  margin-bottom:var(--sp-12);
+}
+.countdown-circle {
+  width:70px; height:70px; border-radius:50%; flex-shrink:0;
+  background:var(--card-bg); display:flex; flex-direction:column;
+  align-items:center; justify-content:center;
+  box-shadow:0 4px 14px rgba(201,184,232,0.3);
+}
+.countdown-num { font-family:'Fraunces', serif; font-size:var(--fs-2xl); font-weight:600; color:var(--tc-lav); line-height:var(--lh-none); }
+.countdown-unit { font-size:var(--fs-base); font-weight:400; text-transform:uppercase; letter-spacing:var(--ls-normal); color:var(--mid); }
+.vacc-info h3 { font-size:var(--fs-lg); font-weight:600; color:var(--text); }
+.vacc-info p { font-size:var(--fs-base); font-weight:400; color:var(--mid); margin-top:var(--sp-2); }
+
+.vacc-log-item:last-child { border:none; }
+
+/* ── Vaccination Intelligence Upgrade CSS ── */
+#vaccOriginalContent {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-16);
+  width: 100%;
+}
+#vaccCompletionOverlay { width: 100%; }
+.vc-hidden { display: none; }
+.vc-complete-card {
+  background: transparent;
+  border-radius: var(--r-xl);
+  padding: var(--sp-4) 0;
+}
+.vc-complete-multi { padding: var(--sp-16) var(--sp-12); }
+.vc-complete-title {
+  font-size: var(--fs-md);
+  font-weight: 700;
+  color: var(--tc-lav);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-6);
+}
+.vc-complete-q {
+  font-size: var(--fs-base);
+  font-weight: 600;
+  color: var(--text);
+  margin-top: var(--sp-10);
+}
+.vc-complete-actions {
+  display: flex;
+  gap: var(--sp-8);
+  margin-top: var(--sp-12);
+  flex-wrap: wrap;
+}
+.vc-complete-checks {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-6);
+  margin-top: var(--sp-8);
+}
+.vc-complete-check {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-8);
+  font-size: var(--fs-base);
+  color: var(--text);
+  padding: var(--sp-6) var(--sp-10);
+  border-radius: var(--r-lg);
+  background: var(--glass);
+  cursor: pointer;
+  user-select: none;
+}
+.vc-complete-check.checked { background: rgba(110,94,154,0.1); }
+.vc-check-input { accent-color: var(--tc-lav); width: var(--sp-16); height: var(--sp-16); }
+
+/* Delay card */
+.vc-delay-card {
+  background: transparent;
+  border-radius: var(--r-xl);
+  padding: var(--sp-4) 0;
+}
+.vc-delay-q {
+  font-size: var(--fs-base);
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: var(--sp-8);
+}
+.vc-delay-reasons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-10);
+}
+.vc-delay-chip {
+  padding: var(--sp-10) var(--sp-20);
+  border-radius: var(--r-full);
+  border: 2px solid rgba(110,94,154,0.3);
+  background: var(--glass);
+  font-size: var(--fs-sm);
+  color: var(--text);
+  cursor: pointer;
+  transition: background var(--ease-fast), border-color var(--ease-fast);
+}
+.vc-delay-chip:hover, .vc-delay-chip.active {
+  background: rgba(110,94,154,0.15);
+  border-color: var(--tc-lav);
+  color: var(--tc-lav);
+  font-weight: 600;
+}
+.vc-delay-assessment {
+  border-radius: var(--r-lg);
+  padding: var(--sp-12);
+  margin-top: var(--sp-8);
+}
+.vc-assess-safe { background: var(--sage-light); border-left: 3px solid var(--tc-sage); }
+.vc-assess-warn { background: var(--amber-light); border-left: 3px solid var(--tc-amber); }
+.vc-assess-danger { background: var(--rose-light); border-left: 3px solid var(--tc-danger); }
+.vc-assess-header {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-6);
+  font-size: var(--fs-sm);
+  font-weight: 700;
+}
+.vc-assess-safe .vc-assess-header { color: var(--tc-sage); }
+.vc-assess-warn .vc-assess-header { color: var(--tc-amber); }
+.vc-assess-danger .vc-assess-header { color: var(--tc-danger); }
+
+/* Reaction modal */
+.vc-reaction-modal { max-width: 420px; position: relative; }
+.vc-reaction-modal > .ql-modal-close {
+  position: absolute;
+  top: var(--sp-12);
+  right: var(--sp-12);
+  z-index: 1;
+}
+.vc-reaction-severity {
+  display: flex;
+  gap: var(--sp-8);
+  margin-top: var(--sp-8);
+}
+.vc-severity-chip {
+  flex: 1;
+  text-align: center;
+  padding: var(--sp-10) var(--sp-4);
+  border-radius: var(--r-xl);
+  border: 2px solid rgba(110,94,154,0.2);
+  background: var(--glass);
+  font-size: var(--fs-sm);
+  color: var(--text);
+  cursor: pointer;
+  font-weight: 500;
+  transition: all var(--ease-fast);
+}
+.vc-severity-chip[data-arg="none"] { border-color: rgba(58,112,96,0.25); background: rgba(58,112,96,0.06); color: var(--tc-sage); }
+.vc-severity-chip[data-arg="mild"] { border-color: rgba(138,101,32,0.25); background: rgba(138,101,32,0.06); color: var(--tc-amber); }
+.vc-severity-chip[data-arg="moderate"] { border-color: rgba(135,90,32,0.25); background: rgba(135,90,32,0.06); color: var(--tc-caution); }
+.vc-severity-chip[data-arg="severe"] { border-color: rgba(158,62,82,0.25); background: rgba(158,62,82,0.06); color: var(--tc-danger); }
+.vc-severity-chip.active {
+  font-weight: 700;
+}
+.vc-severity-chip[data-arg="none"].active {
+  background: var(--sage-light);
+  border-color: var(--tc-sage);
+  color: var(--tc-sage);
+}
+.vc-severity-chip[data-arg="mild"].active {
+  background: var(--amber-light);
+  border-color: var(--tc-amber);
+  color: var(--tc-amber);
+}
+.vc-severity-chip[data-arg="moderate"].active {
+  background: var(--peach-light);
+  border-color: var(--tc-caution);
+  color: var(--tc-caution);
+}
+.vc-severity-chip[data-arg="severe"].active {
+  background: var(--rose-light);
+  border-color: var(--tc-danger);
+  color: var(--tc-danger);
+}
+.vc-symptom-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-10);
+  margin-top: var(--sp-8);
+}
+.vc-symptom-chip {
+  padding: var(--sp-8) var(--sp-12);
+  border-radius: var(--r-full);
+  border: 1.5px solid rgba(110,94,154,0.3);
+  background: var(--glass);
+  font-size: var(--fs-xs);
+  color: var(--mid);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  transition: all var(--ease-fast);
+}
+.vc-symptom-chip.active {
+  background: var(--lav-light);
+  border-color: var(--tc-lav);
+  color: var(--tc-lav);
+  font-weight: 600;
+}
+.vc-temp-row, .vc-cry-row {
+  display: flex;
+  gap: var(--sp-10);
+  flex-wrap: wrap;
+  margin-top: var(--sp-8);
+}
+.vc-temp-chip, .vc-cry-chip {
+  padding: var(--sp-8) var(--sp-12);
+  border-radius: var(--r-full);
+  border: 1.5px solid rgba(110,94,154,0.3);
+  background: var(--glass);
+  font-size: var(--fs-xs);
+  color: var(--mid);
+  cursor: pointer;
+  transition: all var(--ease-fast);
+}
+.vc-temp-chip.active, .vc-cry-chip.active {
+  background: var(--lav-light);
+  border-color: var(--tc-lav);
+  color: var(--tc-lav);
+  font-weight: 600;
+}
+.vc-severe-alert {
+  margin-top: var(--sp-10);
+  padding: var(--sp-12);
+  background: var(--rose-light);
+  border-radius: var(--r-lg);
+  border-left: 3px solid var(--tc-danger);
+}
+.vc-severe-msg {
+  font-size: var(--fs-sm);
+  color: var(--tc-danger);
+  font-weight: 600;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--sp-6);
+}
+.vc-reaction-notes {
+  resize: vertical;
+  min-height: 48px;
+}
+.vc-reaction-details { animation: fadeIn 0.2s ease; }
+
+/* Post-save guidance */
+.vc-guidance-card { padding: var(--sp-4) 0; }
+.vc-guidance-section {
+  margin-top: var(--sp-10);
+  padding: var(--sp-12);
+  border-radius: var(--r-lg);
+  background: var(--lav-light);
+}
+.vc-guidance-warn {
+  background: var(--amber-light);
+}
+.vc-guidance-text {
+  font-size: var(--fs-sm);
+  color: var(--text);
+  margin-top: var(--sp-4);
+  line-height: var(--lh-relaxed);
+}
+
+/* Monitoring card */
+.vc-monitor-card {
+  background: var(--lav-light);
+  border-radius: var(--r-xl);
+  padding: var(--sp-12) var(--sp-16);
+  border: 1.5px solid rgba(110,94,154,0.15);
+  margin-bottom: var(--sp-8);
+}
+.vc-monitor-header {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-6);
+  font-size: var(--fs-base);
+  color: var(--tc-lav);
+}
+.vc-monitor-status { margin-top: var(--sp-8); }
+.vc-monitor-guide { margin-top: var(--sp-6); }
+.vc-monitor-ok {
+  font-size: var(--fs-xs);
+  color: var(--tc-sage);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+}
+.vc-monitor-watch {
+  font-size: var(--fs-xs);
+  color: var(--tc-caution);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  margin-top: var(--sp-4);
+}
+.vc-monitor-actions {
+  display: flex;
+  gap: var(--sp-8);
+  margin-top: var(--sp-10);
+  flex-wrap: wrap;
+}
+.vc-monitor-logged {
+  background: var(--sage-light);
+  border-color: rgba(58,112,96,0.15);
+}
+.vc-monitor-logged .vc-monitor-header { color: var(--tc-sage); }
+
+/* Overdue buttons */
+.vc-overdue-btns {
+  display: flex;
+  gap: var(--sp-6);
+  margin-top: var(--sp-6);
+  flex-shrink: 0;
+}
+.vc-sm-btn {
+  padding: var(--sp-6) var(--sp-12);
+  font-size: var(--fs-xs);
+  white-space: nowrap;
+}
+/* Booked pill (replaces inline styles) */
+.vc-booked-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-8);
+  padding: var(--sp-4) var(--sp-10);
+  border-radius: var(--r-full);
+  background: var(--surface-sage);
+  cursor: pointer;
+}
+.vc-booked-detail { font-size: var(--fs-xs); font-weight: 400; color: var(--mid); }
+.vc-booked-detail-light { font-size: var(--fs-xs); font-weight: 400; color: var(--light); }
+.vc-book-btn { padding: var(--sp-6) var(--sp-16); font-size: var(--fs-xs); }
+
+/* ── Dark mode: Vaccination Upgrade ── */
+[data-theme="dark"] .vc-complete-card { background: var(--surface); border-radius: var(--r-lg); padding: var(--sp-12) var(--sp-16); }
+[data-theme="dark"] .vc-complete-check { background: rgba(255,255,255,0.06); }
+[data-theme="dark"] .vc-complete-check.checked { background: rgba(110,94,154,0.15); }
+[data-theme="dark"] .vc-delay-card { background: transparent; }
+[data-theme="dark"] .vc-delay-chip { background: rgba(255,255,255,0.1); border-color: rgba(110,94,154,0.55); }
+[data-theme="dark"] .vc-delay-chip.active { background: rgba(110,94,154,0.25); border-color: var(--tc-lav); }
+[data-theme="dark"] .vc-assess-safe { background: rgba(58,112,96,0.12); border-color: var(--tc-sage); }
+[data-theme="dark"] .vc-assess-warn { background: rgba(138,101,32,0.12); border-color: var(--tc-amber); }
+[data-theme="dark"] .vc-assess-danger { background: rgba(158,62,82,0.12); border-color: var(--tc-danger); }
+[data-theme="dark"] .vc-severity-chip[data-arg="none"] { background: rgba(58,112,96,0.12); border-color: rgba(58,112,96,0.4); }
+[data-theme="dark"] .vc-severity-chip[data-arg="mild"] { background: rgba(138,101,32,0.12); border-color: rgba(138,101,32,0.4); }
+[data-theme="dark"] .vc-severity-chip[data-arg="moderate"] { background: rgba(135,90,32,0.12); border-color: rgba(135,90,32,0.4); }
+[data-theme="dark"] .vc-severity-chip[data-arg="severe"] { background: rgba(158,62,82,0.12); border-color: rgba(158,62,82,0.4); }
+[data-theme="dark"] .vc-severity-chip[data-arg="none"].active { background: rgba(58,112,96,0.3); border-color: var(--tc-sage); }
+[data-theme="dark"] .vc-severity-chip[data-arg="mild"].active { background: rgba(138,101,32,0.3); border-color: var(--tc-amber); }
+[data-theme="dark"] .vc-severity-chip[data-arg="moderate"].active { background: rgba(135,90,32,0.3); border-color: var(--tc-caution); }
+[data-theme="dark"] .vc-severity-chip[data-arg="severe"].active { background: rgba(158,62,82,0.3); border-color: var(--tc-danger); }
+[data-theme="dark"] .vc-symptom-chip { background: rgba(255,255,255,0.08); border-color: rgba(110,94,154,0.4); }
+[data-theme="dark"] .vc-symptom-chip.active { background: rgba(110,94,154,0.25); border-color: var(--tc-lav); }
+[data-theme="dark"] .vc-temp-chip, [data-theme="dark"] .vc-cry-chip { background: rgba(255,255,255,0.08); border-color: rgba(110,94,154,0.4); }
+[data-theme="dark"] .vc-temp-chip.active, [data-theme="dark"] .vc-cry-chip.active { background: rgba(110,94,154,0.25); border-color: var(--tc-lav); }
+[data-theme="dark"] .vc-severe-alert { background: rgba(158,62,82,0.15); }
+[data-theme="dark"] .vc-guidance-section { background: rgba(110,94,154,0.12); }
+[data-theme="dark"] .vc-guidance-warn { background: rgba(138,101,32,0.12); }
+[data-theme="dark"] .vc-monitor-card { background: rgba(110,94,154,0.1); border-color: rgba(110,94,154,0.2); }
+[data-theme="dark"] .vc-monitor-logged { background: rgba(58,112,96,0.1); border-color: rgba(58,112,96,0.2); }
+[data-theme="dark"] .vc-booked-pill { background: rgba(58,112,96,0.15); }
+
+/* ── Vaccination Timeline ── */
+.vc-timeline {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  padding: var(--sp-8) 0;
+}
+.vc-timeline-scroll {
+  display: flex;
+  gap: var(--sp-4);
+  min-width: max-content;
+}
+.vc-timeline-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 52px;
+  gap: var(--sp-4);
+}
+.vc-timeline-label {
+  font-size: var(--fs-2xs);
+  font-weight: 700;
+  color: var(--tc-lav);
+  text-align: center;
+  white-space: nowrap;
+  padding-bottom: var(--sp-4);
+  border-bottom: 1.5px solid rgba(110,94,154,0.15);
+  width: 100%;
+}
+.vc-timeline-dots {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--sp-4);
+  padding: var(--sp-4) 0;
+}
+.vc-timeline-dot {
+  width: var(--sp-20);
+  height: var(--sp-20);
+  border-radius: var(--r-full);
+  cursor: pointer;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform var(--ease-fast);
+  border: 1.5px solid transparent;
+}
+.vc-timeline-dot:active { transform: scale(1.15); }
+.vc-timeline-dot.vc-dot-none {
+  background: var(--sage-light);
+  border-color: var(--tc-sage);
+}
+.vc-timeline-dot.vc-dot-mild {
+  background: var(--amber-light);
+  border-color: var(--tc-amber);
+}
+.vc-timeline-dot.vc-dot-moderate {
+  background: var(--peach-light);
+  border-color: var(--tc-caution);
+}
+.vc-timeline-dot.vc-dot-severe {
+  background: var(--rose-light);
+  border-color: var(--tc-danger);
+}
+.vc-timeline-dot.vc-dot-upcoming {
+  background: var(--glass);
+  border-color: rgba(110,94,154,0.3);
+  border-style: dashed;
+}
+.vc-timeline-dot.vc-dot-nodata {
+  background: var(--glass);
+  border-color: rgba(150,150,150,0.3);
+}
+.vc-timeline-delay {
+  position: absolute;
+  top: -3px;
+  right: -3px;
+  width: 10px;
+  height: 10px;
+  border-radius: var(--r-full);
+  background: var(--tc-amber);
+  font-size: 6px;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+}
+.vc-legend-dot {
+  width: 10px;
+  height: 10px;
+  display: inline-flex;
+  vertical-align: middle;
+}
+.ml-6 { margin-left: var(--sp-6); }
+
+/* ─── Vaccination timeline — Gantt reshape (PR-K) ─── */
+.vc-gantt { padding: var(--sp-4) 0; }
+.vc-gantt-rows { display: flex; flex-direction: column; }
+.vc-gantt-row { display: flex; gap: var(--sp-10); }
+.vc-gantt-spine {
+  display: flex; flex-direction: column; align-items: center;
+  width: 18px; flex-shrink: 0;
+}
+.vc-gantt-node {
+  width: 16px; height: 16px; border-radius: var(--r-full); flex-shrink: 0;
+  display: flex; align-items: center; justify-content: center;
+  margin-top: var(--sp-2); border: 2px solid var(--tc-lav);
+}
+.vc-gantt-node-done { background: var(--tc-lav); color: var(--white); }
+.vc-gantt-node-done .zi { width: 9px; height: 9px; }
+.vc-gantt-node-pending { background: var(--card-bg); border-style: dashed; }
+.vc-gantt-spine::after {
+  content: ''; flex: 1; width: 2px;
+  background: rgba(110,94,154,0.2); margin: var(--sp-2) 0;
+}
+.vc-gantt-row:last-child .vc-gantt-spine::after { display: none; }
+.vc-gantt-rowbody { flex: 1; min-width: 0; padding-bottom: var(--sp-16); }
+.vc-gantt-age {
+  font-size: var(--fs-2xs); font-weight: 700; color: var(--tc-lav);
+  text-transform: uppercase; letter-spacing: 0.03em; margin-bottom: var(--sp-6);
+}
+.vc-gantt-chips { display: flex; flex-wrap: wrap; gap: var(--sp-6); }
+.vc-gantt-chip {
+  display: inline-flex; align-items: center; gap: var(--sp-6);
+  padding: var(--sp-4) var(--sp-10); border-radius: var(--r-full);
+  border: 1px solid var(--card-border); background: var(--card-bg);
+  font-size: var(--fs-xs); font-weight: 600; color: var(--text);
+  cursor: pointer; position: relative;
+  transition: transform var(--ease-fast);
+}
+.vc-gantt-chip:active { transform: scale(0.96); }
+.vc-timeline-dot.vc-gantt-chipdot { width: 12px; height: 12px; }
+.vc-gantt-chip-name { white-space: nowrap; }
+.vc-gantt-delay {
+  width: 12px; height: 12px; border-radius: var(--r-full);
+  background: var(--tc-amber); color: #fff; font-size: 7px; font-weight: 700;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+[data-theme="dark"] .vc-gantt-chip { background: var(--surface); border-color: rgba(255,255,255,0.1); }
+[data-theme="dark"] .vc-gantt-spine::after { background: rgba(184,168,224,0.25); }
+
+.vc-timeline-detail {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--warm);
+  border-radius: var(--r-xl) var(--r-xl) 0 0;
+  padding: var(--sp-16) var(--sp-20);
+  box-shadow: 0 -4px 24px rgba(0,0,0,0.12);
+  z-index: 999;
+  animation: fadeIn 0.2s ease;
+}
+.vc-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--sp-8);
+}
+.vc-detail-name {
+  font-size: var(--fs-md);
+  font-weight: 700;
+  color: var(--tc-lav);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-6);
+}
+.vc-detail-date {
+  font-size: var(--fs-sm);
+  color: var(--mid);
+  margin-top: var(--sp-4);
+}
+.vc-detail-reaction {
+  margin-top: var(--sp-8);
+  padding: var(--sp-10);
+  border-radius: var(--r-lg);
+  background: var(--glass);
+}
+.vc-detail-actions {
+  display: flex;
+  gap: var(--sp-8);
+  margin-top: var(--sp-12);
+}
+
+/* Reaction badge on past list */
+.vc-past-item {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-8);
+  padding: var(--sp-6) var(--sp-8);
+  border-radius: var(--r-lg);
+  background: var(--surface-lav);
+  border-left: var(--accent-w) solid var(--lavender);
+}
+.vc-past-icon {
+  width: var(--sp-24);
+  height: var(--sp-24);
+  border-radius: var(--r-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.vc-reaction-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-4);
+  padding: var(--sp-4) var(--sp-8);
+  border-radius: var(--r-full);
+  font-size: var(--fs-2xs);
+  font-weight: 600;
+  cursor: pointer;
+}
+.vc-reaction-badge svg.zi { width: 12px; height: 12px; }
+.vc-badge-none {
+  background: var(--sage-light);
+  color: var(--tc-sage);
+}
+.vc-badge-mild {
+  background: var(--amber-light);
+  color: var(--tc-amber);
+}
+.vc-badge-moderate {
+  background: var(--peach-light);
+  color: var(--tc-caution);
+}
+.vc-badge-severe {
+  background: var(--rose-light);
+  color: var(--tc-danger);
+}
+.vc-badge-nolog {
+  background: var(--glass);
+  color: var(--light);
+}
+
+/* Pattern / prep cards */
+.vc-pattern-card {
+  background: var(--lav-light);
+  border-radius: var(--r-xl);
+  padding: var(--sp-12) var(--sp-16);
+  margin-top: var(--sp-8);
+  border: 1.5px solid rgba(110,94,154,0.12);
+}
+.vc-pattern-title {
+  font-size: var(--fs-sm);
+  font-weight: 700;
+  color: var(--tc-lav);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-6);
+  margin-bottom: var(--sp-8);
+}
+.vc-pattern-row {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-6);
+  padding: var(--sp-4) 0;
+  font-size: var(--fs-xs);
+  color: var(--text);
+}
+.vc-pattern-trend {
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  margin-top: var(--sp-6);
+  padding: var(--sp-6) var(--sp-10);
+  border-radius: var(--r-lg);
+  background: var(--glass);
+}
+.vc-prep-expect {
+  margin-top: var(--sp-8);
+  padding: var(--sp-10);
+  border-radius: var(--r-lg);
+  background: var(--glass);
+  font-size: var(--fs-xs);
+  color: var(--text);
+  line-height: var(--lh-relaxed);
+}
+.vc-prep-consider {
+  margin-top: var(--sp-6);
+  padding: var(--sp-8) var(--sp-10);
+  border-radius: var(--r-lg);
+  background: var(--amber-light);
+  font-size: var(--fs-xs);
+  color: var(--tc-amber);
+}
+.vc-impact-row {
+  font-size: var(--fs-xs);
+  color: var(--mid);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  padding: var(--sp-4) 0;
+}
+.vc-impact-row svg.zi { width: 14px; height: 14px; }
+.vc-pattern-row svg.zi { width: 14px; height: 14px; }
+.vc-pattern-title svg.zi { width: 14px; height: 14px; }
+.vc-pattern-trend svg.zi { width: 14px; height: 14px; }
+.vc-prep-consider svg.zi { width: 14px; height: 14px; }
+
+/* ── Dark mode: Vaccination Session B ── */
+[data-theme="dark"] .vc-timeline-label { border-color: rgba(110,94,154,0.25); }
+[data-theme="dark"] .vc-timeline-dot.vc-dot-none { background: rgba(58,112,96,0.18); border-color: var(--tc-sage); }
+[data-theme="dark"] .vc-timeline-dot.vc-dot-mild { background: rgba(138,101,32,0.18); border-color: var(--tc-amber); }
+[data-theme="dark"] .vc-timeline-dot.vc-dot-moderate { background: rgba(135,90,32,0.18); border-color: var(--tc-caution); }
+[data-theme="dark"] .vc-timeline-dot.vc-dot-severe { background: rgba(158,62,82,0.18); border-color: var(--tc-danger); }
+[data-theme="dark"] .vc-timeline-dot.vc-dot-upcoming { background: rgba(255,255,255,0.06); border-color: rgba(110,94,154,0.35); }
+[data-theme="dark"] .vc-timeline-dot.vc-dot-nodata { background: rgba(255,255,255,0.06); border-color: rgba(150,150,150,0.25); }
+[data-theme="dark"] .vc-timeline-delay { background: var(--tc-amber); }
+[data-theme="dark"] .vc-timeline-detail { background: var(--warm); box-shadow: 0 -4px 24px rgba(0,0,0,0.4); }
+[data-theme="dark"] .vc-detail-reaction { background: rgba(255,255,255,0.06); }
+[data-theme="dark"] .vc-reaction-badge { border: none; }
+[data-theme="dark"] .vc-badge-none { background: rgba(58,112,96,0.15); }
+[data-theme="dark"] .vc-badge-mild { background: rgba(138,101,32,0.15); }
+[data-theme="dark"] .vc-badge-moderate { background: rgba(135,90,32,0.15); }
+[data-theme="dark"] .vc-badge-severe { background: rgba(158,62,82,0.15); }
+[data-theme="dark"] .vc-badge-nolog { background: rgba(255,255,255,0.06); }
+[data-theme="dark"] .vc-past-item { background: rgba(110,94,154,0.1); border-color: rgba(110,94,154,0.4); }
+[data-theme="dark"] .vc-pattern-card { background: rgba(110,94,154,0.1); border-color: rgba(110,94,154,0.2); }
+[data-theme="dark"] .vc-pattern-trend { background: rgba(255,255,255,0.06); }
+[data-theme="dark"] .vc-prep-expect { background: rgba(255,255,255,0.06); }
+[data-theme="dark"] .vc-prep-consider { background: rgba(138,101,32,0.12); }
+
+/* ── Medications ── */
+.icon-mint { background:var(--sage-light); }
+.med-list { display:flex; flex-direction:column; gap:var(--sp-8); }
+.med-item {
+  display:flex; align-items:flex-start; gap:var(--sp-8);
+  padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl);
+  background:var(--warm); border:1.5px solid rgba(168,207,224,0.3);
+  transition:background var(--ease-fast); min-width:0;}
+.med-item.inactive {
+  opacity:0.55; background:var(--glass);
+  border-color:rgba(180,180,180,0.2);
+}
+.med-dot {
+  width:10px; height:10px; border-radius:50%;
+  background:var(--sky); flex-shrink:0; margin-top:var(--sp-4);
+}
+.med-item.inactive .med-dot { background:var(--light); }
+.med-body { flex:1; min-width:0; word-break:break-word;}
+.med-name { font-weight:600; font-size:var(--fs-md); color:var(--text); }
+.med-detail { font-size:var(--fs-base); font-weight:400; color:var(--mid); margin-top:var(--sp-2); line-height:var(--lh-relaxed); }
+.med-brand { font-size:var(--fs-base); color:var(--tc-sky); font-weight:600; margin-top:var(--sp-4); }
+.med-status-badge {
+  font-size:var(--fs-sm); font-weight:700; text-transform:uppercase;
+  letter-spacing:var(--ls-wide); padding:var(--sp-2) var(--sp-8); border-radius:var(--r-2xl);
+  background:var(--sky-light); color:var(--tc-sky);
+}
+.med-item.inactive .med-status-badge { background:var(--glass); color:var(--light); }
+.med-actions { display:flex; gap:var(--sp-4); align-items:flex-start; flex-shrink:0; }
+.med-btn {
+  background:none; border:1.5px solid var(--light); border-radius:var(--r-md);
+  cursor:pointer; font-size:var(--icon-xs); padding:var(--sp-8) var(--sp-12); color:var(--mid);
+  font-family:'Nunito',sans-serif; transition:all var(--ease-fast); min-height:44px;
+  display:flex; align-items:center; justify-content:center;
+}
+.med-btn.toggle-btn:hover { background:var(--sky-light); border-color:var(--sky); color:var(--tc-sky); }
+.med-btn.del-med-btn:hover { background:var(--rose-light); border-color:var(--rose); color:var(--tc-rose); }
+.med-item.inactive .toggle-btn { color:var(--sky); border-color:var(--sky-light); }
+.med-empty { font-size:var(--fs-base); color:var(--light); padding:var(--sp-4) 0; }
+
+/* ── Milestones ── */
+.milestone-list { display:flex; flex-direction:column; gap:var(--sp-8); }
+.milestone-item {
+  display:flex; flex-direction:column;
+  padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl);
+  background:var(--warm); transition:background var(--ease-fast);
+  overflow:hidden; min-width:0;
+}
+.milestone-item.done, .milestone-item.mastered { background:var(--sage-light); }
+.milestone-item.in-progress, .milestone-item.practicing { background:var(--peach-light); border-left:var(--accent-w) solid var(--amber-deep); }
+.milestone-item.emerging { background:rgba(232,168,64,0.08); border-left:var(--accent-w) solid var(--amber-mid); }
+.milestone-item.consistent { background:rgba(90,154,106,0.08); border-left:var(--accent-w) solid var(--sage-mid); }
+.milestone-item.ms-pill-highlight,
+.upcoming-item.ms-pill-highlight {
+  outline:2px solid var(--rose); outline-offset:-2px;
+  animation: pillHighlightPulse 1.5s ease-out;
+}
+@keyframes pillHighlightPulse {
+  0% { outline-color: var(--rose); }
+  70% { outline-color: var(--rose); }
+  100% { outline-color: transparent; }
+}
+.ms-top-row {
+  display:flex; align-items:flex-start; gap:var(--sp-8);
+  min-width:0; flex-wrap:wrap;
+}
+.milestone-check {
+  width:22px; height:22px; border-radius:50%; flex-shrink:0; margin-top:1px;
+  border:2px solid var(--sage); display:flex; align-items:center; justify-content:center;
+  font-size:var(--icon-xs); transition:all var(--ease-fast);
+}
+.milestone-check svg.zi { width:12px; height:12px; }
+.milestone-item.done .milestone-check, .milestone-item.mastered .milestone-check { background:var(--accent-sage-deep); color:white; border-color:var(--accent-sage-deep); }
+.milestone-item.in-progress .milestone-check, .milestone-item.practicing .milestone-check { background:var(--amber-text-deep); color:white; border-color:var(--amber-text-deep); }
+.milestone-item.emerging .milestone-check { background:var(--amber-text-deep); color:white; border-color:var(--amber-text-deep); }
+.milestone-item.consistent .milestone-check { background:var(--accent-sage-deep); color:white; border-color:var(--accent-sage-deep); }
+.milestone-text { flex:1; font-size:var(--fs-base); font-weight:400; min-width:0; word-break:break-word; }
+
+/* Milestone progress bar (4-segment) */
+.ms-progress-bar {
+  display:flex; gap:var(--sp-4); height:6px; margin-top:var(--sp-6); border-radius:var(--r-full); overflow:hidden;
+}
+.ms-progress-seg {
+  flex:1; border-radius:var(--r-full); background:var(--border-subtle); transition:background var(--ease-slow);
+}
+.ms-progress-seg.filled-1 { background:linear-gradient(90deg, var(--amber-mid), var(--amber-deep)); }
+.ms-progress-seg.filled-2 { background:linear-gradient(90deg, var(--amber-deep), var(--amber-deepest)); }
+.ms-progress-seg.filled-3 { background:linear-gradient(90deg, var(--sage-mid), var(--sage-mid)); }
+.ms-progress-seg.filled-4 { background:linear-gradient(90deg, var(--sage-deepest), var(--sage-deepest)); }
+.ms-stage-label { font-size:var(--fs-xs); font-weight:600; text-transform:uppercase; letter-spacing:var(--ls-tight); margin-top:var(--sp-4); }
+
+/* Category progress wheels */
+.ms-cat-wheels { display:flex; gap:var(--sp-12); justify-content:center; padding:var(--sp-8) 0 var(--sp-12); }
+.ms-cat-wheel {
+  display:flex; flex-direction:column; align-items:center; cursor:pointer;
+  transition:transform var(--ease-fast); flex:1; max-width:80px;
+}
+.ms-cat-wheel:active { transform:scale(0.95); }
+/* Cascade-driven accent: --al-tc resolves per-domain via [data-domain]
+   (sage / lavender / peach / amber / sky). The wheel's `color` property
+   feeds both the SVG currentColor stroke (via stroke="currentColor" on
+   .mcw-fill) and the .ms-cat-wheel-pct percent label (inherits color).
+   No per-domain hardcoded hex; registry is single source of truth. */
+.ms-cat-wheel[data-domain] { color: var(--al-tc, var(--tc-lav)); }
+.ms-cat-wheel svg { width:56px; height:56px; transform:rotate(-90deg); }
+.ms-cat-wheel svg circle { fill:none; stroke-linecap:round; }
+.ms-cat-wheel svg .mcw-track { stroke:var(--border-subtle); stroke-width:5; }
+.ms-cat-wheel svg .mcw-fill { stroke-width:5; transition:stroke-dashoffset 0.6s ease; }
+.ms-cat-wheel-pct { font-family:'Fraunces',serif; font-size:var(--fs-sm); font-weight:600; margin-top:var(--sp-2); }
+.ms-cat-wheel-label { font-size:var(--fs-2xs); font-weight:400; color:var(--mid); text-transform:uppercase; letter-spacing:var(--ls-tight); }
+
+/* Milestone timeline */
+.ms-timeline { display:flex; flex-direction:column; gap:0; }
+.ms-tl-item { display:flex; gap:var(--sp-12); padding:var(--sp-8) 0; position:relative; }
+.ms-tl-item:not(:last-child)::before {
+  content:''; position:absolute; left:10px; top:28px; bottom:-4px; width:2px;
+  background:var(--border-subtle);
+}
+.ms-tl-dot { width:22px; height:22px; border-radius:50%; flex-shrink:0; display:flex; align-items:center; justify-content:center; font-size:var(--icon-xs); z-index:1; }
+.ms-tl-body { flex:1; min-width:0; }
+.ms-tl-text { font-size:var(--fs-sm); font-weight:600; color:var(--text); }
+.ms-tl-meta { font-size:var(--fs-xs); color:var(--mid); }
+
+/* Regression alert */
+.ms-regression-alert {
+  padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl); margin-bottom:var(--sp-8);
+  background:rgba(232,168,64,0.08); border:1px solid rgba(232,168,64,0.2);
+  display:flex; align-items:center; gap:var(--sp-8); cursor:pointer;
+}
+.ms-regression-alert:active { opacity:0.8; }
+.ms-regr-icon { font-size:var(--icon-base); }
+.ms-regr-body { flex:1; min-width:0; }
+.ms-regr-title { font-size:var(--fs-sm); font-weight:600; color:var(--text); }
+.ms-regr-meta { font-size:var(--fs-xs); color:var(--mid); }
+.milestone-text strong { display:block; font-weight:600; font-size:var(--fs-md); }
+.milestone-text span { font-size:var(--fs-base); font-weight:400; color:var(--mid); }
+.milestone-meta { display:flex; gap:var(--sp-4); flex-wrap:wrap; margin-top:var(--sp-4); }
+.milestone-meta-badge {
+  font-size:var(--fs-sm); font-weight:700; padding:var(--sp-2) var(--sp-8); border-radius:var(--r-md);
+  text-transform:uppercase; letter-spacing:var(--ls-normal);
+}
+.meta-done { background:var(--sage-light); color:var(--tc-sage); }
+.meta-progress { background:var(--peach-light); color:var(--tc-warn); }
+.meta-age { background:var(--peach-light); color:var(--tc-caution); }
+.meta-time { background:var(--sky-light); color:var(--tc-sky); }
+.badge-adv { font-size:var(--fs-sm); background:var(--border-warn-soft); color:#6b4e00; padding:var(--sp-2) var(--sp-8); border-radius:var(--r-2xl); font-weight:700; flex-shrink:0; }
+.milestone-actions { display:flex; gap:var(--sp-4); flex-shrink:0; margin-left:auto; flex-wrap:wrap; }
+@media(max-width:500px) { .milestone-actions { width:100%; margin-left:0; margin-top:var(--sp-4); } }
+.ms-action-btn {
+  background:none; border:1.5px solid var(--light); border-radius:var(--r-md);
+  cursor:pointer; font-size:var(--icon-xs); padding:var(--sp-8) var(--sp-10); color:var(--mid);
+  font-family:'Nunito',sans-serif; transition:all var(--ease-fast); white-space:nowrap;
+  min-height:44px; min-width:44px; display:flex; align-items:center; justify-content:center;
+}
+.ms-action-btn:hover { border-color:var(--sage); color:var(--tc-sage); background:var(--sage-light); }
+.ms-action-btn.del-ms:hover { border-color:var(--rose); color:var(--tc-rose); background:var(--rose-light); }
+
+/* ── Milestone Tidbits ── */
+.ms-tidbits {
+  margin-top:var(--sp-6); padding:var(--sp-6); border-radius:var(--r-lg);
+  font-size:var(--fs-sm); line-height:var(--lh-relaxed);
+  display:flex; flex-direction:column; gap:var(--sp-8);
+}
+.ms-tidbit {
+  display:flex; align-items:flex-start; gap:var(--sp-8);
+  padding:var(--sp-8) var(--sp-10); border-radius:var(--r-lg); border-left:var(--accent-w) solid transparent;
+}
+.ms-tidbit.tidbit-unlocks {
+  background:var(--peach-light); border-color:var(--tc-caution);
+}
+.ms-tidbit.tidbit-doctor {
+  background:var(--sky-light); border-color:#5b9bd5;
+}
+.ms-tidbit.tidbit-fun {
+  background:var(--lav-light); border-color:#a078d0;
+}
+.ms-tidbit-icon { flex-shrink:0; font-size:var(--icon-xs); margin-top:1px; }
+.ms-tidbit-text { flex:1; font-weight:400; color:var(--text); }
+.ms-tidbit.tidbit-unlocks .ms-tidbit-text strong { color:var(--tc-caution); font-weight:700; }
+.ms-tidbit.tidbit-doctor .ms-tidbit-text strong  { color:var(--tc-sky); font-weight:700; }
+.ms-tidbit.tidbit-fun .ms-tidbit-text strong      { color:var(--tc-lav); font-weight:700; }
+.ms-tidbit-toggle {
+  background:none; border:none; cursor:pointer; font-size:var(--fs-sm);
+  color:var(--light); font-family:'Nunito',sans-serif; font-weight:600;
+  padding:var(--sp-8) 0; transition:color var(--ease-fast); min-height:44px;
+  display:inline-flex; align-items:center;
+}
+.ms-tidbit-toggle:hover { color:var(--rose); }
+
+/* ── Milestone Category Cards ── */
+.ms-cats { display:grid; grid-template-columns:1fr 1fr; gap:var(--sp-8); }
+@media(max-width:700px) { .ms-cats { grid-template-columns:1fr; } }
+@media(max-width:400px) { .ms-cats { grid-template-columns:1fr; } }
+.ms-cat-card {
+  border-radius:var(--r-xl); padding:var(--sp-12) var(--sp-16); cursor:pointer;
+  transition:all var(--ease-fast); border:1.5px solid transparent;
+}
+.ms-cat-card.motor    { background:rgba(181,213,197,0.25); border-color:rgba(181,213,197,0.5); }
+.ms-cat-card.language { background:rgba(168,207,224,0.25); border-color:rgba(168,207,224,0.5); }
+.ms-cat-card.social   { background:rgba(250,212,180,0.25); border-color:rgba(250,212,180,0.5); }
+.ms-cat-card.cognitive{ background:rgba(201,184,232,0.25); border-color:rgba(201,184,232,0.5); }
+.ms-cat-card:hover { filter:brightness(0.96); }
+.ms-cat-card.expanded { border-radius:var(--r-xl) var(--r-xl) 0 0; }
+.ms-cat-top { display:flex; align-items:center; gap:var(--sp-8); }
+.ms-cat-icon { font-size:var(--icon-lg); }
+.ms-cat-info { flex:1; }
+.ms-cat-name { font-weight:600; font-size:var(--fs-md); }
+.ms-cat-card.motor .ms-cat-name    { color:var(--tc-sage); }
+.ms-cat-card.language .ms-cat-name  { color:var(--tc-sky); }
+.ms-cat-card.social .ms-cat-name    { color:var(--tc-caution); }
+.ms-cat-card.cognitive .ms-cat-name { color:var(--tc-lav); }
+.ms-cat-count { font-size:var(--fs-base); font-weight:400; color:var(--mid); }
+.ms-cat-chevron { font-size:var(--icon-xs); color:var(--light); transition:transform var(--ease-fast); }
+.ms-cat-card.expanded .ms-cat-chevron { transform:rotate(180deg); }
+.ms-cat-items {
+  display:none; padding:var(--sp-8) var(--sp-10) var(--sp-10);
+  border-radius:0 0 var(--r-xl) var(--r-xl); border:1.5px solid transparent;
+  border-top:none; margin-top:-1px;
+  overflow:hidden; min-width:0;
+}
+.ms-cat-items.motor    { background:rgba(181,213,197,0.1); border-color:rgba(181,213,197,0.5); }
+.ms-cat-items.language { background:rgba(168,207,224,0.1); border-color:rgba(168,207,224,0.5); }
+.ms-cat-items.social   { background:rgba(250,212,180,0.1); border-color:rgba(250,212,180,0.5); }
+.ms-cat-items.cognitive{ background:rgba(201,184,232,0.1); border-color:rgba(201,184,232,0.5); }
+.ms-cat-items.open { display:block; }
+
+/* ── Activities ── */
+.activity-cats { display:grid; grid-template-columns:1fr 1fr 1fr; gap:var(--sp-8); }
+@media(max-width:700px) { .activity-cats { grid-template-columns:1fr; } }
+@media(max-width:400px) { .activity-cats { grid-template-columns:1fr; } }
+.activity-cat-card {
+  border-radius:var(--r-xl); padding:var(--sp-12) var(--sp-16); cursor:pointer;
+  transition:all var(--ease-fast); border:1.5px solid transparent;
+}
+.activity-cat-card.motor    { background:var(--sage-light); border-color:rgba(181,213,197,0.4); }
+.activity-cat-card.sensory  { background:var(--lav-light); border-color:rgba(201,184,232,0.4); }
+.activity-cat-card.language { background:var(--sky-light); border-color:rgba(168,207,224,0.4); }
+.activity-cat-card.social   { background:var(--peach-light); border-color:rgba(250,212,180,0.4); }
+.activity-cat-card:hover { filter:brightness(0.97); }
+.activity-cat-card.expanded { border-radius:var(--r-xl) var(--r-xl) 0 0; }
+.act-cat-top {
+  display:flex; align-items:center; gap:var(--sp-8);
+}
+.act-cat-icon { font-size:var(--icon-lg); }
+.act-cat-info { flex:1; }
+.act-cat-name { font-weight:600; font-size:var(--fs-md); color:var(--text); text-transform:capitalize; }
+.act-cat-count { font-size:var(--fs-base); font-weight:400; color:var(--mid); }
+.act-cat-chevron { font-size:var(--icon-xs); color:var(--light); transition:transform var(--ease-fast); }
+.activity-cat-card.expanded .act-cat-chevron { transform:rotate(180deg); }
+.act-cat-items {
+  display:none; padding:0 var(--sp-16) var(--sp-12);
+  border-radius:0 0 var(--r-xl) var(--r-xl); border:1.5px solid transparent;
+  border-top:none; margin-top:-1px;
+  overflow:hidden; min-width:0;
+}
+.act-cat-items.motor    { background:var(--sage-light); border-color:rgba(181,213,197,0.4); }
+.act-cat-items.sensory  { background:var(--lav-light); border-color:rgba(201,184,232,0.4); }
+.act-cat-items.language { background:var(--sky-light); border-color:rgba(168,207,224,0.4); }
+.act-cat-items.social   { background:var(--peach-light); border-color:rgba(250,212,180,0.4); }
+.act-cat-items.open { display:block; }
+.activity-item {
+  display:flex; align-items:flex-start; gap:var(--sp-8);
+  padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl);
+  background:var(--glass); margin-bottom:var(--sp-8);
+  border-left:var(--accent-w) solid var(--sage);
+}
+.activity-item:last-child { margin-bottom:0; }
+.activity-item.motor    { border-color:var(--sage); background:rgba(181,213,197,0.15); }
+.activity-item.sensory  { border-color:var(--lavender); background:rgba(201,184,232,0.15); }
+.activity-item.language { border-color:var(--sky); background:rgba(168,207,224,0.15); }
+.activity-item.social   { border-color:var(--peach); background:rgba(250,212,180,0.15); }
+.activity-icon { font-size:var(--icon-md); flex-shrink:0; margin-top:1px; }
+.activity-body strong { font-size:var(--fs-md); font-weight:700; display:block; color:var(--text); }
+.activity-body span   { font-size:var(--fs-base); font-weight:400; color:var(--mid); line-height:var(--lh-relaxed); }
+.activity-cat-label {
+  font-size:var(--fs-sm); font-weight:600; text-transform:uppercase;
+  letter-spacing:var(--ls-normal); padding:var(--sp-2) var(--sp-8); border-radius:var(--r-md);
+  display:inline-block; margin-top:var(--sp-4);
+}
+.activity-cat-label.motor    { background:rgba(181,213,197,0.3); color:var(--tc-sage); }
+.activity-cat-label.sensory  { background:rgba(201,184,232,0.3); color:var(--tc-lav); }
+.activity-cat-label.language { background:rgba(168,207,224,0.3); color:var(--tc-sky); }
+.activity-cat-label.social   { background:rgba(250,212,180,0.3); color:var(--tc-caution); }
+
+/* ── Upcoming Milestones ── */
+.upcoming-cats { display:grid; grid-template-columns:1fr 1fr 1fr; gap:var(--sp-8); }
+@media(max-width:700px) { .upcoming-cats { grid-template-columns:1fr; } }
+@media(max-width:400px) { .upcoming-cats { grid-template-columns:1fr; } }
+.upcoming-cat-card {
+  border-radius:var(--r-xl); padding:var(--sp-12) var(--sp-16); cursor:pointer;
+  transition:all var(--ease-fast); border:1.5px solid transparent;
+}
+.upcoming-cat-card.pending   { background:var(--warm); border-color:rgba(250,212,180,0.4); }
+.upcoming-cat-card.in_progress { background:var(--peach-light); border-color:rgba(255,193,7,0.3); }
+.upcoming-cat-card.done      { background:var(--sage-light); border-color:rgba(181,213,197,0.4); }
+.upcoming-cat-card:hover { filter:brightness(0.97); }
+.upcoming-cat-card.expanded { border-radius:var(--r-xl) var(--r-xl) 0 0; }
+.upc-top { display:flex; align-items:center; gap:var(--sp-8); }
+.upc-icon { font-size:var(--icon-lg); }
+.upc-info { flex:1; }
+.upc-name { font-weight:600; font-size:var(--fs-md); color:var(--text); }
+.upc-count { font-size:var(--fs-base); font-weight:400; color:var(--mid); }
+.upc-chevron { font-size:var(--icon-xs); color:var(--light); transition:transform var(--ease-fast); }
+.upcoming-cat-card.expanded .upc-chevron { transform:rotate(180deg); }
+.upc-items {
+  display:none; padding:var(--sp-8) var(--sp-12) var(--sp-12);
+  border-radius:0 0 var(--r-xl) var(--r-xl); border:1.5px solid transparent;
+  border-top:none; margin-top:-1px;
+  overflow:hidden; min-width:0;
+}
+.upc-items.pending   { background:var(--warm); border-color:rgba(250,212,180,0.4); }
+.upc-items.in_progress { background:var(--peach-light); border-color:rgba(255,193,7,0.3); }
+.upc-items.done      { background:var(--sage-light); border-color:rgba(181,213,197,0.4); }
+.upc-items.open { display:block; }
+.upc-subcat {
+  margin-bottom:var(--sp-10); border-radius:var(--r-lg); overflow:hidden;
+}
+.upc-subcat:last-child { margin-bottom:0; }
+.upc-subcat-header {
+  display:flex; align-items:center; gap:var(--sp-8); cursor:pointer;
+  padding:var(--sp-8) var(--sp-10); border-radius:var(--r-lg); margin-bottom:0;
+  transition:background var(--ease-fast); border-left:var(--accent-w) solid transparent;
+}
+.upc-subcat.expanded .upc-subcat-header { border-radius:var(--r-lg) var(--r-lg) 0 0; }
+.upc-subcat-header.motor    { background:rgba(181,213,197,0.25); border-color:var(--sage); }
+.upc-subcat-header.language { background:rgba(168,207,224,0.25); border-color:var(--sky); }
+.upc-subcat-header.social   { background:rgba(250,212,180,0.25); border-color:var(--peach); }
+.upc-subcat-header.cognitive{ background:rgba(201,184,232,0.25); border-color:var(--lavender); }
+.upc-subcat-header:hover { filter:brightness(0.95); }
+.upc-subcat-icon { font-size:var(--icon-sm); }
+.upc-subcat-label { font-size:var(--fs-base); font-weight:600; flex:1; }
+.upc-subcat-header.motor .upc-subcat-label    { color:var(--tc-sage); }
+.upc-subcat-header.language .upc-subcat-label  { color:var(--tc-sky); }
+.upc-subcat-header.social .upc-subcat-label    { color:var(--tc-caution); }
+.upc-subcat-header.cognitive .upc-subcat-label { color:var(--tc-lav); }
+.upc-subcat-count {
+  font-size:var(--fs-sm); font-weight:700; padding:1px var(--sp-8);
+  border-radius:var(--r-lg); background:var(--glass-strong);
+}
+.upc-subcat-header.motor .upc-subcat-count    { color:var(--tc-sage); }
+.upc-subcat-header.language .upc-subcat-count  { color:var(--tc-sky); }
+.upc-subcat-header.social .upc-subcat-count    { color:var(--tc-caution); }
+.upc-subcat-header.cognitive .upc-subcat-count { color:var(--tc-lav); }
+.upc-subcat-chevron { font-size:var(--icon-xs); color:var(--light); transition:transform var(--ease-fast); }
+.upc-subcat.expanded .upc-subcat-chevron { transform:rotate(180deg); }
+.upc-subcat-items {
+  display:none; padding:var(--sp-6) var(--sp-6) var(--sp-8);
+  border-left:var(--accent-w) solid transparent; overflow:hidden; min-width:0;}
+.upc-subcat.expanded .upc-subcat-items { display:block; }
+.upc-subcat-items.motor    { background:rgba(181,213,197,0.1); border-color:rgba(181,213,197,0.3); }
+.upc-subcat-items.language { background:rgba(168,207,224,0.1); border-color:rgba(168,207,224,0.3); }
+.upc-subcat-items.social   { background:rgba(250,212,180,0.1); border-color:rgba(250,212,180,0.3); }
+.upc-subcat-items.cognitive{ background:rgba(201,184,232,0.1); border-color:rgba(201,184,232,0.3); }
+.upcoming-list { display:flex; flex-direction:column; gap:var(--sp-8); }
+.upcoming-item {
+  display:flex; align-items:flex-start; gap:var(--sp-8);
+  padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl);
+  border-left:var(--accent-w) solid transparent;
+  background:var(--glass);
+  min-width:0; overflow:hidden;
+}
+.upcoming-item.normal  { border-color:var(--peach); }
+.upcoming-item.advanced { border-color:var(--lavender); }
+.upcoming-item.in-progress { border-color:var(--border-warn); }
+.upcoming-item.done { border-color:var(--sage); }
+.upcoming-icon { font-size:var(--icon-base); flex-shrink:0; margin-top:1px; }
+.upcoming-body { flex:1; min-width:0; word-break:break-word; }
+.upcoming-body strong { font-size:var(--fs-md); font-weight:700; display:block; color:var(--text); }
+.upcoming-body span { font-size:var(--fs-base); font-weight:400; color:var(--mid); line-height:var(--lh-relaxed); }
+.upcoming-badge {
+  font-size:var(--fs-sm); font-weight:600; text-transform:uppercase;
+  letter-spacing:var(--ls-wide); padding:var(--sp-2) var(--sp-8); border-radius:var(--r-lg);
+  display:inline-block; margin-top:var(--sp-4);
+}
+.upcoming-badge.age-badge { background:var(--peach-light); color:var(--tc-caution); }
+.upcoming-badge.adv-badge { background:var(--lav-light); color:var(--tc-lav); }
+.upcoming-badge.achieved-badge { background:var(--sage-light); color:var(--tc-sage); }
+
+/* ── Notes ── */
+.notes-list { display:flex; flex-direction:column; gap:var(--sp-8); margin-bottom:var(--sp-12); max-height:300px; overflow-y:auto; }
+.note-item {
+  border-radius:var(--r-xl); padding:var(--sp-12) var(--sp-12);
+  background:var(--warm); border:1.5px solid rgba(250,212,180,0.4);
+  transition:all var(--ease-fast);
+}
+.note-item.done {
+  background:var(--sage-light); border-color:rgba(181,213,197,0.5);
+  opacity:0.75;
+}
+.note-item.done .note-text { text-decoration:line-through; color:var(--mid); }
+.note-top { display:flex; align-items:flex-start; gap:var(--sp-8); }
+.note-text { flex:1; font-size:var(--fs-base); line-height:var(--lh-relaxed); word-break:break-word; }
+.note-date { font-size:var(--fs-base); font-weight:400; color:var(--light); margin-top:var(--sp-4); }
+.note-actions { display:flex; gap:var(--sp-4); flex-shrink:0; }
+.note-btn {
+  background:none; border:1.5px solid var(--light); border-radius:var(--r-md);
+  cursor:pointer; font-size:var(--icon-xs); padding:var(--sp-8) var(--sp-12); color:var(--mid);
+  font-family:'Nunito',sans-serif; transition:all var(--ease-fast); min-height:44px;
+  display:flex; align-items:center; justify-content:center;
+}
+.note-btn.complete-btn:hover { background:var(--sage-light); border-color:var(--sage); color:var(--tc-sage); }
+.note-btn.del-note-btn:hover { background:var(--rose-light); border-color:var(--rose); color:var(--tc-rose); }
+.note-item.done .complete-btn { background:var(--sage-light); border-color:var(--sage); color:var(--tc-sage); }
+
+/* Note category filter */
+.note-cat-filter {
+  display:flex; gap:var(--sp-4); flex-wrap:wrap; margin-bottom:var(--sp-10);
+}
+.ncf-btn {
+  padding:var(--sp-10) var(--sp-16); border-radius:var(--r-md); border:1.5px solid var(--light);
+  background:var(--card-bg); color:var(--mid); font-family:'Nunito',sans-serif;
+  font-size:var(--fs-sm); font-weight:700; cursor:pointer; transition:all var(--ease-fast);
+  min-height:40px; display:inline-flex; align-items:center;
+}
+.ncf-btn:hover { border-color:var(--peach); color:var(--peach); }
+.ncf-btn.active { background:#966525; color:white; border-color:#966525; }
+
+/* Note category badge */
+.note-cat-badge {
+  font-size:var(--fs-xs); font-weight:600; text-transform:uppercase;
+  letter-spacing:var(--ls-normal); padding:var(--sp-2) var(--sp-8); border-radius:var(--r-md);
+  display:inline-block; margin-top:var(--sp-4);
+}
+.note-cat-badge.general  { background:var(--peach-light); color:var(--tc-caution); }
+.note-cat-badge.diet     { background:var(--sage-light);  color:var(--tc-sage); }
+.note-cat-badge.medical  { background:var(--lav-light);   color:var(--tc-lav); }
+.note-cat-badge.milestone{ background:var(--peach-light);            color:var(--tc-warn); }
+.note-cat-badge.growth   { background:var(--rose-light);  color:var(--tc-rose); }
+
+/* Note photo */
+.note-photo {
+  margin-top:var(--sp-8); cursor:pointer;
+}
+.note-photo img {
+  max-width:100%; max-height:180px; border-radius:var(--r-lg);
+  object-fit:cover; border:1.5px solid rgba(250,212,180,0.3);
+}
+
+/* ── Scrapbook ── */
+.scrap-entry {
+  display:flex; gap:var(--sp-12); align-items:flex-start;
+  padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl);
+  background:var(--blush); border:1.5px solid rgba(242,168,184,0.2); min-width:0;}
+
+/* Note attachment buttons */
+.note-attach-btn {
+  width:44px; height:44px; border-radius:var(--r-md); border:1.5px solid var(--peach-light);
+  background:var(--peach-light); cursor:pointer; font-size:var(--icon-sm);
+  display:flex; align-items:center; justify-content:center;
+  transition:all var(--ease-fast);
+}
+.note-attach-btn:hover, .note-attach-btn:active { border-color:var(--peach); background:var(--peach); }
+
+/* Note attachment previews */
+.note-attach-preview {
+  display:inline-flex; align-items:center; gap:var(--sp-4);
+  padding:var(--sp-4) var(--sp-8); border-radius:var(--r-md);
+  background:var(--peach-light); font-size:var(--fs-base); font-weight:400; color:var(--mid);
+}
+.note-attach-preview img {
+  width:32px; height:32px; border-radius:var(--r-md); object-fit:cover;
+}
+.note-attach-preview audio {
+  height:28px; max-width:160px;
+}
+.note-attach-del {
+  background:none; border:none; cursor:pointer; font-size:var(--icon-xs);
+  color:var(--mid); padding:0; min-width:44px; min-height:44px;
+  display:inline-flex; align-items:center; justify-content:center;
+}
+.note-attach-del:hover { color:var(--tc-danger); }
+.scrap-photo { flex-shrink:0; cursor:pointer; }
+.scrap-photo img {
+  width:80px; height:80px; border-radius:var(--r-lg);
+  object-fit:cover; border:1.5px solid rgba(242,168,184,0.3);
+}
+.scrap-body { flex:1; min-width:0; }
+.scrap-title {
+  font-weight:600; font-size:var(--fs-md); color:var(--text);
+  line-height:var(--lh-snug); margin-bottom:var(--sp-2);
+}
+.scrap-desc {
+  font-size:var(--fs-md); font-weight:400; color:var(--mid); line-height:var(--lh-relaxed);
+  margin-bottom:var(--sp-4); word-break:break-word;
+}
+.scrap-meta {
+  font-size:var(--fs-sm); font-weight:400; color:var(--light);
+}
+
+.add-note-area {
+  display:flex; flex-direction:column; gap:var(--sp-8);
+  border-top:1.5px solid var(--peach-light); padding-top:var(--sp-12);
+}
+.add-note-area textarea {
+  width:100%; padding:var(--sp-12) var(--sp-12); border-radius:var(--r-lg);
+  border:1.5px solid var(--peach-light);
+  font-family:'Nunito', sans-serif; font-size:var(--fs-base);
+  background:var(--peach-light); color:var(--text);
+  outline:none; resize:none; min-height:72px; line-height:var(--lh-relaxed);
+}
+.add-note-area textarea:focus { border-color:var(--peach); }
+
+/* ── Quick Stats (used in all tabs) ── */
+.diet-stat {
+  flex:1 1 auto; min-width:0; text-align:center;
+  background:var(--white); border-radius:var(--r-xl); padding:var(--sp-10) var(--sp-12);
+  box-shadow:0 2px 10px var(--shadow);
+  cursor:pointer; transition:all var(--ease-fast);
+  border:1.5px solid transparent;
+  overflow:hidden; word-break:break-word;
+}
+.diet-stat:hover { filter:brightness(0.96); transform:translateY(-1px); }
+.diet-stat:active { transform:translateY(0); }
+.diet-stat-val {
+  font-family:'Fraunces',serif; font-size:var(--fs-md); font-weight:600; color:var(--tc-rose); line-height:var(--lh-tight);
+  word-break:break-word; overflow-wrap:break-word;
+}
+.diet-stat-label {
+  font-size:var(--fs-xs); text-transform:uppercase; letter-spacing:var(--ls-normal); color:var(--light); margin-top:var(--sp-4);
+  line-height:var(--lh-snug);
+}
+.diet-stat-val.ds-val-sm { font-size:var(--fs-base); }
+.diet-stat-icon { font-size:var(--icon-base); margin-bottom:var(--sp-4); }
+.diet-stat.alert { border-color:var(--border-warn); background:var(--surface-warn); }
+.diet-stat.alert .diet-stat-val { color:var(--tc-caution); }
+.diet-stat.ds-rose { background:var(--blush); border-color:rgba(242,168,184,0.3); }
+.diet-stat.ds-rose .diet-stat-val { color:var(--tc-rose); }
+.diet-stat.ds-sky { background:var(--sky-light); border-color:rgba(168,207,224,0.3); }
+.diet-stat.ds-sky .diet-stat-val { color:var(--tc-sky); }
+.diet-stat.ds-sage { background:var(--sage-light); border-color:rgba(181,213,197,0.3); }
+.diet-stat.ds-sage .diet-stat-val { color:var(--tc-sage); }
+.diet-stat.ds-lav { background:var(--lav-light); border-color:rgba(201,184,232,0.3); }
+.diet-stat.ds-lav .diet-stat-val { color:var(--tc-lav); }
+.diet-stat.ds-peach { background:var(--peach-light); border-color:rgba(250,212,180,0.3); }
+.diet-stat.ds-peach .diet-stat-val { color:var(--tc-caution); }
+.diet-stat.ds-amber { background:var(--amber-light); border-color:rgba(232,184,109,0.3); }
+.diet-stat.ds-amber .diet-stat-val { color:var(--tc-amber); }
+
+/* ── Tip Categories ── */
+.tip-cats { display:grid; grid-template-columns:1fr 1fr 1fr; gap:var(--sp-8); }
+@media(max-width:700px) { .tip-cats { grid-template-columns:1fr; } }
+@media(max-width:400px) { .tip-cats { grid-template-columns:1fr; } }
+.tip-cat-card {
+  border-radius:var(--r-lg); padding:var(--sp-12) var(--sp-12); cursor:pointer;
+  transition:all var(--ease-fast); border:1.5px solid transparent;
+}
+.tip-cat-card:hover { filter:brightness(0.96); }
+.tip-cat-card.expanded { border-radius:var(--r-lg) var(--r-lg) 0 0; }
+.tip-cat-card.tip-cat-card.tip-cat-card.tc-info   { background:var(--sky-light); border-color:rgba(168,207,224,0.4); }
+.tip-cat-card.tip-cat-card.tip-cat-card.tc-avoid  { background:var(--rose-light); border-color:rgba(176,72,94,0.25); }
+.tip-cat-card.tip-cat-card.tip-cat-card.tc-watch  { background:var(--peach-light); border-color:rgba(255,193,7,0.3); }
+.tip-cat-card.tip-cat-card.tip-cat-card.tc-add    { background:var(--sage-light); border-color:rgba(181,213,197,0.4); }
+.tip-cat-card .tc-top { display:flex; align-items:center; gap:var(--sp-8); }
+.tc-icon { font-size:var(--icon-md); }
+.tc-info-wrap { flex:1; }
+.tc-name { font-size:var(--fs-md); font-weight:600; color:var(--text); }
+.tc-count { font-size:var(--fs-base); font-weight:400; color:var(--mid); }
+.tc-chevron { font-size:var(--icon-xs); color:var(--light); transition:transform var(--ease-fast); }
+.tip-cat-card.expanded .tc-chevron { transform:rotate(180deg); }
+.tc-items {
+  display:none; padding:var(--sp-8) var(--sp-10) var(--sp-10);
+  border-radius:0 0 var(--r-lg) var(--r-lg); border:1.5px solid transparent; border-top:none; margin-top:-1px;
+  overflow:hidden; min-width:0;
+}
+.tc-items.tc-items.tc-items.tc-info  { background:rgba(232,244,250,0.5); border-color:rgba(168,207,224,0.4); }
+.tc-items.tc-items.tc-items.tc-avoid { background:rgba(253,232,237,0.5); border-color:rgba(176,72,94,0.25); }
+.tc-items.tc-items.tc-items.tc-watch { background:rgba(255,248,225,0.5); border-color:rgba(255,193,7,0.3); }
+.tc-items.tc-items.tc-items.tc-add   { background:rgba(232,245,239,0.5); border-color:rgba(181,213,197,0.4); }
+.tc-items.tc-items.open { display:block; }
+
+/* ── Poop swatch (anatomical color reference) ──
+   Class-based replacement for inline-style colored dots across the
+   picker, legend, timeline, anomaly cards, and Color Guide. */
+.poop-swatch {
+  display:inline-block; flex-shrink:0;
+  width:14px; height:14px; border-radius:50%;
+  border:1px solid rgba(0,0,0,0.08);
+  vertical-align:middle;
+  background:var(--mid); /* fallback for unknown colors */
+}
+.poop-swatch--sm { width:10px; height:10px; }
+.poop-swatch--md { width:14px; height:14px; }
+.poop-swatch--lg { width:20px; height:20px; }
+.poop-swatch[data-pcolor="yellow"] { background:var(--poop-c-yellow); }
+.poop-swatch[data-pcolor="green"]  { background:var(--poop-c-green); }
+.poop-swatch[data-pcolor="brown"]  { background:var(--poop-c-brown); }
+.poop-swatch[data-pcolor="dark"]   { background:var(--poop-c-dark); }
+.poop-swatch[data-pcolor="orange"] { background:var(--poop-c-orange); }
+.poop-swatch[data-pcolor="red"]    { background:var(--poop-c-red); }
+.poop-swatch[data-pcolor="white"]  { background:var(--poop-c-white); border-color:rgba(0,0,0,0.18); box-shadow:inset 0 0 0 1px rgba(0,0,0,0.08); }
+.poop-swatch[data-pcolor="black"]  { background:var(--poop-c-black); }
+
+/* Bar-chart segment uses the same color tokens; width stays inline-dynamic.
+   var(--mid) fallback ensures unknown/orphan colors (e.g. legacy 'tan' /
+   'mustard' from SAFE_POOP_COLORS) render as a recognizable "other" segment
+   instead of an invisible gap that breaks the visual 100% sum. */
+.poop-bar-seg { height:100%; background:var(--mid); }
+.poop-bar-seg[data-pcolor="yellow"] { background:var(--poop-c-yellow); }
+.poop-bar-seg[data-pcolor="green"]  { background:var(--poop-c-green); }
+.poop-bar-seg[data-pcolor="brown"]  { background:var(--poop-c-brown); }
+.poop-bar-seg[data-pcolor="dark"]   { background:var(--poop-c-dark); }
+.poop-bar-seg[data-pcolor="orange"] { background:var(--poop-c-orange); }
+.poop-bar-seg[data-pcolor="red"]    { background:var(--poop-c-red); }
+.poop-bar-seg[data-pcolor="white"]  { background:var(--poop-c-white); }
+.poop-bar-seg[data-pcolor="black"]  { background:var(--poop-c-black); }
+
+/* ── Poop Guide collapsible category cards ──
+   Class-based replacement for the inline-style chrome inside renderPoopGuide. */
+.pg-cat-card { border-radius:var(--r-xl); overflow:hidden; border:1.5px solid var(--amber-light); margin-bottom:var(--sp-8); }
+.pg-cat-card.is-amber    { border-color:var(--amber-light); }
+.pg-cat-card.is-sky      { border-color:var(--sky-light); }
+.pg-cat-card.is-sage     { border-color:var(--sage-light); }
+.pg-cat-card.is-rose     { border-color:var(--rose-light); }
+.pg-cat-top {
+  display:flex; align-items:center; justify-content:space-between;
+  padding:var(--sp-10) var(--sp-12); cursor:pointer;
+  background:var(--amber-light);
+}
+.pg-cat-card.is-amber .pg-cat-top { background:var(--amber-light); }
+.pg-cat-card.is-sky   .pg-cat-top { background:var(--sky-light); }
+.pg-cat-card.is-sage  .pg-cat-top { background:var(--sage-light); }
+.pg-cat-card.is-rose  .pg-cat-top { background:var(--rose-light); }
+.pg-cat-head { display:flex; align-items:center; gap:var(--sp-8); }
+.pg-cat-icon { font-size:var(--icon-base); display:inline-flex; align-items:center; }
+.pg-cat-label { font-size:var(--fs-base); font-weight:600; color:var(--tc-amber); }
+.pg-cat-card.is-amber .pg-cat-label { color:var(--tc-amber); }
+.pg-cat-card.is-sky   .pg-cat-label { color:#3a7090; }
+.pg-cat-card.is-sage  .pg-cat-label { color:#3a7060; }
+.pg-cat-card.is-rose  .pg-cat-label { color:#b0485e; }
+.pg-cat-chev { color:var(--tc-amber); display:inline-flex; align-items:center; }
+.pg-cat-card.is-sky   .pg-cat-chev { color:#3a7090; }
+.pg-cat-card.is-sage  .pg-cat-chev { color:#3a7060; }
+.pg-cat-card.is-rose  .pg-cat-chev { color:#b0485e; }
+.pg-cat-body { display:none; padding:var(--sp-10) var(--sp-12); }
+.pg-cat-body.open { display:block; }
+.pg-cat-row { display:flex; gap:var(--sp-12); align-items:flex-start; margin-bottom:var(--sp-10); }
+.pg-cat-row:last-child { margin-bottom:0; }
+.pg-cat-row-icon { font-size:var(--icon-base); flex-shrink:0; margin-top:2px; display:inline-flex; align-items:center; gap:var(--sp-4); }
+.pg-cat-row-icon .poop-swatch { margin-top:var(--sp-2); }
+.pg-cat-row-title { font-size:var(--fs-sm); font-weight:600; color:var(--text); margin-bottom:2px; display:flex; align-items:center; gap:var(--sp-4); flex-wrap:wrap; }
+.pg-cat-row-text { line-height:var(--lh-normal); }
+.pg-cat-warn { display:inline-flex; align-items:center; font-size:var(--icon-xs); color:#b0485e; }
+.pg-cat-card.expanded .pg-cat-chev { transform:rotate(180deg); }
+
+.history-meal-row { display:flex; gap:var(--sp-8); margin-bottom:var(--sp-2); align-items:flex-start; }
+.history-meal-label { font-size:var(--fs-sm); font-weight:600; text-transform:uppercase; color:var(--light); min-width:62px; padding-top:1px; }
+.history-meal-val { color:var(--text); line-height:var(--lh-normal); }
+.history-entry-del:hover { color:var(--tc-danger); }
+
+/* ── Insights & Tips card ── */
+.icon-amber { background:var(--peach-light); }
+.tip-item {
+  display:flex; align-items:flex-start; gap:var(--sp-8);
+  padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl);
+  border-left:var(--accent-w) solid transparent; min-width:0;}
+.tip-item.add   { background:var(--sage-light); border-color:var(--sage); }
+.tip-item.avoid { background:var(--rose-light); border-color:var(--rose); }
+.tip-item.watch { background:var(--peach-light); border-color:var(--border-warn-soft); }
+.tip-item.info  { background:var(--sky-light); border-color:var(--sky); }
+.tip-icon { font-size:var(--icon-md); flex-shrink:0; margin-top:1px; }
+.tip-body strong { font-size:var(--fs-md); font-weight:700; display:block; color:var(--text); }
+.tip-body span   { font-size:var(--fs-base); font-weight:400; color:var(--mid); line-height:var(--lh-relaxed); }
+.tips-empty { font-size:var(--fs-base); color:var(--light); }
+
+/* ── Modal ── */
+.modal-overlay {
+  position:fixed; inset:0; background:rgba(60,40,40,0.25);
+  backdrop-filter:blur(4px); z-index:100;
+  display:none; align-items:center; justify-content:center;
+}
+.modal-overlay.open { display:flex; }
+.modal {
+  background:white; border-radius:var(--r-2xl); padding:var(--sp-24);
+  max-width:420px; width:90%; box-shadow:0 20px 60px rgba(0,0,0,0.15);
+  animation:popIn 0.25s ease;
+}
+@keyframes popIn { from{opacity:0;transform:scale(0.92)} to{opacity:1;transform:scale(1)} }
+.modal h3 { font-family:'Fraunces', serif; font-size:var(--fs-xl); margin-bottom:var(--sp-16); }
+.modal-btns { display:flex; gap:var(--sp-8); justify-content:flex-end; margin-top:var(--sp-16); }
+.modal-input {
+  width:100%; padding:var(--sp-10) var(--sp-12); border-radius:var(--r-lg);
+  border:1.5px solid var(--rose-light);
+  font-family:'Nunito',sans-serif; font-size:var(--fs-base);
+  background:var(--blush); color:var(--text); outline:none;
+  transition:border-color var(--ease-fast);
+}
+.modal-input:focus { border-color:var(--rose); }
+.modal-input::placeholder { color:var(--light); }
+
+/* ── Settings sub-tabs ── */
+.settings-tab {
+  flex:1; padding:var(--sp-8) var(--sp-4); border:none; border-radius:var(--r-lg);
+  background:transparent; cursor:pointer;
+  font-family:'Nunito',sans-serif; font-size:var(--fs-sm); font-weight:700;
+  color:var(--mid); transition:all var(--ease-fast);
+  display:flex; align-items:center; justify-content:center; gap:var(--sp-4);
+  white-space:nowrap;
+}
+.settings-tab:hover { background:rgba(242,168,184,0.15); }
+.settings-tab.active-st {
+  background:var(--card-bg, white); color:var(--tc-rose);
+  box-shadow:0 2px 8px rgba(0,0,0,0.06);
+}
+.settings-pane { display:none; }
+.settings-pane.active-sp { display:block; }
+.settings-pane-wrap {
+  min-height:auto; overflow-y:auto; flex:1;
+}
+
+/* ── Settings Sidebar Drawer ── */
+.sidebar-overlay {
+  position:fixed; inset:0; background:rgba(0,0,0,0.35);
+  z-index:9998; display:none; opacity:0;
+  transition:opacity var(--ease-med);
+}
+.sidebar-overlay.open { display:block; opacity:1; }
+.sidebar {
+  position:fixed; top:0; left:0; bottom:0;
+  width:min(85vw, 360px); background:var(--cream);
+  z-index:9999; transform:translateX(-100%);
+  transition:transform var(--ease-slow);
+  display:flex; flex-direction:column;
+  box-shadow:4px 0 24px rgba(0,0,0,0.12);
+  overflow:hidden;
+}
+.sidebar.open { transform:translateX(0); }
+.sidebar-header {
+  display:flex; align-items:center; justify-content:space-between;
+  padding:var(--sp-16) var(--sp-20) var(--sp-12); flex-shrink:0;
+  border-bottom:1px solid var(--border-subtle);
+}
+.sidebar-title { font-family:'Fraunces',serif; font-size:var(--fs-xl); font-weight:700; color:var(--text); }
+.sidebar-close {
+  width:32px; height:32px; border:none; background:transparent;
+  cursor:pointer; font-size:var(--icon-md); color:var(--light);
+  border-radius:var(--r-full); display:flex; align-items:center; justify-content:center;
+  transition:background var(--ease-fast);
+}
+.sidebar-close:hover { background:rgba(0,0,0,0.06); }
+.sidebar-tabs {
+  display:flex; gap:var(--sp-4); padding:var(--sp-8) var(--sp-16); flex-shrink:0;
+  overflow-x:auto; -webkit-overflow-scrolling:touch;
+  scrollbar-width:none; background:var(--warm);
+}
+.sidebar-tabs::-webkit-scrollbar { display:none; }
+.sidebar-body {
+  flex:1; overflow-y:auto; padding:var(--sp-16) var(--sp-20) var(--sp-24);
+  -webkit-overflow-scrolling:touch;
+}
+/* App version line (Phase 2 PR-3): populated by displayAppVersion() reading
+   manifest.json. :empty hide keeps the row collapsed before fetch settles. */
+.app-version-line {
+  margin-top:var(--sp-16); padding:var(--sp-12) var(--sp-16);
+  font-family:'Nunito',sans-serif; font-size:var(--fs-xs);
+  color:var(--mid); text-align:center;
+  border-top:1px solid var(--border-subtle);
+}
+.app-version-line:empty { display:none; }
+/* Quick save button at top of sidebar */
+.sidebar-save-btn {
+  display:flex; align-items:center; gap:var(--sp-12); width:100%;
+  padding:var(--sp-12) var(--sp-24); border:none; cursor:pointer;
+  font-family:'Nunito',sans-serif; font-size:var(--fs-md); font-weight:700;
+  color:var(--tc-sage); background:var(--sage-light);
+  border-bottom:1px solid var(--border-subtle); flex-shrink:0;
+  transition:background var(--ease-fast);
+}
+.sidebar-save-btn:active { background:var(--accent-sage-deep); color:white; }
+.sidebar-save-btn .save-icon { font-size:var(--icon-md); }
+.sidebar-save-btn .save-meta { font-size:var(--fs-xs); font-weight:400; color:var(--mid); margin-top:1px; }
+/* Toggle switch */
+.toggle-track {
+  position:absolute; inset:0; cursor:pointer;
+  background:var(--light); border-radius:var(--r-lg); transition:all var(--ease-med);
+}
+.toggle-track::before {
+  content:''; position:absolute; left:3px; top:3px;
+  width:18px; height:18px; border-radius:50%;
+  background:white; transition:all var(--ease-med);
+  box-shadow:0 1px 4px rgba(0,0,0,0.15);
+}
+input:checked + .toggle-track { background:var(--sage); }
+input:checked + .toggle-track::before { transform:translateX(20px); }
+
+/* ── Zoom Slider ── */
+.zoom-slider-wrap { padding:var(--sp-8) 0; }
+.zoom-slider { -webkit-appearance:none; appearance:none; width:100%; height:6px;
+  border-radius:var(--r-full); background:var(--border-subtle); outline:none; }
+.zoom-slider::-webkit-slider-thumb { -webkit-appearance:none; appearance:none;
+  width:24px; height:24px; border-radius:50%; background:var(--tc-indigo);
+  cursor:pointer; box-shadow:0 2px 8px rgba(0,0,0,0.15); }
+.zoom-slider::-moz-range-thumb { width:24px; height:24px; border-radius:50%;
+  background:var(--tc-indigo); cursor:pointer; border:none;
+  box-shadow:0 2px 8px rgba(0,0,0,0.15); }
+.zoom-ticks { display:flex; justify-content:space-between; padding:var(--sp-4) var(--sp-2) 0;
+  font-size:var(--fs-2xs); color:var(--light); font-weight:600;
+  text-transform:uppercase; letter-spacing:var(--ls-wide); }
+.zoom-preview { margin-top:var(--sp-8); padding:var(--sp-10) var(--sp-12); border-radius:var(--r-md);
+  background:var(--warm); font-size:var(--fs-base); color:var(--text);
+  text-align:center; transition:font-size 0.2s ease; }
+
+/* ── Growth facts ── */
+.growth-fact {
+  display:flex; align-items:flex-start; gap:var(--sp-12);
+  padding:var(--sp-12) var(--sp-16); border-radius:var(--r-xl); border-left:var(--accent-w) solid var(--rose);
+  background:var(--blush);
+}
+.growth-fact.positive { background:var(--sage-light); border-color:var(--sage); }
+.growth-fact.info     { background:var(--sky-light); border-color:var(--sky); }
+.growth-fact-icon { font-size:var(--icon-md); flex-shrink:0; }
+.growth-fact-body strong { font-size:var(--fs-md); font-weight:700; display:block; color:var(--text); }
+.growth-fact-body span   { font-size:var(--fs-base); font-weight:400; color:var(--mid); line-height:var(--lh-relaxed); }
+
+/* ── Growth Velocity ── */
+.velocity-gauges { display:flex; flex-wrap:wrap; gap:var(--sp-8); }
+.velocity-gauge {
+  padding:var(--sp-8) var(--sp-10); border-radius:var(--r-lg);
+  border:1.5px solid transparent;
+  display:flex; align-items:center; gap:var(--sp-8);
+  flex:0 1 auto;
+}
+.velocity-gauge.vg-sage    { background:var(--sage-light); border-color:rgba(181,213,197,0.4); }
+.velocity-gauge.vg-rose    { background:var(--blush); border-color:rgba(242,168,184,0.3); }
+.velocity-gauge.vg-sky     { background:var(--sky-light); border-color:rgba(168,207,224,0.3); }
+.velocity-gauge.vg-lav     { background:var(--lav-light); border-color:rgba(201,184,232,0.3); }
+.vg-icon { font-size:var(--icon-sm); flex-shrink:0; }
+.vg-info { flex:1; min-width:0; }
+.vg-value { font-family:'Fraunces',serif; font-size:var(--fs-md); font-weight:600; line-height:var(--lh-none); display:inline; }
+.vg-unit { font-size:var(--fs-xs); color:var(--mid); display:inline; margin-left:var(--sp-2); }
+.vg-label { font-size:var(--fs-base); font-weight:400; color:var(--mid); margin-top:1px; }
+.vg-context { font-size:var(--fs-sm); font-weight:400; color:var(--light); margin-top:1px; }
+
+/* ── Size Comparison ── */
+.size-item {
+  display:flex; align-items:center; gap:var(--sp-8);
+  padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl);
+  border:1.5px solid transparent;
+}
+.size-item.si-rose { background:var(--blush); border-color:rgba(242,168,184,0.3); }
+.size-item.si-rose strong { color:var(--tc-rose); }
+.size-item.si-sky  { background:var(--sky-light); border-color:rgba(168,207,224,0.3); }
+.size-item.si-sky strong { color:var(--tc-sky); }
+.size-item.si-lav  { background:var(--lav-light); border-color:rgba(201,184,232,0.3); }
+.size-item.si-lav strong { color:var(--tc-lav); }
+.size-icon { font-size:var(--fs-3xl); flex-shrink:0; }
+.size-body strong { font-size:var(--fs-md); font-weight:700; display:block; }
+.size-body span { font-size:var(--fs-base); font-weight:400; color:var(--mid); line-height:var(--lh-normal); }
+
+/* ── Weigh-in Reminder ── */
+.weighin-alert {
+  display:flex; align-items:center; gap:var(--sp-12);
+  padding:var(--sp-12) var(--sp-16); border-radius:var(--r-xl);
+}
+.weighin-alert.due { background:var(--peach-light); border-left:var(--accent-w) solid var(--border-warn); }
+.weighin-alert.recent { background:var(--sage-light); border-left:var(--accent-w) solid var(--sage); }
+.weighin-icon { font-size:var(--icon-lg); flex-shrink:0; }
+.weighin-body { flex:1; }
+.weighin-body strong { font-size:var(--fs-md); font-weight:700; display:block; color:var(--text); }
+.weighin-body span { font-size:var(--fs-base); font-weight:400; color:var(--mid); }
+
+/* ── Supplement alert ── */
+.supp-alert {
+  display:flex; flex-direction:column; gap:var(--sp-8);
+  padding:var(--sp-12) var(--sp-16); border-radius:var(--r-xl);
+  background:var(--peach-light);
+  border-left:var(--accent-w) solid var(--border-warn);
+  transition:all var(--ease-slow);
+}
+.supp-alert.done {
+  background:var(--sage-light);
+  border-left-color:var(--sage);
+}
+.supp-alert.missed {
+  background:var(--rose-light);
+  border-left-color:var(--tc-danger);
+}
+.supp-alert-top {
+  /* HF-2: reverts PR #117's flex-wrap (no longer needed). The action row is now a
+     SIBLING of .supp-alert-top, not a child — see home.js render branches. So
+     .supp-alert-top only needs to lay out icon + title on a single row. */
+  display:flex; align-items:center; gap:var(--sp-8);
+}
+.supp-alert-icon { font-size:var(--icon-md); flex-shrink:0; }
+.supp-alert-title {
+  /* HF-2: reverts PR #117's min-width:0 (no longer needed). With the action row out
+     of .supp-alert-top, the title competes with nothing — it gets the full row width
+     after the icon. flex:1 lets it expand to fill; default min-width:auto lets long
+     unbroken words break naturally if ever wider than the card. */
+  flex:1; font-size:var(--fs-md); font-weight:600; color:var(--text);
+}
+.supp-alert.done .supp-alert-title { color:var(--tc-sage); }
+.supp-alert.missed .supp-alert-title { color:var(--tc-rose); }
+.supp-alert-action { flex-shrink:0; display:flex; gap:var(--sp-4); align-items:center; flex-wrap:wrap; justify-content:flex-end; }
+.supp-alert-detail { font-size:var(--fs-base); font-weight:400; color:var(--mid); padding-left:var(--sp-24); line-height:var(--lh-normal); }
+.supp-alert.done .supp-alert-detail { color:var(--tc-sage); }
+.supp-alert.missed .supp-alert-detail { color:var(--tc-rose); }
+.supp-check-btn {
+  font-family:'Nunito',sans-serif; font-size:var(--fs-sm); font-weight:700;
+  padding:var(--sp-10) var(--sp-16); border-radius:var(--r-2xl); border:none;
+  cursor:pointer; transition:all var(--ease-fast); letter-spacing:var(--ls-normal);
+  background:var(--accent-sage-deep); color:white; white-space:nowrap;
+  min-height:40px; display:inline-flex; align-items:center;
+}
+.supp-check-btn:hover { filter:brightness(1.05); transform:translateY(-1px); }
+.supp-check-btn.checked {
+  background:transparent; border:1.5px solid var(--sage);
+  color:var(--tc-sage); cursor:default; padding:3.var(--sp-6) var(--sp-10);
+}
+.supp-skip-btn {
+  font-family:'Nunito',sans-serif; font-size:var(--fs-sm); font-weight:700;
+  padding:var(--sp-10) var(--sp-16); border-radius:var(--r-2xl);
+  border:1.5px solid var(--light); background:transparent;
+  color:var(--mid); cursor:pointer; transition:all var(--ease-fast); letter-spacing:var(--ls-normal); white-space:nowrap;
+  min-height:40px; display:inline-flex; align-items:center;
+}
+.supp-skip-btn:hover { border-color:var(--rose); color:var(--rose); background:var(--rose-light); }
+
+/* Vit D3 tracking v1 — done-state card, inline time-edit, and pattern card */
+.supp-alert-done {
+  background:var(--sage-light);
+  border-left-color:var(--sage);
+}
+.supp-alert-done .supp-alert-title { color:var(--tc-sage); }
+.supp-alert-done .supp-alert-detail { color:var(--tc-sage); }
+.supp-check-btn-alt {
+  background:transparent;
+  color:var(--tc-sage);
+  border:1.5px solid var(--sage);
+}
+.supp-check-btn-alt:hover { background:var(--sage-light); }
+.supp-time-input {
+  font-family:'Nunito',sans-serif; font-size:var(--fs-base);
+  padding:var(--sp-6) var(--sp-10); border-radius:var(--r-md);
+  border:1.5px solid var(--border); background:var(--bg);
+  color:var(--text); min-height:40px;
+}
+.supp-fat-badge {
+  display:inline-flex; align-items:center; gap:var(--sp-4);
+  font-size:var(--fs-sm); color:var(--tc-sage); font-weight:600;
+}
+.supp-fat-badge-neutral { color:var(--mid); font-weight:400; }
+.supp-adjust-btn {
+  font-size:var(--fs-sm); padding:var(--sp-4) var(--sp-10);
+  min-height:auto;
+}
+/* CR-5: skipped-state reminder card variant — distinct from done/missed */
+.supp-alert-skipped {
+  background:var(--amber-light);
+  border-left-color:var(--amber);
+}
+.supp-alert-skipped .supp-alert-title { color:var(--tc-warn); }
+.supp-alert-skipped .supp-alert-detail { color:var(--tc-warn); }
+/* CR-7: openMedAdjust hint when no historical time was captured.
+   V-V-10: explicit --mid colour so the italic reads as neutral observation rather than
+   inheriting --tc-sage from .supp-alert-done (which read as confirmatory not directive).
+   V-V-11: baked-in fs-sm so the class is self-contained if a future caller forgets t-sm. */
+.supp-adjust-hint {
+  display:inline-block; margin-right:var(--sp-6);
+  font-style:italic; font-size:var(--fs-sm); color:var(--mid);
+}
+.med-d3-summary {
+  padding:var(--sp-8) 0; line-height:var(--lh-relaxed);
+  font-size:var(--fs-base); color:var(--mid);
+}
+.med-d3-summary-row { padding:var(--sp-2) 0; }
+.med-d3-log {
+  padding-top:var(--sp-6); border-top:1px solid var(--border);
+  font-size:var(--fs-sm); line-height:var(--lh-normal);
+}
+.med-d3-log-row {
+  display:flex; gap:var(--sp-12); padding:var(--sp-2) 0;
+  flex-wrap:nowrap;
+}
+.med-d3-log-row > :last-child { min-width:0; overflow-wrap:break-word; flex:1; }
+.med-d3-log-date {
+  min-width:64px; color:var(--mid); font-weight:400; flex-shrink:0;
+}
+
+/* ── Home stat pills ── */
+/* ── Stat pills grid — balanced sizing ── */
+.stat-pills-grid {
+  display:grid;
+  grid-template-columns:repeat(4, 1fr);
+  gap:var(--sp-8);
+}
+@media(max-width:400px) {
+  .stat-pills-grid { grid-template-columns:repeat(3, 1fr); gap:var(--sp-8); }
+}
+
+/* ─── "Today for Ziva" — the Home lede (PR-K) ─── */
+.today-hero {
+  background:linear-gradient(135deg, var(--peach-light), var(--warm));
+  border:1px solid rgba(250,212,180,0.5);
+}
+.th-head { display:flex; align-items:baseline; justify-content:space-between; gap:var(--sp-8); }
+.th-title {
+  font-family:'Fraunces', serif; font-size:var(--fs-xl); font-weight:600;
+  color:var(--text); line-height:1.2;
+}
+.th-age { font-size:var(--fs-sm); font-weight:600; color:var(--mid); flex-shrink:0; }
+.th-date { font-size:var(--fs-sm); color:var(--light); margin-top:var(--sp-2); }
+.th-focus { margin-top:var(--sp-12); }
+.th-focus-row {
+  display:flex; align-items:center; gap:var(--sp-10);
+  padding:var(--sp-10) var(--sp-12); border-radius:var(--r-lg);
+  /* translucent so the row settles into the warm card rather than reading
+     as a stark white block floating on top of it */
+  background:rgba(255,255,255,0.62); border-left:3px solid var(--sage);
+}
+.th-focus-row.thf-action { border-left-color:var(--rose); }
+.th-focus-row.thf-watch  { border-left-color:var(--amber); }
+.th-focus-row.thf-clear  { border-left-color:var(--sage); }
+.th-focus-icon {
+  width:36px; height:36px; flex-shrink:0; border-radius:var(--r-full);
+  background:var(--peach-light); display:flex; align-items:center; justify-content:center;
+}
+.th-focus-icon .zi { width:var(--icon-md); height:var(--icon-md); }
+.th-focus-body { flex:1; min-width:0; }
+.th-focus-label {
+  font-size:var(--fs-2xs); font-weight:700; letter-spacing:0.04em;
+  text-transform:uppercase; color:var(--light);
+}
+.th-focus-text { font-size:var(--fs-sm); font-weight:600; color:var(--text); margin-top:var(--sp-2); }
+.th-focus-btn {
+  flex-shrink:0; font-size:var(--fs-sm); font-weight:600;
+  padding:var(--sp-6) var(--sp-12); border-radius:var(--r-full);
+  /* soft card-toned pill — calmer than a hard dark button, themes correctly */
+  border:1px solid var(--card-border); background:var(--card-bg); color:var(--text);
+  cursor:pointer;
+}
+.th-focus-btn:active { transform:scale(0.95); }
+[data-theme="dark"] .today-hero {
+  background:linear-gradient(135deg, rgba(250,212,180,0.10), rgba(255,255,255,0.03));
+  border-color:rgba(250,212,180,0.2);
+}
+/* dark: a subtle elevated surface — NOT var(--mid), which is a light mauve
+   in dark mode and rendered the row as a glaring pale block (feedback fix) */
+[data-theme="dark"] .th-focus-row { background:rgba(255,255,255,0.05); }
+[data-theme="dark"] .th-focus-btn { background:rgba(255,255,255,0.08); border-color:rgba(255,255,255,0.12); }
+[data-theme="dark"] .th-focus-icon { background:rgba(250,212,180,0.14); }
+
+.home-stat-pill {
+  border-radius:var(--r-xl); padding:var(--sp-12);
+  text-align:center; min-width:0;
+  border:1.5px solid transparent;
+  transition:transform var(--ease-fast), box-shadow var(--ease-fast);
+  overflow:hidden; word-break:break-word;
+  /* v2.4: lift pills off hero gradient */
+  background:rgba(255,255,255,0.7);
+  box-shadow:0 2px 8px rgba(180,120,120,0.06);
+  backdrop-filter:blur(8px); -webkit-backdrop-filter:blur(8px);
+}
+.home-stat-pill[onclick] { cursor:pointer; }
+.home-stat-pill[onclick]:hover { transform:translateY(-1px); box-shadow:0 4px 16px var(--shadow); }
+.home-stat-pill[onclick]:active { transform:scale(0.97); }
+.home-stat-pill.hsp-rose  { background:var(--blush); border-color:rgba(242,168,184,0.3); }
+.home-stat-pill.hsp-rose .hsp-val { color:var(--tc-rose); }
+.home-stat-pill.hsp-sky   { background:var(--sky-light); border-color:rgba(168,207,224,0.3); }
+.home-stat-pill.hsp-sky .hsp-val { color:var(--tc-sky); }
+.home-stat-pill.hsp-lav   { background:var(--lav-light); border-color:rgba(201,184,232,0.3); }
+.home-stat-pill.hsp-lav .hsp-val { color:var(--tc-lav); }
+.home-stat-pill.hsp-sage  { background:var(--sage-light); border-color:rgba(181,213,197,0.3); }
+.home-stat-pill.hsp-sage .hsp-val { color:var(--tc-sage); }
+.home-stat-pill.hsp-peach { background:var(--peach-light); border-color:rgba(250,212,180,0.3); }
+.home-stat-pill.hsp-peach .hsp-val { color:var(--tc-caution); }
+.hsp-icon { font-size:var(--icon-md); margin-bottom:var(--sp-4); }
+.hsp-val  { font-family:'Fraunces',serif; font-size:var(--fs-md); font-weight:600; line-height:var(--lh-tight); word-break:break-word; }
+.hsp-label{ font-size:var(--fs-2xs); text-transform:uppercase; letter-spacing:var(--ls-tight); color:var(--mid); margin-top:var(--sp-4); line-height:var(--lh-tight); }
+.hsp-trend { font-size:var(--fs-xs); font-weight:400; margin-top:var(--sp-2); line-height:var(--lh-tight); letter-spacing:var(--ls-tight); }
+.hsp-trend.trend-up   { color:#207242; }
+.hsp-trend.trend-down { color:var(--tc-rose); }
+.hsp-trend.trend-flat { color:var(--mid); }
+[data-theme="dark"] .hsp-trend.trend-up   { color:#6fcf97; }
+[data-theme="dark"] .hsp-trend.trend-down { color:var(--rose); }
+[data-theme="dark"] .hsp-trend.trend-flat { color:var(--mid); }
+
+/* ── Home Hierarchy Tiers ── */
+/* Section labels — 3-tier visual cascade */
+.home-section-label {
+  font-family:'Fraunces',serif; font-size:var(--fs-sm); font-weight:600;
+  text-transform:uppercase; letter-spacing:var(--ls-wide);
+  color:var(--light); margin:var(--sp-12) 0 var(--sp-6); padding-left:var(--sp-4);
+  display:flex; align-items:center; gap:var(--sp-8);
+}
+.home-section-label::after {
+  content:''; flex:1; height:1px;
+  background:linear-gradient(90deg, rgba(180,120,120,0.10), transparent);
+}
+.home-section-label:first-of-type { margin-top:var(--sp-8); }
+.card-hero + .home-section-label { border-top:none; padding-top:0; }
+/* Section Tier 1: primary action sections — larger, bolder, thicker rule */
+.home-section-label.sec-t1 {
+  font-size:var(--fs-lg); font-weight:600; color:var(--text);
+  letter-spacing:var(--ls-wide); margin:var(--sp-20) 0 var(--sp-8);
+  padding-top:var(--sp-4); border-top:1px solid var(--border-subtle);
+}
+.home-section-label.sec-t1::after {
+  height:2px; background:linear-gradient(90deg, rgba(180,120,120,0.25), transparent);
+}
+/* Section Tier 2: secondary sections — mid weight */
+.home-section-label.sec-t2 {
+  font-size:var(--fs-md); color:var(--mid);
+}
+.home-section-label.sec-t2::after {
+  height:1.5px; background:linear-gradient(90deg, rgba(180,120,120,0.15), transparent);
+}
+/* Section Tier 3: reference/info sections — lightest */
+.home-section-label.sec-t3 {
+  font-size:var(--fs-sm); color:var(--light); font-weight:500;
+  letter-spacing:var(--ls-wide);
+}
+
+/* Tier 2: Action cards — bold left border, elevated */
+.card.card-action {
+  border-left:var(--accent-w) solid var(--rose);
+  box-shadow:0 4px 20px var(--shadow);
+  background:var(--white);
+  border:1px solid rgba(200,180,190,0.12);
+  border-left:var(--accent-w) solid var(--rose);
+}
+.card.card-action .card-title { font-size:var(--fs-lg); }
+.card.card-action .card-title .icon {
+  width:28px; height:28px; font-size:var(--icon-base); border-radius:var(--r-md);
+}
+
+/* Hero card header — largest title, bigger icon, no chevron needed */
+.card.card-hero .card-header { margin-bottom:var(--sp-16); }
+.card.card-hero .card-title {
+  font-size:var(--fs-xl); font-weight:700; letter-spacing:-0.02em;
+}
+.card.card-hero .card-title .icon {
+  width:40px; height:40px; font-size:var(--icon-lg); border-radius:var(--r-lg);
+}
+
+/* Tier 2: Daily interaction cards — compact header, warm tint */
+.card.card-daily {
+  padding:var(--sp-12) var(--sp-12);
+  box-shadow:0 2px 12px rgba(180,120,120,0.08);
+  border-radius:var(--r-xl);
+  background:linear-gradient(135deg, var(--white) 60%, var(--warm));
+  border-left:3px solid var(--border-subtle);
+}
+.card.card-daily .card-title {
+  font-size:var(--fs-base); font-family:'Nunito',sans-serif;
+}
+.card.card-daily .card-title .icon {
+  width:24px; height:24px; font-size:var(--icon-sm); border-radius:var(--r-md);
+}
+.card.card-daily .card-header { margin-bottom:var(--sp-10); }
+
+/* Tier 3: Info cards — receded, cool tint, dashed border */
+.card.card-info {
+  box-shadow:0 1px 8px rgba(180,120,120,0.05);
+  background:var(--warm);
+  border:1px dashed var(--border-subtle);
+}
+.card.card-info .card-header { margin-bottom:var(--sp-10); }
+.card.card-info .card-title {
+  font-size:var(--fs-sm); font-family:'Nunito',sans-serif;
+  font-weight:600; color:var(--mid);
+}
+.card.card-info .card-title .icon {
+  width:22px; height:22px; font-size:var(--icon-xs); border-radius:var(--r-md);
+  opacity:0.7;
+}
+
+/* Primary CTA button — larger, bolder than regular buttons */
+.btn-primary {
+  font-family:'Nunito', sans-serif;
+  font-size:var(--fs-md); font-weight:700;
+  padding:var(--sp-12) var(--sp-24); border-radius:var(--r-2xl); border:none;
+  cursor:pointer; transition:all var(--ease-fast);
+  letter-spacing:var(--ls-normal); min-height:48px;
+  display:inline-flex; align-items:center; justify-content:center;
+  box-shadow:0 3px 12px rgba(0,0,0,0.1);
+}
+.btn-primary:hover, .btn-primary:active { filter:brightness(1.05); transform:translateY(-1px); }
+.btn-primary.bp-rose   { background:#b0485e; color:white; }
+.btn-primary.bp-sage   { background:var(--accent-sage-deep); color:white; }
+.btn-primary.bp-lav    { background:#7e66b4; color:white; }
+.btn-primary.btn-primary.bp-peach  { background:#966525; color:white; }
+.btn-primary.bp-indigo { background:#5a6498; color:white; }
+.btn-primary.bp-amber  { background:#8a6520; color:white; }
+
+/* Hero stat — the most important number on each tab */
+.hero-stat {
+  font-family:'Fraunces',serif;
+  font-size:var(--fs-3xl); font-weight:600; line-height:var(--lh-none);
+  color:var(--tc-rose);
+}
+
+/* ── Compact vitals quick pills ── */
+.hvq-pill {
+  display:inline-flex; align-items:baseline; gap:var(--sp-4);
+  padding:var(--sp-4) var(--sp-8); border-radius:var(--r-full);
+  font-family:'Fraunces',serif; font-size:var(--fs-sm); font-weight:600;
+  color:var(--text); background:var(--warm);
+  border:1px solid var(--border-subtle);
+  cursor:pointer; transition:all var(--ease-fast);
+}
+.hvq-pill:active { transform:scale(0.95); }
+.hvq-label { font-family:'Nunito',sans-serif; font-size:var(--fs-2xs); font-weight:500; color:var(--light); text-transform:uppercase; letter-spacing:var(--ls-tight); }
+.zs-ring-mini {
+  width:40px; height:40px; border-radius:50%;
+  display:flex; align-items:center; justify-content:center;
+  border:2.5px solid var(--sage); background:var(--sage-light);
+  cursor:pointer; transition:all var(--ease-fast); flex-shrink:0;
+}
+.zs-ring-mini:active { transform:scale(0.9); }
+.zs-number-mini { font-family:'Fraunces',serif; font-size:var(--fs-sm); font-weight:700; color:var(--tc-sage); }
+[data-theme="dark"] .hvq-pill { background:rgba(255,255,255,0.05); border-color:rgba(255,255,255,0.08); }
+[data-theme="dark"] .zs-ring-mini { background:rgba(58,112,96,0.15); border-color:rgba(181,213,197,0.3); }
+
+/* ── Home reco food ── */
+.reco-item {
+  display:flex; align-items:flex-start; gap:var(--sp-8);
+  padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl);
+  background:var(--peach-light); margin-bottom:var(--sp-8); min-width:0;}
+.reco-item:last-child { margin-bottom:0; }
+.reco-icon { font-size:var(--icon-md); flex-shrink:0; }
+.reco-body strong { font-size:var(--fs-md); font-weight:700; display:block; }
+.reco-body span   { font-size:var(--fs-base); font-weight:400; color:var(--mid); line-height:var(--lh-normal); }
+
+/* ── Insights Tab ── */
+.insights-pulse {
+  background:linear-gradient(135deg, var(--peach-light), var(--blush));
+  border-radius:var(--r-xl); padding:var(--sp-16); margin-bottom:0;
+  border:1.5px solid rgba(242,168,184,0.2);
+  cursor:pointer;
+}
+[data-theme="dark"] .insights-pulse { background:linear-gradient(135deg, rgba(60,45,35,0.5), rgba(60,35,45,0.5)); }
+.insights-pulse-text { font-size:var(--fs-base); line-height:var(--lh-relaxed); color:var(--text); }
+
+/* ── Insight card colour coding ── */
+.ins-card-growth { border-left:var(--accent-w) solid var(--rose); }
+.ins-card-sleep  { border-left:var(--accent-w) solid var(--indigo); }
+.ins-card-poop   { border-left:var(--accent-w) solid var(--peach); }
+.ins-card-feed   { border-left:var(--accent-w) solid var(--sage); }
+.ins-card-cross  { border-left:var(--accent-w) solid var(--lavender); }
+
+/* ── Insight preview strips ── */
+.ins-preview {
+  display:flex; align-items:center; gap:var(--sp-8); flex-wrap:wrap;
+}
+.ins-preview-pill {
+  display:inline-flex; align-items:center; gap:var(--sp-4);
+  padding:var(--sp-4) var(--sp-10); border-radius:var(--r-2xl); font-size:var(--fs-sm); font-weight:600;
+}
+.ins-preview-pill.ipp-good  { background:var(--sage-light); color:var(--tc-sage); }
+.ins-preview-pill.ipp-warn  { background:var(--peach-light); color:var(--tc-caution); }
+.ins-preview-pill.ipp-bad   { background:var(--rose-light); color:var(--tc-rose); }
+.ins-preview-pill.ipp-info  { background:var(--sky-light); color:var(--tc-sky); }
+.ins-preview-pill.ipp-neutral { background:var(--glass); color:var(--mid); }
+
+/* ── Trend Chips (v2.4 — compact insight rows) ── */
+.trend-chip {
+  display:flex; align-items:center; gap:var(--sp-12);
+  padding:var(--sp-12) var(--sp-12); cursor:pointer;
+  transition:background var(--ease-fast);
+  border-bottom:1px solid var(--border-subtle); min-width:0;}
+.trend-chip:last-of-type { border-bottom:none; }
+.trend-chip:active { background:var(--warm); }
+.trend-chip-icon { font-size:var(--icon-md); flex-shrink:0; }
+.trend-chip-body { flex:1; min-width:0; }
+.trend-chip-label { font-size:var(--fs-base); font-weight:600; color:var(--text); }
+.trend-chip-value { font-size:var(--fs-xs); color:var(--mid); margin-top:1px; }
+.trend-chip-delta {
+  font-size:var(--fs-sm); font-weight:700; flex-shrink:0;
+  padding:var(--sp-2) var(--sp-8); border-radius:var(--r-full);
+}
+.trend-chip-delta.tc-good { color:var(--tc-sage); background:var(--sage-light); }
+.trend-chip-delta.tc-warn { color:var(--tc-amber); background:var(--amber-light); }
+.trend-chip-delta.tc-bad  { color:var(--tc-rose); background:var(--rose-light); }
+.trend-chip-delta.tc-neutral { color:var(--mid); background:var(--glass); }
+.trend-chip-chevron { font-size:var(--icon-xs); color:var(--light); transition:transform var(--ease-fast); flex-shrink:0; }
+.trend-chip.expanded .trend-chip-chevron { transform:rotate(180deg); }
+.trend-chip-detail {
+  display:none; padding:var(--sp-10) var(--sp-12) var(--sp-12);
+  border-bottom:1px solid var(--border-subtle);
+  animation:fadeUp 0.25s ease both;
+}
+.trend-chip-detail.open { display:block; }
+[data-theme="dark"] .trend-chip:active { background:rgba(255,255,255,0.04); }
+[data-theme="dark"] .trend-chip-delta.tc-good { background:rgba(50,70,60,0.3); }
+[data-theme="dark"] .trend-chip-delta.tc-warn { background:rgba(70,55,35,0.3); }
+[data-theme="dark"] .trend-chip-delta.tc-bad  { background:rgba(70,40,50,0.3); }
+
+.insights-section { margin-bottom:var(--sp-20); }
+.insights-section-title {
+  font-family:'Fraunces',serif; font-size:var(--fs-lg); font-weight:600;
+  margin-bottom:var(--sp-10); display:flex; align-items:center; gap:var(--sp-8);
+}
+.insight-row {
+  display:flex; align-items:center; gap:var(--sp-12); padding:var(--sp-12) var(--sp-12);
+  border-radius:var(--r-xl); margin-bottom:var(--sp-6);
+  background:var(--card-bg); border:1px solid var(--card-border); min-width:0;}
+.insight-row .ir-icon { font-size:var(--icon-md); flex-shrink:0; }
+.insight-row .ir-body { flex:1; min-width:0; }
+.insight-row .ir-label { font-size:var(--fs-sm); font-weight:400; color:var(--mid); }
+.insight-row .ir-value { font-family:'Fraunces',serif; font-size:var(--fs-md); font-weight:600; }
+.insight-row .ir-delta { font-size:var(--fs-xs); font-weight:600; margin-left:var(--sp-6); }
+.insight-row .ir-delta.trend-up   { color:#207242; }
+.insight-row .ir-delta.trend-down { color:var(--tc-rose); }
+.insight-row .ir-delta.trend-flat { color:var(--mid); }
+[data-theme="dark"] .insight-row .ir-delta.trend-up   { color:#6fcf97; }
+[data-theme="dark"] .insight-row .ir-delta.trend-down { color:var(--rose); }
+.insight-narrative {
+  padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl); margin-bottom:var(--sp-8);
+  font-size:var(--fs-base); font-weight:400; line-height:var(--lh-relaxed); color:var(--text);
+  border-left:var(--accent-w) solid var(--sage);
+  background:var(--sage-light);
+}
+[data-theme="dark"] .insight-narrative { background:rgba(50,70,60,0.3); }
+.insight-narrative.in-rose { border-left-color:var(--rose); background:var(--blush); }
+[data-theme="dark"] .insight-narrative.in-rose { background:rgba(70,40,50,0.3); }
+.insight-narrative.in-amber { border-left-color:var(--peach); background:var(--peach-light); }
+[data-theme="dark"] .insight-narrative.in-amber { background:rgba(70,55,35,0.3); }
+.insight-narrative.in-indigo { border-left-color:var(--indigo); background:rgba(99,102,241,0.08); }
+[data-theme="dark"] .insight-narrative.in-indigo { background:rgba(99,102,241,0.12); }
+.insight-narrative.in-lav { border-left-color:var(--lav); background:var(--lav-light); }
+[data-theme="dark"] .insight-narrative.in-lav { background:rgba(60,50,80,0.3); }
+.insight-pattern {
+  display:flex; align-items:flex-start; gap:var(--sp-8); padding:var(--sp-12) var(--sp-12);
+  border-radius:var(--r-xl); margin-bottom:var(--sp-6);
+  background:rgba(99,102,241,0.06); border:1px solid rgba(99,102,241,0.12);
+}
+[data-theme="dark"] .insight-pattern { background:rgba(99,102,241,0.1); border-color:rgba(99,102,241,0.2); }
+.insight-pattern .ip-icon { font-size:var(--icon-base); flex-shrink:0; margin-top:1px; }
+.insight-pattern .ip-text { font-size:var(--fs-sm); line-height:var(--lh-relaxed); color:var(--text); }
+
+/* ── Info (PreAlpha) Tab ── */
+.hero-info {
+  background:linear-gradient(135deg, var(--lav-light), var(--sky-light));
+  border:1.5px solid rgba(180,160,220,0.2);
+}
+[data-theme="dark"] .hero-info { background:linear-gradient(135deg, rgba(60,50,80,0.4), rgba(40,55,75,0.4)); }
+.info-intro-chart {
+  display:flex; align-items:flex-end; gap:var(--sp-4); height:100px;
+  padding:var(--sp-8) 0;
+}
+.info-intro-bar-col {
+  flex:1; display:flex; flex-direction:column; align-items:center; gap:var(--sp-2);
+  min-width:0;
+}
+.info-intro-bar-track {
+  width:100%; height:60px; display:flex; align-items:flex-end; justify-content:center;
+}
+.info-intro-bar {
+  width:70%; max-width:32px; border-radius:var(--r-md) var(--r-md) 0 0;
+  background:linear-gradient(180deg, var(--sage), var(--sage-light));
+  transition:height var(--ease-med); min-height:3px;
+}
+[data-theme="dark"] .info-intro-bar {
+  background:linear-gradient(180deg, rgba(80,140,110,0.6), rgba(80,140,110,0.25));
+}
+.info-food-chip {
+  display:inline-block; padding:var(--sp-4) var(--sp-10); border-radius:var(--r-full);
+  font-size:var(--fs-xs); font-weight:600;
+}
+.info-food-chip.is-sage { background:var(--sage-light); color:var(--tc-sage); }
+.info-food-chip.is-warn { background:var(--amber-light); color:var(--tc-amber); }
+[data-theme="dark"] .info-food-chip.is-sage { background:rgba(50,70,60,0.3); }
+[data-theme="dark"] .info-food-chip.is-warn { background:rgba(70,55,35,0.3); }
+
+/* ── Nutrient Heatmap ── */
+.nh-grid {
+  display:grid; grid-template-columns:72px repeat(7, 1fr);
+  gap:var(--sp-4); font-size:var(--fs-xs); min-width:0;
+  width:100%;
+}
+.nh-header {
+  text-align:center; font-weight:600; color:var(--light);
+  padding:var(--sp-4) 0; font-size:var(--fs-xs);
+}
+.nh-label {
+  display:flex; align-items:center; gap:var(--sp-4);
+  font-weight:600; color:var(--mid);
+  white-space:nowrap; font-size:var(--fs-xs);
+  overflow:hidden;
+}
+.nh-cell {
+  aspect-ratio:1; border-radius:var(--r-md); min-height:28px; max-height:40px;
+  display:flex; align-items:center; justify-content:center;
+  font-size:var(--fs-xs); font-weight:600;
+  transition:background var(--ease-fast); cursor:pointer;
+}
+.nh-cell.nh-0 { background:rgba(0,0,0,0.04); color:var(--light); }
+.nh-cell.nh-nodata { background:repeating-linear-gradient(45deg,transparent,transparent 3px,rgba(0,0,0,0.03) 3px,rgba(0,0,0,0.03) 6px); color:var(--light); font-size:10px; }
+.nh-cell.nh-1 { color:var(--tc-sage); }
+.nh-cell.nh-2 { color:white; }
+.nh-cell.nh-3 { color:white; }
+
+/* Per-nutrient row colors */
+.nh-row-iron.nh-1     { background:rgba(220,100,120,0.2); }
+.nh-row-iron.nh-2     { background:rgba(220,100,120,0.5); }
+.nh-row-iron.nh-3     { background:rgba(220,100,120,0.8); }
+.nh-row-calcium.nh-1  { background:rgba(130,185,210,0.2); }
+.nh-row-calcium.nh-2  { background:rgba(130,185,210,0.5); }
+.nh-row-calcium.nh-3  { background:rgba(130,185,210,0.8); }
+.nh-row-protein.nh-1  { background:rgba(140,190,160,0.2); }
+.nh-row-protein.nh-2  { background:rgba(140,190,160,0.5); }
+.nh-row-protein.nh-3  { background:rgba(140,190,160,0.8); }
+.nh-row-vitc.nh-1     { background:rgba(240,180,140,0.25); }
+.nh-row-vitc.nh-2     { background:rgba(240,180,140,0.55); }
+.nh-row-vitc.nh-3     { background:rgba(240,180,140,0.85); }
+.nh-row-fibre.nh-1    { background:rgba(210,170,100,0.2); }
+.nh-row-fibre.nh-2    { background:rgba(210,170,100,0.5); }
+.nh-row-fibre.nh-3    { background:rgba(210,170,100,0.8); }
+.nh-row-vita.nh-1     { background:rgba(180,160,220,0.2); }
+.nh-row-vita.nh-2     { background:rgba(180,160,220,0.5); }
+.nh-row-vita.nh-3     { background:rgba(180,160,220,0.8); }
+.nh-row-omega3.nh-1   { background:rgba(99,102,241,0.15); }
+.nh-row-omega3.nh-2   { background:rgba(99,102,241,0.4); }
+.nh-row-omega3.nh-3   { background:rgba(99,102,241,0.7); }
+.nh-row-zinc.nh-1     { background:rgba(240,190,160,0.2); }
+.nh-row-zinc.nh-2     { background:rgba(240,190,160,0.5); }
+.nh-row-zinc.nh-3     { background:rgba(240,190,160,0.8); }
+
+[data-theme="dark"] .nh-cell.nh-0 { background:rgba(255,255,255,0.06); }
+[data-theme="dark"] .nh-cell.nh-nodata { background:repeating-linear-gradient(45deg,transparent,transparent 3px,rgba(255,255,255,0.04) 3px,rgba(255,255,255,0.04) 6px); }
+[data-theme="dark"] .nh-cell.nh-1 { opacity:0.85; }
+
+.nh-detail-panel {
+  padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl);
+  background:var(--warm); font-size:var(--fs-sm); color:var(--text);
+  line-height:var(--lh-relaxed); display:none;
+}
+.nh-detail-panel.open { display:block; animation:fadeUp 0.2s ease both; }
+[data-theme="dark"] .nh-detail-panel { background:rgba(255,255,255,0.04); }
+
+/* ── Meal Nutrient Breakdown (Feature 4) ── */
+.mb-meal-grid { display:flex; flex-direction:column; gap:var(--sp-8); }
+.mb-meal-card {
+  padding:var(--sp-8) var(--sp-12); border-radius:var(--r-xl);
+  background:var(--warm); position:relative; overflow:hidden;
+}
+[data-theme="dark"] .mb-meal-card { background:rgba(255,255,255,0.04); }
+.mb-meal-label {
+  font-size:var(--fs-sm); font-weight:700; color:var(--text);
+  margin-bottom:var(--sp-2);
+}
+.mb-meal-score {
+  font-size:var(--fs-lg); font-weight:800; line-height:1.1;
+}
+.mb-meal-nutrients {
+  font-size:var(--fs-xs); color:var(--light); margin-top:var(--sp-2);
+}
+.mb-meal-bar {
+  position:absolute; bottom:0; left:0; height:3px;
+  border-radius:0 var(--r-full) var(--r-full) 0;
+  transition:width var(--ease-med);
+}
+.mb-dist-bar {
+  display:flex; height:24px; border-radius:var(--r-full);
+  overflow:hidden; background:rgba(0,0,0,0.04);
+}
+[data-theme="dark"] .mb-dist-bar { background:rgba(255,255,255,0.06); }
+.mb-dist-seg {
+  display:flex; align-items:center; justify-content:center;
+  font-size:var(--fs-xs); font-weight:700; color:var(--text);
+  transition:flex var(--ease-med); min-width:0;
+}
+.mb-alert-item {
+  display:flex; align-items:flex-start; gap:var(--sp-8);
+  padding:var(--sp-6) 0; font-size:var(--fs-sm); line-height:var(--lh-relaxed);
+}
+.mb-alert-item.alert-good { color:var(--tc-sage); }
+.mb-alert-item.alert-warn { color:var(--tc-amber); }
+.mb-weekly-row {
+  display:grid; grid-template-columns:64px repeat(4, 1fr);
+  gap:var(--sp-4); align-items:center;
+}
+.mb-weekly-cell {
+  aspect-ratio:1.6; border-radius:var(--r-md); min-height:22px; max-height:32px;
+  display:flex; align-items:center; justify-content:center;
+  font-weight:600; transition:background var(--ease-fast);
+}
+[data-theme="dark"] .mb-weekly-cell { opacity:0.85; }
+
+/* ── Logging Streak (PR-N) ── */
+.streak-hero {
+  display:flex; align-items:center; gap:var(--sp-12);
+  padding:var(--sp-12) var(--sp-16); border-radius:var(--r-xl);
+  background:var(--amber-light);
+}
+[data-theme="dark"] .streak-hero { background:rgba(70,55,35,0.3); }
+.streak-flame { color:var(--tc-amber); display:flex; }
+.streak-flame .zi { width:30px; height:30px; }
+.streak-num {
+  font-family:'Fraunces', serif; font-size:var(--fs-3xl); font-weight:600;
+  color:var(--tc-amber); line-height:var(--lh-none);
+}
+.streak-cap { font-size:var(--fs-sm); color:var(--mid); font-weight:600; }
+.streak-hero-best { margin-left:auto; text-align:right; }
+.streak-best { font-size:var(--fs-xs); color:var(--light); }
+.streak-best-val { font-size:var(--fs-sm); font-weight:700; color:var(--tc-amber); }
+.streak-miles { display:flex; gap:var(--sp-8); }
+.streak-mile {
+  flex:1; text-align:center; padding:var(--sp-8) var(--sp-4);
+  border-radius:var(--r-lg); background:var(--warm);
+  border:1.5px solid transparent;
+}
+[data-theme="dark"] .streak-mile { background:rgba(255,255,255,0.04); }
+.streak-mile.reached { background:var(--amber-light); border-color:var(--tc-amber); }
+[data-theme="dark"] .streak-mile.reached { background:rgba(70,55,35,0.4); }
+.streak-mile-icon { color:var(--light); display:flex; justify-content:center; }
+.streak-mile-icon .zi { width:18px; height:18px; }
+.streak-mile.reached .streak-mile-icon { color:var(--tc-amber); }
+.streak-mile-label {
+  font-size:var(--fs-xs); font-weight:700; color:var(--mid);
+  margin-top:var(--sp-2);
+}
+.streak-mile.reached .streak-mile-label { color:var(--tc-amber); }
+.streak-grid { display:flex; gap:var(--sp-4); flex-wrap:wrap; }
+.streak-day { text-align:center; }
+.streak-dot {
+  width:18px; height:18px; border-radius:var(--r-sm);
+  background:var(--warm); margin:0 auto;
+}
+[data-theme="dark"] .streak-dot { background:rgba(255,255,255,0.06); }
+.streak-dot.partial { background:rgba(232,184,109,0.4); }
+.streak-dot.on { background:var(--tc-amber); }
+.streak-dot-label { font-size:9px; color:var(--light); margin-top:var(--sp-2); }
+
+/* ── Smart Pairing Suggestions (Feature 5) ── */
+.sp-pair-card {
+  padding:var(--sp-8) var(--sp-12); border-radius:var(--r-xl);
+  background:var(--warm); transition:background var(--ease-fast);
+}
+[data-theme="dark"] .sp-pair-card { background:rgba(255,255,255,0.04); }
+.sp-pair-foods {
+  font-size:var(--fs-sm); font-weight:600; color:var(--text);
+}
+.sp-pair-reason {
+  font-size:var(--fs-xs); color:var(--light); margin-top:var(--sp-2);
+  line-height:var(--lh-relaxed);
+}
+.sp-pair-type {
+  display:inline-block; padding:1px var(--sp-8); border-radius:var(--r-full);
+  font-size:10px; font-weight:700; text-transform:uppercase;
+  letter-spacing:var(--ls-wide); margin-top:var(--sp-4);
+}
+.sp-type-absorption { background:rgba(220,100,120,0.12); color:var(--tc-rose); }
+.sp-type-complete { background:rgba(180,160,220,0.15); color:var(--tc-lav); }
+.sp-type-digestion { background:rgba(140,190,160,0.15); color:var(--tc-sage); }
+[data-theme="dark"] .sp-type-absorption { background:rgba(220,100,120,0.2); }
+[data-theme="dark"] .sp-type-complete { background:rgba(180,160,220,0.2); }
+[data-theme="dark"] .sp-type-digestion { background:rgba(140,190,160,0.2); }
+.sp-gap-chip {
+  display:inline-block; padding:var(--sp-2) var(--sp-8); border-radius:var(--r-full);
+  font-size:var(--fs-xs); font-weight:600;
+  background:var(--amber-light); color:var(--tc-amber);
+  text-transform:capitalize;
+}
+[data-theme="dark"] .sp-gap-chip { background:rgba(70,55,35,0.3); }
+
+/* ── Meal Breakdown ── */
+.mb-meal-grid {
+  display:grid; grid-template-columns:1fr 1fr; gap:var(--sp-8);
+}
+.mb-meal-card {
+  padding:var(--sp-12); border-radius:var(--r-xl);
+  background:var(--warm); position:relative; overflow:hidden;
+}
+[data-theme="dark"] .mb-meal-card { background:rgba(255,255,255,0.04); }
+.mb-meal-label {
+  font-size:var(--fs-xs); font-weight:700; text-transform:uppercase;
+  letter-spacing:var(--ls-wide); color:var(--mid); margin-bottom:var(--sp-4);
+}
+.mb-meal-score {
+  font-size:var(--fs-xl); font-weight:800; line-height:1;
+  font-family:'Bricolage Grotesque',sans-serif;
+}
+.mb-meal-bar {
+  position:absolute; bottom:0; left:0; right:0; height:3px;
+  border-radius:0 0 var(--r-xl) var(--r-xl);
+  transition:width var(--ease-med);
+}
+.mb-meal-nutrients {
+  margin-top:var(--sp-4); font-size:var(--fs-xs); color:var(--light);
+  line-height:var(--lh-relaxed);
+}
+.mb-dist-bar {
+  display:flex; gap:var(--sp-2); height:20px; border-radius:var(--r-lg); overflow:hidden;
+  margin-top:var(--sp-8);
+}
+.mb-dist-seg {
+  border-radius:var(--r-sm); display:flex; align-items:center; justify-content:center;
+  font-size:9px; font-weight:700; color:white; min-width:16px;
+  transition:flex var(--ease-med);
+}
+.mb-alert-item {
+  display:flex; align-items:flex-start; gap:var(--sp-8);
+  padding:var(--sp-8) var(--sp-12); border-radius:var(--r-xl);
+  font-size:var(--fs-sm); line-height:var(--lh-relaxed);
+}
+.mb-alert-item.alert-warn { background:var(--amber-light); color:var(--tc-amber); }
+.mb-alert-item.alert-good { background:var(--sage-light); color:var(--tc-sage); }
+[data-theme="dark"] .mb-alert-item.alert-warn { background:rgba(70,55,35,0.3); }
+[data-theme="dark"] .mb-alert-item.alert-good { background:rgba(50,70,60,0.3); }
+.mb-weekly-row {
+  display:grid; grid-template-columns:56px repeat(4, 1fr); gap:var(--sp-4);
+  align-items:center; font-size:var(--fs-xs);
+}
+.mb-weekly-cell {
+  height:24px; border-radius:var(--r-sm); display:flex;
+  align-items:center; justify-content:center; font-weight:600;
+}
+
+/* ── Smart Pairing ── */
+.sp-pair-card {
+  padding:var(--sp-12); border-radius:var(--r-xl);
+  background:var(--warm); display:flex; flex-direction:column; gap:var(--sp-4);
+}
+[data-theme="dark"] .sp-pair-card { background:rgba(255,255,255,0.04); }
+.sp-pair-foods {
+  font-weight:700; font-size:var(--fs-base); color:var(--text);
+}
+.sp-pair-reason {
+  font-size:var(--fs-sm); color:var(--mid); line-height:var(--lh-relaxed);
+}
+.sp-pair-type {
+  display:inline-block; padding:var(--sp-2) var(--sp-8); border-radius:var(--r-full);
+  font-size:10px; font-weight:700; text-transform:uppercase;
+  letter-spacing:var(--ls-wide);
+}
+.sp-type-absorption { background:rgba(220,100,120,0.12); color:var(--tc-rose); }
+.sp-type-complete { background:rgba(140,190,160,0.15); color:var(--tc-sage); }
+.sp-type-digestion { background:rgba(180,160,220,0.15); color:var(--tc-lav); }
+[data-theme="dark"] .sp-type-absorption { background:rgba(220,100,120,0.2); }
+[data-theme="dark"] .sp-type-complete { background:rgba(140,190,160,0.2); }
+[data-theme="dark"] .sp-type-digestion { background:rgba(180,160,220,0.2); }
+.sp-gap-chip {
+  display:inline-flex; align-items:center; gap:var(--sp-4);
+  padding:var(--sp-4) var(--sp-12); border-radius:var(--r-full);
+  font-size:var(--fs-xs); font-weight:600;
+  background:var(--amber-light); color:var(--tc-amber);
+}
+[data-theme="dark"] .sp-gap-chip { background:rgba(70,55,35,0.3); }
+
+/* ── Medical Intelligence ── */
+.mi-timeline { display:flex; flex-direction:column; gap:var(--sp-8); }
+.mi-tl-row { display:flex; align-items:center; gap:var(--sp-8); min-height:28px; }
+.mi-tl-month { width:48px; font-size:var(--fs-xs); color:var(--light); text-align:right; flex-shrink:0; }
+.mi-tl-bar { flex:1; display:flex; gap:var(--sp-2); align-items:center; min-height:20px; }
+.mi-tl-block { height:18px; border-radius:var(--r-sm); min-width:6px; position:relative; cursor:default; }
+.mi-tl-block[title]:hover { opacity:0.8; }
+.mi-tl-block.mi-fever { background:var(--tc-rose); }
+.mi-tl-block.mi-diarrhoea { background:var(--tc-amber); }
+.mi-tl-block.mi-vomiting { background:var(--tc-caution); }
+.mi-tl-block.mi-cold { background:var(--tc-sky); }
+.mi-legend { display:flex; gap:var(--sp-12); flex-wrap:wrap; margin-top:var(--sp-8); }
+.mi-legend-item { display:flex; align-items:center; gap:var(--sp-4); font-size:var(--fs-xs); color:var(--mid); white-space:nowrap; }
+.mi-legend-dot { width:10px; height:10px; border-radius:var(--r-sm); flex-shrink:0; }
+.mi-vacc-row { display:flex; align-items:flex-start; gap:var(--sp-8); padding:var(--sp-8) 0; border-bottom:1px solid var(--border); }
+.mi-vacc-row:last-child { border-bottom:none; }
+.mi-vacc-dot { width:8px; height:8px; border-radius:var(--r-full); margin-top:var(--sp-6); flex-shrink:0; }
+.mi-vacc-info { flex:1; }
+.mi-vacc-name { font-size:var(--fs-sm); font-weight:600; color:var(--text); }
+.mi-vacc-detail { font-size:var(--fs-xs); color:var(--light); margin-top:var(--sp-2); }
+.mi-vacc-fever { font-size:var(--fs-xs); color:var(--tc-rose); font-weight:500; margin-top:var(--sp-2); }
+.mi-food-row { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-8) 0; border-bottom:1px solid var(--border); }
+.mi-food-row:last-child { border-bottom:none; }
+.mi-food-name { font-size:var(--fs-sm); font-weight:600; color:var(--text); min-width:80px; }
+.mi-food-bar { flex:1; height:6px; border-radius:var(--r-full); background:rgba(0,0,0,0.06); overflow:hidden; }
+.mi-food-fill { height:100%; border-radius:var(--r-full); }
+.mi-food-count { font-size:var(--fs-xs); color:var(--light); width:40px; text-align:right; }
+.mi-recovery-entry { background:var(--surface-alt); border-radius:var(--r-md); padding:var(--sp-12); }
+.mi-recovery-header { display:flex; justify-content:space-between; align-items:center; margin-bottom:var(--sp-8); }
+.mi-recovery-type { font-size:var(--fs-xs); font-weight:600; text-transform:uppercase; letter-spacing:var(--ls-wide); }
+.mi-recovery-dates { font-size:var(--fs-xs); color:var(--light); }
+.mi-recovery-metric { display:flex; justify-content:space-between; align-items:center; font-size:var(--fs-sm); padding:var(--sp-4) 0; }
+.mi-recovery-label { color:var(--mid); }
+.mi-recovery-val { font-weight:600; }
+.mi-sleep-grid { display:grid; grid-template-columns:48px repeat(7, 1fr); gap:var(--sp-4); font-size:var(--fs-xs); }
+.mi-sleep-header { text-align:center; color:var(--light); font-weight:500; padding:var(--sp-2) 0; }
+.mi-sleep-label { display:flex; align-items:center; justify-content:flex-end; padding-right:var(--sp-4); color:var(--light); }
+.mi-sleep-cell { text-align:center; border-radius:var(--r-sm); padding:var(--sp-4) var(--sp-2); min-height:24px; display:flex; align-items:center; justify-content:center; }
+.mi-sleep-normal { background:rgba(140,190,160,0.15); color:var(--tc-sage); }
+.mi-sleep-disrupted { background:rgba(240,180,100,0.2); color:var(--tc-amber); }
+.mi-sleep-sick { background:rgba(230,100,100,0.15); color:var(--tc-rose); }
+.mi-sleep-nodata { background:repeating-linear-gradient(45deg,transparent,transparent 3px,rgba(0,0,0,0.03) 3px,rgba(0,0,0,0.03) 6px); color:var(--light); }
+.mi-frt-entry { padding:var(--sp-8) 0; border-bottom:1px solid var(--border); }
+.mi-frt-entry:last-child { border-bottom:none; }
+.mi-frt-header { display:flex; justify-content:space-between; align-items:center; }
+.mi-frt-food { font-size:var(--fs-sm); font-weight:600; color:var(--text); }
+.mi-frt-status { font-size:var(--fs-xs); font-weight:500; padding:var(--sp-2) var(--sp-8); border-radius:var(--r-full); }
+.mi-frt-status-ok { background:rgba(140,190,160,0.2); color:var(--tc-sage); }
+.mi-frt-status-watch { background:rgba(240,180,100,0.2); color:var(--tc-amber); }
+.mi-frt-status-react { background:rgba(230,100,100,0.15); color:var(--tc-rose); }
+.mi-frt-timeline { display:flex; align-items:center; gap:0; margin-top:var(--sp-4); padding:var(--sp-4) 0; }
+.mi-frt-dot { width:8px; height:8px; border-radius:var(--r-full); flex-shrink:0; }
+.mi-frt-line { flex:1; height:2px; background:var(--border); min-width:12px; }
+.mi-frt-event { font-size:10px; color:var(--light); white-space:nowrap; }
+.mi-frt-node { display:flex; flex-direction:column; align-items:center; gap:var(--sp-2); flex-shrink:0; min-width:60px; text-align:center; }
+.mi-nodata { font-size:var(--fs-sm); color:var(--light); text-align:center; padding:var(--sp-16) 0; }
+
+/* MI dark mode */
+[data-theme="dark"] .mi-recovery-entry { background:rgba(255,255,255,0.04); }
+[data-theme="dark"] .mi-food-bar { background:rgba(255,255,255,0.08); }
+[data-theme="dark"] .mi-sleep-nodata { background:repeating-linear-gradient(45deg,transparent,transparent 3px,rgba(255,255,255,0.04) 3px,rgba(255,255,255,0.04) 6px); }
+[data-theme="dark"] .mi-vacc-row { border-bottom-color:rgba(255,255,255,0.06); }
+[data-theme="dark"] .mi-food-row { border-bottom-color:rgba(255,255,255,0.06); }
+[data-theme="dark"] .mi-frt-entry { border-bottom-color:rgba(255,255,255,0.06); }
+[data-theme="dark"] .mi-frt-line { background:rgba(255,255,255,0.1); }
+
+/* ── Medical Intelligence Phase 2 ── */
+.mi-adherence-row { display:flex; flex-wrap:wrap; gap:var(--sp-4); }
+.mi-adherence-dot { width:14px; height:14px; border-radius:var(--r-sm); display:flex; align-items:center; justify-content:center; font-size:8px; }
+.mi-adherence-dot.mi-adh-done { background:rgba(58,112,96,0.2); color:var(--tc-sage); }
+.mi-adherence-dot.mi-adh-missed { background:rgba(230,100,100,0.2); color:var(--tc-rose); }
+.mi-adherence-dot.mi-adh-skipped { background:rgba(240,180,80,0.2); color:var(--tc-amber); }
+.mi-adherence-dot.mi-adh-late { background:rgba(180,180,180,0.2); color:var(--mid); }
+.mi-adherence-dot.mi-adh-future { background:rgba(0,0,0,0.03); }
+.mi-velocity-range { position:relative; height:8px; border-radius:var(--r-full); background:rgba(0,0,0,0.06); overflow:visible; margin:var(--sp-8) 0; }
+.mi-velocity-expected { position:absolute; top:0; height:100%; border-radius:var(--r-full); background:rgba(58,112,96,0.15); }
+.mi-velocity-marker { position:absolute; top:-4px; width:16px; height:16px; border-radius:var(--r-full); border:2px solid var(--surface); box-shadow:0 1px 4px rgba(0,0,0,0.15); transform:translateX(-50%); }
+[data-theme="dark"] .mi-adherence-dot.mi-adh-future { background:rgba(255,255,255,0.04); }
+[data-theme="dark"] .mi-velocity-range { background:rgba(255,255,255,0.08); }
+[data-theme="dark"] .mi-velocity-marker { border-color:var(--surface); }
+
+/* ── Texture Progression ── */
+.mi-tex-stage { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-8) 0; }
+.mi-tex-icon { width:32px; height:32px; border-radius:var(--r-full); display:flex; align-items:center; justify-content:center; font-size:16px; flex-shrink:0; }
+.mi-tex-info { flex:1; }
+.mi-tex-label { font-size:var(--fs-sm); font-weight:600; color:var(--text); }
+.mi-tex-detail { font-size:var(--fs-xs); color:var(--light); margin-top:var(--sp-2); }
+.mi-tex-bar { height:4px; border-radius:var(--r-full); background:rgba(0,0,0,0.06); margin-top:var(--sp-4); overflow:hidden; }
+.mi-tex-fill { height:100%; border-radius:var(--r-full); transition:width 0.3s ease; }
+.mi-tex-connector { width:2px; height:12px; background:var(--border); margin-left:15px; }
+.mi-tex-week-grid { display:grid; gap:var(--sp-2); font-size:10px; margin-top:var(--sp-8); }
+.mi-tex-week-label { display:flex; align-items:center; justify-content:flex-end; padding-right:var(--sp-4); color:var(--light); font-size:var(--fs-xs); }
+.mi-tex-week-cell { text-align:center; border-radius:var(--r-sm); padding:var(--sp-4) 1px; min-height:20px; display:flex; align-items:center; justify-content:center; }
+.mi-tex-puree { background:rgba(200,160,220,0.2); color:rgba(150,100,180,0.9); }
+.mi-tex-mashed { background:rgba(240,180,100,0.2); color:var(--tc-amber); }
+.mi-tex-soft { background:rgba(140,190,160,0.2); color:var(--tc-sage); }
+.mi-tex-finger { background:rgba(100,180,230,0.2); color:var(--tc-sky); }
+.mi-tex-mixed { background:rgba(230,160,160,0.15); color:var(--tc-rose); }
+[data-theme="dark"] .mi-tex-bar { background:rgba(255,255,255,0.08); }
+[data-theme="dark"] .mi-tex-connector { background:rgba(255,255,255,0.1); }
+[data-theme="dark"] .mi-tex-icon { color:inherit; }
+[data-theme="dark"] .mi-tex-week-cell { color:inherit; }
+
+/* ── Hydration Intelligence ── */
+.hy-grid {
+  display:grid; grid-template-columns:52px repeat(7, 1fr);
+  gap:var(--sp-4); font-size:var(--fs-xs); min-width:0; width:100%;
+}
+.hy-header {
+  text-align:center; font-weight:600; color:var(--light);
+  padding:var(--sp-4) 0; font-size:var(--fs-xs);
+}
+.hy-label {
+  display:flex; align-items:center; gap:var(--sp-2);
+  font-weight:600; color:var(--mid); white-space:nowrap;
+  font-size:var(--fs-xs); overflow:hidden;
+}
+.hy-cell {
+  aspect-ratio:1; border-radius:var(--r-md); min-height:28px; max-height:40px;
+  display:flex; align-items:center; justify-content:center;
+  font-size:10px; font-weight:600; transition:background var(--ease-fast);
+}
+.hy-cell.hy-nodata { background:repeating-linear-gradient(45deg,transparent,transparent 3px,rgba(0,0,0,0.03) 3px,rgba(0,0,0,0.03) 6px); color:var(--light); }
+.hy-temp-hot { background:rgba(240,100,80,0.15); color:rgba(200,60,40,0.9); }
+.hy-temp-warm { background:rgba(240,180,100,0.15); color:var(--tc-amber); }
+.hy-temp-cool { background:rgba(130,185,210,0.15); color:var(--tc-sky); }
+.hy-hydra-0 { background:rgba(0,0,0,0.04); color:var(--light); }
+.hy-hydra-1 { background:rgba(100,180,230,0.2); color:var(--tc-sky); }
+.hy-hydra-2 { background:rgba(100,180,230,0.45); color:white; }
+.hy-hydra-3 { background:rgba(100,180,230,0.7); color:white; }
+.hy-poop-ok { background:rgba(140,190,160,0.2); }
+.hy-poop-hard { background:rgba(240,100,80,0.2); color:var(--tc-rose); }
+.hy-poop-loose { background:rgba(240,180,100,0.2); color:var(--tc-amber); }
+[data-theme="dark"] .hy-cell.hy-nodata { background:repeating-linear-gradient(45deg,transparent,transparent 3px,rgba(255,255,255,0.04) 3px,rgba(255,255,255,0.04) 6px); }
+[data-theme="dark"] .hy-temp-hot { background:rgba(240,100,80,0.2); }
+[data-theme="dark"] .hy-hydra-1 { opacity:0.85; }
+.hy-alert-item {
+  display:flex; align-items:flex-start; gap:var(--sp-8);
+  padding:var(--sp-4) 0; font-size:var(--fs-sm); line-height:var(--lh-relaxed);
+}
+
+/* ── Meal Diversity Index ── */
+.mdi-bar {
+  display:flex; height:5px; border-radius:var(--r-full);
+  background:rgba(0,0,0,0.06); overflow:hidden; margin-top:var(--sp-4);
+}
+[data-theme="dark"] .mdi-bar { background:rgba(255,255,255,0.06); }
+.mdi-bar-fill {
+  height:100%; border-radius:var(--r-full);
+  transition:width var(--ease-med);
+}
+.mdi-great { background:var(--sage); }
+.mdi-ok { background:var(--amber); }
+.mdi-low { background:var(--rose); }
+.mdi-home-wrap {
+  margin-top:var(--sp-8); padding:var(--sp-8) var(--sp-12); border-radius:var(--r-lg);
+  background:var(--warm);
+}
+[data-theme="dark"] .mdi-home-wrap { background:rgba(255,255,255,0.04); }
+.mdi-home-row {
+  display:flex; align-items:center; gap:var(--sp-8);
+  font-size:var(--fs-xs);
+}
+.mdi-home-label { font-weight:600; color:var(--mid); width:40px; }
+.mdi-home-bar { flex:1; min-width:0; }
+.mdi-home-val { font-weight:700; width:28px; text-align:right; }
+
+/* ── Diet Quick Picker (per-meal zones) ── */
+.dqp-zone {
+  display:none; padding:var(--sp-4) 0 var(--sp-6);
+}
+.dqp-zone.has-pills { display:block; }
+.dqp-pills {
+  display:flex; flex-wrap:wrap; gap:var(--sp-4);
+}
+.dqp-pill {
+  display:inline-flex; align-items:center; gap:var(--sp-4);
+  padding:var(--sp-6) var(--sp-12); border-radius:var(--r-2xl);
+  font-size:var(--fs-xs); font-weight:600;
+  background:var(--sage-light); color:var(--tc-sage);
+  border:1px solid rgba(140,190,160,0.15);
+  cursor:pointer; transition:all var(--ease-fast);
+  white-space:nowrap;
+}
+.dqp-pill:active { transform:scale(0.95); background:var(--sage); color:white; }
+[data-theme="dark"] .dqp-pill { background:rgba(58,112,96,0.12); border-color:rgba(181,213,197,0.15); color:var(--tc-sage); }
+[data-theme="dark"] .dqp-pill:active { background:var(--accent-sage-deep); color:var(--body-bg); }
+
+/* ── Today's Suggestions (Home) ── */
+.sg-row { display:flex; align-items:flex-start; gap:var(--sp-8); padding:var(--sp-8) 0; border-bottom:1px solid rgba(0,0,0,0.04); }
+.sg-row:last-child { border-bottom:none; }
+.sg-row-icon { font-size:var(--fs-sm); flex-shrink:0; width:20px; text-align:center; padding-top:var(--sp-2); color:var(--mid); }
+.sg-row-icon .zi { width:16px; height:16px; }
+.sg-row-body { flex:1; min-width:0; }
+.sg-chips { display:flex; flex-wrap:wrap; gap:var(--sp-4); margin-bottom:var(--sp-4); }
+.sg-chip { display:inline-flex; align-items:center; padding:var(--sp-4) var(--sp-10); border-radius:var(--r-full); font-size:var(--fs-xs); font-weight:500; background:rgba(181,213,197,0.15); border:1px solid rgba(58,112,96,0.12); color:var(--tc-sage); cursor:pointer; transition:transform 0.1s,background 0.15s; }
+.sg-chip:active { transform:scale(0.95); background:var(--sage); color:white; }
+.sg-reason { font-size:var(--fs-xs); color:var(--light); line-height:var(--lh-relaxed); }
+.sg-tag { display:inline-block; font-size:var(--fs-2xs); text-transform:uppercase; letter-spacing:var(--ls-wide); font-weight:600; padding:1px var(--sp-6); border-radius:var(--r-sm); margin-left:var(--sp-4); vertical-align:middle; }
+.sg-tag-gap { background:rgba(220,120,80,0.1); color:var(--tc-rose); }
+.sg-tag-syn { background:rgba(58,112,96,0.08); color:var(--tc-sage); }
+.sg-tag-tpl { background:rgba(140,120,180,0.1); color:var(--tc-lav); }
+.sg-tag-hyd { background:rgba(100,160,210,0.1); color:var(--tc-sky); }
+.sg-status { flex-shrink:0; width:24px; text-align:center; font-size:var(--fs-sm); padding-top:var(--sp-2); }
+.sg-status-pending { opacity:0.3; }
+.sg-status-used { color:var(--tc-sage); }
+.sg-status-missed { color:var(--light); opacity:0.5; }
+.sg-counter { font-size:var(--fs-xs); color:var(--light); font-weight:500; }
+.sg-more-toggle { font-size:var(--fs-xs); color:var(--tc-sage); cursor:pointer; padding:var(--sp-4) 0; text-align:center; font-weight:500; }
+.sg-more-toggle:active { opacity:0.7; }
+
+/* ── Adoption Tracker (Info) ── */
+.sa-heatmap { display:grid; grid-template-columns:repeat(7,1fr); gap:var(--sp-4); }
+.sa-day-label { font-size:var(--fs-2xs); color:var(--light); text-align:center; font-weight:500; }
+.sa-cell { width:100%; aspect-ratio:1; border-radius:var(--r-md); transition:transform 0.1s; }
+.sa-cell-empty { background:rgba(0,0,0,0.03); border:1px dashed rgba(0,0,0,0.08); }
+.sa-cell-today { box-shadow:0 0 0 2px var(--tc-sage); }
+.sa-cell-0   { background:rgba(220,60,60,0.25); }
+.sa-cell-25  { background:rgba(240,180,80,0.3); }
+.sa-cell-50  { background:rgba(240,200,80,0.35); }
+.sa-cell-75  { background:rgba(120,190,120,0.35); }
+.sa-cell-100 { background:rgba(58,112,96,0.4); }
+.sa-type-row { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-4) 0; }
+.sa-type-icon { font-size:var(--fs-sm); flex-shrink:0; width:20px; text-align:center; }
+.sa-type-label { font-size:var(--fs-xs); font-weight:500; flex-shrink:0; min-width:80px; }
+.sa-type-bar { flex:1; height:6px; border-radius:var(--r-full); background:rgba(0,0,0,0.06); overflow:hidden; }
+.sa-type-fill { height:100%; border-radius:var(--r-full); transition:width 0.3s ease; }
+.sa-type-fill-gap { background:var(--tc-rose); }
+.sa-type-fill-syn { background:var(--tc-sage); }
+.sa-type-fill-tpl { background:var(--tc-lav); }
+.sa-type-fill-hyd { background:var(--tc-sky); }
+.sa-type-pct { font-size:var(--fs-xs); font-weight:600; flex-shrink:0; min-width:32px; text-align:right; }
+.sa-foods { font-size:var(--fs-xs); color:var(--light); line-height:var(--lh-relaxed); padding-top:var(--sp-4); }
+.sa-foods strong { color:var(--text); font-weight:600; }
+
+/* Dark mode — suggestions */
+[data-theme="dark"] .sg-row { border-bottom-color:rgba(255,255,255,0.04); }
+[data-theme="dark"] .sg-chip { background:rgba(58,112,96,0.12); border-color:rgba(181,213,197,0.15); color:var(--tc-sage); }
+[data-theme="dark"] .sg-chip:active { background:var(--accent-sage-deep); color:var(--body-bg); }
+[data-theme="dark"] .sg-tag-gap { background:rgba(220,120,80,0.15); }
+[data-theme="dark"] .sg-tag-syn { background:rgba(58,112,96,0.12); }
+[data-theme="dark"] .sg-tag-tpl { background:rgba(140,120,180,0.15); }
+[data-theme="dark"] .sg-tag-hyd { background:rgba(100,160,210,0.15); }
+/* Dark mode — adoption */
+[data-theme="dark"] .sa-cell-empty { background:rgba(255,255,255,0.03); border-color:rgba(255,255,255,0.08); }
+[data-theme="dark"] .sa-cell-0   { background:rgba(220,60,60,0.3); }
+[data-theme="dark"] .sa-cell-25  { background:rgba(240,180,80,0.3); }
+[data-theme="dark"] .sa-cell-50  { background:rgba(240,200,80,0.3); }
+[data-theme="dark"] .sa-cell-75  { background:rgba(120,190,120,0.3); }
+[data-theme="dark"] .sa-cell-100 { background:rgba(58,112,96,0.35); }
+[data-theme="dark"] .sa-type-bar { background:rgba(255,255,255,0.06); }
+[data-theme="dark"] .sa-foods strong { color:var(--text); }
+
+/* ── Fever Episode Tracking ── */
+.fe-card { position:relative; }
+.fe-temp-display { font-size:var(--fs-2xl); font-weight:800; line-height:1.1; text-align:center; padding:var(--sp-8) 0 var(--sp-4); }
+.fe-severity { display:inline-block; font-size:var(--fs-xs); font-weight:700; text-transform:uppercase; letter-spacing:var(--ls-wide); padding:var(--sp-2) var(--sp-10); border-radius:var(--r-full); text-align:center; }
+.fe-severity-low { background:rgba(240,180,80,0.12); color:var(--tc-amber); }
+.fe-severity-mild { background:rgba(240,180,80,0.15); color:var(--tc-amber); }
+.fe-severity-moderate { background:rgba(220,120,80,0.12); color:var(--tc-caution); }
+.fe-severity-high { background:rgba(224,112,112,0.12); color:var(--tc-danger); }
+.fe-severity-critical { background:rgba(224,112,112,0.18); color:var(--tc-danger); animation:fe-pulse 1.5s ease-in-out infinite; }
+@keyframes fe-pulse { 0%,100%{opacity:1} 50%{opacity:0.5} }
+.fe-last-reading { font-size:var(--fs-xs); color:var(--light); text-align:center; margin-top:var(--sp-4); }
+.fe-input-row { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-8) 0; background:rgba(0,0,0,0.02); border-radius:var(--r-lg); padding:var(--sp-10) var(--sp-12); margin:var(--sp-8) 0; }
+.fe-input-row input[type="number"] { width:80px; padding:var(--sp-8) var(--sp-10); border-radius:var(--r-md); border:1.5px solid var(--sage-light); font-family:'Nunito',sans-serif; font-size:var(--fs-base); font-weight:700; background:var(--body-bg); color:var(--text); text-align:center; outline:none; }
+.fe-input-row input[type="number"]:focus { border-color:var(--sage); }
+.fe-input-row input[type="time"] { padding:var(--sp-8) var(--sp-6); border-radius:var(--r-md); border:1.5px solid var(--sage-light); font-family:'Nunito',sans-serif; font-size:var(--fs-sm); background:var(--body-bg); color:var(--text); outline:none; }
+.fe-input-label { font-size:var(--fs-xs); color:var(--light); }
+.fe-countdown { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-8) 0; }
+.fe-countdown-text { font-size:var(--fs-sm); font-weight:600; flex-shrink:0; }
+.fe-countdown-bar { flex:1; height:6px; border-radius:var(--r-full); background:rgba(0,0,0,0.06); overflow:hidden; }
+.fe-countdown-fill { height:100%; border-radius:var(--r-full); transition:width 1s linear; background:var(--tc-sage); }
+.fe-countdown-fill.fe-overdue { background:var(--tc-danger); animation:fe-pulse 1.5s ease-in-out infinite; }
+.fe-section-title { font-size:var(--fs-xs); font-weight:600; text-transform:uppercase; letter-spacing:var(--ls-wide); color:var(--light); padding:var(--sp-8) 0 var(--sp-4); border-top:1px solid rgba(0,0,0,0.04); margin-top:var(--sp-8); }
+.fe-timeline { display:flex; flex-direction:column; gap:0; }
+.fe-tl-entry { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-6) 0; position:relative; }
+.fe-tl-dot { width:10px; height:10px; border-radius:50%; flex-shrink:0; }
+.fe-tl-line { position:absolute; left:4px; top:18px; bottom:-5px; width:2px; background:rgba(0,0,0,0.06); }
+.fe-tl-entry:last-child .fe-tl-line { display:none; }
+.fe-tl-time { font-size:var(--fs-xs); color:var(--light); min-width:60px; }
+.fe-tl-temp { font-size:var(--fs-sm); font-weight:700; }
+.fe-tl-notes { font-size:var(--fs-xs); color:var(--light); margin-left:var(--sp-4); }
+.fe-dose-row { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-6) 0; font-size:var(--fs-sm); }
+.fe-dose-next { font-size:var(--fs-xs); color:var(--tc-sage); font-weight:500; padding:var(--sp-4) 0; }
+.fe-action-chips { display:flex; flex-wrap:wrap; gap:var(--sp-4); padding:var(--sp-4) 0; }
+.fe-action-chip { display:inline-flex; align-items:center; padding:var(--sp-4) var(--sp-10); border-radius:var(--r-full); font-size:var(--fs-xs); font-weight:500; background:rgba(181,213,197,0.15); border:1px solid rgba(58,112,96,0.12); color:var(--tc-sage); cursor:pointer; transition:transform 0.1s; }
+.fe-action-chip:active { transform:scale(0.95); background:var(--sage); color:white; }
+.fe-action-entry { font-size:var(--fs-xs); color:var(--mid); padding:var(--sp-4) 0; }
+.fe-guidance { font-size:var(--fs-xs); color:var(--mid); line-height:var(--lh-relaxed); padding:var(--sp-4) 0; }
+.fe-guidance li { margin-bottom:var(--sp-4); }
+.fe-resolve { text-align:center; padding:var(--sp-12) 0 var(--sp-4); }
+.fe-sparkline { display:block; margin:var(--sp-8) auto; }
+.fe-history-entry { padding:var(--sp-8) 0; border-bottom:1px solid rgba(0,0,0,0.04); }
+.fe-history-entry:last-child { border-bottom:none; }
+.fe-history-date { font-size:var(--fs-sm); font-weight:600; color:var(--text); }
+.fe-history-detail { font-size:var(--fs-xs); color:var(--light); line-height:var(--lh-relaxed); }
+.fe-home-banner { display:flex; align-items:center; justify-content:space-between; gap:var(--sp-8); padding:var(--sp-10) var(--sp-12); border-radius:var(--r-lg); margin-bottom:var(--sp-8); cursor:pointer; border-left:4px solid transparent; }
+.fe-home-banner-low, .fe-home-banner-mild { background:rgba(240,180,80,0.08); border-left-color:var(--tc-amber); }
+.fe-home-banner-moderate { background:rgba(220,120,80,0.08); border-left-color:var(--tc-caution); }
+.fe-home-banner-high, .fe-home-banner-critical { background:rgba(224,112,112,0.1); border-left-color:var(--tc-danger); }
+.fe-home-banner-info { flex:1; min-width:0; }
+.fe-home-banner-temp { font-size:var(--fs-base); font-weight:700; }
+.fe-home-banner-sub { font-size:var(--fs-xs); color:var(--light); }
+.fe-diet-banner { padding:var(--sp-12) var(--sp-12); border-radius:var(--r-lg); border-left:4px solid var(--tc-caution); background:rgba(240,180,80,0.06); margin-bottom:var(--sp-8); }
+.fe-diet-title { font-size:var(--fs-sm); font-weight:700; color:var(--tc-caution); margin-bottom:var(--sp-4); }
+.fe-diet-body { font-size:var(--fs-xs); color:var(--mid); line-height:var(--lh-relaxed); }
+.fe-diet-body strong { color:var(--text); font-weight:600; }
+.fe-more-toggle { font-size:var(--fs-xs); color:var(--tc-sage); cursor:pointer; padding:var(--sp-4) 0; text-align:center; font-weight:500; }
+
+/* Dark mode — fever */
+[data-theme="dark"] .fe-input-row { background:rgba(255,255,255,0.03); }
+[data-theme="dark"] .fe-input-row input[type="number"], [data-theme="dark"] .fe-input-row input[type="time"] { background:var(--body-bg); border-color:rgba(181,213,197,0.15); }
+[data-theme="dark"] .fe-countdown-bar { background:rgba(255,255,255,0.06); }
+[data-theme="dark"] .fe-section-title { border-top-color:rgba(255,255,255,0.04); }
+[data-theme="dark"] .fe-tl-line { background:rgba(255,255,255,0.06); }
+[data-theme="dark"] .fe-action-chip { background:rgba(58,112,96,0.12); border-color:rgba(181,213,197,0.15); color:var(--tc-sage); }
+[data-theme="dark"] .fe-action-chip:active { background:var(--accent-sage-deep); color:var(--body-bg); }
+[data-theme="dark"] .fe-history-entry { border-bottom-color:rgba(255,255,255,0.04); }
+[data-theme="dark"] .fe-home-banner-low, [data-theme="dark"] .fe-home-banner-mild { background:rgba(240,180,80,0.06); }
+[data-theme="dark"] .fe-home-banner-moderate { background:rgba(220,120,80,0.06); }
+[data-theme="dark"] .fe-home-banner-high, [data-theme="dark"] .fe-home-banner-critical { background:rgba(224,112,112,0.08); }
+[data-theme="dark"] .fe-diet-banner { background:rgba(240,180,80,0.05); }
+[data-theme="dark"] .fe-severity-low, [data-theme="dark"] .fe-severity-mild { background:rgba(240,180,80,0.15); }
+[data-theme="dark"] .fe-severity-moderate { background:rgba(220,120,80,0.15); }
+[data-theme="dark"] .fe-severity-high { background:rgba(224,112,112,0.15); }
+[data-theme="dark"] .fe-severity-critical { background:rgba(224,112,112,0.2); }
+
+/* ── Diarrhoea Episode Tracking ── */
+.de-stool-count { font-size:var(--fs-2xl); font-weight:800; line-height:1.1; text-align:center; padding:var(--sp-8) 0 var(--sp-4); color:var(--tc-amber); }
+.de-severity { display:inline-block; font-size:var(--fs-xs); font-weight:700; text-transform:uppercase; letter-spacing:var(--ls-wide); padding:var(--sp-2) var(--sp-10); border-radius:var(--r-full); text-align:center; }
+.de-severity-mild { background:rgba(240,180,80,0.12); color:var(--tc-amber); }
+.de-severity-moderate { background:rgba(220,120,80,0.12); color:var(--tc-caution); }
+.de-severity-severe { background:rgba(224,112,112,0.12); color:var(--tc-danger); }
+.de-hydra-bar { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-8) 0; }
+.de-hydra-label { font-size:var(--fs-sm); font-weight:600; }
+.de-hydra-track { flex:1; height:8px; border-radius:var(--r-full); background:rgba(0,0,0,0.06); overflow:hidden; }
+.de-hydra-fill { height:100%; border-radius:var(--r-full); background:var(--tc-sky); transition:width 0.3s ease; }
+.de-hydra-count { font-size:var(--fs-sm); font-weight:700; color:var(--tc-sky); }
+.de-diaper-row { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-6) 0; font-size:var(--fs-sm); }
+.de-diaper-icon { font-size:var(--fs-base); }
+.de-stool-entry { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-6) 0; font-size:var(--fs-sm); border-bottom:1px solid rgba(0,0,0,0.03); }
+.de-stool-entry:last-child { border-bottom:none; }
+.de-home-banner { display:flex; align-items:center; justify-content:space-between; gap:var(--sp-8); padding:var(--sp-10) var(--sp-12); border-radius:var(--r-lg); margin-bottom:var(--sp-8); cursor:pointer; border-left:4px solid var(--tc-amber); background:rgba(240,180,80,0.08); }
+.de-home-banner-severe { border-left-color:var(--tc-danger); background:rgba(224,112,112,0.08); }
+
+/* Dark mode — diarrhoea */
+[data-theme="dark"] .de-hydra-track { background:rgba(255,255,255,0.06); }
+[data-theme="dark"] .de-stool-entry { border-bottom-color:rgba(255,255,255,0.03); }
+[data-theme="dark"] .de-home-banner { background:rgba(240,180,80,0.06); }
+[data-theme="dark"] .de-home-banner-severe { background:rgba(224,112,112,0.06); }
+[data-theme="dark"] .de-severity-mild { background:rgba(240,180,80,0.15); }
+[data-theme="dark"] .de-severity-moderate { background:rgba(220,120,80,0.15); }
+[data-theme="dark"] .de-severity-severe { background:rgba(224,112,112,0.15); }
+
+/* ── Vomiting & Cold Episode Tracking ── */
+.ve-count-display { font-size:var(--fs-2xl); font-weight:800; line-height:1.1; text-align:center; padding:var(--sp-8) 0 var(--sp-4); color:var(--tc-caution); }
+.ve-home-banner { display:flex; align-items:center; justify-content:space-between; gap:var(--sp-8); padding:var(--sp-10) var(--sp-12); border-radius:var(--r-lg); margin-bottom:var(--sp-8); cursor:pointer; border-left:4px solid var(--tc-caution); background:rgba(220,120,80,0.06); }
+.ce-day-display { font-size:var(--fs-xl); font-weight:800; line-height:1.1; text-align:center; padding:var(--sp-8) 0 var(--sp-4); color:var(--tc-sky); }
+.ce-symptom-row { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-6) 0; font-size:var(--fs-sm); border-bottom:1px solid rgba(0,0,0,0.03); }
+.ce-symptom-row:last-child { border-bottom:none; }
+.ce-home-banner { display:flex; align-items:center; justify-content:space-between; gap:var(--sp-8); padding:var(--sp-10) var(--sp-12); border-radius:var(--r-lg); margin-bottom:var(--sp-8); cursor:pointer; border-left:4px solid var(--tc-sky); background:rgba(100,160,210,0.06); }
+[data-theme="dark"] .ve-home-banner { background:rgba(220,120,80,0.05); }
+[data-theme="dark"] .ce-home-banner { background:rgba(100,160,210,0.05); }
+[data-theme="dark"] .ce-symptom-row { border-bottom-color:rgba(255,255,255,0.03); }
+
+/* ── Sleep Intelligence (.si-*) ── */
+.si-nodata { font-size:var(--fs-xs); color:var(--light); text-align:center; padding:var(--sp-12); font-style:italic; }
+.si-stat-grid { display:grid; grid-template-columns:1fr 1fr; gap:var(--sp-8); margin:var(--sp-8) 0; }
+.si-stat { text-align:center; padding:var(--sp-8); border-radius:var(--r-md); background:var(--warm); }
+.si-stat-val { font-family:'Fraunces',serif; font-size:var(--fs-lg); font-weight:700; line-height:var(--lh-none); }
+.si-stat-label { font-size:var(--fs-2xs); color:var(--light); margin-top:var(--sp-2); text-transform:uppercase; letter-spacing:var(--ls-wide); }
+.si-insight { padding:var(--sp-8) var(--sp-12); border-radius:var(--r-md); margin:var(--sp-4) 0; font-size:var(--fs-sm); font-weight:500; }
+.si-insight-good { background:rgba(58,112,96,0.08); color:var(--tc-sage); }
+.si-insight-warn { background:rgba(240,180,80,0.08); color:var(--tc-caution); }
+.si-insight-info { background:rgba(155,168,216,0.08); color:var(--tc-indigo); }
+.si-bar-row { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-4) 0; }
+.si-bar-label { font-size:var(--fs-2xs); color:var(--light); min-width:42px; text-align:right; }
+.si-bar-track { flex:1; height:14px; background:var(--warm); border-radius:var(--r-md); overflow:hidden; }
+.si-bar-track.is-stacked { display:flex; height:20px; }
+.si-bar-fill { height:100%; border-radius:var(--r-md); transition:width 0.4s ease; }
+.si-bar-val { font-size:var(--fs-2xs); font-weight:600; min-width:32px; }
+.si-check-row { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-6) 0; border-bottom:1px solid rgba(0,0,0,0.03); }
+.si-check-row:last-child { border-bottom:none; }
+.si-check-icon { font-size:var(--fs-base); width:24px; text-align:center; flex-shrink:0; }
+.si-check-text { font-size:var(--fs-sm); flex:1; }
+.si-check-status { font-size:var(--fs-xs); font-weight:600; }
+.si-readiness-bar { height:8px; background:var(--warm); border-radius:var(--r-md); overflow:hidden; margin:var(--sp-8) 0; }
+.si-readiness-fill { height:100%; border-radius:var(--r-md); transition:width 0.4s ease; }
+.si-ww-segment { display:flex; align-items:stretch; gap:var(--sp-2); margin:var(--sp-8) 0; border-radius:var(--r-md); overflow:hidden; }
+.si-ww-block { flex:1; min-height:32px; display:flex; flex-direction:column; align-items:center; justify-content:center; font-size:var(--fs-2xs); font-weight:600; }
+.si-ww-sleep { background:rgba(155,168,216,0.2); color:var(--tc-indigo); }
+.si-ww-wake { color:var(--text); }
+.si-report-hero { display:flex; align-items:center; gap:var(--sp-16); padding:var(--sp-8) 0; }
+.si-report-ring { width:90px; height:90px; border-radius:50%; display:flex; flex-direction:column; align-items:center; justify-content:center; flex-shrink:0; box-shadow:0 4px 16px rgba(0,0,0,0.08); border:3px solid transparent; }
+.si-report-number { font-family:'Fraunces',serif; font-size:var(--fs-2xl); font-weight:700; line-height:var(--lh-none); }
+.si-report-label { font-size:var(--fs-2xs); font-weight:600; text-transform:uppercase; letter-spacing:var(--ls-normal); margin-top:var(--sp-2); }
+.si-report-stats { flex:1; min-width:0; }
+.si-sparkline { display:flex; align-items:flex-end; gap:var(--sp-2); height:32px; }
+.si-spark-bar { flex:1; border-radius:2px 2px 0 0; min-width:0; }
+[data-theme="dark"] .si-stat { background:var(--base); }
+[data-theme="dark"] .si-bar-track { background:rgba(255,255,255,0.06); }
+[data-theme="dark"] .si-check-row { border-bottom-color:rgba(255,255,255,0.03); }
+[data-theme="dark"] .si-readiness-bar { background:rgba(255,255,255,0.06); }
+[data-theme="dark"] .si-ww-sleep { background:rgba(155,168,216,0.1); }
+[data-theme="dark"] .si-report-ring { box-shadow:0 4px 16px rgba(0,0,0,0.2); }
+.si-scatter-dot { transition:opacity 0.2s; }
+.si-factor-row { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-6) 0; }
+.si-factor-icon { font-size:var(--fs-base); width:24px; text-align:center; flex-shrink:0; }
+.si-factor-text { font-size:var(--fs-sm); flex:1; min-width:0; }
+.si-factor-impact { font-size:var(--fs-xs); font-weight:700; min-width:40px; text-align:right; }
+.si-regression-bar { display:flex; align-items:flex-end; gap:var(--sp-2); height:48px; margin:var(--sp-8) 0; }
+.si-reg-col { flex:1; border-radius:2px 2px 0 0; min-width:0; transition:height 0.3s ease; }
+.si-reg-label { font-size:var(--fs-2xs); color:var(--light); text-align:center; margin-top:var(--sp-2); }
+.si-reg-cause { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-6) var(--sp-10); border-radius:var(--r-md); background:rgba(240,180,80,0.06); margin:var(--sp-4) 0; font-size:var(--fs-xs); }
+.si-reg-cause-icon { font-size:var(--fs-sm); flex-shrink:0; }
+.si-reg-cause-text { flex:1; color:var(--mid); }
+[data-theme="dark"] .si-reg-cause { background:rgba(240,180,80,0.04); }
+.si-sub-label { font-size:var(--fs-2xs); color:var(--light); text-transform:uppercase; letter-spacing:var(--ls-wide); }
+/* ── Poop Intelligence (.pi-*) ── */
+.pi-color-timeline { display:flex; gap:var(--sp-4); flex-wrap:wrap; margin:var(--sp-8) 0; }
+.pi-color-legend { display:flex; gap:var(--sp-8); flex-wrap:wrap; margin-top:var(--sp-4); }
+.pi-color-legend-row { display:flex; align-items:center; gap:var(--sp-4); font-size:var(--fs-2xs); color:var(--light); }
+.pi-color-tl-row { display:flex; align-items:center; gap:var(--sp-4); margin-bottom:2px; }
+.pi-color-tl-label { font-size:var(--fs-2xs); color:var(--light); min-width:42px; text-align:right; }
+.pi-watch-progress { height:8px; background:var(--warm); border-radius:var(--r-md); overflow:hidden; margin:var(--sp-4) 0; }
+.pi-watch-fill { height:100%; border-radius:var(--r-md); transition:width 0.4s ease; }
+.pi-amount-bar { display:flex; align-items:center; gap:var(--sp-4); }
+.pi-amount-track { flex:1; height:12px; background:var(--warm); border-radius:var(--r-md); overflow:hidden; }
+.pi-amount-fill { height:100%; border-radius:var(--r-md); transition:width 0.4s ease; background:var(--tc-amber); }
+.pi-symptom-dot { width:10px; height:10px; border-radius:50%; flex-shrink:0; display:inline-block; }
+.pi-symptom-row { display:flex; align-items:center; gap:var(--sp-6); flex-wrap:wrap; }
+[data-theme="dark"] .pi-watch-progress { background:rgba(255,255,255,0.06); }
+[data-theme="dark"] .pi-amount-track { background:rgba(255,255,255,0.06); }
+
+/* ── Episode Entry Edit System ── */
+.ep-entry-tap { cursor:pointer; transition:background 0.15s ease; border-radius:var(--r-md); padding-left:var(--sp-4); padding-right:var(--sp-4); margin:0 -var(--sp-4); }
+.ep-entry-tap:active { background:rgba(0,0,0,0.04); }
+[data-theme="dark"] .ep-entry-tap:active { background:rgba(255,255,255,0.04); }
+.ep-edit-overlay {
+  position:fixed; inset:0; background:rgba(60,40,40,0.2);
+  backdrop-filter:blur(2px); z-index:1010;
+  display:flex; align-items:flex-end; justify-content:center;
+  animation:fadeIn 0.15s ease;
+}
+.ep-edit-sheet {
+  background:white; border-radius:var(--r-xl) var(--r-xl) 0 0; padding:var(--sp-20) var(--sp-20) calc(var(--sp-24) + env(safe-area-inset-bottom, 0px));
+  box-shadow:0 -8px 40px rgba(0,0,0,0.15); max-width:400px; width:100%;
+  animation:epSlideUp 0.2s ease;
+  padding-bottom:calc(80px + env(safe-area-inset-bottom, 0px));
+}
+@keyframes epSlideUp { from{transform:translateY(60px);opacity:0} to{transform:translateY(0);opacity:1} }
+.ep-edit-title { font-size:var(--fs-base); font-weight:700; color:var(--text); margin-bottom:var(--sp-12); }
+.ep-edit-field { margin-bottom:var(--sp-12); }
+.ep-edit-label { font-size:var(--fs-xs); font-weight:600; color:var(--mid); text-transform:uppercase; letter-spacing:var(--ls-wide); margin-bottom:var(--sp-4); }
+.ep-edit-input { width:100%; padding:var(--sp-8) var(--sp-12); border:1px solid var(--border-subtle); border-radius:var(--r-md); font-size:var(--fs-sm); background:var(--warm); color:var(--text); box-sizing:border-box; }
+.ep-edit-input:focus { border-color:var(--indigo); outline:none; }
+.ep-edit-btns { display:flex; gap:var(--sp-8); justify-content:space-between; margin-top:var(--sp-16); }
+.ep-edit-btns .btn { flex:1; }
+.ep-time-row { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-6) 0; margin-bottom:var(--sp-4); }
+.ep-time-row label { font-size:var(--fs-xs); font-weight:600; color:var(--mid); white-space:nowrap; }
+.ep-time-row input[type="time"] { flex:1; padding:var(--sp-6) var(--sp-10); border:1px solid var(--border-subtle); border-radius:var(--r-md); font-size:var(--fs-sm); background:var(--warm); color:var(--text); }
+.ep-time-row input[type="time"]:focus { border-color:var(--indigo); outline:none; }
+.ep-time-row .ep-now-btn { padding:var(--sp-6) var(--sp-12); border:1px solid var(--border-subtle); border-radius:var(--r-md); font-size:var(--fs-xs); font-weight:600; background:var(--warm); color:var(--mid); cursor:pointer; }
+.ep-time-row .ep-now-btn:active { background:var(--surface); }
+[data-theme="dark"] .ep-edit-sheet { background:var(--surface); }
+[data-theme="dark"] .ep-edit-input { background:var(--base); border-color:rgba(255,255,255,0.08); }
+[data-theme="dark"] .ep-time-row input[type="time"] { background:var(--base); border-color:rgba(255,255,255,0.08); color:var(--text); }
+[data-theme="dark"] .ep-time-row .ep-now-btn { background:var(--base); border-color:rgba(255,255,255,0.08); color:var(--light); }
+
+.dqp-same {
+  padding:var(--sp-6) var(--sp-10); border-radius:var(--r-2xl);
+  font-size:var(--fs-xs); font-weight:500;
+  background:var(--warm); color:var(--mid);
+  border:1px solid var(--border-subtle);
+  cursor:pointer; transition:all var(--ease-fast);
+  white-space:nowrap;
+}
+.dqp-same:active { transform:scale(0.95); background:var(--sky-light); color:var(--tc-sky); }
+[data-theme="dark"] .dqp-same { background:rgba(255,255,255,0.04); border-color:rgba(255,255,255,0.08); }
+
+/* ── Sleep In-Progress Banner ── */
+.sip-banner {
+  padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl);
+  background:linear-gradient(135deg, rgba(99,102,241,0.08), rgba(180,160,220,0.08));
+  border:1.5px solid rgba(99,102,241,0.2);
+  display:flex; align-items:center; gap:var(--sp-12); flex-wrap:wrap;
+}
+[data-theme="dark"] .sip-banner { background:linear-gradient(135deg, rgba(99,102,241,0.12), rgba(180,160,220,0.1)); border-color:rgba(99,102,241,0.25); }
+.sip-pulse {
+  width:10px; height:10px; border-radius:var(--r-full);
+  background:var(--tc-indigo); flex-shrink:0;
+  animation:sipPulse 2s ease-in-out infinite;
+}
+@keyframes sipPulse {
+  0%, 100% { opacity:1; transform:scale(1); }
+  50% { opacity:0.4; transform:scale(0.8); }
+}
+.sip-elapsed { font-size:var(--fs-lg); font-weight:800; color:var(--tc-indigo); }
+.sip-end-btn {
+  padding:var(--sp-6) var(--sp-16); border-radius:var(--r-2xl); border:none;
+  background:var(--tc-indigo); color:white; font-weight:700;
+  font-size:var(--fs-sm); font-family:'Nunito',sans-serif;
+  cursor:pointer; margin-left:auto;
+}
+.sip-end-btn:active { transform:scale(0.95); opacity:0.9; }
+.sip-tab-dot {
+  position:absolute; top:4px; right:4px;
+  width:7px; height:7px; border-radius:var(--r-full);
+  background:var(--tc-indigo);
+  animation:sipPulse 2s ease-in-out infinite;
+}
+
+/* ── Tabs (moved to v1.9 section) ── */
+.tab-save-btn {
+  flex:0 0 42px; padding:var(--sp-6) 0; border:none; border-radius:var(--r-lg);
+  background:transparent; cursor:pointer; font-size:var(--icon-base);
+  color:var(--light); transition:all var(--ease-med); min-height:48px;
+  display:flex; align-items:center; justify-content:center;
+  border-left:1px solid var(--border-subtle);
+}
+.tab-save-btn:hover { background:var(--sage-light); color:var(--tc-sage); }
+.tab-save-btn.just-saved { color:var(--tc-sage); animation:savePulse 0.6s ease; }
+@keyframes savePulse {
+  0% { transform:scale(1); }
+  50% { transform:scale(1.2); }
+  100% { transform:scale(1); }
+}
+.tab-panel { display:none; min-width:0; }
+.tab-panel.active { display:block; animation:fadeUp 0.3s ease both; }
+
+/* ── Welcome Guide ── */
+.welcome-guide {
+  background:linear-gradient(135deg, var(--blush), var(--peach-light));
+  border:1.5px solid rgba(242,168,184,0.25);
+}
+[data-theme="dark"] .welcome-guide { background:linear-gradient(135deg, rgba(60,35,45,0.5), rgba(60,45,35,0.5)); }
+.wg-header { display:flex; align-items:flex-start; justify-content:space-between; }
+.wg-close {
+  width:28px; height:28px; border:none; background:transparent; cursor:pointer;
+  font-size:var(--icon-base); color:var(--light); border-radius:var(--r-full);
+  display:flex; align-items:center; justify-content:center; flex-shrink:0;
+}
+.wg-close:hover { background:rgba(0,0,0,0.06); }
+.wg-steps { margin-top:var(--sp-12); }
+.wg-step {
+  display:none; gap:var(--sp-12); align-items:flex-start;
+  animation:fadeUp 0.25s ease both;
+}
+.wg-step.active { display:flex; }
+.wg-step-num {
+  width:28px; height:28px; border-radius:50%; flex-shrink:0;
+  background:var(--rose); color:white; font-size:var(--fs-sm); font-weight:700;
+  display:flex; align-items:center; justify-content:center;
+}
+.wg-step-body { flex:1; min-width:0; }
+.wg-step-body strong { display:block; font-size:var(--fs-md); color:var(--text); margin-bottom:var(--sp-4); }
+.wg-step-body span { font-size:var(--fs-base); color:var(--mid); line-height:var(--lh-relaxed); }
+.wg-nav {
+  display:flex; align-items:center; justify-content:space-between;
+  margin-top:var(--sp-16); gap:var(--sp-8);
+}
+.wg-btn { min-width:80px; }
+.wg-dots { display:flex; gap:var(--sp-6); align-items:center; }
+.wg-dot {
+  width:8px; height:8px; border-radius:50%;
+  background:var(--light); opacity:0.3; transition:all var(--ease-fast);
+}
+.wg-dot.active { background:var(--rose); opacity:1; width:20px; border-radius:4px; }
+
+/* ── Essential Mode (essential-mode class) ── */
+body.essential-mode .tab-btn[aria-label="Insights tab"],
+body.essential-mode .tab-btn[aria-label="Info tab"] { display:none; }
+body.essential-mode .stat-pills-grid { display:none !important; }
+body.essential-mode #homePoopCard { display:none !important; }
+body.essential-mode .ca-view-all { display:none; }
+body.essential-mode #insightsTrendsCard { display:none; }
+body.essential-mode .ins-card-corr,
+body.essential-mode .ins-card-cross,
+body.essential-mode .ins-card-alert-intel { display:none !important; }
+
+/* ── Essential Mode: Vitals card — hide expand affordance ── */
+body.essential-mode #homeVitalsChevron { display:none; }
+body.essential-mode #homeVitalsCard { cursor:default; }
+body.essential-mode #headerFull { display:none !important; }
+/* ── Essential Mode: Trim Home cards — hide analytics-adjacent cards ── */
+body.essential-mode #homeSuggestionsCard { display:none !important; }
+body.essential-mode #outingPlannerCard { display:none !important; }
+body.essential-mode #tomorrowPrepCard { display:none !important; }
+
+/* ── Essential Mode: Warm Hero Card ("Home Screen" feel) ── */
+.hero-avatar-bg {
+  display:none; position:absolute; inset:0;
+  background-size:cover; background-position:center;
+  opacity:0; filter:blur(30px) saturate(1.4);
+  z-index:0; pointer-events:none;
+  border-radius:var(--r-2xl);
+}
+body.essential-mode .hero-avatar-bg {
+  display:block; opacity:0.1;
+}
+body.essential-mode #homeVitalsCard {
+  position:relative;
+}
+body.essential-mode #homeVitalsCard > * {
+  position:relative; z-index:1;
+}
+body.essential-mode .hero-avatar-bg { z-index:0; }
+
+/* Greeting row — visible only in Essential Mode */
+.hero-greet-row {
+  display:none;
+}
+body.essential-mode .hero-greet-row {
+  display:flex; align-items:flex-start; justify-content:space-between;
+  gap:var(--sp-12); margin-bottom:var(--sp-12);
+}
+.hero-greet-left { flex:1; min-width:0; }
+.hero-greet-text {
+  font-family:'Fraunces', serif;
+  font-size:var(--fs-xl); font-weight:400; font-style:italic;
+  color:var(--tc-rose); line-height:var(--lh-tight);
+}
+.hero-age-text {
+  font-size:var(--fs-sm); color:var(--mid); margin-top:var(--sp-2);
+}
+.hero-weather-pill {
+  flex-shrink:0; font-size:var(--fs-sm); color:var(--mid);
+  display:flex; align-items:center; gap:var(--sp-4);
+  padding:var(--sp-4) var(--sp-8);
+  background:var(--glass); border-radius:var(--r-full);
+  line-height:var(--lh-tight); white-space:nowrap;
+}
+.hero-weather-pill:empty { display:none; }
+
+/* In Essential Mode, hide the old "Age Today" label + age stat (greeting replaces them) */
+body.essential-mode .hero-age-block { display:none; }
+
+/* Vitals row layout (replaces inline styles) */
+.hero-vitals-row {
+  display:flex; align-items:center; gap:var(--sp-12); flex-wrap:wrap;
+}
+.hero-age-block { flex:1; min-width:120px; }
+.hero-age-label {
+  font-size:var(--fs-2xs); font-weight:600; text-transform:uppercase;
+  letter-spacing:var(--ls-normal); color:var(--light); margin-bottom:1px;
+}
+.hero-stat { font-size:var(--fs-lg); }
+.hero-quick-pills { display:flex; gap:var(--sp-8); flex-wrap:wrap; }
+.collapse-chevron { font-size:var(--fs-sm); color:var(--light); }
+
+/* Time-of-day gradient tint (set via JS data attribute) */
+body.essential-mode .hero-home[data-tod="morning"] {
+  background:linear-gradient(135deg, #fff5ee, #fff9f0, #f0faf5) !important;
+}
+body.essential-mode .hero-home[data-tod="afternoon"] {
+  background:linear-gradient(135deg, #f0faf5, #f5f8ff, #fff9f0) !important;
+}
+body.essential-mode .hero-home[data-tod="evening"] {
+  background:linear-gradient(135deg, #f0eafa, #f5f0ff, #fff5f7) !important;
+}
+body.essential-mode .hero-home[data-tod="night"] {
+  background:linear-gradient(135deg, var(--indigo-light), #f0eafa, #f5f0ff) !important;
+}
+
+/* Dark mode variants */
+[data-theme="dark"] .hero-greet-text { color:#f0b8c8; }
+[data-theme="dark"] .hero-age-text { color:var(--text); }
+[data-theme="dark"] .hero-weather-pill { background:rgba(255,255,255,0.08); color:var(--text); }
+[data-theme="dark"] body.essential-mode .hero-avatar-bg,
+body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
+[data-theme="dark"] body.essential-mode .hero-home[data-tod="morning"] {
+  background:linear-gradient(135deg, #302820, #282e22) !important;
+}
+[data-theme="dark"] body.essential-mode .hero-home[data-tod="afternoon"] {
+  background:linear-gradient(135deg, #222e28, #252830) !important;
+}
+[data-theme="dark"] body.essential-mode .hero-home[data-tod="evening"] {
+  background:linear-gradient(135deg, #2e2238, #302530) !important;
+}
+[data-theme="dark"] body.essential-mode .hero-home[data-tod="night"] {
+  background:linear-gradient(135deg, #222438, #2a2238) !important;
+}
+
+/* ── Doctor visits ── */
+.visit-list { display:flex; flex-direction:column; gap:var(--sp-8); }
+.visit-item {
+  border-radius:var(--r-xl); padding:var(--sp-12) var(--sp-12);
+  background:var(--warm); border:1.5px solid rgba(181,213,197,0.4);
+}
+.visit-item.done { background:var(--sage-light); }
+.visit-header { display:flex; align-items:center; justify-content:space-between; margin-bottom:var(--sp-6); min-width:0;}
+.visit-date { font-weight:600; font-size:var(--fs-md); color:var(--tc-sage); }
+.visit-doctor { font-size:var(--fs-base); font-weight:400; color:var(--mid); }
+.visit-notes-text { font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); }
+.visit-actions { display:flex; gap:var(--sp-4); }
+.visit-add-form {
+  display:flex; flex-direction:column; gap:var(--sp-8);
+  border-top:1.5px solid var(--sage-light); padding-top:var(--sp-12); margin-top:var(--sp-4);
+}
+.visit-add-form input, .visit-add-form textarea {
+  padding:var(--sp-8) var(--sp-12); border-radius:var(--r-lg);
+  border:1.5px solid var(--sage-light);
+  font-family:'Nunito', sans-serif; font-size:var(--fs-base);
+  background:var(--sage-light); color:var(--text); outline:none;
+}
+.visit-add-form textarea { min-height:70px; resize:none; }
+.visit-add-form input:focus, .visit-add-form textarea:focus { border-color:var(--sage); }
+
+/* ── Can I Give This? ── */
+.combo-result {
+  border-radius:var(--r-xl); padding:var(--sp-16) var(--sp-16); margin-top:var(--sp-8);
+  border-left:var(--accent-w) solid var(--sage); background:var(--sage-light);
+  animation:fadeUp 0.3s ease both;
+}
+.combo-result.caution { border-color:var(--border-warn); background:var(--surface-warn); }
+.combo-result.avoid   { border-color:var(--tc-danger); background:var(--surface-danger); }
+.combo-verdict { font-family:'Fraunces',serif; font-size:var(--fs-lg); font-weight:600; margin-bottom:var(--sp-8); }
+.combo-verdict.safe    { color:var(--tc-sage); }
+.combo-verdict.caution { color:var(--tc-warn); }
+.combo-verdict.avoid   { color:var(--tc-danger); }
+.combo-section { margin-top:var(--sp-10); }
+.combo-section-title { font-size:var(--fs-base); font-weight:600; text-transform:uppercase; letter-spacing:var(--ls-wide); color:var(--mid); margin-bottom:var(--sp-4); }
+.combo-body { font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); white-space:pre-line; }
+.combo-dos { font-size:var(--fs-base); line-height:var(--lh-relaxed); }
+.combo-dos .do  { color:var(--tc-sage); }
+.combo-dos .dont { color:var(--tc-danger); }
+.combo-recipe { background:var(--glass); border-radius:var(--r-lg); padding:var(--sp-12) var(--sp-12); margin-top:var(--sp-6); font-size:var(--fs-base); line-height:var(--lh-relaxed); white-space:pre-line; }
+@keyframes spin { to { transform:rotate(360deg); } }
+.combo-hist-item { font-size:var(--fs-base); padding:var(--sp-8) var(--sp-10); border-radius:var(--r-lg); background:var(--warm); margin-bottom:var(--sp-4); cursor:pointer; transition:background var(--ease-fast); }
+.combo-hist-item:hover { background:var(--sage-light); }
+.combo-hist-q { font-weight:600; color:var(--text); }
+.combo-hist-a { color:var(--mid); font-size:var(--fs-sm); margin-top:var(--sp-2); }
+
+/* ── Chips ── */
+.chip {
+  display:inline-flex; align-items:center; font-size:var(--fs-sm); padding:var(--sp-8) var(--sp-16); border-radius:var(--r-2xl);
+  background:var(--card-bg); color:var(--mid); cursor:pointer;
+  border:1.5px solid var(--light); transition:all var(--ease-fast);
+  white-space:nowrap; min-height:44px;
+}
+.chip:hover { filter:brightness(0.95); transform:translateY(-1px); }
+.chip-safe   { background:var(--sage-light); color:var(--tc-sage); border-color:rgba(181,213,197,0.6); }
+.chip-safe:hover { background:var(--accent-sage-deep); color:white; }
+.chip-caution { background:var(--peach-light); color:var(--tc-warn); border-color:rgba(255,209,102,0.6); }
+.chip-caution:hover { background:#946225; color:white; }
+.chip-avoid  { background:var(--rose-light); color:var(--tc-danger); border-color:rgba(242,168,184,0.6); }
+.chip-avoid:hover { background:var(--tc-danger); color:white; }
+
+/* ── Milestone tag chips (PR-ε.0 §7.3 / Subclass C) ──
+   Lavender domain: tag chips on memory entries. Container role="list"
+   + chip role="listitem"; chip-x is the tag-remove button. PC-10.6:
+   all tokens via var(); no raw hex. PC-2.4 escape contract enforced
+   in renderScrapMilestoneChips. */
+.chip-milestone {
+  background: var(--lav-light);
+  color: var(--text);
+  border-color: rgba(201, 184, 232, 0.6);
+  cursor: default;
+  padding-right: var(--sp-4);
+  gap: var(--sp-6);
+}
+.chip-milestone:hover { filter: none; transform: none; }
+.chip-label {
+  font-size: var(--fs-sm);
+  white-space: normal;
+  word-break: break-word;
+  max-width: 200px;
+  line-height: var(--lh-snug);
+}
+.chip-x {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 28px; height: 28px;
+  min-width: 44px; min-height: 44px;
+  padding: var(--sp-8);
+  margin-left: calc(-1 * var(--sp-4));
+  margin-right: calc(-1 * var(--sp-4));
+  border: none; background: transparent;
+  color: var(--mid);
+  cursor: pointer;
+  border-radius: var(--r-full);
+  transition: background var(--ease-fast), color var(--ease-fast);
+}
+.chip-x:hover { background: var(--surface-lav); color: var(--text); }
+.chip-x .zi { width: var(--icon-xs); height: var(--icon-xs); }
+
+/* ── Scrapbook form: milestone link row (PR-ε.0 §7.3) ── */
+.scrap-form-row {
+  display: flex; flex-direction: column;
+  gap: var(--sp-6);
+  margin-top: var(--sp-8);
+}
+.scrap-form-label {
+  font-size: var(--fs-sm); color: var(--mid);
+  font-family: 'Nunito', sans-serif;
+}
+.milestone-chips {
+  display: flex; flex-wrap: wrap;
+  gap: var(--sp-6);
+  min-height: 32px;
+}
+.milestone-chips[data-empty="true"] { min-height: 0; }
+.scrap-tag-btn {
+  align-self: flex-start;
+  display: inline-flex; align-items: center; gap: var(--sp-6);
+}
+.scrap-tag-btn .zi { width: var(--icon-sm); height: var(--icon-sm); }
+
+/* ── Picker modal (PR-ε.0 §7.3 / S-17) ── */
+.scrap-picker-modal {
+  max-width: 480px;
+  max-height: 80vh;
+  display: flex; flex-direction: column;
+  padding: var(--sp-20) var(--sp-24);
+}
+.scrap-picker-modal h3 { margin-bottom: var(--sp-12); }
+.picker-list {
+  flex: 1; overflow-y: auto;
+  display: flex; flex-direction: column; gap: var(--sp-16);
+  padding: var(--sp-4) 0;
+  margin-bottom: var(--sp-16);
+}
+.picker-cat-group { display: flex; flex-direction: column; gap: var(--sp-4); }
+.picker-cat-header {
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-xs); font-weight: 700;
+  text-transform: uppercase; letter-spacing: var(--ls-wide);
+  color: var(--mid);
+  padding: 0 var(--sp-4);
+}
+.picker-row {
+  display: flex;
+  align-items: flex-start; /* v6 fix: was center; broke multi-line wrap alignment */
+  gap: var(--sp-10);
+  padding: var(--sp-8) var(--sp-10);
+  border-radius: var(--r-lg);
+  cursor: pointer;
+  transition: background var(--ease-fast);
+  min-height: 44px;
+  border: none; background: transparent;
+  text-align: left; width: 100%;
+  font-family: inherit; color: var(--text);
+}
+.picker-row:hover { background: var(--surface-lav); }
+.picker-row-check {
+  width: 22px; height: 22px;
+  border: 1.5px solid var(--lavender);
+  border-radius: var(--r-sm);
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+  background: var(--card-bg);
+  transition: background var(--ease-fast);
+  margin-top: 2px; /* v6 fix: optical-align with first-line cap height */
+}
+.picker-row-check[data-checked="1"] { background: var(--lavender); }
+.picker-row-check[data-checked="0"] .zi { display: none; }
+.picker-row-check .zi { width: 14px; height: 14px; color: white; }
+.picker-row-label {
+  font-size: var(--fs-base);
+  color: var(--text);
+  word-break: break-word;
+  line-height: var(--lh-snug);
+}
+.picker-empty {
+  display: flex; flex-direction: column; align-items: center;
+  gap: var(--sp-8);
+  padding: var(--sp-32) var(--sp-16);
+  color: var(--mid);
+  text-align: center;
+}
+.picker-empty .zi { width: var(--icon-lg); height: var(--icon-lg); color: var(--lavender); }
+.picker-empty p { margin: 0; font-size: var(--fs-base); }
+.picker-empty-sub { color: var(--light); font-size: var(--fs-sm); }
+
+/* ── Help tooltips ── */
+.help-btn {
+  display:inline-flex; align-items:center; justify-content:center;
+  background:none; border:none; color:var(--light);
+  font-size:var(--fs-sm); font-weight:600; cursor:pointer;
+  font-family:'Nunito',sans-serif; padding:var(--sp-8);
+  min-width:44px; min-height:44px;
+  opacity:0.6; transition:opacity var(--ease-fast);
+}
+.help-btn:hover { opacity:1; color:var(--mid); }
+.help-tip {
+  display:none; padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl);
+  background:var(--sky-light); border-left:var(--accent-w) solid var(--sky);
+  font-size:var(--fs-base); font-weight:400; color:var(--text); line-height:var(--lh-relaxed);
+  margin-top:var(--sp-8); animation:fadeUp 0.2s ease both;
+}
+.help-tip.open { display:block; }
+
+/* ── Collapse animation ── */
+.collapse-body {
+  overflow:hidden; transition:max-height var(--ease-slow), opacity var(--ease-med);
+  max-height:0; opacity:0;
+}
+.collapse-body.open {
+  max-height:2000px; opacity:1;
+}
+
+/* ── Confirm delete ── */
+.confirm-overlay {
+  position:fixed; inset:0; background:rgba(60,40,40,0.2);
+  backdrop-filter:blur(2px); z-index:110;
+  display:flex; align-items:center; justify-content:center;
+  animation:fadeIn 0.15s ease;
+}
+@keyframes fadeIn { from{opacity:0} to{opacity:1} }
+.confirm-box {
+  background:white; border-radius:var(--r-xl); padding:22px var(--sp-24);
+  box-shadow:0 12px 40px rgba(0,0,0,0.15); max-width:300px; width:85%;
+  text-align:center; animation:popIn 0.2s ease;
+}
+.confirm-box p { font-size:var(--fs-base); color:var(--text); margin-bottom:var(--sp-16); line-height:var(--lh-relaxed); }
+.confirm-btns { display:flex; gap:var(--sp-8); justify-content:center; }
+
+/* ── Finding A — age-gate consequence card ── */
+.consequence-overlay {
+  position:fixed; inset:0; background:rgba(60,40,40,0.28);
+  backdrop-filter:blur(2px); z-index:130;
+  display:flex; align-items:center; justify-content:center;
+  animation:fadeIn 0.15s ease; padding:var(--sp-16);
+}
+.consequence-card {
+  background:white; border-radius:var(--r-xl); padding:var(--sp-24);
+  box-shadow:0 12px 40px rgba(0,0,0,0.18); max-width:360px; width:90%;
+  text-align:left; animation:popIn 0.2s ease;
+  border-top:4px solid var(--amber);
+}
+.consequence-card.cons-critical { border-top-color:var(--rose); }
+.cons-head { display:flex; align-items:center; gap:var(--sp-8); margin-bottom:var(--sp-12); }
+.cons-head .zi { width:var(--icon-md); height:var(--icon-md); flex:none; color:var(--amber-deep); }
+.cons-critical .cons-head .zi { color:var(--rose-deep); }
+.cons-title { font-size:var(--fs-lg); margin:0; color:var(--text); }
+.cons-why { font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); margin:0 0 var(--sp-16); }
+.cons-watch { background:var(--surface-amber); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); margin-bottom:var(--sp-12); }
+.cons-watch-h { font-size:var(--fs-sm); font-weight:700; color:var(--text); text-transform:uppercase; letter-spacing:0.3px; margin-bottom:var(--sp-8); }
+.cons-watch-list { margin:0; padding-left:var(--sp-20); }
+.cons-watch-list li { font-size:var(--fs-base); color:var(--text); margin:var(--sp-4) 0; line-height:var(--lh-relaxed); }
+.cons-seek { display:flex; align-items:flex-start; gap:var(--sp-8); font-size:var(--fs-sm); color:var(--rose-deep); margin:0 0 var(--sp-16); line-height:var(--lh-relaxed); }
+.cons-seek .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--rose-deep); margin-top:3px; }
+/* Severe-reaction strip (food-effects-v2 A-1/V-1): the emergency floor. Amber
+   per V-3 (serious-without-alarm; rose stays reserved for acute-toxin honey).
+   Left bar + fill give it weight so a half-awake parent can't skim past it; it
+   renders unconditionally and is never collapsed. */
+.cons-severe { background:var(--surface-amber); border-left:3px solid var(--amber-deep); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); margin-bottom:var(--sp-16); }
+.cons-severe-h { display:flex; align-items:center; gap:var(--sp-8); font-size:var(--fs-sm); font-weight:700; color:var(--amber-deep); text-transform:uppercase; letter-spacing:0.3px; margin-bottom:var(--sp-8); }
+.cons-severe-h .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--amber-deep); }
+.cons-severe-list { margin:0; padding-left:var(--sp-20); }
+.cons-severe-list li { font-size:var(--fs-base); color:var(--text); margin:var(--sp-4) 0; line-height:var(--lh-relaxed); }
+.cons-btns { display:flex; gap:var(--sp-8); justify-content:flex-end; }
+[data-theme="dark"] .consequence-overlay { background:var(--overlay-bg); }
+[data-theme="dark"] .consequence-card { background:var(--surface); }
+[data-theme="dark"] .cons-severe { background:var(--surface-amber); }
+
+/* ── food-effects v2 Phase γ — persistent encourage (nut-introduction) card ──
+   Polarity→color (V-3): SAGE leads (encourage); the severe strip borrows the
+   shared .cons-severe AMBER (serious-without-alarm); rose stays reserved for
+   acute-toxin. The benefit banner is the only top-of-card affirmer — green-topped
+   reads pre-literately as "do this," never "avoid." */
+.enc-benefit { background:var(--surface-sage); border-left:3px solid var(--sage-deepest); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); margin-bottom:var(--sp-16); }
+.enc-benefit-h { display:flex; align-items:center; gap:var(--sp-8); font-size:var(--fs-sm); font-weight:700; color:var(--sage-deepest); text-transform:uppercase; letter-spacing:0.3px; margin-bottom:var(--sp-8); }
+.enc-benefit-h .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--sage-deepest); }
+.enc-claim { font-size:var(--fs-base); font-weight:700; color:var(--text); line-height:var(--lh-relaxed); margin:0 0 var(--sp-4); }
+.enc-evidence { font-size:var(--fs-sm); color:var(--light); line-height:var(--lh-relaxed); margin:0 0 var(--sp-8); }
+.enc-why-list { margin:0; padding-left:var(--sp-20); }
+.enc-why-list li { font-size:var(--fs-base); color:var(--text); margin:var(--sp-4) 0; line-height:var(--lh-relaxed); }
+.enc-block { margin-bottom:var(--sp-16); }
+.enc-block-h { display:flex; align-items:center; gap:var(--sp-8); font-size:var(--fs-sm); font-weight:700; color:var(--text); text-transform:uppercase; letter-spacing:0.3px; margin-bottom:var(--sp-8); }
+.enc-block-h .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--tc-sage); }
+.enc-proto { margin:0 0 var(--sp-12); display:flex; flex-direction:column; gap:var(--sp-4); }
+.enc-proto-row { font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); }
+.enc-proto-row b { color:var(--sage-deepest); }
+.enc-form { background:var(--surface-sage); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); }
+.enc-form-sub { font-size:var(--fs-sm); font-weight:700; color:var(--text); text-transform:uppercase; letter-spacing:0.3px; margin:0 0 var(--sp-8); }
+.enc-form-list { margin:0 0 var(--sp-8); padding-left:var(--sp-20); }
+.enc-form-list li { font-size:var(--fs-base); color:var(--text); margin:var(--sp-4) 0; line-height:var(--lh-relaxed); }
+.enc-form-list.enc-never li { color:var(--rose-deep); }
+.enc-form-note { font-size:var(--fs-base); font-weight:700; color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-8) 0 0; }
+/* V-V-γ-1 (Vela): advisory, NOT emergency — a neutral fill + calm left accent
+   keeps the amber register reserved for the severe strip (caution-and-up), so
+   the two no longer blur at the §2/§3 seam. */
+.enc-highrisk { font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-12) 0 0; padding:var(--sp-8) var(--sp-12); background:var(--surface-neutral); border-left:3px solid var(--border-subtle); border-radius:var(--r-sm); }
+.enc-emergency { display:flex; align-items:flex-start; gap:var(--sp-8); font-size:var(--fs-sm); color:var(--amber-deepest); margin:var(--sp-8) 0 0; line-height:var(--lh-relaxed); }
+.enc-emergency .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--amber-deep); margin-top:3px; }
+.enc-myth { display:flex; align-items:flex-start; gap:var(--sp-8); font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); margin:var(--sp-16) 0 0; padding:var(--sp-12) var(--sp-16); background:var(--surface-lav); border-radius:var(--r-md); }
+.enc-myth .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--tc-lav); margin-top:3px; }
+
+/* ── food-effects-v2 P1c (milk polarities, milk-spec §3/§4/§5) ──────────────
+   The drink-timing SPLIT lead (cow milk) and the substitute-caveat SKY inform
+   banner (plant milk) — the two never-rendered v2 polarities. Composition over
+   new vocabulary (V-5): the split reuses the shipped sage + amber fills; the
+   inform banner is the one genuinely new modifier (sky, V-V-3). Shared-module
+   triple-Gov (Vela-first). */
+.enc-split { display:flex; flex-direction:column; gap:var(--sp-8); margin-bottom:var(--sp-16); }
+.enc-split-good { background:var(--surface-sage); border-left:3px solid var(--sage-deepest); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); }
+/* M-2 skim-proof: the gate band carries weight EQUAL-OR-GREATER than the carve-out —
+   the amber fill + the cons-severe-strength left accent + bold body — so the prevalent
+   diluted-top-milk reader cannot under-read the gate as a trailing qualifier. */
+.enc-split-gate { background:var(--surface-amber); border-left:3px solid var(--amber-deep); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); }
+.enc-split-h { display:flex; align-items:center; gap:var(--sp-8); font-size:var(--fs-sm); font-weight:700; text-transform:uppercase; letter-spacing:0.3px; margin-bottom:var(--sp-4); }
+.enc-split-good .enc-split-h { color:var(--sage-deepest); }
+.enc-split-gate .enc-split-h { color:var(--amber-deepest); }
+.enc-split-h .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; }
+.enc-split-good .enc-split-h .zi { color:var(--sage-deepest); }
+.enc-split-gate .enc-split-h .zi { color:var(--amber-deep); }
+.enc-split-body { font-size:var(--fs-base); color:var(--text); line-height:var(--lh-relaxed); margin:0; }
+.enc-split-gate .enc-split-body { font-weight:700; }
+
+/* substitute-caveat INFORM banner (V-V-3): SKY, not neutral — neutral is a near-white
+   wash and register-less; sky is the existing drink/hydration domain color, AA-legible,
+   with a border-left for weight. The hardest fact (rice <5 = arsenic) is fronted in the lead. */
+.enc-inform { background:var(--surface-sky); border-left:3px solid var(--tc-sky); border-radius:var(--r-md); padding:var(--sp-12) var(--sp-16); margin-bottom:var(--sp-16); }
+.enc-inform-h { display:flex; align-items:center; gap:var(--sp-8); font-size:var(--fs-sm); font-weight:700; color:var(--tc-sky); text-transform:uppercase; letter-spacing:0.3px; margin-bottom:var(--sp-8); }
+.enc-inform-h .zi { width:var(--icon-sm); height:var(--icon-sm); flex:none; color:var(--tc-sky); }
+.enc-inform-lead { font-size:var(--fs-base); font-weight:700; color:var(--text); line-height:var(--lh-relaxed); margin:0 0 var(--sp-4); }
+.enc-inform-body { font-size:var(--fs-sm); color:var(--mid); line-height:var(--lh-relaxed); margin:0; }
+
+/* ── Viz detail popup (PR-I — viz interactivity layer) ── */
+/* Tap affordance: every wired data element (SVG dot/cell/bar/segment or
+   HTML cell) gets a pointer cursor without a per-element class. */
+[data-action="vizShowDetail"] { cursor:pointer; }
+.viz-detail-overlay {
+  position:fixed; inset:0; background:rgba(60,40,40,0.24);
+  backdrop-filter:blur(3px);
+  /* Above the floating FAB + corner buttons (z-index 1000-1002) so the
+     bottom-sheet card is not occluded by them. */
+  z-index:1100;
+  display:flex; align-items:flex-end; justify-content:center;
+  animation:fadeIn 0.15s ease;
+}
+.viz-detail-card {
+  background:var(--surface); width:100%; max-width:420px;
+  border-radius:var(--r-2xl) var(--r-2xl) 0 0;
+  border-top:4px solid var(--vd-accent, var(--tc-lav));
+  box-shadow:0 -8px 44px rgba(0,0,0,0.18);
+  padding:var(--sp-20) var(--sp-24) var(--sp-24);
+  position:relative; animation:vizSheetUp 0.24s ease;
+}
+@keyframes vizSheetUp { from{opacity:0;transform:translateY(48px)} to{opacity:1;transform:translateY(0)} }
+@media (min-width:500px) {
+  .viz-detail-overlay { align-items:center; }
+  .viz-detail-card {
+    border-radius:var(--r-2xl); max-width:360px;
+    box-shadow:0 20px 60px rgba(0,0,0,0.2); animation:popIn 0.22s ease;
+  }
+}
+.viz-detail-close {
+  position:absolute; top:var(--sp-8); right:var(--sp-8);
+  width:44px; height:44px; min-width:44px; min-height:44px;
+  border:none; background:transparent; color:var(--light);
+  cursor:pointer; border-radius:var(--r-md);
+  display:flex; align-items:center; justify-content:center;
+  transition:color var(--ease-fast);
+}
+.viz-detail-close:hover { color:var(--mid); }
+.viz-detail-head {
+  display:flex; align-items:center; gap:var(--sp-10);
+  margin-bottom:var(--sp-12); padding-right:var(--sp-32);
+}
+.viz-detail-icon {
+  width:36px; height:36px; border-radius:var(--r-lg); flex-shrink:0;
+  background:var(--vd-tint, var(--lav-light)); color:var(--vd-accent, var(--tc-lav));
+  display:flex; align-items:center; justify-content:center;
+}
+.viz-detail-titles { min-width:0; }
+.viz-detail-title {
+  font-family:'Fraunces', serif; font-size:var(--fs-lg); font-weight:600;
+  color:var(--text); line-height:var(--lh-tight);
+}
+.viz-detail-subtitle { font-size:var(--fs-sm); color:var(--mid); margin-top:var(--sp-2); }
+.viz-detail-rows { display:flex; flex-direction:column; }
+.viz-detail-row {
+  display:flex; justify-content:space-between; gap:var(--sp-16);
+  padding:var(--sp-8) 0; border-bottom:1px solid var(--surface-alt);
+}
+.viz-detail-row:last-child { border-bottom:none; }
+.viz-detail-row-label { font-size:var(--fs-sm); color:var(--mid); font-weight:600; flex-shrink:0; }
+.viz-detail-row-value {
+  font-size:var(--fs-sm); color:var(--text); font-weight:700;
+  text-align:right; word-break:break-word;
+}
+.viz-detail-note {
+  margin-top:var(--sp-12); padding:var(--sp-10) var(--sp-12);
+  background:var(--vd-tint, var(--lav-light)); border-radius:var(--r-lg);
+  font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-relaxed);
+}
+.viz-detail-sage   { --vd-accent:var(--tc-sage);   --vd-tint:var(--sage-light); }
+.viz-detail-rose   { --vd-accent:var(--tc-rose);   --vd-tint:var(--rose-light); }
+.viz-detail-amber  { --vd-accent:var(--tc-amber);  --vd-tint:var(--amber-light); }
+.viz-detail-lav    { --vd-accent:var(--tc-lav);    --vd-tint:var(--lav-light); }
+.viz-detail-sky    { --vd-accent:var(--tc-sky);    --vd-tint:var(--sky-light); }
+.viz-detail-indigo { --vd-accent:var(--tc-indigo); --vd-tint:var(--indigo-light); }
+.viz-detail-peach  { --vd-accent:var(--tc-amber);  --vd-tint:var(--peach-light); }
+
+/* ── Unity System: Shared utility classes ── */
+
+/* Flex layouts */
+.fx        { display:flex; }
+.fx-col    { display:flex; flex-direction:column; }
+.fx-wrap   { display:flex; flex-wrap:wrap; }
+.fx-center { display:flex; align-items:center; }
+.fx-start  { display:flex; align-items:flex-start; }
+.fx-between { justify-content:space-between; }
+.fx-end    { justify-content:flex-end; }
+
+/* Gap scale (4px base) */
+.g4  { gap:var(--sp-4); }
+.g8  { gap:var(--sp-8); }
+.g12 { gap:var(--sp-12); }
+.g16 { gap:var(--sp-16); }
+
+/* Info strip — the most common JS pattern: icon + text row in colored bg */
+.info-strip {
+  display:flex; align-items:flex-start; gap:var(--sp-8);
+  padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl);
+  font-size:var(--fs-base); line-height:var(--lh-relaxed); min-width:0;}
+.info-strip-icon { font-size:var(--icon-md); flex-shrink:0; margin-top:1px; }
+
+/* ── Contextual Alert Cards (v2.0b) ── */
+.ctx-alert {
+  position:relative;
+  border-radius:var(--r-xl);
+  padding:var(--sp-12) var(--sp-12);
+  border:1px solid var(--card-border);
+  border-left:var(--accent-w) solid var(--sage);
+  background:var(--sage-light);
+  transition:opacity var(--ease-med), transform var(--ease-med);
+}
+.ctx-alert.ca-watch  { border-left-color:#d4960a; border-left-width:5px; background:linear-gradient(135deg, var(--amber-light), #fdf0d8); }
+.ctx-alert.ca-action { border-left-color:var(--tc-danger); border-left-width:5px; background:linear-gradient(135deg, #fef0f0, #fde5e5); }
+.ctx-alert.ca-info   { border-left-color:var(--sage); background:var(--sage-light); }
+.ctx-alert.ca-positive { border-left-color:#4aaf6e; background:linear-gradient(135deg, #e0f5e8, #eafaf0); border-left-width:5px; }
+.ctx-alert-sev.sev-positive { background:var(--sage-light); color:#207242; border:1px solid rgba(32,114,66,0.2); }
+.ca-synthesis-narrative {
+  font-size:var(--fs-sm); font-weight:400; color:var(--tc-amber);
+  padding:var(--sp-6) var(--sp-10); border-radius:var(--r-md); background:var(--amber-light);
+  border:1px dashed rgba(138,101,32,0.2); margin-bottom:var(--sp-4);
+}
+/* Today's Plan schedule items */
+.plan-item {
+  display:flex; gap:var(--sp-12); align-items:flex-start;
+  padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl);
+  border:1px solid var(--card-border); background:var(--white);
+  transition:background var(--ease-fast); min-width:0;}
+.plan-item:active { background:var(--cream); }
+.plan-time { font-size:var(--fs-xs); font-weight:600; color:var(--light); min-width:42px; padding-top:var(--sp-2); }
+.plan-icon { font-size:var(--icon-md); flex-shrink:0; }
+.plan-body { flex:1; min-width:0; }
+.plan-title { font-size:var(--fs-md); font-weight:600; color:var(--text); line-height:var(--lh-snug); }
+.plan-detail { font-size:var(--fs-base); font-weight:400; color:var(--mid); line-height:var(--lh-normal); margin-top:var(--sp-2); }
+.plan-tag {
+  display:inline-block; font-size:var(--fs-xs); font-weight:600;
+  padding:1px var(--sp-6); border-radius:var(--r-full); margin-right:var(--sp-4);
+}
+.plan-tag.pt-food { background:var(--peach-light); color:var(--tc-caution); }
+.plan-tag.pt-sleep { background:var(--indigo-light); color:var(--tc-indigo); }
+.plan-tag.pt-poop { background:var(--amber-light); color:var(--tc-amber); }
+.plan-tag.pt-play { background:var(--sage-light); color:var(--tc-sage); }
+.plan-tag.pt-med { background:var(--sky-light); color:var(--tc-sky); }
+.plan-tag.pt-lookout { background:var(--rose-light); color:var(--tc-rose); }
+.plan-section-label { font-size:var(--fs-xs); font-weight:600; color:var(--light); letter-spacing:var(--ls-normal); text-transform:uppercase; padding:var(--sp-4) 0; }
+.ctx-alert-top { display:flex; align-items:flex-start; gap:var(--sp-8); }
+.ctx-alert-icon { font-size:var(--icon-md); flex-shrink:0; line-height:var(--lh-tight); }
+.ctx-alert-body { flex:1; min-width:0; }
+.ctx-alert-title { font-size:var(--fs-md); font-weight:600; color:var(--text); line-height:var(--lh-snug); }
+.ctx-alert-sev {
+  display:inline-block; font-size:var(--fs-xs); font-weight:700;
+  padding:1px var(--sp-6); border-radius:var(--r-full); margin-left:var(--sp-6);
+  vertical-align:middle; letter-spacing:var(--ls-tight);
+}
+.ctx-alert-sev.sev-info   { background:var(--sage-light); color:var(--tc-sage); border:1px solid rgba(58,112,96,0.2); }
+.ctx-alert-sev.sev-watch  { background:var(--amber-light); color:var(--tc-amber); border:1px solid rgba(138,101,32,0.2); }
+.ctx-alert-sev.sev-action { background:var(--rose-light); color:var(--tc-rose); border:1px solid rgba(176,72,94,0.2); }
+.ctx-alert-msg { font-size:var(--fs-md); font-weight:400; color:var(--mid); line-height:var(--lh-normal); margin-top:var(--sp-4); }
+.ctx-alert-tip {
+  display:none; font-size:var(--fs-base); font-weight:400; color:var(--light); line-height:var(--lh-normal);
+  margin-top:var(--sp-6); padding:var(--sp-8) var(--sp-10); border-radius:var(--r-md);
+  background:rgba(255,255,255,0.5); border:1px dashed rgba(0,0,0,0.08);
+}
+.ctx-alert-tip.open { display:block; }
+.ctx-alert-tip-toggle {
+  font-size:var(--fs-sm); color:var(--tc-sky); cursor:pointer;
+  margin-top:var(--sp-4); display:inline-block; font-weight:600;
+}
+.ctx-alert-tip-toggle:hover { text-decoration:underline; }
+.ctx-alert-actions { display:flex; gap:var(--sp-8); margin-top:var(--sp-8); flex-wrap:wrap; }
+.ctx-alert-btn {
+  font-size:var(--fs-sm); font-weight:600; padding:var(--sp-6) var(--sp-12);
+  border-radius:var(--r-full); border:none; cursor:pointer;
+  transition:transform var(--ease-fast), box-shadow var(--ease-fast);
+}
+.ctx-alert-btn:active { transform:scale(0.95); }
+.ctx-alert-btn.cab-primary {
+  background:var(--text); color:var(--white);
+}
+.ctx-alert-btn.cab-secondary {
+  background:transparent; color:var(--mid); border:1px solid var(--card-border);
+}
+/* PR-K 4-mode controls: acknowledge ("Got it") + snooze */
+.ctx-alert-btn.cab-ack {
+  background:var(--sage-light); color:var(--tc-sage); border:1px solid var(--sage);
+}
+.ctx-alert-btn.cab-snooze {
+  background:transparent; color:var(--mid); border:1px solid var(--card-border);
+}
+.ctx-alert-btn .zi { width:var(--icon-xs); height:var(--icon-xs); vertical-align:-1px; }
+.ctx-alert-dismiss {
+  position:absolute; top:8px; right:8px; width:24px; height:24px;
+  border:none; background:transparent; cursor:pointer; font-size:var(--icon-sm);
+  color:var(--light); border-radius:var(--r-full); display:flex;
+  align-items:center; justify-content:center; transition:background var(--ease-fast);
+}
+.ctx-alert-dismiss:hover { background:rgba(0,0,0,0.06); }
+.ctx-alert.dismissing { opacity:0; transform:translateX(40px); pointer-events:none; }
+
+/* Alert count badge for Home "view all" link */
+.ca-view-all {
+  display:flex; align-items:center; justify-content:center; gap:var(--sp-8);
+  padding:var(--sp-8); font-size:var(--fs-sm); font-weight:600; color:var(--tc-sky);
+  cursor:pointer; border-radius:var(--r-md);
+  transition:background var(--ease-fast);
+}
+.ca-view-all:hover { background:var(--sky-light); }
+.ca-badge {
+  display:inline-flex; align-items:center; justify-content:center;
+  min-width:18px; height:18px; padding:0 var(--sp-6); border-radius:var(--r-full);
+  font-size:var(--fs-xs); font-weight:700; background:var(--tc-sky); color:var(--white);
+}
+
+/* Alert History timeline (History tab) */
+.alert-hist-item {
+  display:flex; gap:var(--sp-8); padding:var(--sp-8) 0;
+  border-bottom:1px solid var(--border-subtle); font-size:var(--fs-sm);
+}
+.alert-hist-item:last-child { border-bottom:none; }
+.alert-hist-dot {
+  width:8px; height:8px; border-radius:var(--r-full); margin-top:var(--sp-6); flex-shrink:0;
+}
+.alert-hist-dot.ahd-triggered { background:var(--amber); }
+.alert-hist-dot.ahd-resolved  { background:var(--sage); }
+.alert-hist-dot.ahd-dismissed { background:var(--mid); }
+.alert-hist-body { flex:1; min-width:0; }
+.alert-hist-title { font-weight:600; color:var(--text); }
+.alert-hist-meta { font-size:var(--fs-xs); font-weight:400; color:var(--light); margin-top:1px; }
+.alert-hist-empty { text-align:center; padding:var(--sp-16); color:var(--light); font-size:var(--fs-sm); }
+
+/* Strip color variants */
+.is-sage   { background:var(--sage-light); border-left:var(--accent-w) solid var(--sage); }
+.is-rose   { background:var(--rose-light); border-left:var(--accent-w) solid #b0485e; }
+.is-lav    { background:var(--lav-light); border-left:var(--accent-w) solid var(--lavender); }
+.is-sky    { background:var(--sky-light); border-left:var(--accent-w) solid var(--sky); }
+.is-peach  { background:var(--peach-light); border-left:var(--accent-w) solid var(--peach); }
+.is-warn   { background:var(--peach-light); border-left:var(--accent-w) solid var(--border-warn); }
+.is-danger { background:var(--rose-light); border-left:var(--accent-w) solid var(--tc-danger); }
+.is-success { background:var(--sage-light); border-left:var(--accent-w) solid var(--sage); }
+.vacc-slot-btn.active { background:var(--accent-sage-deep); color:white; border-color:var(--accent-sage-deep); }
+.is-neutral { background:var(--warm); border-left:var(--accent-w) solid var(--light); }
+.is-indigo  { background:var(--indigo-light); border-left:var(--accent-w) solid var(--indigo); }
+.is-amber   { background:var(--amber-light); border-left:var(--accent-w) solid var(--amber); }
+
+/* Semantic text colors */
+
+/* Badge — small uppercase label */
+.badge-sm {
+  font-size:var(--fs-xs); font-weight:700; text-transform:uppercase;
+  letter-spacing:var(--ls-normal); padding:var(--sp-2) var(--sp-8); border-radius:var(--r-md);
+  display:inline-block;
+}
+
+/* Section micro-label */
+.micro-label {
+  font-size:var(--fs-xs); font-weight:500; text-transform:uppercase;
+  letter-spacing:var(--ls-normal); color:var(--light);
+}
+
+/* Intra-card sub-header — intermediate level between card-title and body */
+.card-sub-header {
+  font-family:'Fraunces',serif; font-size:var(--fs-base); font-weight:600;
+  color:var(--text); margin:var(--sp-12) 0 var(--sp-6); padding-top:var(--sp-8);
+  border-top:1px solid rgba(180,120,120,0.08);
+}
+.card-sub-header:first-child { border-top:none; margin-top:0; padding-top:0; }
+.card.card-hero .card-sub-header { font-size:var(--fs-md); }
+.card.card-info .card-sub-header { font-size:var(--fs-sm); font-family:'Nunito',sans-serif; }
+
+/* Common text patterns — intra-card hierarchy */
+.t-title { font-weight:600; font-size:var(--fs-md); color:var(--text); }
+.t-sub   { font-size:var(--fs-base); font-weight:400; color:var(--mid); }
+.t-sub-light { font-size:var(--fs-base); font-weight:400; color:var(--light); }
+
+/* ── Intra-card hierarchy: enforces title > body > detail > meta gap ── */
+/* Card body text — one full step below card title */
+.card .card-body-text { font-size:var(--fs-base); line-height:var(--lh-relaxed); color:var(--text); }
+.card .card-detail  { font-size:var(--fs-sm); font-weight:400; line-height:var(--lh-relaxed); color:var(--mid); }
+.card .card-meta    { font-size:var(--fs-xs); line-height:var(--lh-normal); color:var(--light); text-transform:uppercase; letter-spacing:var(--ls-normal); font-weight:600; }
+/* Hero intra-card: bump body up to md, detail to base */
+.card.card-hero .card-body-text { font-size:var(--fs-md); }
+.card.card-hero .card-detail  { font-size:var(--fs-base); }
+.card.card-hero .card-meta    { font-size:var(--fs-sm); }
+/* Info intra-card: compress one step down */
+.card.card-info .card-body-text { font-size:var(--fs-xs); }
+.card.card-info .card-detail  { font-size:var(--fs-xs); }
+
+/* List item base — shared by milestone, note, med, visit, tip, activity, sleep-entry, poop-entry, reco, plan, scrap */
+.list-item {
+  padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl);
+  background:var(--warm); transition:background var(--ease-fast);
+}
+/* List item layout variants */
+.list-item.li-row   { display:flex; align-items:flex-start; gap:var(--sp-8); }
+.list-item.li-col   { display:flex; flex-direction:column; gap:var(--sp-4); }
+.list-item.li-between { display:flex; align-items:center; justify-content:space-between; }
+/* List item with border accent */
+.list-item.li-accent { border-left:var(--accent-w) solid transparent; }
+/* List item icon (leading icon in a row layout) */
+.list-item .li-icon  { font-size:var(--icon-md); flex-shrink:0; margin-top:1px; }
+/* List item body (flex:1 text area) */
+.list-item .li-body  { flex:1; min-width:0; }
+.list-item .li-body strong { font-size:var(--fs-md); font-weight:700; display:block; color:var(--text); }
+.list-item .li-body span   { font-size:var(--fs-base); font-weight:400; color:var(--mid); line-height:var(--lh-relaxed); }
+/* List item actions (flex-shrink row of buttons) */
+.list-item .li-actions { display:flex; gap:var(--sp-4); flex-shrink:0; align-items:flex-start; }
+
+/* Item action button base — shared by ms-action-btn, med-btn, note-btn, del-btn */
+.item-action-btn {
+  background:none; border:1.5px solid var(--light); border-radius:var(--r-md);
+  cursor:pointer; font-size:var(--icon-xs); padding:var(--sp-8) var(--sp-10); color:var(--mid);
+  font-family:'Nunito',sans-serif; transition:all var(--ease-fast);
+  min-height:44px; min-width:44px; display:flex; align-items:center; justify-content:center;
+}
+.item-action-btn:hover { border-color:var(--sage); color:var(--tc-sage); background:var(--sage-light); }
+.item-action-btn.iab-danger:hover { border-color:var(--rose); color:var(--tc-rose); background:var(--rose-light); }
+.item-action-btn.iab-sky:hover { border-color:var(--sky); color:var(--tc-sky); background:var(--sky-light); }
+.item-action-btn.iab-no-border { border:none; }
+[data-theme="dark"] .item-action-btn.iab-danger:hover { background:var(--rose-light); color:var(--tc-rose); }
+
+/* Clickable modifier */
+.tappable { cursor:pointer; }
+.tappable:active { transform:scale(0.98); }
+
+/* Collapse chevron — canonical chevron base for all expand/collapse/nav indicators */
+.collapse-chevron {
+  font-size:var(--icon-xs); color:var(--light);
+  transition:transform var(--ease-fast);
+  flex-shrink:0; display:inline-block;
+}
+
+/* ── Sleep Tracker ── */
+.sleep-entry-card {
+  padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl);
+  background:var(--indigo-light); border:1.5px solid rgba(155,168,216,0.3);
+  display:flex; flex-direction:column; gap:var(--sp-4);
+}
+.sleep-entry-header {
+  display:flex; align-items:center; justify-content:space-between; gap:var(--sp-8); min-width:0; flex-wrap:wrap;}
+.sleep-entry-times {
+  font-family:'Fraunces',serif; font-size:var(--fs-md); font-weight:600;
+  color:var(--tc-indigo);
+}
+.sleep-entry-duration {
+  font-size:var(--fs-sm); font-weight:700; color:var(--tc-indigo);
+  background:rgba(155,168,216,0.25); padding:var(--sp-2) var(--sp-10); border-radius:var(--r-md);
+}
+.sleep-entry-meta {
+  display:flex; align-items:center; gap:var(--sp-8); flex-wrap:wrap;
+}
+.sleep-quality-badge {
+  font-size:var(--fs-xs); font-weight:700; padding:var(--sp-2) var(--sp-8);
+  border-radius:var(--r-md); text-transform:uppercase; letter-spacing:var(--ls-normal);
+}
+.sq-good    { background:var(--sage-light); color:var(--tc-sage); }
+.sq-fair    { background:var(--peach-light); color:var(--tc-warn); }
+.sq-poor    { background:var(--rose-light); color:var(--tc-rose); }
+.sq-btn {
+  padding:var(--sp-8) var(--sp-16); border-radius:var(--r-lg); border:1.5px solid var(--indigo-light);
+  background:var(--indigo-light); color:var(--tc-indigo); font-family:'Nunito',sans-serif;
+  font-size:var(--fs-base); font-weight:600; cursor:pointer; transition:all var(--ease-fast);
+}
+.sq-btn.active-sq { background:#5a6498; color:white; border-color:#5a6498; }
+.sleep-log-seg {
+  display:flex; gap:var(--sp-8);
+  margin:var(--sp-8) 0 var(--sp-16);
+}
+.sleep-log-seg .sq-btn {
+  flex:1; display:flex; align-items:center; justify-content:center; gap:var(--sp-6);
+}
+.sleep-stat-hero {
+  font-family:'Fraunces',serif; font-size:var(--fs-3xl); font-weight:600;
+  color:var(--tc-indigo); line-height:var(--lh-tight);
+}
+.hsp-indigo {
+  background:var(--indigo-light); border:1.5px solid rgba(155,168,216,0.3);
+}
+.hsp-indigo .hsp-val { color:var(--tc-indigo); }
+.hsp-amber {
+  background:var(--amber-light); border:1.5px solid rgba(232,184,109,0.3);
+}
+.hsp-amber .hsp-val { color:var(--tc-amber); }
+
+/* ── Poop Tracker ── */
+.poop-entry-card {
+  padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl);
+  background:var(--amber-light); border:1.5px solid rgba(232,184,109,0.3);
+  display:flex; flex-direction:column; gap:var(--sp-4);
+}
+.poop-entry-header {
+  display:flex; align-items:center; justify-content:space-between; gap:var(--sp-8); min-width:0; flex-wrap:wrap;}
+.poop-entry-time {
+  font-family:'Fraunces',serif; font-size:var(--fs-md); font-weight:600;
+  color:var(--tc-amber);
+}
+.poop-entry-meta {
+  display:flex; align-items:center; gap:var(--sp-8); flex-wrap:wrap;
+}
+.poop-badge {
+  font-size:var(--fs-xs); font-weight:700; padding:var(--sp-2) var(--sp-8);
+  border-radius:var(--r-md); letter-spacing:var(--ls-normal);
+}
+.poop-color-circle {
+  width:18px; height:18px; border-radius:50%; display:inline-block;
+  border:1.5px solid rgba(0,0,0,0.12); vertical-align:middle;
+}
+.poop-color-circle.pcc-sm { width:14px; height:14px; }
+.pq-btn {
+  padding:var(--sp-8) var(--sp-16); border-radius:var(--r-lg); border:1.5px solid var(--amber-light);
+  background:var(--amber-light); color:var(--tc-amber); font-family:'Nunito',sans-serif;
+  font-size:var(--fs-base); font-weight:600; cursor:pointer; transition:all var(--ease-fast);
+}
+.pq-btn.active-pq { background:#8a6520; color:white; border-color:#8a6520; }
+.poop-color-btn {
+  display:flex; align-items:center; gap:var(--sp-8);
+  padding:var(--sp-6) var(--sp-12); border-radius:var(--r-lg); border:1.5px solid var(--amber-light);
+  background:var(--amber-light); color:var(--tc-amber); font-family:'Nunito',sans-serif;
+  font-size:var(--fs-sm); font-weight:600; cursor:pointer; transition:all var(--ease-fast);
+}
+.poop-color-btn .poop-swatch {
+  width:16px; height:16px;
+  border:1.5px solid rgba(0,0,0,0.1);
+}
+.poop-color-btn.active-pq { background:#8a6520; color:white; border-color:#8a6520; }
+.poop-color-btn.active-pq .poop-swatch { border-color:rgba(255,255,255,0.5); }
+.poop-check-row {
+  display:flex; gap:var(--sp-16); align-items:center; margin-top:var(--sp-4);
+}
+.poop-check-label {
+  display:flex; align-items:center; gap:var(--sp-8); font-size:var(--fs-base);
+  font-weight:600; color:var(--tc-amber); cursor:pointer;
+}
+.poop-check-label input[type="checkbox"] {
+  width:18px; height:18px; accent-color:var(--amber); cursor:pointer;
+}
+
+/* ── Responsive ── */
+/* ── Avatar Lightbox ── */
+.avatar-lightbox {
+  position:fixed; inset:0; z-index:200;
+  background:rgba(20,15,15,0.92); backdrop-filter:blur(8px);
+  display:none; align-items:center; justify-content:center;
+  flex-direction:column; gap:var(--sp-16);
+  animation:fadeIn 0.2s ease;
+}
+.avatar-lightbox.open { display:flex; }
+.avatar-lightbox img {
+  max-width:85vw; max-height:70vh; border-radius:var(--r-xl);
+  box-shadow:0 20px 60px rgba(0,0,0,0.5);
+  object-fit:contain;
+}
+.avatar-lightbox .lb-name {
+  font-family:'Fraunces',serif; font-size:var(--fs-xl); color:white;
+  font-weight:600; letter-spacing:-0.02em;
+}
+.avatar-lightbox .lb-sub { font-size:var(--fs-base); color:rgba(255,255,255,0.5); }
+.avatar-lightbox .lb-close {
+  position:absolute; top:16px; right:16px;
+  width:36px; height:36px; border-radius:50%;
+  background:rgba(255,255,255,0.15); border:none;
+  color:white; font-size:var(--icon-md); cursor:pointer;
+  display:flex; align-items:center; justify-content:center;
+}
+.avatar-lightbox .lb-actions {
+  display:flex; gap:var(--sp-8);
+}
+.avatar-lightbox .lb-btn {
+  padding:var(--sp-10) var(--sp-20); border-radius:var(--r-2xl); border:none;
+  font-family:'Nunito',sans-serif; font-size:var(--fs-base); font-weight:700;
+  cursor:pointer; color:white; background:rgba(255,255,255,0.15);
+  min-height:44px; display:inline-flex; align-items:center;
+}
+.avatar-lightbox .lb-btn:hover { background:rgba(255,255,255,0.25); }
+
+/* ── Avatar Crop Modal ── */
+.crop-overlay {
+  position:fixed; inset:0; z-index:210;
+  background:rgba(20,15,15,0.95);
+  display:none; flex-direction:column;
+  align-items:center; justify-content:center;
+}
+.crop-overlay.open { display:flex; }
+.crop-container {
+  position:relative; width:280px; height:280px;
+  overflow:hidden; border-radius:50%;
+  border:3px solid rgba(255,255,255,0.3);
+  box-shadow:0 0 0 9999px rgba(20,15,15,0.7);
+  touch-action:none;
+  z-index:1;
+}
+.crop-container img {
+  position:absolute; cursor:grab;
+  touch-action:none; user-select:none; -webkit-user-select:none;
+}
+.crop-container img:active { cursor:grabbing; }
+.crop-controls {
+  display:flex; align-items:center; gap:var(--sp-16); margin-top:var(--sp-20);
+  position:relative; z-index:2;
+}
+.crop-controls input[type=range] {
+  width:180px; accent-color:var(--rose);
+}
+.crop-btns {
+  display:flex; gap:var(--sp-8); margin-top:var(--sp-16);
+  position:relative; z-index:2;
+}
+.crop-btns button {
+  padding:var(--sp-12) var(--sp-32); border-radius:var(--r-2xl); border:2px solid transparent;
+  font-family:'Nunito',sans-serif; font-size:var(--fs-md); font-weight:700;
+  cursor:pointer; letter-spacing:var(--ls-normal);
+}
+.crop-cancel { background:#ffffff; color:#3d2e2e; border-color:#ffffff; }
+.crop-cancel:active { background:#e8e8e8; }
+.crop-save { background:#e8607a; color:#ffffff; border-color:#e8607a; }
+.crop-save:active { background:#d44d67; }
+
+@media(max-width:700px) {
+  .grid { grid-template-columns:1fr; }
+  .header { flex-wrap:wrap; }
+}
+/* ── Print ── */
+@media print {
+  body { background:white !important; }
+  body::before { display:none !important; }
+  .tab-bar, .header .avatar-edit, #avatarInput, .btn,
+  .add-food, .add-note-area, .del-btn, .food-del, .note-actions, .med-actions,
+  .visit-actions, .modal-overlay, .confirm-overlay,
+  .chart-filter-btn, .visit-add-form { display:none !important; }
+  .app { max-width:100%; padding:var(--sp-10); }
+  .header { box-shadow:none; margin-bottom:var(--sp-10); }
+  .card { box-shadow:none; border:1px solid #ddd; break-inside:avoid; margin-bottom:var(--sp-10); }
+  .tab-panel { display:block !important; }
+  .collapse-body { max-height:none !important; opacity:1 !important; display:block !important; }
+  .grid { display:block; }
+  .col-full { grid-column:1; }
+}
+/* ── Reduced Motion ── */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration:0.01ms !important;
+    animation-iteration-count:1 !important;
+    transition-duration:0.01ms !important;
+  }
+}
+
+/* ═══════════════════════════════════════════════════
+   v1.9 — DESIGN TOKENS, UTILITY CLASSES, POLISH
+   ═══════════════════════════════════════════════════ */
+
+/* ── Utility: Layout ── */
+.d-none     { display:none; }
+.d-flex     { display:flex; }
+.d-iflex    { display:inline-flex; }
+.flex-col   { flex-direction:column; }
+.flex-wrap  { flex-wrap:wrap; }
+.flex-1     { flex:1; }
+.flex-1-min { flex:1; min-width:0; }
+.items-center { align-items:center; }
+.justify-end  { justify-content:flex-end; }
+.justify-between { justify-content:space-between; }
+.gap-4  { gap:var(--sp-4); }
+.gap-6  { gap:var(--sp-8); }
+.gap-8  { gap:var(--sp-8); }
+.gap-12 { gap:var(--sp-12); }
+.gap-16 { gap:var(--sp-16); }
+.gap-20 { gap:var(--sp-20); }
+.gap-24 { gap:var(--sp-24); }
+.mt-2  { margin-top:var(--sp-2); }
+.mt-4  { margin-top:var(--sp-4); }
+.mt-6  { margin-top:var(--sp-6); }
+.mt-8  { margin-top:var(--sp-8); }
+.mt-10 { margin-top:var(--sp-10); }
+.mt-12 { margin-top:var(--sp-12); }
+.mt-16 { margin-top:var(--sp-16); }
+.mb-4  { margin-bottom:var(--sp-4); }
+.mb-8  { margin-bottom:var(--sp-8); }
+.mb-0  { margin-bottom:0; }
+.mb-10 { margin-bottom:var(--sp-10); }
+.mb-12 { margin-bottom:var(--sp-12); }
+.py-4  { padding-top:var(--sp-4); padding-bottom:var(--sp-4); }
+.nowrap { white-space:nowrap; }
+.shrink-0 { flex-shrink:0; }
+.overflow-visible { overflow:visible; }
+.text-center { text-align:center; }
+.cursor-pointer { cursor:pointer; }
+.scroll-list { max-height:400px; overflow-y:auto; }
+
+/* ── Utility: Typography ── */
+.t-xs   { font-size:var(--fs-xs); }
+.t-sm   { font-size:var(--fs-sm); }
+.t-base { font-size:var(--fs-base); }
+.t-md   { font-size:var(--fs-md); }
+.t-lg   { font-size:var(--fs-lg); }
+.t-xl   { font-size:var(--fs-xl); }
+.t-mid  { color:var(--mid); }
+.t-light{ color:var(--light); }
+.t-icon { font-size:var(--icon-base); }
+.fw-600 { font-weight:600; }
+.fw-700 { font-weight:700; }
+
+/* ── Utility: Semantic Text Colours ── */
+.tc-sage   { color:var(--tc-sage); }
+.tc-rose   { color:var(--tc-rose); }
+.tc-lav    { color:var(--tc-lav); }
+.tc-sky    { color:var(--tc-sky); }
+.tc-warn   { color:var(--tc-warn); }
+.tc-danger { color:var(--tc-danger); }
+.tc-amber  { color:var(--tc-amber); }
+.tc-indigo { color:var(--tc-indigo); }
+.tc-light  { color:var(--light); }
+.tc-mid    { color:var(--mid); }
+.fs-2xs    { font-size:var(--fs-2xs); }
+
+/* ── Utility: Disabled State ── */
+.disabled-state { opacity:0.4; pointer-events:none; }
+
+/* ── M2 Migration: Status Text Utilities ── */
+.status-good     { color:var(--tc-sage); font-weight:600; }
+.status-warn     { color:var(--tc-caution); font-weight:600; }
+.status-action   { color:var(--tc-danger); font-weight:600; }
+.status-good-xs  { color:var(--tc-sage); font-weight:600; font-size:var(--fs-xs); }
+.status-warn-xs  { color:var(--tc-caution); font-weight:600; font-size:var(--fs-xs); }
+.status-good-sm  { color:var(--tc-sage); font-weight:600; font-size:var(--fs-sm); }
+.status-warn-sm  { color:var(--tc-caution); font-weight:600; font-size:var(--fs-sm); }
+.status-action-sm{ color:var(--tc-danger); font-weight:600; font-size:var(--fs-sm); }
+.status-lav-sm   { color:var(--tc-lav); font-weight:600; font-size:var(--fs-sm); }
+.status-sky-sm   { color:var(--tc-sky); font-weight:600; font-size:var(--fs-sm); }
+.status-indigo-sm{ color:var(--tc-indigo); font-weight:600; font-size:var(--fs-sm); }
+
+/* ── M2 Migration: Stat Value Utilities ── */
+.stat-val-sage   { color:var(--tc-sage); font-weight:600; }
+.stat-val-amber  { color:var(--tc-amber); font-weight:600; }
+.stat-val-rose   { color:var(--tc-rose); font-weight:600; }
+.stat-val-indigo { color:var(--tc-indigo); font-weight:600; }
+.stat-val-lav    { color:var(--tc-lav); font-weight:600; }
+.stat-val-sky    { color:var(--tc-sky); font-weight:600; }
+
+/* ── M2 Migration: Section Label ── */
+.section-label   { font-size:var(--fs-sm); font-weight:600; text-transform:uppercase; letter-spacing:var(--ls-wide); color:var(--mid); margin-bottom:var(--sp-4); }
+.section-label-danger { font-size:var(--fs-sm); font-weight:600; text-transform:uppercase; letter-spacing:var(--ls-wide); color:var(--tc-danger); margin-bottom:var(--sp-6); }
+.section-label-warn   { font-size:var(--fs-sm); font-weight:600; text-transform:uppercase; letter-spacing:var(--ls-wide); color:var(--tc-warn); margin:var(--sp-12) 0 var(--sp-6); }
+.section-label-info   { font-size:var(--fs-sm); font-weight:600; text-transform:uppercase; letter-spacing:var(--ls-wide); color:var(--mid); margin:var(--sp-12) 0 var(--sp-6); }
+
+/* ── M2 Migration: Insight/Guidance Boxes ── */
+.insight-box      { padding:var(--sp-8) var(--sp-12); border-radius:var(--r-md); font-size:var(--fs-sm); }
+.insight-box-sage { padding:var(--sp-8) var(--sp-12); border-radius:var(--r-md); font-size:var(--fs-sm); background:var(--sage-light); color:var(--tc-sage); }
+.insight-box-rose { padding:var(--sp-8) var(--sp-12); border-radius:var(--r-md); font-size:var(--fs-sm); background:var(--rose-light); color:var(--tc-rose); }
+.insight-box-amber{ padding:var(--sp-8) var(--sp-12); border-radius:var(--r-md); font-size:var(--fs-sm); background:var(--amber-light); color:var(--tc-amber); }
+
+/* ── M2 Migration: Alert Blocks ── */
+.alert-block-danger { padding:var(--sp-8) var(--sp-12); border-radius:var(--r-md); margin:var(--sp-4) 0; background:var(--surface-rose); font-size:var(--fs-sm); font-weight:600; color:var(--tc-danger); }
+.alert-block-caution{ padding:var(--sp-8) var(--sp-12); border-radius:var(--r-md); margin:var(--sp-4) 0; background:var(--amber-light); font-size:var(--fs-sm); font-weight:600; color:var(--tc-caution); }
+
+/* ── M2 Migration: Illness Tracker Utilities ── */
+.fe-center-action  { text-align:center; padding:var(--sp-10) 0; }
+.fe-center-status  { text-align:center; padding:var(--sp-10) 0; font-size:var(--fs-xs); color:var(--tc-sage); font-weight:600; }
+.fe-sub-label      { font-weight:600; color:var(--mid); margin-bottom:var(--sp-8); }
+.fe-section-gap    { margin:var(--sp-12) 0 var(--sp-4); }
+.ep-list           { margin:0; padding-left:var(--sp-16); }
+
+/* ── M2 Migration: Content Utilities ── */
+.source-attribution { font-size:var(--fs-2xs); color:var(--light); text-align:center; padding-top:var(--sp-4); font-style:italic; }
+.guidance-text      { font-size:var(--fs-sm); color:var(--mid); margin-bottom:var(--sp-10); line-height:var(--lh-relaxed); }
+.section-label-light{ font-size:var(--fs-sm); font-weight:600; text-transform:uppercase; letter-spacing:var(--ls-normal); color:var(--light); margin-bottom:var(--sp-6); }
+
+/* ── Polish-5: Cross-jurisdiction class extraction (8 new classes) ──
+   Class-name introduction approved at Polish-charter time by Maren+Kael
+   scouts. Replaces ~17 inline-style HR-2 sites with class references
+   across split/medical.js + split/intelligence.js. The broader
+   `.section-caption` cousin-pattern sweep (44 varied sites) deferred to
+   charter §6 R-10 P-7 per `narrow-scope-and-defer-broader-audit-to-R-10`
+   doctrine (RATIFIED 3/3 PR-26). */
+.guidance-section-title-do {
+  font-weight: 600;
+  font-size: var(--fs-sm);
+  color: var(--tc-sage);
+  text-transform: uppercase;
+  letter-spacing: var(--ls-wide);
+  margin-bottom: 4px;
+}
+.guidance-section-title-dont {
+  font-weight: 600;
+  font-size: var(--fs-sm);
+  color: var(--tc-rose);
+  text-transform: uppercase;
+  letter-spacing: var(--ls-wide);
+  margin-bottom: 4px;
+}
+.guidance-bullet {
+  font-size: var(--fs-base);
+  color: var(--text);
+  padding: 3px 0 3px 18px;
+  position: relative;
+  line-height: var(--lh-relaxed);
+}
+.guidance-bullet > .guidance-bullet-marker {
+  position: absolute;
+  left: 0;
+}
+.doctor-cta-call,
+.doctor-cta-map {
+  min-height: 44px;
+  padding: 8px 14px;
+  border-radius: var(--r-2xl);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-8);
+  text-decoration: none;
+  font-size: var(--fs-sm);
+  font-weight: 700;
+  color: white;
+  font-family: 'Nunito', sans-serif;
+}
+.doctor-cta-call { background: var(--tc-sage); }
+.doctor-cta-map  { background: var(--tc-sky); }
+.kc-row-flex-wrap {
+  display: flex;
+  gap: var(--sp-8);
+  flex-wrap: wrap;
+  padding: var(--sp-4) 0;
+}
+.nh-legend-swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: var(--r-sm);
+}
+
+/* ── Polish-6: CSS-custom-property pivot for dynamic-required surfaces ──
+   First-instance candidate for `CSS-custom-property-pivot-for-dynamic-
+   required-surfaces` doctrine (Aurelius PR-23 Ruling 5; sister to Polish-4's
+   `spec-amendment-in-substitution-PR`). Convention: dynamic-required values
+   move from `style="width:${pct}%"` to `style="--dyn-pct:${pct}%"` consumed
+   via class-side `var()`. See DESIGN_PRINCIPLES.md "CSS-Custom-Property
+   Pivot Convention" section for full rationale + locked-exclusion list.
+   Path C narrow-scope: --dyn-pct width-pivot only at Polish-6; --dyn-bg /
+   --dyn-fg / --dyn-border deferred to Polish-7+ first-instance evaluations
+   per Maren+Kael Mode 2 dual-endorsement. */
+.dyn-fill {
+  width: var(--dyn-pct);
+}
+.dyn-fill-h {
+  height: var(--dyn-pct);
+}
+.badge-amber        { background:var(--amber-light); color:var(--tc-amber); }
+.fx-row-wrap        { align-items:center; flex-wrap:wrap; }
+.btn-sm-inline      { padding:var(--sp-6) var(--sp-12); font-size:var(--fs-xs); }
+
+[data-theme="dark"] .badge-amber { background:rgba(138,101,32,0.15); }
+
+/* ── M2 Migration: Button Edit/Delete Inline ── */
+.btn-icon-edit   { background:none; border:none; font-size:var(--icon-sm); color:var(--tc-lav); padding:var(--sp-4); cursor:pointer; }
+.btn-icon-delete { background:none; border:none; font-size:var(--icon-sm); color:var(--light); padding:var(--sp-4); cursor:pointer; }
+.btn-icon-amber  { background:none; border:none; font-size:var(--icon-sm); color:var(--tc-amber); padding:var(--sp-4); cursor:pointer; }
+.btn-full-base   { width:100%; padding:var(--sp-12); font-size:var(--fs-base); }
+
+[data-theme="dark"] .insight-box-sage  { background:rgba(58,112,96,0.15); }
+[data-theme="dark"] .insight-box-rose  { background:rgba(158,62,82,0.15); }
+[data-theme="dark"] .insight-box-amber { background:rgba(138,101,32,0.15); }
+[data-theme="dark"] .alert-block-danger{ background:rgba(158,62,82,0.15); }
+[data-theme="dark"] .alert-block-caution{ background:rgba(138,101,32,0.15); }
+
+/* ── M3 Migration: Static HTML Utility Classes ── */
+
+/* Settings section header */
+.settings-section-hdr { font-size:var(--fs-base); font-weight:600; margin-bottom:var(--sp-8); }
+.settings-section-hdr-caution { color:var(--tc-caution); }
+.settings-section-hdr-lav { color:var(--tc-lav); }
+.settings-section-hdr-indigo { color:var(--tc-indigo); }
+.settings-section-hdr-sky { color:var(--tc-sky); }
+.settings-section-hdr-sage { color:var(--tc-sage); }
+.settings-section-hdr-sm { font-size:var(--fs-sm); margin-bottom:var(--sp-6); }
+
+/* Form input (peach variant for quick-note) */
+.input-peach-inline { flex:1; padding:var(--sp-8) var(--sp-12); border-radius:var(--r-lg); border:1.5px solid var(--peach-light); font-family:'Nunito',sans-serif; font-size:var(--fs-base); background:var(--peach-light); color:var(--text); outline:none; }
+[data-theme="dark"] .input-peach-inline { background:rgba(254,243,234,0.08); border-color:rgba(254,243,234,0.15); }
+
+/* Growth velocity section divider */
+.velocity-section { margin-top:var(--sp-12); border-top:1px solid var(--border-subtle); padding-top:var(--sp-12); }
+
+/* Growth velocity header */
+.velocity-hdr { font-size:var(--fs-xs); font-weight:600; text-transform:uppercase; letter-spacing:var(--ls-normal); color:var(--mid); margin-bottom:var(--sp-8); }
+
+/* Chevron rotate (for open collapse) */
+.chevron-open { transform:rotate(180deg); }
+
+/* Footer text */
+/* Footer credit — special treatment now that it sits front-and-centre on the
+   lean landing. "Ziva" wears the hero's wavelength gradient (a bookend to the
+   warm-wave stripe); the heart beats softly (reduced-motion floor); Fraunces
+   italic = the warm "voice" (§9.6). Replaces the old inline opacity:0.4 dim. */
+.app-footer { text-align:center; padding:var(--sp-24) 0 var(--sp-8); }
+.footer-text-style {
+  display:inline-flex; align-items:center; justify-content:center; gap:var(--sp-6);
+  font-family:'Fraunces', serif; font-style:italic; font-weight:600;
+  font-size:var(--fs-base); color:var(--light); letter-spacing:var(--ls-wide);
+}
+.footer-name {
+  font-family:'Fraunces', serif; font-style:italic; font-weight:700;
+  /* Same warm-wave as the hero stripe: a sheen sweeps over the fixed
+     wavelength gradient, clipped to the glyphs — reuses @keyframes ld-wave so
+     the cadence matches the hero exactly. */
+  background-image:
+    linear-gradient(100deg, transparent 35%, rgba(255,255,255,0.7) 50%, transparent 65%),
+    linear-gradient(90deg, var(--rose), var(--peach), var(--amber), var(--sage), var(--sky), var(--indigo), var(--lavender));
+  background-size:35% 100%, 100% 100%;
+  background-repeat:no-repeat;
+  background-position:-35% 0, 0 0;
+  -webkit-background-clip:text; background-clip:text;
+  -webkit-text-fill-color:transparent; color:transparent;
+  animation:ld-wave 4.4s ease-in-out infinite;
+}
+/* Dark parity (Vela V-V-3): the light wavelength pastels wash toward the dark
+   footer surface — "Ziva" is the one word the footer exists to say. Lift the
+   stops to the dark-tuned --tc-* hues (the §9.2 hue-swap the doors use), same
+   wavelength order (rose→peach→amber→sage→sky→indigo→lavender). */
+[data-theme="dark"] .footer-name {
+  background-image:
+    linear-gradient(100deg, transparent 35%, rgba(255,255,255,0.7) 50%, transparent 65%),
+    linear-gradient(90deg, var(--tc-rose), var(--tc-caution), var(--tc-amber), var(--tc-sage), var(--tc-sky), var(--tc-indigo), var(--tc-lav));
+}
+.footer-heart {
+  width:var(--icon-base); height:var(--icon-base); color:var(--tc-rose);
+  transform-origin:center; animation:footer-beat 2.4s ease-in-out infinite;
+}
+@keyframes footer-beat {
+  0%, 30%, 100% { transform:scale(1); }
+  8%  { transform:scale(1.18); }
+  16% { transform:scale(1); }
+  22% { transform:scale(1.12); }
+}
+@media (prefers-reduced-motion: reduce) { .footer-heart, .footer-name { animation:none; } }
+
+/* Vitals expanded inner divider */
+.vitals-expanded-inner { border-top:1px solid var(--border-subtle); margin-top:var(--sp-12); padding-top:var(--sp-12); }
+
+/* Flex utility: 1 min-width:100px */
+.flex-1-min100 { flex:1; min-width:100px; }
+
+/* Poop color dot backgrounds (static — JS-toggled active state handles the check) */
+.pcolor-yellow { background:#e8c840; }
+.pcolor-green  { background:#6b9e4a; }
+.pcolor-brown  { background:#8b6914; }
+.pcolor-dark   { background:#3d2b1f; }
+.pcolor-orange { background:#e0882a; }
+.pcolor-red    { background:#c0392b; }
+.pcolor-white  { background:#f0ede6; border-color:#ccc; }
+.pcolor-black  { background:#1a1a1a; }
+
+/* Button: full width reset variant */
+.btn-full-danger { width:100%; padding:var(--sp-12); font-size:var(--fs-base); color:var(--tc-danger); border-color:var(--rose-light); }
+
+/* PWA install button */
+.btn-full-pwa { width:100%; padding:var(--sp-12); font-size:var(--fs-base); display:none; }
+
+/* Search icon overlay */
+.search-icon-white { color:white; font-size:var(--icon-sm); }
+
+/* Settings storage label row */
+.storage-label { font-size:var(--fs-base); font-weight:600; }
+.storage-chip { font-size:var(--fs-xs); padding:3px 8px; border-radius:var(--r-md); background:var(--card-bg); color:var(--mid); border:1px solid rgba(168,207,224,0.3); }
+.storage-chip-pct { opacity:0.5; }
+.storage-chip-toggle { font-size:var(--fs-xs); padding:3px 8px; border-radius:var(--r-md); background:var(--warm); color:var(--light); border:1px solid rgba(168,207,224,0.2); cursor:pointer; }
+.storage-rest-chips { display:none; flex-wrap:wrap; gap:var(--sp-8); width:100%; }
+.storage-rest-chips.is-open { display:flex; }
+
+/* Collapsible header w/ flex display */
+.collapse-hdr-flex { font-size:var(--fs-base); color:var(--mid); display:flex; align-items:center; gap:var(--sp-8); }
+
+/* Combo check button min-width */
+.btn-min80 { min-width:80px; }
+
+/* Save button padding compact */
+.btn-compact { padding:var(--sp-8) var(--sp-12); }
+
+/* Toggle switch structure (static HTML) */
+.toggle-switch-wrap { position:relative; display:inline-block; width:44px; height:24px; flex-shrink:0; }
+.toggle-switch-input { opacity:0; width:0; height:0; }
+
+/* Milestone category button size */
+.rtog-sm { font-size:var(--fs-sm); }
+
+/* Vacc slot flex */
+.vacc-slot-flex { flex:1; }
+
+/* Indigo info box */
+.info-box-indigo { padding:var(--sp-12) var(--sp-12); border-radius:var(--r-lg); background:var(--indigo-light); border:1.5px solid rgba(155,168,216,0.3); }
+[data-theme="dark"] .info-box-indigo { background:rgba(74,80,128,0.12); border-color:rgba(155,168,216,0.15); }
+
+/* Descriptive text under settings */
+.settings-desc { font-size:var(--fs-sm); color:var(--light); font-family:'Nunito',sans-serif; font-weight:400; }
+
+/* Settings row with flex + gap */
+.settings-row { display:flex; gap:var(--sp-8); align-items:center; }
+
+/* Settings sub-label (mid weight) */
+.settings-sub { font-size:var(--fs-sm); color:var(--mid); font-weight:600; }
+
+/* Chart context hidden default */
+.chart-context-hidden { display:none; margin-bottom:var(--sp-8); }
+
+/* Flex gap-8 wrap mb-10 */
+.flex-gap8-wrap-mb { display:flex; gap:var(--sp-8); flex-wrap:wrap; margin-bottom:var(--sp-10); }
+
+/* Max-height expansion for collapse body */
+.collapse-body-expanded { max-height:none; margin-top:var(--sp-10); }
+
+/* Margin zero */
+.m-0 { margin:0; }
+
+/* Flex-wrap */
+.flex-wrap { flex-wrap:wrap; }
+
+/* Flex:1 */
+.flex-1 { flex:1; }
+
+/* ── M3 Migration: Render Code Utility Classes ── */
+
+/* Illness tracker: action chip inline style */
+.fe-symptom-chip { cursor:pointer; padding:var(--sp-6) var(--sp-12); border-radius:var(--r-full); font-size:var(--fs-sm); border:1.5px solid var(--border-subtle); background:var(--card-bg); transition:all var(--ease-fast); }
+.fe-symptom-chip-active { background:var(--sage); color:white; }
+
+/* Visit prep: section with top border */
+.vp-section { padding:var(--sp-8) 0; border-bottom:1px solid var(--border-subtle); }
+.vp-section:last-child { border-bottom:none; }
+
+/* Hydration grid cell */
+.hydration-cell { text-align:center; padding:var(--sp-4); border-radius:var(--r-sm); font-size:var(--fs-xs); }
+
+/* Alert start button */
+.alert-start-btn { padding:var(--sp-8) var(--sp-12); border-radius:var(--r-lg); font-size:var(--fs-sm); font-weight:600; cursor:pointer; border:1.5px solid; transition:all var(--ease-fast); }
+.alert-start-btn-rose { background:var(--rose-light); color:var(--tc-rose); border-color:var(--tc-rose); }
+.alert-start-btn-amber { background:var(--amber-light); color:var(--tc-amber); border-color:var(--tc-amber); }
+
+/* Medical intelligence episode card */
+.mi-episode-card { padding:var(--sp-8) var(--sp-12); border-radius:var(--r-md); margin-bottom:var(--sp-4); }
+.mi-episode-sage { background:var(--sage-light); }
+.mi-episode-rose { background:var(--rose-light); }
+.mi-episode-amber { background:var(--amber-light); }
+[data-theme="dark"] .mi-episode-sage  { background:rgba(58,112,96,0.12); }
+[data-theme="dark"] .mi-episode-rose  { background:rgba(158,62,82,0.12); }
+[data-theme="dark"] .mi-episode-amber { background:rgba(138,101,32,0.12); }
+
+/* Sleep intelligence stat card */
+.si-stat-card { padding:var(--sp-8) var(--sp-12); border-radius:var(--r-md); text-align:center; }
+.si-stat-val  { font-family:'Fraunces',serif; font-size:var(--fs-lg); font-weight:600; }
+.si-stat-label { font-size:var(--fs-2xs); color:var(--mid); text-transform:uppercase; letter-spacing:var(--ls-normal); }
+
+/* Food intelligence: timeline item */
+.fi-timeline-item { padding:var(--sp-4) 0; border-bottom:1px solid var(--border-subtle); }
+.fi-timeline-item:last-child { border-bottom:none; }
+
+/* Supplement timeline dot */
+.supp-dot { width:8px; height:8px; border-radius:50%; display:inline-block; }
+.supp-dot-sage { background:var(--tc-sage); }
+.supp-dot-rose { background:var(--tc-danger); }
+
+/* Hydration legend item */
+.hydration-legend { display:inline-flex; align-items:center; gap:var(--sp-4); font-size:var(--fs-2xs); }
+
+[data-theme="dark"] .settings-section-hdr-caution { color:var(--tc-caution); }
+[data-theme="dark"] .settings-section-hdr-lav { color:var(--tc-lav); }
+[data-theme="dark"] .settings-section-hdr-indigo { color:var(--tc-indigo); }
+[data-theme="dark"] .settings-section-hdr-sky { color:var(--tc-sky); }
+[data-theme="dark"] .settings-section-hdr-sage { color:var(--tc-sage); }
+
+/* ── M3 Migration: Render Code Utilities (Phase 2) ── */
+.t-light    { color:var(--light); }
+.t-mid      { color:var(--mid); }
+.t-amber    { color:var(--tc-amber); }
+.t-sage     { color:var(--tc-sage); }
+.t-rose     { color:var(--tc-rose); }
+.t-caution  { color:var(--tc-caution); }
+.t-sky      { color:var(--tc-sky); }
+.t-lav      { color:var(--tc-lav); }
+.t-indigo   { color:var(--tc-indigo); }
+.t-danger   { color:var(--tc-danger); }
+.w-full     { width:100%; }
+.mb-4       { margin-bottom:var(--sp-4); }
+.mb-8       { margin-bottom:var(--sp-8); }
+.mt-8       { margin-top:var(--sp-8); }
+.fw-600     { font-weight:600; }
+.fw-400     { font-weight:400; }
+.ptr        { cursor:pointer; }
+.fs-xs      { font-size:var(--fs-xs); }
+.fs-sm      { font-size:var(--fs-sm); }
+.fs-xs-mid  { font-size:var(--fs-xs); color:var(--mid); }
+.fs-xs-light{ font-size:var(--fs-xs); color:var(--light); }
+.fs-sm-600  { font-size:var(--fs-sm); font-weight:600; color:var(--text); }
+.fs-sm-500  { font-size:var(--fs-sm); font-weight:500; }
+.op-60      { opacity:0.6; }
+.fw-400-op  { font-weight:400; opacity:0.6; }
+.flex-1-min0{ flex:1; min-width:0; }
+.text-center{ text-align:center; }
+.dot-10     { width:10px; height:10px; font-size:0; }
+.dot-16     { width:16px; height:16px; min-height:auto; aspect-ratio:auto; font-size:var(--fs-2xs); }
+.insight-bg-sage { padding:var(--sp-10) var(--sp-12); border-radius:var(--r-md); margin:var(--sp-8) 0; background:rgba(58,112,96,0.08); font-size:var(--fs-sm); }
+[data-theme="dark"] .insight-bg-sage { background:rgba(58,112,96,0.12); }
+
+/* ── Unified Form Input ── */
+.form-input {
+  width:100%; padding:var(--sp-10) var(--sp-12); border-radius:var(--r-lg);
+  border:1.5px solid var(--input-border, rgba(200,180,180,0.4));
+  font-family:'Nunito',sans-serif; font-size:var(--fs-md);
+  background:var(--input-bg, var(--warm)); color:var(--text); outline:none;
+  transition:border-color var(--ease-fast), box-shadow var(--ease-fast);
+}
+.form-input:focus { border-color:var(--input-focus, var(--rose)); box-shadow:0 0 0 2px var(--input-glow, var(--rose-light)); }
+/* Tab-contextual input accents */
+.input-ctx-indigo { --input-border:rgba(155,168,216,0.4); --input-bg:var(--indigo-light); --input-focus:var(--indigo); --input-glow:rgba(155,168,216,0.2); }
+.input-ctx-amber  { --input-border:rgba(232,184,109,0.4); --input-bg:var(--amber-light); --input-focus:var(--amber); --input-glow:rgba(232,184,109,0.2); }
+.input-ctx-rose   { --input-border:rgba(242,168,184,0.4); --input-bg:var(--rose-light); --input-focus:var(--rose); --input-glow:rgba(242,168,184,0.2); }
+.input-ctx-sage   { --input-border:rgba(181,213,197,0.4); --input-bg:var(--sage-light); --input-focus:var(--sage); --input-glow:rgba(181,213,197,0.2); }
+.input-ctx-sky    { --input-border:rgba(168,207,224,0.4); --input-bg:var(--sky-light); --input-focus:var(--sky); --input-glow:rgba(168,207,224,0.2); }
+.input-ctx-lav    { --input-border:rgba(201,184,232,0.4); --input-bg:var(--lav-light); --input-focus:var(--lavender); --input-glow:rgba(201,184,232,0.2); }
+.input-ctx-peach  { --input-border:rgba(250,212,180,0.4); --input-bg:var(--peach-light); --input-focus:var(--peach); --input-glow:rgba(250,212,180,0.2); }
+
+/* Day label beside date inputs */
+.day-label { font-size:var(--fs-base); font-weight:600; white-space:nowrap; min-width:80px; }
+.day-label-indigo { color:var(--tc-indigo); }
+.day-label-amber  { color:var(--tc-amber); }
+
+/* Stepper button (wake-ups, etc.) */
+.stepper-btn {
+  width:34px; height:34px; border-radius:50%; border:1.5px solid var(--input-border, rgba(200,180,180,0.4));
+  background:var(--input-bg, var(--warm)); color:var(--stepper-color, var(--mid));
+  font-size:var(--fs-lg); font-weight:700; cursor:pointer;
+  display:flex; align-items:center; justify-content:center;
+  transition:all var(--ease-fast);
+}
+.stepper-btn:hover { filter:brightness(0.95); }
+.stepper-val {
+  font-family:'Fraunces',serif; font-size:var(--fs-xl); font-weight:600;
+  color:var(--stepper-color, var(--mid)); min-width:28px; text-align:center;
+}
+.stepper-ctx-indigo { --input-border:rgba(155,168,216,0.4); --input-bg:var(--indigo-light); --stepper-color:var(--tc-indigo); }
+.stepper-ctx-amber  { --input-border:rgba(232,184,109,0.4); --input-bg:var(--amber-light); --stepper-color:var(--tc-amber); }
+
+/* ── Unified Chart Container ── */
+.chart-container { position:relative; height:220px; margin-top:var(--sp-8); }
+.chart-insight   { margin-top:var(--sp-8); text-align:center; font-size:var(--fs-md); color:var(--mid); }
+
+/* ── Status strip (Phase 2 PR-2.5) ──
+   Always-visible thin band above the tab-bar; hosts the sl-1-2 sync indicator
+   relocated from #headerFull (which is hidden in body.essential-mode). Designed
+   as a future host for PR-5's "update available" reload affordance.
+   Container is always present (so its visibility is mode-independent); the
+   #syncStatus child manages its own [hidden] state on cold boot per sl-1-2 r2. */
+/* Visually-hidden but present in the accessibility tree (issue #6 / V-V-2 /
+   V-M-1). Used by the persistent #a11yLive announce region: it must stay in
+   the a11y tree at all times (NOT display:none, which would remove it), so
+   _a11yAnnounce() writes reliably fire a polite announcement. Standard
+   clip-rect technique. */
+.sr-only {
+  position: absolute !important;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.status-strip {
+  display:flex; align-items:center; justify-content:flex-end;
+  gap:var(--sp-8);
+  min-height:28px;
+  padding:var(--sp-4) var(--sp-12);
+  margin-bottom:var(--sp-8);
+  background:var(--surface);
+  border-radius:var(--r-lg);
+  box-shadow:0 2px 10px var(--card-shadow);
+}
+/* Collapse the strip entirely when every child ([syncStatus], [syncActivity],
+   [update-toast]) is hidden — otherwise an empty band with background + shadow
+   lingers once the sync indicator goes silent (PR-P follow-up). */
+.status-strip:not(:has(> :not([hidden]))) { display:none; }
+
+/* Update-available toast (Phase 2 PR-5). Surfaced when SW emits
+   'updatefound' AND the new worker reaches 'installed' state with an
+   existing controller. Lives inside #statusStrip; HR-2/HR-5 token-driven.
+   Tap routes to syncReload() via the data-action dispatcher (HR-3/HR-6). */
+.update-toast {
+  display:inline-flex; align-items:center; gap:var(--sp-8);
+  padding:var(--sp-4) var(--sp-12);
+  border:1.5px solid var(--tc-sage); background:var(--sage-light); color:var(--tc-sage);
+  border-radius:var(--r-full);
+  font-family:'Nunito',sans-serif; font-size:var(--fs-xs); font-weight:600;
+  cursor:pointer;
+}
+.update-toast[hidden] { display:none !important; }
+.update-toast:focus-visible { outline:2px solid var(--tc-sky); outline-offset:2px; }
+
+/* Activity pill (Phase 3 PR-19 — permanent-attribution Surface C). Surfaced
+   for ~45s after a remote listener fire. Lives inside #statusStrip alongside
+   #syncStatus and #updateToast; the strip's binary mode contract is gated by
+   the [hidden] attribute on this element (state mode = hidden, activity mode
+   = visible). HR-2/HR-5 token-driven. Color tokens borrow the lavender pair
+   (--tc-lav / --lav-light) to read distinctly from the sync-indicator's
+   state colors and the update-toast's sage. */
+.sync-activity {
+  display:inline-flex; align-items:center; gap:var(--sp-6);
+  padding:var(--sp-4) var(--sp-12);
+  border:1.5px solid var(--tc-lav); background:var(--lav-light); color:var(--tc-lav);
+  border-radius:var(--r-full);
+  font-family:'Nunito',sans-serif; font-size:var(--fs-xs); font-weight:600;
+  white-space:nowrap;
+}
+.sync-activity[hidden] { display:none !important; }
+.update-toast__icon { display:inline-flex; }
+.update-toast__icon .zi { width:14px; height:14px; }
+
+/* ── Scrollable Tab Bar ── */
+.tab-bar {
+  display:flex; gap:0;
+  background:var(--surface); border-radius:var(--r-xl);
+  padding:var(--sp-4); margin-bottom:var(--sp-12);
+  box-shadow:0 4px 20px var(--card-shadow);
+  overflow-x:auto; -webkit-overflow-scrolling:touch;
+}
+.tab-bar::-webkit-scrollbar { display:none; }
+
+/* ── Track Tab Sub-Navigation ── */
+.track-sub-bar {
+  display:flex; gap:var(--sp-4); padding:var(--sp-6) var(--sp-12); overflow-x:auto; -webkit-overflow-scrolling:touch;
+  background:var(--cream); position:sticky; top:0; z-index:20;
+  border-bottom:1px solid var(--border-subtle);
+}
+.track-sub-bar::-webkit-scrollbar { display:none; }
+.track-sub-btn {
+  flex:1 0 auto; display:flex; align-items:center; justify-content:center; gap:var(--sp-4);
+  padding:var(--sp-8) var(--sp-10); border-radius:var(--r-full);
+  font-size:var(--fs-sm); font-weight:600; white-space:nowrap;
+  cursor:pointer; transition:all var(--ease-fast);
+  border:1.5px solid transparent; background:transparent; color:var(--mid);
+  position:relative; min-width:0;
+}
+.track-sub-btn:active { transform:scale(0.96); }
+.track-sub-btn.active { background:var(--blush); border-color:var(--rose); color:var(--tc-rose); font-weight:700; box-shadow:0 1px 6px rgba(242,168,184,0.2); }
+.track-sub-btn .tsb-icon { font-size:var(--icon-sm); }
+.track-sub-btn .tsb-score { font-family:'Fraunces',serif; font-weight:600; font-size:var(--fs-sm); }
+.track-sub-panel { display:none; }
+.track-sub-panel.active { display:block; }
+.tab-btn {
+  flex:1 0 auto; padding:var(--sp-8) var(--sp-8) var(--sp-6); border:none; border-radius:var(--r-lg);
+  background:transparent; cursor:pointer;
+  font-family:'Nunito', sans-serif; font-size:var(--fs-xs); font-weight:700;
+  color:var(--mid); transition:all var(--ease-med); letter-spacing:var(--ls-normal);
+  display:flex; flex-direction:column; align-items:center; justify-content:center; gap:var(--sp-4);
+  min-height:48px; min-width:56px;
+  text-transform:uppercase; white-space:nowrap;
+}
+.tab-btn:hover { background:var(--blush); color:var(--tc-rose); }
+.tab-btn.active {
+  background:linear-gradient(135deg, var(--rose-light), var(--peach-light));
+  color:var(--tc-rose); box-shadow:0 2px 10px rgba(242,168,184,0.25);
+  position:relative;
+}
+.tab-btn.active::after {
+  content:''; position:absolute; bottom:2px; left:25%; right:25%; height:3px;
+  border-radius:var(--r-full); background:var(--tc-rose);
+}
+.tab-btn .tab-icon { font-size:var(--icon-md); line-height:var(--lh-none); color:var(--light); }
+.tab-btn.active .tab-icon { font-size:var(--icon-md); color:var(--tc-rose); }
+
+/* ── Insights Quick View FAB ── */
+.insights-fab {
+  position:fixed; bottom:20px; left:20px; z-index:1000;
+  width:48px; height:48px; border-radius:50%;
+  background:linear-gradient(135deg, #8a6520, #966525);
+  color:white; border:none; cursor:pointer; font-size:var(--icon-lg);
+  display:flex; align-items:center; justify-content:center;
+  box-shadow:0 4px 16px rgba(212,160,74,0.35);
+  transition:all var(--ease-med);
+}
+.insights-fab:hover { transform:scale(1.08); }
+.insights-fab:active { transform:scale(0.95); }
+.insights-fab.fab-active { background:var(--mid); box-shadow:0 4px 16px rgba(0,0,0,0.2); }
+.insights-popup-overlay {
+  position:fixed; inset:0; background:rgba(0,0,0,0.35);
+  z-index:9996; display:none; opacity:0; transition:opacity var(--ease-med);
+}
+.insights-popup-overlay.open { display:block; opacity:1; }
+.insights-popup {
+  position:fixed; bottom:0; left:0; right:0;
+  max-height:80vh; z-index:9997;
+  background:var(--cream); border-radius:var(--r-2xl) var(--r-2xl) 0 0;
+  box-shadow:0 -8px 32px rgba(0,0,0,0.12);
+  transform:translateY(100%); transition:transform var(--ease-slow);
+  display:flex; flex-direction:column;
+}
+.insights-popup.open { transform:translateY(0); }
+.insights-popup-handle { width:36px; height:4px; border-radius:2px; background:var(--light); opacity:0.3; margin:var(--sp-10) auto 0; }
+.insights-popup-header { display:flex; align-items:center; justify-content:space-between; padding:var(--sp-12) var(--sp-20) var(--sp-8); flex-shrink:0; }
+.insights-popup-title { font-family:'Fraunces',serif; font-size:var(--fs-lg); font-weight:700; color:var(--text); }
+.insights-popup-close { width:28px; height:28px; border:none; background:transparent; cursor:pointer; font-size:var(--icon-base); color:var(--light); border-radius:var(--r-full); display:flex; align-items:center; justify-content:center; }
+.insights-popup-close:hover { background:rgba(0,0,0,0.06); }
+.insights-popup-body { flex:1; overflow-y:auto; padding:0 var(--sp-20) var(--sp-12); -webkit-overflow-scrolling:touch; }
+.insights-popup-footer { padding:var(--sp-12) var(--sp-20); text-align:center; flex-shrink:0; font-size:var(--fs-sm); font-weight:600; color:var(--tc-sky); cursor:pointer; border-top:1px solid var(--border-subtle); }
+.insights-popup-footer:hover { background:var(--sky-light); }
+.popup-plan-item { display:flex; gap:var(--sp-12); align-items:flex-start; padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl); border:1px solid var(--card-border); background:var(--white); cursor:pointer; transition:background var(--ease-fast), transform var(--ease-fast); margin-bottom:var(--sp-6); }
+.popup-plan-item:active { background:var(--cream); transform:scale(0.98); }
+.popup-plan-item.ppi-done { opacity:0.55; }
+.popup-plan-item .plan-chevron { color:var(--light); font-size:var(--icon-sm); flex-shrink:0; margin-top:var(--sp-4); margin-left:auto; }
+
+/* ── Dark Mode Toggle ── */
+.dark-toggle {
+  position:fixed; bottom:20px; right:20px; z-index:1000;
+  width:48px; height:48px; border-radius:50%;
+  background:var(--surface); border:1.5px solid var(--border-subtle);
+  box-shadow:0 4px 16px var(--card-shadow);
+  cursor:pointer; font-size:var(--icon-md);
+  display:flex; align-items:center; justify-content:center;
+  transition:all var(--ease-med);
+}
+.dark-toggle:hover { transform:scale(1.1); }
+/* ── Home FAB — fixed bottom-left ── */
+.home-fab {
+  position:fixed; bottom:var(--sp-20); left:var(--sp-20); z-index:1000;
+  width:48px; height:48px; border-radius:50%;
+  background:var(--surface); border:1.5px solid var(--border-subtle);
+  box-shadow:0 4px 16px var(--card-shadow);
+  cursor:pointer; font-size:var(--icon-md);
+  display:flex; align-items:center; justify-content:center;
+  transition:all var(--ease-med);
+}
+.home-fab:hover { transform:scale(1.1); }
+.home-fab:active { transform:scale(0.95); }
+
+/* ── Dark Mode ── */
+[data-theme="dark"] {
+  --cream:    #1a1520;
+  --warm:     #221c28;
+  --white:    #2a2230;
+  --text:     #e8e0ec;
+  --mid:      #b0a0b8;
+  --light:    #9a8aa2;
+  --shadow:   rgba(0,0,0,0.30);
+  --blush:    #3a2838;
+  --surface:       #2a2230;
+  --surface-alt:   #221c28;
+  --body-bg:       #1a1520;
+  --card-shadow:   rgba(0,0,0,0.30);
+  --border-subtle: rgba(140,120,160,0.2);
+  --overlay-bg:    rgba(10,5,15,0.7);
+
+  --rose-light: #3a2030;
+  --peach-light:#352820;
+  --sage-light: #1e3028;
+  --lav-light:  #2a2240;
+  --sky-light:  #1e2838;
+  --indigo-light:#252838;
+  --amber-light: #352e1e;
+
+  --tc-sage:   #7ac0a0;
+  --tc-sage-light: #a0d8b8;
+  --tc-rose:   #e090a8;
+  --rose-deep: #f0a6bd;   /* D2 phase-spec §2.3 — DO-NOT callout border, dark theme. Brighter than --tc-rose dark for amplification on dark surfaces. */
+  --tc-lav:    #b8a8e0;
+  --tc-sky:    #80b8d8;
+  --tc-warn:   #d4b040;
+  --tc-danger: #f09090;
+  --tc-caution:#e8b870;
+  --tc-amber:  #d4a848;
+  --tc-indigo: #a0b0e0;
+  --tc-peach:  #e8b488;   /* v1.4 — peach text-on-wash, dark theme (§10.5). */
+  --surface-danger:  rgba(242,168,184,0.08);
+  --surface-warn:    rgba(255,193,7,0.06);
+  --surface-warn-grad: linear-gradient(135deg, rgba(255,193,7,0.08), rgba(255,193,7,0.04));
+  --surface-neutral: rgba(255,253,248,0.04);
+  --surface-sage:    rgba(122,192,160,0.10);
+  --surface-rose:    rgba(224,144,168,0.10);
+  --surface-amber:   rgba(212,168,72,0.10);
+  --surface-lav:     rgba(184,168,224,0.10);
+  --surface-caution: rgba(232,184,112,0.08);
+  --surface-sky:     rgba(128,184,216,0.08);
+  --glass: rgba(255,255,255,0.06);
+  --glass-strong: rgba(255,255,255,0.08);
+  --card-bg: var(--surface);
+  --card-border: rgba(140,120,160,0.2);
+}
+[data-theme="dark"] body {
+  background:var(--body-bg);
+}
+[data-theme="dark"] body::before {
+  background:
+    radial-gradient(ellipse 600px 400px at 10% 20%, rgba(242,168,184,0.06) 0%, transparent 70%),
+    radial-gradient(ellipse 500px 350px at 85% 70%, rgba(181,213,197,0.06) 0%, transparent 70%),
+    radial-gradient(ellipse 400px 300px at 50% 50%, rgba(201,184,232,0.04) 0%, transparent 70%);
+}
+[data-theme="dark"] .header::before {
+  background: linear-gradient(90deg, var(--rose), var(--peach), var(--sage), var(--lavender));
+  opacity:0.6;
+}
+[data-theme="dark"] .card { background:var(--surface); box-shadow:0 4px 20px var(--card-shadow); }
+[data-theme="dark"] .card.card-action { border-color:rgba(255,255,255,0.06); border-left:var(--accent-w) solid var(--rose); }
+[data-theme="dark"] .card.card-hero { box-shadow:0 8px 32px var(--card-shadow), 0 2px 8px rgba(0,0,0,0.15); }
+[data-theme="dark"] .meal-card.breakfast { background:rgba(250,212,180,0.08); border-color:rgba(250,212,180,0.15); }
+[data-theme="dark"] .meal-card.lunch     { background:rgba(181,213,197,0.08); border-color:rgba(181,213,197,0.15); }
+[data-theme="dark"] .meal-card.dinner    { background:rgba(201,184,232,0.08); border-color:rgba(201,184,232,0.15); }
+[data-theme="dark"] .meal-card.snack     { background:rgba(240,200,120,0.08); border-color:rgba(240,200,120,0.15); }
+[data-theme="dark"] .btn-ghost { border-color:var(--light); color:var(--mid); }
+[data-theme="dark"] .btn-ghost:hover { border-color:var(--rose); color:var(--rose); background:rgba(242,168,184,0.1); }
+[data-theme="dark"] .chart-filter-btn { background:var(--surface); border-color:var(--light); color:var(--mid); }
+[data-theme="dark"] .milestone-item { background:var(--surface-alt); }
+[data-theme="dark"] .milestone-item.done { background:rgba(181,213,197,0.1); }
+[data-theme="dark"] .food-tag.ok { background:rgba(181,213,197,0.15); }
+[data-theme="dark"] .food-tag.watch { background:rgba(255,209,102,0.12); color:var(--tc-warn); }
+[data-theme="dark"] .history-month-header { background:linear-gradient(135deg,rgba(250,212,180,0.1),var(--surface-alt)); border-color:rgba(250,212,180,0.15); }
+[data-theme="dark"] .history-day-header { background:var(--surface-alt); }
+[data-theme="dark"] .modal-overlay { background:var(--overlay-bg); }
+[data-theme="dark"] .modal { background:var(--surface); }
+[data-theme="dark"] .date-nav button:hover { background:rgba(242,168,184,0.1); }
+[data-theme="dark"] .date-nav input[type=date] { background:var(--surface-alt); border-color:rgba(242,168,184,0.2); color:var(--text); }
+[data-theme="dark"] .poop-color-btn { background:var(--surface-alt); border-color:var(--border-subtle); color:var(--text); }
+[data-theme="dark"] .pq-btn { background:var(--surface-alt); border-color:var(--border-subtle); color:var(--text); }
+[data-theme="dark"] .sq-btn { background:var(--surface-alt); border-color:var(--border-subtle); color:var(--text); }
+/* Dark mode active toggle overrides — tinted surface + colored text instead of deep solid bg */
+[data-theme="dark"] .pq-btn.active-pq { background:rgba(212,168,72,0.18); color:var(--tc-amber); border-color:rgba(212,168,72,0.35); }
+[data-theme="dark"] .poop-color-btn.active-pq { background:rgba(212,168,72,0.18); color:var(--tc-amber); border-color:rgba(212,168,72,0.35); }
+[data-theme="dark"] .poop-color-btn.active-pq .poop-swatch { border-color:var(--tc-amber); }
+/* V-M-10: --poop-c-black (#2a2a2a) and --poop-c-dark (#5a4a2a) dissolve into
+   the dark-theme surface (#2a2230) — a parent reading a "Black stool" anomaly
+   in dark theme would see an effectively-empty swatch and read the card as
+   benign. Lighten just the swatch/segment renders in dark mode; the
+   anatomical token stays accurate for chart-fill contexts that need raw hex.
+   V-M-10b (PR-B) — initial overrides (#4a4a4a / #7a6440) only reached 1.7:1
+   and 2.7:1 against --surface dark, below WCAG 1.4.11's 3:1 AA-large threshold
+   for graphical UI components. Brightened to #7a7a7a (3.57:1) and #8a7050
+   (3.30:1); verify via docs/POOP_COLOR_REFERENCE.html contrast cells. */
+[data-theme="dark"] .poop-swatch[data-pcolor="black"]  { background:#7a7a7a; border-color:rgba(255,255,255,0.25); }
+[data-theme="dark"] .poop-swatch[data-pcolor="dark"]   { background:#8a7050; border-color:rgba(255,255,255,0.20); }
+[data-theme="dark"] .poop-bar-seg[data-pcolor="black"] { background:#7a7a7a; }
+[data-theme="dark"] .poop-bar-seg[data-pcolor="dark"]  { background:#8a7050; }
+[data-theme="dark"] .sq-btn.active-sq { background:rgba(155,168,216,0.14); color:var(--tc-indigo); border-color:rgba(155,168,216,0.35); }
+[data-theme="dark"] .rtog.active-ok { background:rgba(122,192,160,0.18); color:var(--tc-sage); border-color:rgba(122,192,160,0.35); }
+[data-theme="dark"] .rtog.active-watch { background:rgba(212,176,64,0.18); color:var(--tc-warn); border-color:rgba(212,176,64,0.35); }
+[data-theme="dark"] .ncf-btn.active { background:rgba(212,168,72,0.18); color:var(--tc-amber); border-color:rgba(212,168,72,0.35); }
+[data-theme="dark"] .vacc-slot-btn.active { background:rgba(122,192,160,0.18); color:var(--tc-sage); border-color:rgba(122,192,160,0.35); }
+[data-theme="dark"] .chart-filter-btn.active { background:rgba(224,144,168,0.18); color:var(--tc-rose); border-color:rgba(224,144,168,0.35); }
+[data-theme="dark"] .chart-filter-btn.active-india { background:rgba(212,168,72,0.18); color:var(--tc-amber); border-color:rgba(212,168,72,0.35); }
+[data-theme="dark"] .chart-filter-btn.active-both { background:rgba(184,168,224,0.18); color:var(--tc-lav); border-color:rgba(184,168,224,0.35); }
+[data-theme="dark"] .meal-input-wrap .meal-input { background:rgba(255,255,255,0.05); color:var(--text); }
+[data-theme="dark"] .meal-dropdown { background:var(--surface); border-color:rgba(242,168,184,0.15); }
+[data-theme="dark"] .meal-dd-item:hover { background:rgba(242,168,184,0.1); }
+[data-theme="dark"] .vacc-card { background:linear-gradient(135deg,rgba(201,184,232,0.12),rgba(168,207,224,0.12)); }
+[data-theme="dark"] .countdown-circle { background:var(--surface); box-shadow:0 4px 14px rgba(0,0,0,0.3); }
+[data-theme="dark"] .ms-tidbit.tidbit-unlocks { background:rgba(240,160,96,0.08); }
+[data-theme="dark"] .ms-tidbit.tidbit-doctor { background:rgba(91,155,213,0.08); }
+[data-theme="dark"] .ms-tidbit.tidbit-fun { background:rgba(160,120,208,0.08); }
+[data-theme="dark"] .visit-item { background:var(--surface-alt); }
+[data-theme="dark"] .confirm-overlay { background:var(--overlay-bg); }
+[data-theme="dark"] .confirm-box { background:var(--surface); }
+[data-theme="dark"] .viz-detail-overlay { background:var(--overlay-bg); }
+[data-theme="dark"] .pbadge.pb-rose { background:rgba(242,168,184,0.1); }
+[data-theme="dark"] .pbadge.pb-sky { background:rgba(168,207,224,0.1); }
+[data-theme="dark"] .pbadge.pb-sage { background:rgba(181,213,197,0.1); }
+[data-theme="dark"] .pbadge.pb-lav { background:rgba(201,184,232,0.1); }
+[data-theme="dark"] .gh-gauge-ring svg .gh-track { stroke:rgba(255,255,255,0.1); }
+[data-theme="dark"] .gh-meta-pill { background:var(--card-bg); border-color:var(--card-border); }
+[data-theme="dark"] .ms-cat-card.motor { background:rgba(181,213,197,0.08); }
+[data-theme="dark"] .ms-cat-card.language { background:rgba(168,207,224,0.08); }
+[data-theme="dark"] .ms-cat-card.social { background:rgba(250,212,180,0.08); }
+[data-theme="dark"] .ms-cat-card.cognitive { background:rgba(201,184,232,0.08); }
+[data-theme="dark"] .growth-row:last-child:not(.header-row) { background:rgba(242,168,184,0.1); }
+[data-theme="dark"] .growth-row.growth-row:not(.header-row):hover { background:rgba(242,168,184,0.06); }
+[data-theme="dark"] .rtog { background:var(--surface-alt); border-color:var(--border-subtle); color:var(--text); }
+[data-theme="dark"] .footer-text { color:var(--light); }
+[data-theme="dark"] .home-section-label { color:var(--light); }
+[data-theme="dark"] .home-section-label.sec-t1 { color:var(--text); }
+[data-theme="dark"] .home-section-label.sec-t2 { color:var(--mid); }
+[data-theme="dark"] .home-section-label.sec-t3 { color:var(--light); }
+[data-theme="dark"] .card.card-info .card-title { color:var(--mid); }
+[data-theme="dark"] .card.card-daily { background:linear-gradient(135deg, var(--surface) 60%, var(--surface-alt)); }
+[data-theme="dark"] .card.card-info { background:var(--surface-alt); border-color:rgba(140,120,160,0.15); }
+[data-theme="dark"] .micro-label { color:var(--mid); }
+[data-theme="dark"] .help-tip { background:rgba(168,207,224,0.08); color:var(--mid); }
+/* Dark mode form inputs */
+[data-theme="dark"] .form-input { color:var(--text); }
+/* Dark mode scrollbar tint */
+[data-theme="dark"] .tab-bar { background:var(--surface); box-shadow:0 4px 20px var(--card-shadow); }
+[data-theme="dark"] .track-sub-bar { background:var(--body-bg); border-bottom-color:rgba(255,255,255,0.06); }
+[data-theme="dark"] .track-sub-btn.active { background:rgba(242,168,184,0.1); border-color:rgba(242,168,184,0.2); }
+[data-theme="dark"] .tab-btn.active { background:linear-gradient(135deg,rgba(242,168,184,0.15),rgba(250,212,180,0.15)); }
+/* Stat card gradients in dark mode */
+[data-theme="dark"] .stat-card-sleep { background:linear-gradient(135deg,rgba(155,168,216,0.12),rgba(201,184,232,0.08)) !important; }
+[data-theme="dark"] .stat-card-poop  { background:linear-gradient(135deg,rgba(232,184,109,0.12),rgba(254,246,232,0.05)) !important; }
+
+/* ── Dark mode: hardcoded text color overrides ── */
+[data-theme="dark"] .pbadge.pb-sky .pbadge-val { color:var(--tc-sky); }
+[data-theme="dark"] .pbadge.pb-sage .pbadge-val { color:var(--tc-sage); }
+[data-theme="dark"] .pbadge.pb-lav .pbadge-val { color:var(--tc-lav); }
+[data-theme="dark"] .meta-done { background:rgba(181,213,197,0.15); color:var(--tc-sage); }
+[data-theme="dark"] .meta-progress { background:rgba(214,190,80,0.12); color:var(--tc-warn); }
+[data-theme="dark"] .meta-age { background:rgba(250,212,180,0.12); color:var(--tc-caution); }
+[data-theme="dark"] .meta-time { background:rgba(168,207,224,0.12); color:var(--tc-sky); }
+[data-theme="dark"] .ms-action-btn:hover { color:var(--tc-sage); }
+[data-theme="dark"] .ms-tidbit.tidbit-doctor .ms-tidbit-text strong { color:var(--tc-sky); }
+[data-theme="dark"] .ms-cat-card.motor .ms-cat-name { color:var(--tc-sage); }
+[data-theme="dark"] .ms-cat-card.language .ms-cat-name { color:var(--tc-sky); }
+[data-theme="dark"] .ms-cat-card.social .ms-cat-name { color:var(--tc-caution); }
+[data-theme="dark"] .ms-cat-card.cognitive .ms-cat-name { color:var(--tc-lav); }
+[data-theme="dark"] .food-tag.ok { color:var(--tc-sage); }
+[data-theme="dark"] .food-tag.watch { color:var(--tc-warn); }
+[data-theme="dark"] .countdown-num { color:var(--tc-lav); }
+[data-theme="dark"] .hd-date { color:var(--tc-rose); }
+[data-theme="dark"] .diet-stat .diet-stat-val { color:var(--tc-rose); }
+[data-theme="dark"] .diet-stat.alert .diet-stat-val { color:var(--tc-caution); }
+[data-theme="dark"] .diet-stat.ds-rose .diet-stat-val { color:var(--tc-rose); }
+[data-theme="dark"] .diet-stat.ds-sky .diet-stat-val { color:var(--tc-sky); }
+[data-theme="dark"] .diet-stat.ds-sage .diet-stat-val { color:var(--tc-sage); }
+[data-theme="dark"] .diet-stat.ds-lav .diet-stat-val { color:var(--tc-lav); }
+[data-theme="dark"] .diet-stat.ds-peach .diet-stat-val { color:var(--tc-caution); }
+[data-theme="dark"] .diet-stat.ds-amber .diet-stat-val { color:var(--tc-amber); }
+[data-theme="dark"] .note-btn.complete-btn:hover { color:var(--tc-sage); }
+[data-theme="dark"] .note-item.done .complete-btn { color:var(--tc-sage); }
+[data-theme="dark"] .note-cat-badge.general { background:rgba(250,212,180,0.12); color:var(--tc-caution); }
+[data-theme="dark"] .note-cat-badge.diet { background:rgba(181,213,197,0.12); color:var(--tc-sage); }
+[data-theme="dark"] .note-cat-badge.medical { background:rgba(201,184,232,0.12); color:var(--tc-lav); }
+[data-theme="dark"] .note-cat-badge.milestone { background:rgba(214,190,80,0.12); color:var(--tc-warn); }
+[data-theme="dark"] .note-cat-badge.growth { background:rgba(242,168,184,0.12); color:var(--tc-rose); }
+[data-theme="dark"] .visit-date { color:var(--tc-sage); }
+[data-theme="dark"] .sleep-entry-duration { color:var(--tc-indigo); }
+[data-theme="dark"] .sleep-entry-times { color:var(--tc-indigo); }
+[data-theme="dark"] .sq-good { background:rgba(181,213,197,0.15); color:var(--tc-sage); }
+[data-theme="dark"] .sq-fair { background:rgba(214,190,80,0.12); color:var(--tc-warn); }
+[data-theme="dark"] .sq-poor { background:rgba(242,168,184,0.15); color:var(--tc-rose); }
+[data-theme="dark"] .sleep-stat-hero { color:var(--tc-indigo); }
+[data-theme="dark"] .poop-entry-duration { color:var(--tc-amber); }
+[data-theme="dark"] .size-item.si-sky strong { color:var(--tc-sky); }
+[data-theme="dark"] .home-stat-pill.hsp-rose .hsp-val { color:var(--tc-rose); }
+[data-theme="dark"] .home-stat-pill.hsp-sky .hsp-val { color:var(--tc-sky); }
+[data-theme="dark"] .home-stat-pill.hsp-lav .hsp-val { color:var(--tc-lav); }
+[data-theme="dark"] .home-stat-pill.hsp-sage .hsp-val { color:var(--tc-sage); }
+[data-theme="dark"] .home-stat-pill.hsp-peach .hsp-val { color:var(--tc-caution); }
+[data-theme="dark"] .hsp-indigo .hsp-val { color:var(--tc-indigo); }
+[data-theme="dark"] .hsp-amber .hsp-val { color:var(--tc-amber); }
+[data-theme="dark"] .diet-stat.alert { border-color:rgba(255,193,7,0.3); background:rgba(255,193,7,0.06); }
+[data-theme="dark"] .badge-adv { background:rgba(255,209,102,0.2); }
+[data-theme="dark"] .ms-tidbit-text { color:var(--text); }
+[data-theme="dark"] .combo-result.caution { border-color:rgba(255,193,7,0.3); background:rgba(255,193,7,0.06); }
+[data-theme="dark"] .del-btn:hover { color:var(--tc-danger); background:var(--rose-light); }
+[data-theme="dark"] .history-entry-del:hover { color:var(--tc-danger); }
+[data-theme="dark"] .note-btn.del-note-btn:hover { background:var(--rose-light); color:var(--tc-rose); }
+[data-theme="dark"] .note-attach-del:hover { color:var(--tc-danger); }
+[data-theme="dark"] .ms-action-btn.del-ms:hover { background:var(--rose-light); color:var(--tc-rose); }
+[data-theme="dark"] .header-info h1 span { color:var(--tc-rose); }
+[data-theme="dark"] .meal-dd-item:hover { color:var(--tc-rose); }
+[data-theme="dark"] .pbadge.pb-rose .pbadge-val { color:var(--tc-rose); }
+/* ── Dark mode: white-rgba glass backgrounds ── */
+[data-theme="dark"] .history-meal-insight { background:rgba(255,255,255,0.06); }
+[data-theme="dark"] .activity-item { background:rgba(255,255,255,0.04); }
+[data-theme="dark"] .upcoming-item { background:rgba(255,255,255,0.04); }
+[data-theme="dark"] .upc-subcat-count { background:rgba(255,255,255,0.08); }
+[data-theme="dark"] .combo-recipe { background:rgba(255,255,255,0.06); }
+[data-theme="dark"] .meal-card .form-input { background:rgba(255,255,255,0.05); }
+[data-theme="dark"] .meal-skip-btn { background:rgba(255,255,255,0.06); border-color:rgba(255,255,255,0.1); color:var(--light); }
+[data-theme="dark"] .meal-skip-btn:hover { background:rgba(250,212,180,0.15); color:var(--peach); }
+[data-theme="dark"] .meal-skip-btn.skipped { background:rgba(250,212,180,0.1); color:var(--peach); }
+
+/* ── Tab bar responsive ── */
+@media(min-width:700px) {
+  .tab-btn { padding:var(--sp-10) var(--sp-16); }
+}
+@media(max-width:700px) {
+  .tab-btn { padding:var(--sp-6) var(--sp-2); }
+}
+
+/* Stat gradient cards */
+.stat-card-sleep { background:linear-gradient(135deg,var(--indigo-light),#f5f0fa); }
+.stat-card-poop  { background:linear-gradient(135deg,var(--amber-light),#fef9f0); }
+.card-gradient-warm { background:linear-gradient(135deg,#fff5f7,#fff9f5); }
+[data-theme="dark"] .card-gradient-warm { background:linear-gradient(135deg,rgba(60,35,45,0.3),rgba(60,45,35,0.3)); }
+.growth-overview-card {
+  background:linear-gradient(135deg, #fef0f3, #fef6f0) !important;
+  border-left-color:var(--rose) !important;
+  box-shadow:0 4px 24px rgba(242,168,184,0.1);
+}
+[data-theme="dark"] .growth-overview-card {
+  background:linear-gradient(135deg, rgba(70,35,45,0.25), rgba(70,50,35,0.2)) !important;
+}
+.card-gradient-cool { background:linear-gradient(135deg,var(--lav-light),var(--sky-light)); }
+[data-theme="dark"] .card-gradient-cool { background:linear-gradient(135deg,rgba(50,40,70,0.3),rgba(35,50,65,0.3)); }
+
+/* ── Differentiated Hero Cards (v2.4) ── */
+/* Base hero: page-header feel — wider, more breathing room, thick accent */
+.card.card-hero {
+  padding:var(--sp-24) var(--sp-24) 22px;
+  border-radius:var(--r-2xl);
+  box-shadow:0 8px 32px var(--shadow), 0 2px 8px rgba(180,120,120,0.06);
+  position:relative; overflow:hidden;
+}
+.card.card-hero::before {
+  content:''; position:absolute; top:0; left:0; right:0; height:5px;
+  z-index:1;
+}
+/* On mobile, hero bleeds wider for page-header feel */
+@media(max-width:500px) {
+  .card.card-hero {
+    border-radius:var(--r-xl);
+    margin-left:-var(--sp-4); margin-right:-var(--sp-4);
+    padding:var(--sp-24) var(--sp-16) var(--sp-16);
+  }
+}
+
+/* Home hero — rainbow gradient (the app's signature) */
+.card.card-hero.hero-home {
+  background:linear-gradient(135deg, #fff5f7, #fff9f5, #f0faf5);
+}
+.card.card-hero.hero-home::before {
+  background:linear-gradient(90deg, var(--rose), var(--peach), var(--sage), var(--lavender));
+}
+[data-theme="dark"] .card.card-hero.hero-home {
+  background:linear-gradient(135deg, rgba(60,35,45,0.4), rgba(60,45,35,0.3), rgba(40,60,50,0.3));
+}
+
+/* ─────────────────────────────────────────
+   LEAN LANDING (app-open surface) — ld-*
+   Built to the Recipes design language (DP §9, ratified 2026-06-03):
+   • hero stripe = 4px de-neoned WAVELENGTH warm-wave with a sweeping sheen (§9.3/§9.4)
+   • day's story = Fraunces *italic* "voice" line over a Nunito eyebrow (typography C, §9.6)
+   • doors = whisper-fade (transparent→domain rgba) + domain border (§9.2, reaffirms HR-6)
+   "Home leans on its hero" (DP §72) — warmth, not a score (C2).
+   ───────────────────────────────────────── */
+#ldContent { display:flex; flex-direction:column; gap:var(--sp-16); }
+
+/* 0 · Care pre-empt — loud-rose action cards (reuse .card.card-action), persistent */
+.ld-care { display:flex; flex-direction:column; gap:var(--sp-12); }
+.ld-care-card {
+  display:flex; align-items:center; gap:var(--sp-12);
+  width:100%; text-align:left; cursor:pointer; min-height:44px;
+}
+.ld-care-card .icon {
+  width:var(--sp-32); height:var(--sp-32); border-radius:var(--r-md);
+  display:inline-flex; align-items:center; justify-content:center; flex-shrink:0;
+  /* calm "being-tracked" chip (matches .icon-rose); .ld-care-hot lifts to the
+     louder solid --rose so action-needed reads hotter than tracked (Vela V-V-4) */
+  background:var(--rose-light); color:var(--tc-rose);
+}
+.ld-care-body { display:flex; flex-direction:column; flex:1; min-width:0; }
+.ld-care-title { font-family:'Fraunces', serif; font-weight:600; font-size:var(--fs-md); color:var(--text); }
+.ld-care-sub { font-family:'Nunito', sans-serif; font-size:var(--fs-sm); color:var(--mid); }
+.ld-care-chev { color:var(--tc-rose); display:inline-flex; flex-shrink:0; }
+.ld-care-chev svg.zi { width:var(--icon-base); height:var(--icon-base); }
+/* action-needed (overdue / due) runs hotter than calm "being-tracked" (Maren) */
+.ld-care-hot .icon { background:var(--rose); color:var(--tc-rose); }
+.ld-care-hot .ld-care-title { color:var(--tc-rose); }
+
+/* 1 · The day's glance as the signature HERO. Reuses .card.card-hero.hero-home
+   for the body gradient; ld-hero overrides the top stripe with the warm-wave. */
+.ld-hero { display:flex; flex-direction:column; align-items:flex-start; gap:var(--sp-10); }
+
+/* Warm-wave stripe (§9.3/§9.4): a fixed wavelength gradient (rose→…→lav) with a
+   translucent sheen sweeping left→right — only the sheen moves. Later + equal
+   specificity to .hero-home::before, so it overrides it. */
+.card.card-hero.ld-hero::before {
+  height:4px;
+  background-image:
+    linear-gradient(100deg, transparent 35%, rgba(255,255,255,0.6) 50%, transparent 65%),
+    linear-gradient(90deg, var(--rose), var(--peach), var(--amber), var(--sage), var(--sky), var(--indigo), var(--lavender));
+  background-size:35% 100%, 100% 100%;
+  background-repeat:no-repeat;
+  background-position:-35% 0, 0 0;
+  animation:ld-wave 4.4s ease-in-out infinite;
+}
+@keyframes ld-wave {
+  0%   { background-position:-35% 0, 0 0; }
+  100% { background-position:135% 0, 0 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .card.card-hero.ld-hero::before { animation:none; background-position:0 0, 0 0; }
+}
+
+.ld-hero-eyebrow { display:flex; align-items:center; gap:var(--sp-8); }
+.ld-hero-icon {
+  width:var(--sp-32); height:var(--sp-32); border-radius:var(--r-full);
+  display:inline-flex; align-items:center; justify-content:center; flex-shrink:0;
+}
+.ld-hero-icon svg.zi { width:var(--icon-md); height:var(--icon-md); }
+.ld-hero-label {
+  font-family:'Nunito', sans-serif; font-size:var(--fs-sm); font-weight:700;
+  text-transform:uppercase; letter-spacing:var(--ls-wide); color:var(--mid);
+}
+/* The "voice" line — Fraunces ITALIC (italic reserved for voice, §9.6) */
+.ld-hero-voice {
+  font-family:'Fraunces', serif; font-style:italic; font-weight:600;
+  font-size:var(--fs-xl); line-height:var(--lh-snug); color:var(--text);
+  max-width:92%; text-wrap:balance;
+}
+.ld-hero[data-empty="true"] .ld-hero-voice { color:var(--mid); }
+.ld-hero-action {
+  display:inline-flex; align-items:center; gap:var(--sp-8);
+  font-family:'Nunito', sans-serif; font-weight:700; font-size:var(--fs-sm);
+  color:var(--tc-sage); background:var(--surface);
+  border:1.5px solid var(--sage); border-radius:var(--r-full);
+  padding:var(--sp-8) var(--sp-16); min-height:44px; cursor:pointer;
+}
+.ld-hero-action svg.zi { width:var(--icon-base); height:var(--icon-base); }
+/* Compact hero — when _ldFitHero marks #ldContent .ld-crowded (Care pre-empts
+   pushed Emergency below the fold), the hero drops its voice line + Start-with-
+   breakfast button and reveals a single "Start with [picker]" row, reclaiming
+   the vertical space so Emergency stays reachable without a scroll. */
+.ld-hero-compact {
+  display:none; align-items:center; gap:var(--sp-8); flex-wrap:wrap; margin-top:var(--sp-4);
+}
+.ld-crowded .ld-hero-voice,
+.ld-crowded .ld-hero-action { display:none; }
+.ld-crowded .ld-hero-compact { display:flex; }
+.ld-hero-compact-label {
+  font-family:'Fraunces', serif; font-style:italic; font-weight:600;
+  font-size:var(--fs-base); color:var(--text);
+}
+.ld-hero-select {
+  font-family:'Nunito', sans-serif; font-weight:700; font-size:var(--fs-base);
+  color:var(--text); background:var(--warm);
+  border:1.5px solid var(--border-subtle); border-radius:var(--r-md);
+  padding:var(--sp-8) var(--sp-12); min-height:44px; cursor:pointer;
+}
+
+/* 2 · Three doors — soft floating tap-cards carrying the whisper-fade (§9.2):
+   a domain corner-glow over the surface + a domain-tinted border (reaffirms
+   HR-6). rgba stops are the domain accents @ .22 (light) / deep --tc hues
+   @ .30 (dark), per the §9.2 hue-swap. Log primary: stronger sage + dominance. */
+.ld-doors { display:grid; grid-template-columns:1fr 1fr; gap:var(--sp-12); }
+.ld-door {
+  display:flex; flex-direction:column; align-items:center; justify-content:center; gap:var(--sp-8);
+  background-color:var(--surface); border-radius:var(--r-2xl);
+  padding:var(--sp-20) var(--sp-12); cursor:pointer;
+  font-family:'Nunito', sans-serif; text-align:center;
+  box-shadow:0 4px 20px var(--shadow);
+  transition:transform var(--ease-fast), box-shadow var(--ease-med);
+}
+.ld-door:active { transform:scale(0.97); }
+.ld-door .icon {
+  width:var(--sp-32); height:var(--sp-32); border-radius:var(--r-full);
+  display:inline-flex; align-items:center; justify-content:center; flex-shrink:0;
+}
+.ld-door .icon svg.zi { width:var(--icon-lg); height:var(--icon-lg); }
+.ld-door-label { font-family:'Nunito', sans-serif; font-size:var(--fs-base); font-weight:700; color:var(--text); line-height:var(--lh-snug); }
+.ld-door-sub { font-family:'Nunito', sans-serif; font-size:var(--fs-xs); color:var(--mid); line-height:var(--lh-snug); }
+
+/* whisper-fade — Today (sky) + Ask (lavender) */
+.ld-door-today { background-image:linear-gradient(135deg, transparent 40%, rgba(168,207,224,0.22)); border:1.5px solid var(--sky); }
+.ld-door-ask   { background-image:linear-gradient(135deg, transparent 40%, rgba(201,184,232,0.22)); border:1.5px solid var(--lavender); }
+[data-theme="dark"] .ld-door-today { background-image:linear-gradient(135deg, transparent 30%, rgba(51,101,128,0.30)); }
+[data-theme="dark"] .ld-door-ask   { background-image:linear-gradient(135deg, transparent 30%, rgba(110,94,154,0.30)); }
+
+/* Primary Log door — full-width row, stronger sage whisper, dominant */
+.ld-door-primary {
+  grid-column:1 / -1; flex-direction:row; justify-content:flex-start; align-items:center;
+  gap:var(--sp-16); padding:var(--sp-20); text-align:left;
+  background-image:linear-gradient(135deg, transparent 30%, rgba(181,213,197,0.40)); border:1.5px solid var(--sage);
+}
+[data-theme="dark"] .ld-door-primary { background-image:linear-gradient(135deg, transparent 30%, rgba(58,112,96,0.45)); }
+.ld-door-primary .ld-door-body { display:flex; flex-direction:column; gap:var(--sp-2); align-items:flex-start; }
+.ld-door-primary .ld-door-label { font-family:'Fraunces', serif; font-size:var(--fs-lg); }
+
+/* 3 · Emergency — always-present quick access (rose whisper-fade + outline:
+   calm by default, unmistakable in a panic). The container carries no action;
+   .ld-emergency-main opens the chooser; the call pills are independent tel:
+   links (dial straight through, never open the chooser). */
+.ld-emergency {
+  background-color:var(--surface);
+  background-image:linear-gradient(135deg, transparent 40%, rgba(242,168,184,0.22));
+  border:1.5px solid var(--rose); border-radius:var(--r-2xl);
+  padding:var(--sp-12);
+  box-shadow:0 4px 20px var(--shadow);
+  display:flex; flex-direction:column; gap:var(--sp-10);
+}
+[data-theme="dark"] .ld-emergency { background-image:linear-gradient(135deg, transparent 30%, rgba(158,62,82,0.30)); }
+.ld-emergency-main {
+  display:flex; align-items:center; gap:var(--sp-12); width:100%; text-align:left; cursor:pointer;
+  background:transparent; border:none; padding:var(--sp-4); min-height:44px;
+  transition:transform var(--ease-fast);
+}
+.ld-emergency-main:active { transform:scale(0.98); }
+.ld-emergency-main .icon { width:var(--sp-32); height:var(--sp-32); border-radius:var(--r-full); display:inline-flex; align-items:center; justify-content:center; flex-shrink:0; }
+.ld-emergency-body { display:flex; flex-direction:column; flex:1; min-width:0; }
+.ld-emergency-label { font-family:'Fraunces', serif; font-weight:600; font-size:var(--fs-md); color:var(--tc-rose); }
+.ld-emergency-sub { font-family:'Nunito', sans-serif; font-size:var(--fs-sm); color:var(--mid); }
+.ld-emergency-chev { color:var(--tc-rose); display:inline-flex; flex-shrink:0; }
+.ld-emergency-chev svg.zi { width:var(--icon-base); height:var(--icon-base); }
+/* Quick-dial pills — independent tap targets (≥44px), dark-safe rose chip */
+.ld-emergency-calls { display:flex; gap:var(--sp-8); flex-wrap:wrap; }
+.ld-emergency-call {
+  flex:1 1 40%; min-width:130px; min-height:44px;
+  display:inline-flex; align-items:center; justify-content:center; gap:var(--sp-8);
+  background:var(--rose-light); color:var(--tc-rose);
+  border:1.5px solid var(--rose); border-radius:var(--r-xl);
+  text-decoration:none; padding:var(--sp-8) var(--sp-12);
+  font-family:'Nunito', sans-serif; font-weight:700; font-size:var(--fs-sm);
+}
+.ld-emergency-call svg.zi { width:var(--icon-base); height:var(--icon-base); flex-shrink:0; }
+
+/* Emergency chooser overlay (bottom sheet) — mirrors .ob-overlay */
+.ld-em-overlay {
+  position:fixed; inset:0; z-index:1010;
+  background:var(--overlay-bg);
+  display:flex; align-items:flex-end; justify-content:center;
+  opacity:0; pointer-events:none; padding:var(--sp-16);
+  transition:opacity var(--ease-med);
+}
+.ld-em-overlay.open { opacity:1; pointer-events:auto; }
+.ld-em-sheet {
+  width:100%; max-width:480px;
+  background:var(--surface); border-radius:var(--r-2xl);
+  padding:var(--sp-20);
+  box-shadow:0 8px 32px var(--shadow);
+  display:flex; flex-direction:column; gap:var(--sp-12);
+  transform:translateY(16px); transition:transform var(--ease-slow);
+}
+.ld-em-overlay.open .ld-em-sheet { transform:translateY(0); }
+.ld-em-head { display:flex; align-items:center; justify-content:space-between; }
+.ld-em-title { display:flex; align-items:center; gap:var(--sp-8); font-family:'Fraunces', serif; font-weight:700; font-size:var(--fs-lg); color:var(--tc-rose); }
+.ld-em-title svg.zi { width:var(--icon-lg); height:var(--icon-lg); }
+.ld-em-close {
+  width:var(--sp-32); height:var(--sp-32); border-radius:var(--r-full); border:none;
+  background:var(--surface-alt); color:var(--mid);
+  font-size:var(--fs-lg); line-height:var(--lh-none); cursor:pointer;
+  display:inline-flex; align-items:center; justify-content:center; flex-shrink:0;
+}
+.ld-em-prompt { font-family:'Nunito', sans-serif; font-size:var(--fs-base); color:var(--mid); line-height:var(--lh-relaxed); margin:0; }
+.ld-em-opt {
+  display:flex; align-items:center; gap:var(--sp-12); width:100%; text-align:left; cursor:pointer;
+  background-color:var(--surface);
+  background-image:linear-gradient(135deg, transparent 40%, rgba(242,168,184,0.22));
+  border:1.5px solid var(--rose); border-radius:var(--r-xl);
+  padding:var(--sp-16); min-height:44px;
+  transition:transform var(--ease-fast);
+}
+[data-theme="dark"] .ld-em-opt { background-image:linear-gradient(135deg, transparent 30%, rgba(158,62,82,0.30)); }
+.ld-em-opt:active { transform:scale(0.98); }
+.ld-em-opt .icon { width:var(--sp-32); height:var(--sp-32); border-radius:var(--r-full); display:inline-flex; align-items:center; justify-content:center; flex-shrink:0; }
+.ld-em-opt-body { display:flex; flex-direction:column; flex:1; min-width:0; }
+.ld-em-opt-label { font-family:'Fraunces', serif; font-weight:600; font-size:var(--fs-md); color:var(--text); }
+.ld-em-opt-sub { font-family:'Nunito', sans-serif; font-size:var(--fs-sm); color:var(--mid); }
+.ld-em-opt-chev { color:var(--tc-rose); display:inline-flex; flex-shrink:0; }
+.ld-em-opt-chev svg.zi { width:var(--icon-base); height:var(--icon-base); }
+@media (prefers-reduced-motion: reduce) {
+  .ld-em-overlay, .ld-em-sheet { transition:none; }
+}
+
+/* ── General Emergency Room (lean-landing-v1 §5.3) ──────────────────────
+   Full-screen rose overlay. `.ge-sheet` is the single scroll container so
+   `.ge-callbar` (sticky top:0, a direct child) survives scroll + any item
+   expansion (V-1). z-index 1060 — above the chooser (1010) and the toast
+   band so a lingering transit toast can never cover it (V-4). */
+.ge-overlay {
+  position:fixed; inset:0; z-index:1060;
+  background:var(--overlay-bg);
+  display:flex; align-items:flex-end; justify-content:center;
+  opacity:0; pointer-events:none;
+  transition:opacity var(--ease-med);
+}
+.ge-overlay.open { opacity:1; pointer-events:auto; }
+.ge-sheet {
+  width:100%; max-width:520px; max-height:94vh;
+  overflow-y:auto; -webkit-overflow-scrolling:touch;
+  background:var(--surface);
+  border-radius:var(--r-2xl) var(--r-2xl) 0 0;
+  box-shadow:0 -8px 32px var(--shadow);
+  transform:translateY(20px); transition:transform var(--ease-slow);
+}
+.ge-overlay.open .ge-sheet { transform:translateY(0); }
+.ge-head {
+  display:flex; align-items:center; justify-content:space-between;
+  padding:var(--sp-20) var(--sp-20) var(--sp-12);
+}
+.ge-title { display:flex; align-items:center; gap:var(--sp-8); font-family:'Fraunces', serif; font-weight:700; font-size:var(--fs-lg); color:var(--tc-rose); }
+.ge-title svg.zi { width:var(--icon-lg); height:var(--icon-lg); }
+.ge-close {
+  /* 44px tap target on a panic surface (N-V-1) — the only non-tel exit. */
+  width:44px; height:44px; border-radius:var(--r-full); border:none;
+  background:var(--surface-alt); color:var(--mid);
+  font-size:var(--fs-lg); line-height:var(--lh-none); cursor:pointer;
+  display:inline-flex; align-items:center; justify-content:center; flex-shrink:0;
+}
+/* PINNED callbar — opaque so items scroll invisibly beneath it (V-1). */
+.ge-callbar {
+  position:sticky; top:0; z-index:2;
+  display:flex; align-items:center; flex-wrap:wrap; gap:var(--sp-8);
+  padding:var(--sp-12) var(--sp-20);
+  background:var(--surface);
+  border-top:var(--accent-w) solid var(--tc-rose);
+  border-bottom:1px solid var(--rose-light);
+}
+.ge-callbar-label { display:inline-flex; align-items:center; gap:var(--sp-6); font-family:'Fraunces', serif; font-weight:700; font-size:var(--fs-sm); color:var(--tc-rose); text-transform:uppercase; letter-spacing:0.04em; }
+.ge-callbar-label svg.zi { width:var(--icon-base); height:var(--icon-base); }
+.ge-callbar .ld-emergency-call { font-size:var(--fs-md); font-weight:700; }
+.ge-list { display:flex; flex-direction:column; gap:var(--sp-12); padding:var(--sp-16) var(--sp-20); }
+/* (The old accordion .ge-item* / .ge-lead / .ge-steps styles were retired in
+   emergency-room-v2 M1 — the room is now teaser rows (.ge-row) + pop-up flip cards.) */
+.ge-flags { background:var(--rose-light); border-left:var(--accent-w) solid var(--tc-rose); border-radius:var(--r-md); padding:var(--sp-10) var(--sp-12); }
+[data-theme="dark"] .ge-flags { background:rgba(158,62,82,0.22); }
+/* Unconditional-call items (poison / unresponsive) — lead loud, no list. */
+.ge-flags--always { display:flex; align-items:flex-start; gap:var(--sp-8); background:var(--rose-light); border-left:var(--accent-w) solid var(--rose-deep); }
+[data-theme="dark"] .ge-flags--always { background:rgba(158,62,82,0.30); }
+.ge-flags--always svg.zi { width:var(--icon-base); height:var(--icon-base); color:var(--rose-deep); flex-shrink:0; }
+.ge-flags--always span { font-family:'Fraunces', serif; font-weight:700; font-size:var(--fs-md); color:var(--rose-deep); }
+[data-theme="dark"] .ge-flags--always span, [data-theme="dark"] .ge-flags--always svg.zi { color:var(--rose); }
+.ge-src { margin-top:var(--sp-10); font-family:'Nunito', sans-serif; font-size:var(--fs-xs); color:var(--mid); }
+.ge-disclaimer { display:flex; align-items:flex-start; gap:var(--sp-8); padding:var(--sp-12) var(--sp-20) var(--sp-20); border-top:1px solid var(--rose-light); }
+.ge-disclaimer svg.zi { width:var(--icon-base); height:var(--icon-base); color:var(--tc-rose); flex-shrink:0; margin-top:var(--sp-2); }
+.ge-disclaimer span { font-family:'Nunito', sans-serif; font-size:var(--fs-sm); color:var(--mid); line-height:var(--lh-relaxed); }
+@media (prefers-reduced-motion: reduce) {
+  .ge-overlay, .ge-sheet, .ge-item-chev { transition:none; }
+}
+
+/* ── Emergency Room v2 — whisper-wave call pills, teaser rows, pop-up flip card ── */
+/* Whisper-wave on every Call-112/108 pill inside the emergency surfaces (Room
+   callbar pills, teaser-row chips; the in-card .ec-call carries it separately).
+   Scoped to the Room (V-V-235-1) — the landing's quick-dial pills stay calm/static.
+   Reuses the food .ec-call flow gradient (ecCallFlow). Reduced-motion → static. */
+.ge-callbar .ld-emergency-call, .ge-call-chip {
+  background:linear-gradient(110deg, #c0607a 0%, var(--tc-rose) 28%, var(--rose-deep) 50%, var(--tc-rose) 72%, #c0607a 100%);
+  background-size:280% 100%; color:#fff; border-color:transparent;
+  animation:ecCallFlow 3.4s ease-in-out infinite;
+}
+.ge-callbar .ld-emergency-call svg.zi, .ge-call-chip svg.zi { color:#fff; }
+@media (prefers-reduced-motion: reduce) { .ge-callbar .ld-emergency-call, .ge-call-chip { animation:none; background-position:0 50%; } }
+
+/* Teaser rows (§11 move 3) — name + one-line gist; opens the card on tap. */
+.ge-row {
+  display:flex; align-items:center; gap:var(--sp-12); width:100%; text-align:left; cursor:pointer;
+  background:var(--surface); box-shadow:0 1px 6px var(--shadow);
+  border:none; border-radius:var(--r-xl); padding:var(--sp-12) var(--sp-12); min-height:60px; font-family:inherit;
+}
+.ge-row-ic { width:var(--sp-32); height:var(--sp-32); border-radius:var(--r-md); display:inline-flex; align-items:center; justify-content:center; flex-shrink:0; }
+.ge-row-ic svg.zi { width:var(--icon-base); height:var(--icon-base); }
+.ge-row-tx { display:flex; flex-direction:column; min-width:0; gap:var(--sp-2); flex:1; }
+.ge-row-name { font-family:'Fraunces', serif; font-weight:600; font-size:var(--fs-md); color:var(--text); line-height:var(--lh-snug); }
+.ge-row-teaser { font-family:'Nunito', sans-serif; font-weight:600; font-size:var(--fs-sm); color:var(--mid); line-height:var(--lh-snug); }
+.ge-call-chip { display:inline-flex; align-items:center; gap:var(--sp-4); flex-shrink:0; padding:var(--sp-4) var(--sp-8); border-radius:var(--r-full); font-family:'Nunito', sans-serif; font-weight:700; font-size:var(--fs-xs); white-space:nowrap; }
+.ge-call-chip svg.zi { width:var(--icon-sm); height:var(--icon-sm); }
+.ge-row-chev { flex-shrink:0; color:var(--tc-rose); display:inline-flex; }
+.ge-row-chev svg.zi { width:var(--icon-base); height:var(--icon-base); }
+
+/* Pinned critical card (inline) + pop-up card overlay — both host the flip. */
+.ge-pinned-card { margin:0 var(--sp-20) var(--sp-16); perspective:1400px; border-radius:var(--r-2xl); box-shadow:0 6px 26px var(--shadow); overflow:hidden; background:var(--cream); }
+.ge-card-ov { position:fixed; inset:0; z-index:1280; background:var(--overlay-bg); display:flex; align-items:center; justify-content:center; padding:var(--sp-16); opacity:0; pointer-events:none; transition:opacity var(--ease-med); overflow:auto; }
+.ge-card-ov.open { opacity:1; pointer-events:auto; }
+.ge-pop { perspective:1400px; }
+.ge-card-close { z-index:4; }
+/* The ecard fills the host; the host (pinned card / food-pop) provides the chrome. */
+.ge-cardface { margin:0; box-shadow:none; border-radius:0; background:transparent; display:flex; flex-direction:column; min-height:0; flex:1; }
+.ge-pop .ge-cardface .ec-body { overflow:auto; min-height:0; }
+.ge-card-ov .fp-flip, .ge-pinned-card .fp-flip { perspective:1400px; }
+
+/* Doc-prep face (.docface) — the same fields as the food room's doc-prep, but
+   container-neutral so it renders inside the flip-back (not only the #emDocOv
+   overlay). Mirrors the .em-doc-ov .doc-* rules; tokenised for the 3 zoom tiers. */
+/* Doc-face colours are component-scoped tokens (light/paper defaults). Dark-theme
+   overrides below make the on-screen face match the front card (PR#235 dark-mode fix);
+   the @media print block re-forces these to paper values so any printout stays white. */
+.docface {
+  --doc-paper:#fff; --doc-ink:#2a2020; --doc-ink-soft:#3a2c2c;
+  --doc-line:#ecdfe2; --doc-line-soft:#f0e6e9; --doc-muted:#7a6a6a;
+  --doc-placeholder:#9a8a8a; --doc-dash:#d8b9c2; --doc-note-bg:#fdeef1;
+  --doc-foot-bg:#faf2f4; --doc-btn-bg:#fff; --doc-btn-ghost-border:#e6dcdf;
+  --doc-btn-copy-border:#e6b9c4;
+  display:flex; flex-direction:column; min-height:0; flex:1;
+}
+.docface .doc { width:100%; background:var(--doc-paper); overflow:hidden; display:flex; flex-direction:column; min-height:0; flex:1; }
+.docface .doc-body { padding:var(--sp-20); position:relative; color:var(--doc-ink); overflow:auto; min-height:0; flex:1; }
+.docface .doc-brand { display:flex; align-items:baseline; justify-content:space-between; border-bottom:2px solid var(--doc-line); padding-bottom:var(--sp-10); margin-bottom:var(--sp-12); padding-right:40px; }
+.docface .doc-brand b { font-family:'Fraunces', serif; font-weight:600; font-size:var(--fs-md); color:var(--tc-rose); }
+.docface .doc-brand span { font-size:var(--fs-2xs); color:var(--doc-muted); font-weight:700; }
+.docface .doc-who { font-family:'Nunito', sans-serif; font-weight:800; font-size:var(--fs-base); color:var(--doc-ink); margin:0 0 var(--sp-12); }
+.docface .doc-row { display:flex; gap:var(--sp-10); align-items:flex-start; font-size:var(--fs-sm); padding:var(--sp-8) 0; border-bottom:1px solid var(--doc-line-soft); line-height:var(--lh-normal); }
+.docface .doc-row .k { flex:0 0 38%; max-width:140px; color:var(--tc-rose); font-weight:800; }
+.docface .doc-row .v { flex:1; color:var(--doc-ink); }
+.docface .doc-stamp { flex:1; text-align:left; background:none; border:none; padding:0; font-family:'Nunito', sans-serif; font-size:var(--fs-sm); color:var(--doc-ink); cursor:pointer; border-bottom:1px dashed var(--doc-dash); }
+.docface .doc-stamp em { color:var(--doc-placeholder); font-style:normal; }
+.docface .doc-stamp[data-stamped] { color:var(--tc-rose); font-weight:800; border-bottom-color:transparent; }
+.docface .doc-stamp[data-na] { color:var(--doc-placeholder); font-weight:800; border-bottom-color:transparent; }
+.docface .doc-na { flex:0 0 auto; margin-left:var(--sp-8); background:none; border:1px solid var(--doc-dash); border-radius:var(--r-full); padding:2px 10px; font-family:'Nunito', sans-serif; font-size:var(--fs-xs); font-weight:800; color:var(--doc-placeholder); cursor:pointer; line-height:1.4; }
+.docface .doc-na[data-on] { background:var(--tc-rose); color:#fff; border-color:var(--tc-rose); }
+.docface .doc-note { margin-top:var(--sp-12); font-size:var(--fs-xs); color:var(--doc-ink-soft); line-height:var(--lh-normal); background:var(--doc-note-bg); border-radius:var(--r-md); padding:var(--sp-12); }
+.docface .doc-note b { color:var(--tc-rose); }
+.docface .doc-actions { display:flex; gap:var(--sp-8); padding:var(--sp-12) var(--sp-16); border-top:1px solid var(--doc-line); background:var(--doc-foot-bg); flex-shrink:0; }
+.docface .doc-btn { display:inline-flex; align-items:center; justify-content:center; gap:var(--sp-6); min-height:44px; border-radius:var(--r-xl); font-family:'Nunito', sans-serif; font-weight:800; font-size:var(--fs-sm); cursor:pointer; border:none; }
+.docface .doc-btn svg.zi { width:var(--icon-base); height:var(--icon-base); }
+.docface .doc-btn--ghost { flex:0 0 auto; padding:0 var(--sp-12); background:var(--doc-btn-bg); color:var(--mid); border:1.5px solid var(--doc-btn-ghost-border); }
+.docface .doc-btn--copy { flex:1; background:var(--doc-btn-bg); color:var(--tc-rose); border:1.5px solid var(--doc-btn-copy-border); }
+.docface .doc-btn--save { flex:1; background:var(--tc-rose); color:#fff; }
+.docface .doc-btn--copied { background:var(--sage-light); color:var(--tc-sage); border:1.5px solid var(--sage); }  /* V-K-1 inline copy confirmation */
+/* Dark theme — the doctor face becomes a dark panel consistent with the front card
+   (front uses --surface / --text). Print path re-forces paper values (see @media print). */
+[data-theme="dark"] .docface {
+  --doc-paper:var(--surface); --doc-ink:var(--text); --doc-ink-soft:var(--mid);
+  --doc-line:var(--border-subtle); --doc-line-soft:var(--border-subtle); --doc-muted:var(--mid);
+  --doc-placeholder:var(--light); --doc-dash:rgba(224,144,168,0.40); --doc-note-bg:var(--surface-rose);
+  --doc-foot-bg:var(--surface-alt); --doc-btn-bg:var(--surface-alt); --doc-btn-ghost-border:var(--border-subtle);
+  --doc-btn-copy-border:rgba(224,144,168,0.40);
+}
+@media (prefers-reduced-motion: reduce) { .ge-card-ov { transition:none; } }
+
+/* Growth hero — rose to peach (body/physical) */
+.card.card-hero.hero-growth {
+  background:linear-gradient(135deg, #fff0f3, var(--peach-light));
+  box-shadow:0 6px 28px rgba(242,168,184,0.15);
+}
+.card.card-hero.hero-growth::before {
+  background:linear-gradient(90deg, var(--rose), var(--peach));
+}
+[data-theme="dark"] .card.card-hero.hero-growth {
+  background:linear-gradient(135deg, rgba(70,35,45,0.4), rgba(70,50,35,0.3));
+}
+
+/* Diet hero — sage to peach (nutrition) */
+.card.card-hero.hero-diet {
+  background:linear-gradient(135deg, var(--sage-light), var(--amber-light));
+  box-shadow:0 6px 28px rgba(181,213,197,0.15);
+}
+.card.card-hero.hero-diet::before {
+  background:linear-gradient(90deg, var(--sage), var(--peach));
+}
+[data-theme="dark"] .card.card-hero.hero-diet {
+  background:linear-gradient(135deg, rgba(40,60,50,0.4), rgba(60,50,35,0.3));
+}
+
+/* Sleep hero — indigo to lavender (night/calm) */
+.card.card-hero.hero-sleep {
+  background:linear-gradient(135deg, var(--indigo-light), var(--lav-light));
+  box-shadow:0 6px 28px rgba(155,168,216,0.15);
+}
+.card.card-hero.hero-sleep::before {
+  background:linear-gradient(90deg, var(--indigo), var(--lavender));
+}
+[data-theme="dark"] .card.card-hero.hero-sleep {
+  background:linear-gradient(135deg, rgba(40,45,65,0.4), rgba(50,40,65,0.3));
+}
+
+/* Medical hero — lavender to sky (clinical/trust) */
+.card.card-hero.hero-medical {
+  background:linear-gradient(135deg, var(--lav-light), var(--sky-light));
+  box-shadow:0 6px 28px rgba(201,184,232,0.15);
+}
+.card.card-hero.hero-medical::before {
+  background:linear-gradient(90deg, var(--lavender), var(--sky));
+}
+[data-theme="dark"] .card.card-hero.hero-medical {
+  background:linear-gradient(135deg, rgba(50,40,70,0.4), rgba(35,50,65,0.3));
+}
+
+/* Milestones hero — sage to lavender (growth/achievement) */
+.card.card-hero.hero-milestones {
+  background:linear-gradient(135deg, var(--sage-light), var(--lav-light));
+  box-shadow:0 6px 28px rgba(181,213,197,0.12);
+}
+.card.card-hero.hero-milestones::before {
+  background:linear-gradient(90deg, var(--sage), var(--lavender));
+}
+[data-theme="dark"] .card.card-hero.hero-milestones {
+  background:linear-gradient(135deg, rgba(40,60,50,0.4), rgba(50,40,65,0.3));
+}
+
+/* Poop/Digestion hero — amber to peach (gut/warm) */
+.card.card-hero.hero-poop {
+  background:linear-gradient(135deg, var(--amber-light), var(--peach-light));
+  box-shadow:0 6px 28px rgba(232,184,109,0.12);
+}
+.card.card-hero.hero-poop::before {
+  background:linear-gradient(90deg, var(--amber), var(--peach));
+}
+[data-theme="dark"] .card.card-hero.hero-poop {
+  background:linear-gradient(135deg, rgba(60,50,35,0.4), rgba(60,45,35,0.3));
+}
+
+/* Insights hero — peach to lavender (analysis) */
+.card.card-hero.hero-insights {
+  background:linear-gradient(135deg, var(--peach-light), var(--lav-light));
+  box-shadow:0 6px 28px rgba(250,212,180,0.12);
+}
+.card.card-hero.hero-insights::before {
+  background:linear-gradient(90deg, var(--peach), var(--lavender));
+}
+[data-theme="dark"] .card.card-hero.hero-insights {
+  background:linear-gradient(135deg, rgba(60,45,35,0.4), rgba(50,35,60,0.3));
+}
+
+/* ── Ziva Score Hero ── */
+.ziva-score-hero {
+  display:flex; align-items:center; gap:var(--sp-16);
+  padding:var(--sp-8) 0 var(--sp-12); margin-bottom:var(--sp-8);
+  border-bottom:1px solid var(--border-subtle); min-width:0; flex-wrap:wrap;}
+.zs-ring {
+  display:flex; flex-direction:column; align-items:center; justify-content:center;
+  width:110px; height:110px; border-radius:50%;
+  flex-shrink:0; cursor:pointer;
+  box-shadow:0 6px 24px rgba(0,0,0,0.10);
+  transition:transform var(--ease-fast), box-shadow var(--ease-fast);
+  border:3px solid transparent;
+}
+.zs-ring:active { transform:scale(0.95); }
+.zs-number { font-family:'Fraunces',serif; font-size:var(--fs-3xl); font-weight:700; line-height:var(--lh-none); }
+.zs-label { font-size:var(--fs-2xs); font-weight:600; text-transform:uppercase; letter-spacing:var(--ls-normal); margin-top:var(--sp-2); }
+.zs-trend { font-size:var(--fs-xs); margin-top:1px; font-weight:600; }
+
+/* Score-level ring colors */
+.zs-score-excellent .zs-ring { background:linear-gradient(135deg, #d4f5e0, #b8eacc); border-color:#6fcf97; }
+.zs-score-excellent .zs-number { color:var(--sage-deepest); }
+.zs-score-excellent .zs-label { color:#1a6040; }
+.zs-score-excellent .zs-trend { color:#1a6040; }
+
+.zs-score-great .zs-ring { background:linear-gradient(135deg, #e0f0fa, #cce5f5); border-color:#7fb8d8; }
+.zs-score-great .zs-number { color:#2a6a8a; }
+.zs-score-great .zs-label { color:#2a5870; }
+.zs-score-great .zs-trend { color:#2a5870; }
+
+.zs-score-good .zs-ring { background:linear-gradient(135deg, var(--amber-light), #fcecd0); border-color:#e8c86d; }
+.zs-score-good .zs-number { color:#8a6520; }
+.zs-score-good .zs-label { color:#8a6520; }
+.zs-score-good .zs-trend { color:#8a6520; }
+
+.zs-score-fair .zs-ring { background:linear-gradient(135deg, #fef0e0, #fce0c0); border-color:#e8a050; }
+.zs-score-fair .zs-number { color:#8a5020; }
+.zs-score-fair .zs-label { color:#8a5020; }
+.zs-score-fair .zs-trend { color:#8a5020; }
+
+.zs-score-attention .zs-ring { background:linear-gradient(135deg, var(--rose-light), #f8d0d8); border-color:var(--tc-danger); }
+.zs-score-attention .zs-number { color:#a03030; }
+.zs-score-attention .zs-label { color:#8a2838; }
+.zs-score-attention .zs-trend { color:#8a2838; }
+
+.zs-trend.trend-down { color:var(--tc-danger) !important; }
+
+/* Domain pills — grid */
+.zs-domains { display:grid; grid-template-columns:repeat(6, 1fr); gap:var(--sp-4); flex:1; min-width:0; }
+@media(max-width:360px) { .zs-domains { grid-template-columns:repeat(4, 1fr); }
+  .zs-domain-pill { grid-column:span 2 !important; }
+}
+.zs-domain-pill {
+  display:flex; align-items:center; gap:var(--sp-4);
+  padding:var(--sp-6) var(--sp-8); border-radius:var(--r-lg);
+  cursor:pointer; transition:all var(--ease-fast);
+  border:1.5px solid transparent; box-sizing:border-box;
+  grid-column:span 2;
+}
+.zs-domain-pill:nth-child(4) { grid-column:1 / 4; }
+.zs-domain-pill:nth-child(5) { grid-column:4 / 7; }
+.zs-domain-pill:active { transform:scale(0.96); }
+.zs-domain-pill .zsd-icon { font-size:var(--icon-xs); flex-shrink:0; }
+.zs-domain-pill .zsd-text { min-width:0; }
+.zs-domain-pill .zsd-score { font-family:'Fraunces',serif; font-size:var(--fs-base); font-weight:600; line-height:var(--lh-tight); }
+.zs-domain-pill .zsd-label { font-size:var(--fs-2xs); color:var(--mid); font-weight:600; text-transform:uppercase; letter-spacing:var(--ls-tight); }
+.zs-domain-pill.zsd-stale { opacity:0.55; }
+.zs-domain-pill.zsd-stale .zsd-score::before { content:'~'; font-size:0.7em; }
+
+/* Domain pill score-level colors */
+.zs-domain-pill.zsd-excellent { background:linear-gradient(135deg, var(--sage-light), #d8efdf); border-color:rgba(111,207,151,0.35); }
+.zs-domain-pill.zsd-excellent .zsd-score { color:var(--sage-deepest); }
+.zs-domain-pill.zsd-great { background:linear-gradient(135deg, #e5f0f8, #d5e8f4); border-color:rgba(127,184,216,0.35); }
+.zs-domain-pill.zsd-great .zsd-score { color:#2a6a8a; }
+.zs-domain-pill.zsd-good { background:linear-gradient(135deg, #fef8ee, #fdf0d8); border-color:rgba(232,200,109,0.35); }
+.zs-domain-pill.zsd-good .zsd-score { color:#8a6520; }
+.zs-domain-pill.zsd-fair { background:linear-gradient(135deg, #fef3e5, #fce5c8); border-color:rgba(232,160,80,0.35); }
+.zs-domain-pill.zsd-fair .zsd-score { color:#8a5020; }
+.zs-domain-pill.zsd-attention { background:linear-gradient(135deg, #fef0f0, #fcdcdc); border-color:rgba(224,112,112,0.35); }
+.zs-domain-pill.zsd-attention .zsd-score { color:#a03030; }
+
+/* ── Variety Card ── */
+.variety-bar { display:flex; height:10px; border-radius:var(--r-full); background:var(--border-subtle); overflow:hidden; margin:var(--sp-6) 0; }
+.variety-bar-fill { height:100%; border-radius:var(--r-full); background:linear-gradient(90deg, var(--sage), var(--rose)); transition:width var(--ease-med); }
+.variety-groups { display:flex; gap:var(--sp-8); flex-wrap:wrap; margin:var(--sp-8) 0; }
+.variety-group { display:flex; align-items:center; gap:var(--sp-4); font-size:var(--fs-sm); }
+.variety-group .vg-status { font-size:var(--icon-xs); }
+.variety-gap { font-size:var(--fs-xs); color:var(--tc-warn); padding:var(--sp-6) var(--sp-8); background:var(--surface-warn); border-radius:var(--r-md); margin-top:var(--sp-4); }
+.variety-gap-suggestion { font-size:var(--fs-xs); color:var(--mid); padding-left:var(--sp-16); }
+
+/* ── Nutrient Radar ── */
+.nutrient-row { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-4) 0; }
+.nutrient-emoji { font-size:var(--icon-sm); width:20px; text-align:center; }
+.nutrient-name { font-size:var(--fs-xs); color:var(--mid); width:60px; }
+.nutrient-bar-wrap { flex:1; height:8px; border-radius:var(--r-full); background:var(--border-subtle); overflow:hidden; }
+.nutrient-bar-fill { height:100%; border-radius:var(--r-full); transition:width var(--ease-med); }
+.nutrient-bar-fill.nb-high { background:var(--sage); }
+.nutrient-bar-fill.nb-mid  { background:var(--amber); }
+.nutrient-bar-fill.nb-low  { background:var(--tc-danger); }
+.nutrient-count { font-size:var(--fs-xs); color:var(--mid); width:40px; text-align:right; }
+
+/* ── Correlation Card ── */
+.corr-item { padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl); background:var(--warm); margin-bottom:var(--sp-6); }
+.corr-item.corr-likely { border-left:var(--accent-w) solid var(--tc-danger); }
+.corr-item.corr-suspected { border-left:var(--accent-w) solid var(--tc-caution); }
+.corr-item.corr-watch { border-left:var(--accent-w) solid var(--tc-warn); }
+.corr-header { display:flex; align-items:center; justify-content:space-between; min-width:0;}
+.corr-food { font-weight:600; font-size:var(--fs-base); color:var(--text); }
+.corr-rate { font-size:var(--fs-xs); font-weight:600; padding:var(--sp-2) var(--sp-6); border-radius:var(--r-full); }
+.corr-rate.cr-high { background:var(--rose-light); color:var(--tc-rose); }
+.corr-rate.cr-mid { background:var(--amber-light); color:var(--tc-amber); }
+.corr-rate.cr-low { background:var(--sage-light); color:var(--tc-sage); }
+.corr-detail { font-size:var(--fs-xs); color:var(--mid); margin-top:var(--sp-4); }
+.corr-evidence { font-size:var(--fs-xs); font-weight:400; color:var(--light); margin-top:var(--sp-4); cursor:pointer; }
+.corr-evidence:hover { color:var(--tc-rose); }
+.corr-evidence-trail { display:none; margin-top:var(--sp-4); padding:var(--sp-4) var(--sp-8); background:var(--white); border-radius:var(--r-sm); }
+.corr-evidence-trail.open { display:block; }
+.corr-ev-row { font-size:var(--fs-xs); color:var(--mid); padding:var(--sp-2) 0; border-bottom:1px solid var(--border-subtle); }
+.corr-clear { font-size:var(--fs-xs); color:var(--tc-sage); margin-top:var(--sp-6); }
+
+/* ── Weekly Summary Card ── */
+.weekly-row { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-4) 0; font-size:var(--fs-sm); }
+.weekly-icon { font-size:var(--icon-sm); width:20px; text-align:center; }
+.weekly-label { color:var(--mid); flex:1; }
+.weekly-val { font-weight:600; color:var(--text); }
+.weekly-delta { font-size:var(--fs-xs); color:var(--tc-sage); }
+.weekly-delta.wd-down { color:var(--tc-danger); }
+
+/* ── Alert Intelligence Card ── */
+.ai-section-label { font-size:var(--fs-xs); font-weight:600; text-transform:uppercase; letter-spacing:var(--ls-normal); color:var(--mid); margin:var(--sp-12) 0 var(--sp-6); display:flex; align-items:center; gap:var(--sp-8); }
+.ai-section-label .ai-section-count { font-weight:400; color:var(--light); }
+.ai-item {
+  padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl); margin-bottom:var(--sp-6);
+  border:1px solid var(--border-subtle); background:var(--white);
+  transition:all var(--ease-fast);
+}
+.ai-item.ai-concern { border-left:var(--accent-w) solid var(--tc-danger); }
+.ai-item.ai-recurring { border-left:var(--accent-w) solid var(--tc-caution); }
+.ai-item.ai-resolved { border-left:var(--accent-w) solid var(--sage); }
+.ai-item-header { display:flex; align-items:center; gap:var(--sp-8); }
+.ai-item-icon { font-size:var(--icon-base); flex-shrink:0; }
+.ai-item-title { font-size:var(--fs-sm); font-weight:600; color:var(--text); flex:1; }
+.ai-item-badge {
+  font-size:var(--fs-xs); font-weight:700; padding:var(--sp-2) var(--sp-8); border-radius:var(--r-full);
+  white-space:nowrap; letter-spacing:var(--ls-tight);
+}
+.ai-badge-active { background:var(--rose-light); color:var(--tc-rose); }
+.ai-badge-recurring { background:var(--amber-light); color:var(--tc-amber); }
+.ai-badge-resolved { background:var(--sage-light); color:var(--tc-sage); }
+.ai-item-detail { font-size:var(--fs-xs); color:var(--mid); margin-top:var(--sp-4); line-height:var(--lh-normal); }
+.ai-item-meta { font-size:var(--fs-xs); font-weight:400; color:var(--light); margin-top:var(--sp-4); display:flex; align-items:center; gap:var(--sp-8); }
+.ai-item-trend { display:inline-flex; align-items:center; gap:var(--sp-4); }
+.ai-item-trend.ait-improving { color:var(--tc-sage); }
+.ai-item-trend.ait-worsening { color:var(--tc-danger); }
+.ai-item-trend.ait-stable { color:var(--tc-warn); }
+.ai-summary-bar { display:flex; gap:var(--sp-12); margin-bottom:var(--sp-10); flex-wrap:wrap; }
+.ai-summary-stat {
+  display:flex; align-items:center; gap:var(--sp-4); padding:var(--sp-6) var(--sp-10);
+  border-radius:var(--r-full); font-size:var(--fs-xs); font-weight:600;
+}
+.ai-ss-concern { background:var(--rose-light); color:var(--tc-rose); }
+.ai-ss-recurring { background:var(--amber-light); color:var(--tc-amber); }
+.ai-ss-resolved { background:var(--sage-light); color:var(--tc-sage); }
+
+/* ── Score Badges (shared) ── */
+.score-badge { display:inline-flex; align-items:center; gap:var(--sp-4); padding:var(--sp-2) var(--sp-8); border-radius:var(--r-full); font-size:var(--fs-xs); font-weight:700; letter-spacing:var(--ls-tight); }
+.sb-excellent { background:linear-gradient(135deg, #d4f5e0, #b8eacc); color:#1a6040; border:1px solid rgba(111,207,151,0.3); }
+.sb-great { background:linear-gradient(135deg, #e0f0fa, #cce5f5); color:#2a6a8a; border:1px solid rgba(127,184,216,0.3); }
+.sb-good { background:linear-gradient(135deg, #fef8ee, #fdf0d8); color:#8a6520; border:1px solid rgba(232,200,109,0.3); }
+.sb-fair { background:linear-gradient(135deg, #fef3e5, #fce5c8); color:#8a5020; border:1px solid rgba(232,160,80,0.3); }
+.sb-attention { background:linear-gradient(135deg, #fef0f0, #fcdcdc); color:#a03030; border:1px solid rgba(224,112,112,0.3); }
+
+/* ── Score Breakdown Panel ── */
+.zs-breakdown { display:none; padding:var(--sp-12) 0 var(--sp-4); border-top:1px solid var(--border-subtle); margin-top:var(--sp-12); }
+.zs-breakdown.open { display:block; }
+.zs-domain-row { margin-bottom:var(--sp-10); }
+.zs-domain-header {
+  display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-6) var(--sp-8);
+  border-radius:var(--r-md); cursor:pointer; transition:background var(--ease-fast);
+}
+.zs-domain-header:active { background:rgba(0,0,0,0.03); }
+.zs-domain-chevron { font-size:var(--icon-xs); color:var(--light); transition:transform var(--ease-fast); margin-left:auto; }
+.zs-domain-header.open .zs-domain-chevron { transform:rotate(180deg); }
+.zs-domain-icon { font-size:var(--icon-base); }
+.zs-domain-name { font-size:var(--fs-sm); font-weight:600; color:var(--text); flex:1; }
+.zs-domain-score-label { font-family:'Fraunces',serif; font-size:var(--fs-base); font-weight:600; color:var(--text); }
+.zs-domain-body { display:none; padding:var(--sp-4) var(--sp-8) var(--sp-8) var(--sp-32); }
+.zs-domain-body.open { display:block; }
+.zs-comp-row { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-4) 0; }
+.zs-comp-name { font-size:var(--fs-xs); color:var(--mid); width:80px; flex-shrink:0; }
+.zs-comp-weight { font-size:var(--fs-xs); font-weight:400; color:var(--light); width:28px; text-align:center; flex-shrink:0; }
+.zs-comp-bar { flex:1; height:6px; border-radius:var(--r-full); background:var(--border-subtle); overflow:hidden; }
+.zs-comp-bar-fill { height:100%; border-radius:var(--r-full); transition:width var(--ease-med); }
+.zs-comp-bar-fill.cb-high { background:var(--sage); }
+.zs-comp-bar-fill.cb-mid { background:var(--amber); }
+.zs-comp-bar-fill.cb-low { background:var(--tc-danger); }
+.zs-comp-val { font-size:var(--fs-xs); font-weight:600; color:var(--text); width:28px; text-align:right; flex-shrink:0; }
+.zs-comp-detail { font-size:var(--fs-xs); font-weight:400; color:var(--light); padding:1px 0 var(--sp-4) 0; line-height:var(--lh-snug); cursor:pointer; }
+.zs-comp-detail:hover { color:var(--tc-rose); }
+
+/* ── Score Popup (bottom sheet) ── */
+.score-popup-overlay {
+  position:fixed; inset:0; background:rgba(0,0,0,0.35);
+  z-index:9998; display:none; opacity:0; transition:opacity var(--ease-med);
+}
+.score-popup-overlay.open { display:block; opacity:1; }
+.score-popup {
+  position:fixed; bottom:0; left:0; right:0;
+  max-height:85vh; z-index:9999;
+  background:var(--cream); border-radius:var(--r-2xl) var(--r-2xl) 0 0;
+  box-shadow:0 -8px 32px rgba(0,0,0,0.14);
+  transform:translateY(100%); transition:transform var(--ease-slow);
+  display:flex; flex-direction:column;
+}
+.score-popup.open { transform:translateY(0); }
+.score-popup-handle { width:36px; height:4px; border-radius:2px; background:var(--light); opacity:0.3; margin:var(--sp-10) auto 0; }
+.score-popup-header { display:flex; align-items:center; justify-content:space-between; padding:var(--sp-12) var(--sp-20) var(--sp-6); flex-shrink:0; }
+.score-popup-title { font-family:'Fraunces',serif; font-size:var(--fs-lg); font-weight:700; color:var(--text); }
+.score-popup-close { width:28px; height:28px; border:none; background:transparent; cursor:pointer; font-size:var(--icon-base); color:var(--light); border-radius:var(--r-full); display:flex; align-items:center; justify-content:center; }
+.score-popup-close:hover { background:rgba(0,0,0,0.06); }
+
+/* Score popup hero — compact summary at top */
+.sp-hero { display:flex; align-items:center; gap:var(--sp-12); padding:var(--sp-4) var(--sp-20) var(--sp-10); }
+.sp-ring {
+  width:64px; height:64px; border-radius:50%; display:flex; flex-direction:column;
+  align-items:center; justify-content:center; flex-shrink:0;
+  box-shadow:0 3px 12px rgba(0,0,0,0.08); border:2.5px solid transparent;
+}
+.sp-ring-num { font-family:'Fraunces',serif; font-size:var(--fs-2xl); font-weight:600; line-height:var(--lh-none); }
+.sp-ring-label { font-size:var(--fs-2xs); font-weight:600; text-transform:uppercase; letter-spacing:var(--ls-normal); margin-top:1px; }
+.sp-hero-meta { flex:1; }
+.sp-hero-level { font-family:'Fraunces',serif; font-size:var(--fs-lg); font-weight:600; color:var(--text); }
+.sp-hero-trend { font-size:var(--fs-xs); color:var(--mid); margin-top:var(--sp-2); }
+
+/* Score popup tab bar — horizontally scrollable */
+.sp-tab-bar {
+  display:flex; gap:var(--sp-4); padding:0 var(--sp-16) var(--sp-8); flex-shrink:0;
+  overflow-x:auto; -webkit-overflow-scrolling:touch;
+  scrollbar-width:none; border-bottom:1px solid var(--border-subtle);
+}
+.sp-tab-bar::-webkit-scrollbar { display:none; }
+.sp-tab {
+  display:flex; align-items:center; gap:var(--sp-4);
+  padding:var(--sp-8) var(--sp-12); border-radius:var(--r-full);
+  font-size:var(--fs-sm); font-weight:600; white-space:nowrap;
+  cursor:pointer; transition:all var(--ease-fast);
+  border:1.5px solid transparent; background:transparent; color:var(--mid);
+  flex-shrink:0;
+}
+.sp-tab:active { transform:scale(0.96); }
+.sp-tab.active { background:var(--blush); border-color:var(--rose); color:var(--tc-rose); box-shadow:0 1px 6px rgba(242,168,184,0.2); }
+.sp-tab .sp-tab-icon { font-size:var(--icon-sm); }
+.sp-tab .sp-tab-score { font-family:'Fraunces',serif; font-weight:600; font-size:var(--fs-sm); }
+
+/* Score popup body — scrollable content */
+.sp-body { flex:1; overflow-y:auto; padding:var(--sp-12) var(--sp-20) var(--sp-20); -webkit-overflow-scrolling:touch; }
+
+/* Domain detail card inside popup */
+.sp-domain-card { animation:fadeSlideUp 0.2s ease; }
+@keyframes fadeSlideUp { from { opacity:0; transform:translateY(8px); } to { opacity:1; transform:translateY(0); } }
+.sp-domain-title { display:flex; align-items:center; gap:var(--sp-8); margin-bottom:var(--sp-12); }
+.sp-domain-title-icon { font-size:var(--icon-md); }
+.sp-domain-title-text { font-family:'Fraunces',serif; font-size:var(--fs-lg); font-weight:600; color:var(--text); }
+.sp-domain-title-score {
+  margin-left:auto; font-family:'Fraunces',serif; font-size:var(--fs-lg); font-weight:600;
+  padding:var(--sp-4) var(--sp-12); border-radius:var(--r-full);
+}
+
+/* Component rows inside popup */
+.sp-comp { padding:var(--sp-10) 0; border-bottom:1px solid var(--border-subtle); }
+.sp-comp:last-child { border-bottom:none; }
+.sp-comp-header { display:flex; align-items:center; gap:var(--sp-8); }
+.sp-comp-name { font-size:var(--fs-sm); font-weight:600; color:var(--text); flex:1; }
+.sp-comp-weight { font-size:var(--fs-xs); font-weight:400; color:var(--light); }
+.sp-comp-score { font-family:'Fraunces',serif; font-size:var(--fs-md); font-weight:600; width:32px; text-align:right; }
+.sp-comp-bar { height:8px; border-radius:var(--r-full); background:var(--border-subtle); overflow:hidden; margin:var(--sp-6) 0 var(--sp-4); }
+.sp-comp-bar-fill { height:100%; border-radius:var(--r-full); transition:width var(--ease-slow); }
+.sp-comp-bar-fill.spb-high { background:linear-gradient(90deg, #6fcf97, #4aba7a); }
+.sp-comp-bar-fill.spb-mid  { background:linear-gradient(90deg, #f0c060, var(--amber-mid)); }
+.sp-comp-bar-fill.spb-low  { background:linear-gradient(90deg, var(--tc-danger), #c85050); }
+.sp-comp-detail { font-size:var(--fs-xs); color:var(--mid); line-height:var(--lh-normal); }
+.sp-comp-action {
+  display:inline-flex; align-items:center; gap:var(--sp-4);
+  font-size:var(--fs-xs); font-weight:600; color:var(--tc-sky);
+  cursor:pointer; margin-top:var(--sp-4);
+}
+.sp-comp-action:active { opacity:0.6; }
+.sp-trend-line {
+  display:flex; align-items:center; gap:var(--sp-6);
+  padding:var(--sp-8) var(--sp-12);
+  margin-top:var(--sp-4);
+  background:var(--sky-light);
+  border-radius:var(--r-md);
+  font-size:var(--fs-xs);
+}
+.sp-trend-icon { display:flex; align-items:center; }
+.sp-trend-icon .zi { width:var(--fs-sm); height:var(--fs-sm); }
+.sp-trend-label { font-weight:600; color:var(--mid); }
+.sp-trend-delta { font-family:'Fraunces',serif; font-weight:700; font-size:var(--fs-sm); }
+.sp-trend-up { color:var(--tc-sage); }
+.sp-trend-down { color:var(--tc-amber); }
+.sp-trend-flat { color:var(--mid); }
+.sp-trend-detail { color:var(--mid); font-style:italic; }
+
+/* Overall summary tab */
+.sp-overview-grid { display:grid; grid-template-columns:1fr 1fr; gap:var(--sp-8); margin-bottom:var(--sp-12); }
+@media(max-width:700px) { .sp-overview-grid { grid-template-columns:1fr; } }
+.sp-overview-item {
+  padding:var(--sp-12); border-radius:var(--r-lg); border:1.5px solid transparent;
+  cursor:pointer; transition:all var(--ease-fast); text-align:center;
+}
+.sp-overview-item:active { transform:scale(0.97); }
+.sp-overview-icon { font-size:var(--icon-lg); margin-bottom:var(--sp-4); }
+.sp-overview-score { font-family:'Fraunces',serif; font-size:var(--fs-xl); font-weight:600; line-height:var(--lh-tight); }
+.sp-overview-name { font-size:var(--fs-xs); font-weight:600; color:var(--mid); text-transform:uppercase; letter-spacing:var(--ls-tight); margin-top:var(--sp-2); }
+.sp-overview-sublabel { font-size:var(--fs-xs); font-weight:400; color:var(--light); margin-top:1px; }
+
+/* Tip box at bottom of domain */
+.sp-tip {
+  margin-top:var(--sp-12); padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl);
+  background:var(--sky-light); border:1px solid rgba(168,207,224,0.25);
+  font-size:var(--fs-xs); color:var(--tc-sky); line-height:var(--lh-normal);
+}
+
+/* ── Domain Score Hero (per-tab) ── */
+.domain-score-hero {
+  display:flex; flex-direction:column; gap:0;
+  padding:0; margin-bottom:var(--sp-8);
+}
+.dsh-top {
+  display:flex; align-items:center; gap:var(--sp-12); padding:var(--sp-4) 0 var(--sp-12); min-width:0;}
+.dsh-ring {
+  display:flex; flex-direction:column; align-items:center; justify-content:center;
+  width:72px; height:72px; border-radius:50%;
+  flex-shrink:0; cursor:pointer;
+  box-shadow:0 4px 18px rgba(0,0,0,0.1);
+  transition:transform var(--ease-fast);
+  border:3px solid transparent;
+}
+.dsh-ring:active { transform:scale(0.94); }
+.dsh-number { font-family:'Fraunces',serif; font-size:var(--fs-2xl); font-weight:600; line-height:var(--lh-none); }
+.dsh-label { font-size:var(--fs-2xs); font-weight:600; text-transform:uppercase; letter-spacing:var(--ls-normal); margin-top:var(--sp-2); }
+.dsh-emoji { font-size:var(--fs-xs); margin-top:1px; }
+.dsh-info { flex:1; min-width:0; }
+.dsh-domain-name { font-family:'Fraunces',serif; font-size:var(--fs-lg); font-weight:600; color:var(--text); }
+.dsh-domain-sublabel { font-size:var(--fs-xs); color:var(--mid); margin-top:var(--sp-2); }
+.dsh-components {
+  display:grid; grid-template-columns:1fr 1fr; gap:var(--sp-8);
+}
+@media(max-width:400px) { .dsh-components { grid-template-columns:1fr; } }
+.dsh-comp-pill {
+  display:flex; align-items:center; gap:var(--sp-8);
+  padding:var(--sp-10) var(--sp-10); border-radius:var(--r-lg);
+  cursor:pointer; transition:all var(--ease-fast);
+  border:1px solid var(--border-subtle); background:var(--white);
+  position:relative; overflow:hidden;
+}
+.dsh-comp-pill::before {
+  content:''; position:absolute; left:0; top:0; bottom:0; width:3px;
+  border-radius:2px 0 0 2px;
+}
+.dsh-comp-pill.dcp-high::before { background:linear-gradient(180deg, #6fcf97, #4aba7a); }
+.dsh-comp-pill.dcp-mid::before  { background:linear-gradient(180deg, #f0c060, var(--amber-mid)); }
+.dsh-comp-pill.dcp-low::before  { background:linear-gradient(180deg, var(--tc-danger), #c85050); }
+.dsh-comp-pill:active { transform:scale(0.97); }
+.dsh-comp-pill .dcp-bar {
+  width:32px; height:32px; border-radius:var(--r-lg);
+  display:flex; align-items:center; justify-content:center;
+  font-family:'Fraunces',serif; font-size:var(--fs-base); font-weight:700; flex-shrink:0;
+}
+.dsh-comp-pill .dcp-bar.dcb-high { background:rgba(111,207,151,0.12); color:var(--sage-deepest); }
+.dsh-comp-pill .dcp-bar.dcb-mid  { background:rgba(232,200,109,0.12); color:#8a6520; }
+.dsh-comp-pill .dcp-bar.dcb-low  { background:rgba(224,112,112,0.12); color:#a03030; }
+.dsh-comp-pill .dcp-text { min-width:0; }
+.dsh-comp-pill .dcp-name { font-size:var(--fs-xs); color:var(--text); font-weight:600; text-transform:uppercase; letter-spacing:var(--ls-tight); line-height:var(--lh-tight); }
+.dsh-comp-pill .dcp-detail { font-size:var(--fs-xs); color:var(--mid); line-height:var(--lh-tight); max-width:100%; }
+.dsh-comp-pill .dcp-weight { font-size:var(--fs-2xs); color:var(--light); }
+.dsh-stale { opacity:0.55; }
+.dsh-stale .dsh-number::before { content:'~'; font-size:0.7em; }
+
+/* ── Domain hero ring — score-level colors (replaces inline styles) ── */
+.dsh-ring-excellent { background:linear-gradient(135deg, #d4f5e0, #b8eacc); border-color:#6fcf97; color:var(--sage-deepest); }
+.dsh-ring-great { background:linear-gradient(135deg, #e0f0fa, #cce5f5); border-color:#7fb8d8; color:#2a6a8a; }
+.dsh-ring-good { background:linear-gradient(135deg, var(--amber-light), #fcecd0); border-color:#e8c86d; color:#8a6520; }
+.dsh-ring-fair { background:linear-gradient(135deg, #fef0e0, #fce0c0); border-color:#e8a050; color:#8a5020; }
+.dsh-ring-attention { background:linear-gradient(135deg, var(--rose-light), #f8d0d8); border-color:var(--tc-danger); color:#a03030; }
+
+/* ── Domain-colored comp pills — warm white with domain tint ── */
+.dsh-diet .dsh-comp-pill { background:linear-gradient(135deg, var(--warm), rgba(181,213,197,0.12)); border-color:rgba(181,213,197,0.3); }
+.dsh-sleep .dsh-comp-pill { background:linear-gradient(135deg, var(--warm), rgba(155,168,216,0.12)); border-color:rgba(155,168,216,0.3); }
+.dsh-poop .dsh-comp-pill { background:linear-gradient(135deg, var(--warm), rgba(232,184,109,0.10)); border-color:rgba(232,184,109,0.3); }
+.dsh-medical .dsh-comp-pill { background:linear-gradient(135deg, var(--warm), rgba(242,168,184,0.10)); border-color:rgba(242,168,184,0.3); }
+.dsh-milestones .dsh-comp-pill { background:linear-gradient(135deg, var(--warm), rgba(201,184,232,0.10)); border-color:rgba(201,184,232,0.3); }
+
+/* ── Domain-tinted card backgrounds per track tab ── */
+#tab-diet .card { background:linear-gradient(135deg, var(--warm), rgba(181,213,197,0.10)); }
+#tab-sleep .card { background:linear-gradient(135deg, var(--warm), rgba(155,168,216,0.10)); }
+#tab-poop .card { background:linear-gradient(135deg, var(--warm), rgba(232,184,109,0.08)); }
+#tab-medical .card { background:linear-gradient(135deg, var(--warm), rgba(242,168,184,0.08)); }
+#tab-milestones .card { background:linear-gradient(135deg, var(--warm), rgba(201,184,232,0.08)); }
+
+/* ── Quick Log: Body lock when sheet/modal open ── */
+html.ql-locked, body.ql-locked { overflow:hidden !important; }
+body.ql-locked { position:fixed; width:100%; touch-action:none; }
+body.ql-locked .app { pointer-events:none; }
+body.ql-locked .tab-bar { pointer-events:none; }
+body.ql-locked .dark-toggle { pointer-events:none; }
+
+/* ── Quick Log FAB ── */
+.ql-fab {
+  position:fixed; bottom:20px; left:50%; transform:translateX(-50%);
+  z-index:1001; width:56px; height:56px; border-radius:50%;
+  background:linear-gradient(135deg, #c06070, #b0485e);
+  color:white; border:none; cursor:pointer;
+  font-size:var(--icon-lg); font-weight:300;
+  display:flex; align-items:center; justify-content:center;
+  box-shadow:0 4px 20px rgba(212,116,138,0.4);
+  transition:all var(--ease-med);
+}
+.ql-fab:hover { transform:translateX(-50%) scale(1.08); }
+.ql-fab.ql-fab-open { transform:translateX(-50%) rotate(45deg); background:var(--mid); box-shadow:0 4px 16px rgba(0,0,0,0.2); }
+[data-theme="dark"] .ql-fab { background:linear-gradient(135deg, #c06878, #a05868); box-shadow:0 4px 20px rgba(0,0,0,0.4); }
+[data-theme="dark"] .ql-fab.ql-fab-open { background:var(--light); }
+[data-theme="dark"] .dark-toggle { background:rgba(255,255,255,0.1); border-color:rgba(255,255,255,0.15); box-shadow:0 4px 16px rgba(0,0,0,0.4); color:var(--text); }
+[data-theme="dark"] .home-fab { background:rgba(255,255,255,0.1); border-color:rgba(255,255,255,0.15); box-shadow:0 4px 16px rgba(0,0,0,0.4); color:var(--text); }
+/* Dark mode QL save buttons — brighter for visibility */
+[data-theme="dark"] .ql-save-feed  { background:linear-gradient(135deg, #d4a848, #c49838); color:#1a1520; }
+[data-theme="dark"] .ql-save-sleep { background:linear-gradient(135deg, #7080b8, #6070a8); }
+[data-theme="dark"] .ql-save-nap   { background:linear-gradient(135deg, #7060a8, #6858a0); }
+[data-theme="dark"] .ql-save-poop  { background:linear-gradient(135deg, #d4a848, #c49838); color:#1a1520; }
+
+/* ── Quick Log Bottom Sheet ── */
+.ql-sheet-overlay {
+  position:fixed; inset:0; z-index:1000;
+  background:rgba(0,0,0,0.25);
+  opacity:0; pointer-events:none;
+  transition:opacity var(--ease-med);
+}
+.ql-sheet-overlay.open { opacity:1; pointer-events:auto; }
+.ql-sheet-overlay, .ql-sheet, .ql-modal-overlay { touch-action:auto; }
+[data-theme="dark"] .ql-sheet-overlay { background:rgba(0,0,0,0.4); }
+
+.ql-sheet {
+  position:fixed; bottom:0; left:0; right:0; z-index:1002;
+  background:var(--surface);
+  border-radius:var(--r-2xl) 24px 0 0;
+  padding:var(--sp-20) var(--sp-24) var(--sp-32);
+  box-shadow:0 -8px 40px rgba(0,0,0,0.12);
+  transform:translateY(100%);
+  transition:transform var(--ease-slow);
+}
+.ql-sheet.open { transform:translateY(0); }
+[data-theme="dark"] .ql-sheet { box-shadow:0 -8px 40px rgba(0,0,0,0.4); }
+
+.ql-sheet-handle {
+  width:36px; height:4px; border-radius:2px;
+  background:var(--light); opacity:0.3;
+  margin:0 auto var(--sp-16);
+}
+.ql-sheet-title {
+  font-family:'Fraunces',serif; font-size:var(--fs-lg);
+  font-weight:600; color:var(--text); text-align:center; margin-bottom:var(--sp-16);
+}
+.ql-options {
+  display:grid; grid-template-columns:repeat(3,1fr); gap:var(--sp-12);
+}
+@media(max-width:360px) { .ql-options { grid-template-columns:repeat(2,1fr); } }
+.ql-option {
+  display:flex; flex-direction:column; align-items:center; gap:var(--sp-8);
+  padding:var(--sp-16) var(--sp-8); border-radius:var(--r-xl); border:1.5px solid transparent;
+  background:var(--warm); cursor:pointer;
+  transition:all var(--ease-fast); min-height:44px;
+}
+.ql-option:hover { transform:translateY(-2px); }
+.ql-option:active { transform:scale(0.96); }
+.ql-option-icon { font-size:var(--icon-lg); }
+.ql-option-label { font-size:var(--fs-sm); font-weight:600; color:var(--mid); text-transform:uppercase; letter-spacing:var(--ls-normal); }
+.ql-option.qo-feed   { border-color:rgba(250,212,180,0.4); }
+.ql-option.qo-feed:hover { background:var(--peach-light); }
+.ql-option.qo-sleep  { border-color:rgba(155,168,216,0.4); }
+.ql-option.qo-sleep:hover { background:var(--indigo-light); }
+.ql-option.qo-nap    { border-color:rgba(201,184,232,0.4); }
+.ql-option.qo-nap:hover { background:var(--lav-light); }
+.ql-option.qo-poop   { border-color:rgba(232,184,109,0.4); }
+.ql-option.qo-poop:hover { background:var(--amber-light); }
+.ql-option.qo-activity { border-color:rgba(181,213,197,0.4); }
+.ql-option.qo-activity:hover { background:var(--sage-light); }
+
+/* ── Activity Log Modal ── */
+.al-detect-box {
+  background:var(--warm); border:1px solid var(--border-subtle); border-radius:var(--r-lg);
+  padding:var(--sp-12); margin-top:var(--sp-8);
+}
+.al-detect-title {
+  font-size:var(--fs-xs); font-weight:700; color:var(--mid); text-transform:uppercase;
+  letter-spacing:var(--ls-wide); margin-bottom:var(--sp-8);
+}
+.al-detect-empty { font-size:var(--fs-sm); color:var(--light); font-style:italic; }
+.al-chip-row { display:flex; flex-wrap:wrap; gap:var(--sp-4); }
+.al-chip {
+  display:inline-flex; align-items:center; gap:var(--sp-4);
+  font-size:var(--fs-xs); font-weight:600; padding:var(--sp-4) var(--sp-10); border-radius:var(--r-full);
+  transition:all var(--ease-fast); cursor:default;
+}
+.al-chip-motor    { background:var(--surface-sage); color:var(--tc-sage); }
+.al-chip-language { background:var(--surface-sky); color:var(--tc-sky); }
+.al-chip-social   { background:var(--surface-rose); color:var(--tc-rose); }
+.al-chip-cognitive { background:var(--surface-lav); color:var(--tc-lav); }
+.al-chip-sensory  { background:var(--surface-amber); color:var(--tc-amber); }
+.al-chip .al-chip-x {
+  background:none; border:none; font-size:var(--fs-xs); cursor:pointer;
+  opacity:0.5; padding:0 var(--sp-2); color:inherit;
+}
+.al-chip .al-chip-x:hover { opacity:1; }
+.al-dur-row { display:flex; align-items:center; gap:var(--sp-8); }
+.al-dur-row input[type="number"] {
+  width:64px; padding:var(--sp-8); border-radius:var(--r-lg); border:1.5px solid var(--border-subtle);
+  background:var(--white); font-size:var(--fs-md); font-weight:700; text-align:center; color:var(--text);
+}
+.al-dur-row .al-dur-label { font-size:var(--fs-sm); color:var(--mid); }
+.al-dur-row .al-dur-skip {
+  font-size:var(--fs-xs); background:none; border:none; color:var(--tc-sky);
+  cursor:pointer; text-decoration:underline; padding:var(--sp-4) var(--sp-8);
+}
+.al-presets { display:flex; flex-wrap:wrap; gap:var(--sp-4); margin-top:var(--sp-8); }
+.al-preset {
+  font-size:var(--fs-xs); padding:var(--sp-6) var(--sp-12); border-radius:var(--r-full);
+  background:var(--sage-light); border:1px solid rgba(181,213,197,0.4);
+  color:var(--tc-sage); cursor:pointer; font-weight:600;
+  transition:all var(--ease-fast);
+}
+.al-preset:active { transform:scale(0.95); background:var(--tc-sage); color:white; }
+[data-theme="dark"] .al-detect-box { background:rgba(255,255,255,0.04); }
+[data-theme="dark"] .al-dur-row input[type="number"] { background:var(--card-bg); border-color:var(--card-border); }
+[data-theme="dark"] .ql-save-activity { background:linear-gradient(135deg, #5a8a6a, #4a7a5a); }
+.ql-save-activity { background:linear-gradient(135deg, var(--accent-sage-deep), #357050); }
+
+/* ── Evidence Feed + Evidence Expansion ── */
+.al-feed-list { display:flex; flex-direction:column; gap:var(--sp-4); }
+.al-feed-entry { display:flex; gap:var(--sp-8); align-items:flex-start; padding:var(--sp-6) 0; border-bottom:1px solid var(--border-subtle); }
+.al-feed-time { font-size:var(--fs-2xs); color:var(--light); min-width:50px; text-align:right; }
+.al-feed-body { flex:1; min-width:0; }
+.al-feed-text { font-size:var(--fs-sm); font-weight:600; color:var(--text); }
+.al-feed-chips { display:flex; flex-wrap:wrap; gap:var(--sp-4); margin-top:var(--sp-2); }
+.al-feed-meta { font-size:var(--fs-2xs); color:var(--light); white-space:nowrap; }
+.al-feed-more { font-size:var(--fs-xs); color:var(--light); text-align:center; padding:var(--sp-4); }
+.al-evid-box { padding:var(--sp-8); background:var(--warm); border-radius:var(--r-lg); margin-top:var(--sp-4); }
+.al-evid-item { font-size:var(--fs-xs); padding:var(--sp-4) 0; color:var(--mid); }
+.al-evid-more { font-size:var(--fs-xs); color:var(--light); }
+.al-log-btn { width:100%; padding:var(--sp-12); font-size:var(--fs-md); border-radius:var(--r-xl); }
+[data-theme="dark"] .al-evid-box { background:rgba(255,255,255,0.04); }
+
+/* ── Active Milestones Section ── */
+.ms-active-list { display:flex; flex-direction:column; gap:var(--sp-8); }
+.ms-active-item { padding:var(--sp-12) var(--sp-12); border-radius:var(--r-xl); border-left:var(--accent-w) solid var(--sage); background:var(--glass); transition:background var(--ease-fast); }
+.ms-active-item.motor { border-color:var(--sage); }
+.ms-active-item.language { border-color:#6aafcc; }
+.ms-active-item.social { border-color:var(--amber-deep); }
+.ms-active-item.cognitive { border-color:var(--lavender); }
+.ms-active-top { display:flex; align-items:flex-start; gap:var(--sp-8); }
+.ms-active-icon { font-size:var(--icon-base); flex-shrink:0; margin-top:var(--sp-2); }
+.ms-active-body { flex:1; min-width:0; }
+.ms-active-name { font-weight:600; font-size:var(--fs-md); color:var(--text); }
+.ms-active-stage { display:flex; align-items:center; gap:var(--sp-4); margin-top:var(--sp-2); font-size:var(--fs-sm); font-weight:600; }
+.ms-active-dates { font-size:var(--fs-xs); color:var(--light); margin-top:var(--sp-2); }
+.ms-active-prog { display:flex; align-items:center; gap:var(--sp-8); margin-top:var(--sp-8); }
+.ms-active-bar { flex:1; height:var(--sp-8); background:var(--warm); border-radius:var(--r-md); overflow:hidden; }
+.ms-active-fill { height:100%; border-radius:var(--r-md); transition:width 0.6s ease; }
+.ms-active-fill.stage-emerging { background:linear-gradient(90deg, var(--amber-mid), var(--amber-deep)); }
+.ms-active-fill.stage-practicing { background:linear-gradient(90deg, var(--amber-deep), var(--amber-deepest)); }
+.ms-active-fill.stage-consistent { background:linear-gradient(90deg, var(--sage-mid), var(--sage-mid)); }
+.ms-active-fill.stage-mastered { background:linear-gradient(90deg, var(--sage-deepest), var(--sage-deepest)); }
+.ms-active-obs { font-size:var(--fs-xs); font-weight:600; color:var(--mid); white-space:nowrap; }
+.ms-active-override { font-size:var(--fs-2xs); color:var(--tc-lav); background:var(--lav-light); padding:var(--sp-2) var(--sp-4); border-radius:var(--r-sm); font-weight:600; margin-left:auto; white-space:nowrap; }
+.ms-active-actions { display:flex; gap:var(--sp-4); flex-shrink:0; }
+.ms-active-suggest { font-size:var(--fs-xs); color:var(--tc-sky); background:var(--sky-light); padding:var(--sp-4) var(--sp-8); border-radius:var(--r-md); margin-top:var(--sp-4); display:inline-block; }
+[data-theme="dark"] .ms-active-item { background:rgba(255,255,255,0.03); }
+[data-theme="dark"] .ms-active-bar { background:rgba(255,255,255,0.06); }
+
+/* ── Evidence Feed: Day Groups ── */
+.al-feed-day { margin-bottom:var(--sp-8); }
+.al-feed-day-header { font-size:var(--fs-2xs); font-weight:700; text-transform:uppercase; letter-spacing:var(--ls-wide); color:var(--light); padding:var(--sp-4) 0; border-bottom:1px solid var(--border-subtle); margin-bottom:var(--sp-4); }
+.al-feed-summary { display:flex; gap:var(--sp-8); flex-wrap:wrap; margin:var(--sp-4) 0; }
+.al-feed-summary-chip { font-size:var(--fs-2xs); padding:var(--sp-2) var(--sp-4); border-radius:var(--r-sm); font-weight:600; }
+
+/* ── PR-β: Recent Evidence Feed rollups ── */
+.al-feed-rollups-label { font-size:var(--fs-2xs); font-weight:700; text-transform:uppercase; letter-spacing:var(--ls-wide); color:var(--light); padding:var(--sp-4) 0; margin-bottom:var(--sp-4); }
+.al-feed-rollup { margin-bottom:var(--sp-6); }
+.al-feed-rollup-pill { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-8) var(--sp-12); border-radius:var(--r-md); font-size:var(--fs-sm); cursor:pointer; }
+.al-feed-rollup-icon { flex-shrink:0; }
+.al-feed-rollup-label-text { flex:1; min-width:0; }
+.al-feed-rollup-label-text strong { font-weight:700; }
+.al-feed-rollup-meta { font-size:var(--fs-2xs); opacity:0.8; white-space:nowrap; }
+.al-feed-rollup-chevron { flex-shrink:0; opacity:0.7; }
+.al-feed-rollup-body { padding:var(--sp-4) var(--sp-12); display:flex; flex-direction:column; gap:var(--sp-6); }
+.al-feed-rollup-entry { padding:var(--sp-6) 0; border-bottom:1px solid var(--border-subtle); }
+.al-feed-rollup-entry:last-child { border-bottom:none; }
+.al-feed-rollup-when { font-size:var(--fs-2xs); color:var(--light); font-weight:600; }
+.al-feed-rollup-text { font-size:var(--fs-sm); color:var(--text); margin-top:var(--sp-2); }
+
+/* PR-γ: Edit / Delete affordances on activity-log entries */
+.al-feed-actions { display:flex; gap:var(--sp-4); margin-top:var(--sp-4); align-items:center; }
+.al-feed-action-btn { font-size:var(--fs-2xs); padding:var(--sp-2) var(--sp-6); border-radius:var(--r-sm); background:transparent; color:var(--light); border:1px solid var(--border-subtle); cursor:pointer; line-height:1; }
+.al-feed-action-btn:hover { background:var(--warm); color:var(--text); }
+.al-feed-action-btn.al-feed-del { color:var(--tc-rose); }
+.al-feed-action-btn.al-feed-del:hover { background:var(--surface-rose); }
+
+/* ── Activity Intelligence Cards ── */
+.ai-dot-cal { display:grid; grid-template-columns:repeat(7, 1fr); gap:var(--sp-2); margin:var(--sp-8) 0; }
+.ai-dot { width:100%; aspect-ratio:1; border-radius:var(--r-sm); background:var(--warm); transition:background var(--ease-fast); }
+.ai-dot.active { background:var(--sage); }
+.ai-dot.active-2 { background:var(--sage-mid); }
+.ai-dot.active-3 { background:var(--sage-deepest); }
+.ai-dot-label { font-size:var(--fs-2xs); text-align:center; color:var(--light); }
+.ai-domain-bar { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-2) 0; }
+.ai-domain-label { font-size:var(--fs-2xs); color:var(--light); min-width:60px; text-align:right; text-transform:uppercase; letter-spacing:var(--ls-wide); }
+.ai-domain-track { flex:1; height:var(--sp-12); background:var(--warm); border-radius:var(--r-md); overflow:hidden; }
+.ai-domain-fill { height:100%; border-radius:var(--r-md); transition:width 0.4s ease; }
+.ai-domain-val { font-size:var(--fs-2xs); font-weight:600; min-width:24px; }
+.ai-velocity-item { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-4) 0; border-bottom:1px solid var(--border-subtle); }
+.ai-velocity-item:last-child { border-bottom:none; }
+.ai-velocity-name { flex:1; font-size:var(--fs-sm); font-weight:600; min-width:0; }
+.ai-velocity-rate { font-size:var(--fs-xs); color:var(--mid); white-space:nowrap; }
+.ai-velocity-stale { color:var(--tc-caution); }
+.ai-corr-row { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-4) 0; border-bottom:1px solid var(--border-subtle); }
+.ai-corr-row:last-child { border-bottom:none; }
+.ai-corr-label { flex:1; font-size:var(--fs-sm); min-width:0; }
+.ai-corr-val { font-size:var(--fs-sm); font-weight:700; white-space:nowrap; }
+.ai-corr-diff { font-size:var(--fs-2xs); font-weight:600; padding:var(--sp-2) var(--sp-4); border-radius:var(--r-sm); }
+.ai-corr-pos { background:rgba(58,112,96,0.1); color:var(--tc-sage); }
+.ai-corr-neg { background:rgba(200,80,80,0.1); color:var(--tc-rose); }
+.ai-corr-neutral { background:var(--warm); color:var(--light); }
+.ms-cat-wheel-ev { font-size:var(--fs-2xs); color:var(--light); margin-top:1px; }
+
+/* ══════════════════════════════════════════════════════════════════════
+   milestones-tab-v1 — inner 3-sub-tab layout + 3 input primitives +
+   3 return-visit surfaces. Spec: docs/specs/milestones-tab-v1.md.
+   Chrome doctrine V-V-46: active sub-tab uses uniform-rose .track-sub-btn.active
+   (inherited; no override here). Lavender domain accent surfaces INSIDE
+   sub-tab cards (Milestone Timeline icon-lav header + trajectory ribbon
+   --surface-lav background) per V-M-120 binding-cascade preservation.
+   ══════════════════════════════════════════════════════════════════════ */
+
+/* Sub-tab nav bar — wraps the 3 sub-buttons; horizontal flex; uses existing
+   .track-sub-btn chrome (no rose-chrome override; uniform-rose is shared). */
+.ms-sub-bar { display:flex; gap:var(--sp-4); padding:var(--sp-8) 0 var(--sp-12); justify-content:center; flex-wrap:nowrap; }
+.ms-sub-btn { min-width:80px; }
+
+/* Sub-panel toggling — only .active shows; mirrors track-sub-panel idiom. */
+.ms-sub-panel { display:none; }
+.ms-sub-panel.active { display:block; }
+
+/* ── food-sub-tab-v1 F-1 — inner Log/Library/Patterns sub-tabs on the diet
+   surface. Mirrors the milestones-tab-v1 sub-bar/panel pattern so a parent
+   learns one sub-tab gesture across both tabs (V-V-46 chrome doctrine:
+   uniform-rose active + sage domain accent INSIDE cards per design table).
+   Inherits .track-sub-btn.active styling — no chrome override. */
+.diet-sub-bar { display:flex; gap:var(--sp-4); padding:var(--sp-8) 0 var(--sp-12); justify-content:center; flex-wrap:nowrap; }
+.diet-sub-btn { min-width:80px; }
+.diet-sub-panel { display:none; }
+.diet-sub-panel.active { display:block; }
+
+/* ── "Today" header card (Log sub-tab) — return-visit surface 1 ──
+   4 narration templates (fullData/midState/betweenWindow/emptyState) from
+   _MILESTONE_NARRATION_TEMPLATES. Honesty floor (V-M-104/V-M-121): if
+   #msRegressionAlerts present, NEVER use "quiet stretch" framing. */
+.ms-today-card { padding:var(--sp-12) var(--sp-16); border-left:var(--accent-w) solid var(--lavender); }
+.ms-today-passage { font-family:'Fraunces',serif; font-size:var(--fs-md); color:var(--text); line-height:1.5; }
+.ms-today-meta { font-size:var(--fs-xs); color:var(--light); margin-top:var(--sp-4); }
+
+/* ── activityLevel:1-4 chip strip (Primitive 1) ──
+   V-V-65 fold: non-scrolling at 320px viewport; prompt-as-label-above-strip.
+   Honesty floor: no chip selected at activityLevel:null (parent prompt neutral). */
+.ms-activity-level-strip { padding:var(--sp-8) 0; }
+.ms-al-prompt { font-size:var(--fs-sm); color:var(--mid); margin-bottom:var(--sp-8); text-align:center; }
+.ms-al-chips { display:flex; gap:var(--sp-6); justify-content:space-between; flex-wrap:nowrap; }
+.ms-al-chip {
+  /* activityLevel tiers are intensity (1-4 Quiet/Calm/Active/Peak), NOT a
+     domain — uniform lavender accent for the "milestones-tab-overall"
+     surface per design table. HR-8 floor: min-height 44px via internal
+     label+desc stacking (label fs-sm ~ 14px + desc fs-2xs ~ 9px + sp-8
+     vertical padding ≈ 47px). 2px border baseline so the selected-state
+     border-color change reads without a width jump. */
+  flex:1 1 0;
+  min-width:0;
+  min-height:44px;
+  padding:var(--sp-8) var(--sp-4);
+  border-radius:var(--r-lg);
+  background:var(--warm);
+  border:2px solid var(--border-subtle);
+  cursor:pointer;
+  text-align:center;
+  transition:background var(--ease-fast), border-color var(--ease-fast), transform var(--ease-fast), box-shadow var(--ease-fast);
+}
+.ms-al-chip:active { transform:scale(0.96); }
+.ms-al-chip-label { font-weight:600; font-size:var(--fs-sm); color:var(--text); }
+.ms-al-chip-desc { font-size:var(--fs-2xs); color:var(--light); margin-top:var(--sp-2); }
+/* Selected state — stronger visual closure on "the effect must be apparent"
+   (Architect feedback 2026-05-27 #6). Three reinforcing signals: tinted
+   background, lavender border, lifted scale + soft drop-shadow halo, label
+   font-weight bump + color shift. */
+.ms-al-chip[data-selected="true"] {
+  background:var(--surface-lav);
+  border-color:var(--lavender);
+  transform:scale(1.04);
+  box-shadow:0 4px 12px rgba(201,184,232,0.30);
+}
+.ms-al-chip[data-selected="true"] .ms-al-chip-label { color:var(--tc-lav); font-weight:700; }
+.ms-al-chip[data-selected="true"] .ms-al-chip-desc { color:var(--tc-lav); opacity:0.85; }
+
+/* Inline status under the chip strip — shown only when activityLevel is set.
+   Closes the "what does this do?" gap: confirms what was logged + gives
+   warm contextual narration about the tier. Same lavender tint as the chip,
+   reads as a continuation rather than a separate surface. */
+.ms-al-status {
+  margin-top:var(--sp-12);
+  padding:var(--sp-10) var(--sp-12);
+  border-radius:var(--r-lg);
+  background:var(--surface-lav);
+  border-left:var(--accent-w) solid var(--lavender);
+}
+.ms-al-status-tag {
+  display:flex;
+  align-items:center;
+  gap:var(--sp-4);
+  font-size:var(--fs-sm);
+  color:var(--tc-lav);
+  font-weight:600;
+}
+.ms-al-status-tag .zi { width:14px; height:14px; }
+.ms-al-status-narration {
+  margin-top:var(--sp-4);
+  font-size:var(--fs-xs);
+  color:var(--mid);
+  line-height:var(--lh-relaxed);
+}
+[data-theme="dark"] .ms-al-status { background:rgba(201,184,232,0.12); }
+
+/* Today header activity tag — surfaces the activityLevel as part of the
+   day's anchor narration. Small lavender pill above the Today passage. */
+.ms-today-activity-tag {
+  display:inline-flex;
+  align-items:center;
+  gap:var(--sp-4);
+  margin-bottom:var(--sp-6);
+  padding:var(--sp-2) var(--sp-8);
+  border-radius:var(--r-full);
+  background:var(--lav-light);
+  color:var(--tc-lav);
+  font-size:var(--fs-xs);
+  font-weight:600;
+}
+.ms-today-activity-tag .zi { width:12px; height:12px; }
+
+/* ── In-window milestone proposals (Primitive 2) ──
+   Up to 3 cards (engine cap; safetyTier:true bypasses per V-M-125 in-window
+   qualifier). Status pills (V-V-57 evidenceStatus: confirmed/practicing/not-yet).
+   Three tap targets: zi('check')/zi('trending-flat')/zi('arrow-right').
+   Care-tier safetyTier:true border-accent uses --rose-deep (V-V-64 + V-M-124).
+   Per-domain accent: consumes the canonical [data-domain] cascade
+   (search styles.css for "── Domain Color Cascade ──" — defines
+   --al-tint/--al-tc/--al-border per domain).
+   Border-left + status pill colors flow via cascade; the lavender default
+   only fires for cards without a data-domain attribute. HR-6 closure
+   (Architect feedback 2026-05-27 #4: "don't we have domain colour codes?
+   why is this all uniform?"). */
+.ms-inwindow-stack { display:flex; flex-direction:column; gap:var(--sp-12); }
+.ms-inwindow-card {
+  padding:var(--sp-12) var(--sp-16);
+  border-radius:var(--r-xl);
+  background:var(--surface);
+  border-left:var(--accent-w) solid var(--al-border, var(--lavender));
+  box-shadow:0 1px 4px rgba(0,0,0,0.04);
+  /* Tap-out + push-down animation support (Architect 2026-05-27 #7+#10).
+     Motion One drives the primary animation when window.Motion is available;
+     these CSS rules are the FALLBACK path (offline parent, blocked CDN,
+     cached pre-Motion HTML). Transitions only animate transform + opacity —
+     padding/margin/max-height collapse was removed because non-animatable
+     auto→0 transitions caused an instant height-jump that read as
+     "disappearing" rather than "swiping out" (Architect bug-report fix
+     2026-05-27 #11). The card retains its slot during the slide; the
+     subsequent renderMilestones() removes it from the DOM cleanly. */
+  transform-origin:left center;
+  transition:transform var(--ease-med), opacity var(--ease-med);
+}
+.ms-inwindow-card[data-safety-tier="true"] { border:3px solid var(--rose-deep); }
+.ms-inwindow-card.is-sliding-out {
+  transform:translateX(-110%);
+  opacity:0;
+  pointer-events:none;
+}
+.ms-inwindow-card.is-sliding-down {
+  transform:translateY(40px) scale(0.96);
+  opacity:0.35;
+  pointer-events:none;
+}
+/* Deprioritized cards (pushed to bottom via Not-yet tap) — visually muted
+   so they read as "answered but kept around". Still tappable; the parent
+   can re-tap Confirm or Practicing later when the milestone unfolds. */
+.ms-inwindow-card.is-deprioritized {
+  opacity:0.65;
+  background:var(--warm);
+}
+.ms-inwindow-card.is-deprioritized .ms-inwindow-text { font-weight:500; }
+.ms-inwindow-head { display:flex; align-items:flex-start; gap:var(--sp-8); }
+.ms-inwindow-icon { font-size:var(--icon-base); flex-shrink:0; margin-top:var(--sp-2); }
+.ms-inwindow-body { flex:1; min-width:0; }
+.ms-inwindow-text { font-weight:600; font-size:var(--fs-md); color:var(--text); }
+.ms-inwindow-band { font-size:var(--fs-xs); color:var(--mid); margin-top:var(--sp-2); }
+.ms-inwindow-age { font-size:var(--fs-xs); color:var(--light); margin-top:var(--sp-2); }
+.ms-status-pill { display:inline-flex; align-items:center; gap:var(--sp-4); padding:var(--sp-2) var(--sp-8); border-radius:var(--r-md); font-size:var(--fs-xs); font-weight:600; }
+.ms-status-pill[data-status="confirmed"] { background:rgba(58,112,96,0.1); color:var(--tc-sage); }
+.ms-status-pill[data-status="practicing"] { background:var(--lav-light); color:var(--tc-lav); }
+.ms-status-pill[data-status="not-yet"] { background:var(--warm); color:var(--mid); }
+/* Tap targets — HR-8 floor: ≥36px tap area. min-height:36px ensures the
+   sp-8 padding + line-height still clears the floor on cramped viewports.
+   Color flows from data-action-tap state semantics (sage=confirm,
+   lavender=practicing, neutral=not-yet) — these are STATUS-triad colors,
+   not domain colors per design table row "Status Triad". */
+.ms-tap-targets { display:flex; gap:var(--sp-6); margin-top:var(--sp-12); }
+.ms-tap-btn {
+  flex:1;
+  min-height:36px;
+  padding:var(--sp-8) var(--sp-6);
+  border-radius:var(--r-md);
+  background:var(--warm);
+  border:1px solid var(--border-subtle);
+  cursor:pointer;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  gap:var(--sp-4);
+  font-size:var(--fs-xs);
+  color:var(--text);
+  transition:background var(--ease-fast);
+}
+.ms-tap-btn:hover { background:var(--surface-lav); }
+.ms-tap-btn[data-action-tap="confirm"]    { color:var(--tc-sage); }
+.ms-tap-btn[data-action-tap="practicing"] { color:var(--tc-lav); }
+.ms-tap-btn[data-action-tap="not-yet"]    { color:var(--mid); }
+.ms-tap-btn-icon { font-size:var(--icon-sm); }
+
+/* ── Bulk catch-up grid (Primitive 3) — collapsed-by-default exception path ──
+   The OUTER card (#msBulkGrid) toggles only via render-time visibility (no
+   items → display:none). The chevron in the header toggles the INNER
+   #msBulkGridBody via aria-expanded — so the header (chevron + title)
+   stays reachable for re-open. Per-section domain cascade flows via
+   data-domain on .ms-bulk-section parent into label + chips. */
+.ms-bulk-grid-card { padding:var(--sp-12); }
+.ms-bulk-grid-header { display:flex; align-items:center; justify-content:space-between; margin-bottom:var(--sp-8); }
+.ms-bulk-grid-body { overflow:hidden; transition:max-height var(--ease-fast); }
+.ms-bulk-grid-body[aria-expanded="false"] { max-height:0; visibility:hidden; }
+.ms-bulk-grid-body[aria-expanded="true"]  { max-height:none; visibility:visible; }
+.ms-bulk-section { margin-bottom:var(--sp-12); }
+.ms-bulk-section-label {
+  /* Mirrors .section-label rules from §5 Section Label System: uppercase,
+     fs-sm, ls-wide. Color flows from --al-tc via [data-domain] cascade. */
+  font-size:var(--fs-sm);
+  font-weight:600;
+  text-transform:uppercase;
+  letter-spacing:var(--ls-wide);
+  color:var(--al-tc, var(--mid));
+  margin-bottom:var(--sp-6);
+}
+.ms-bulk-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(140px, 1fr)); gap:var(--sp-6); }
+.ms-bulk-chip {
+  min-height:36px;
+  padding:var(--sp-8) var(--sp-10);
+  border-radius:var(--r-md);
+  background:var(--surface);
+  border:1px solid var(--al-border, var(--border-subtle));
+  cursor:pointer;
+  font-size:var(--fs-xs);
+  color:var(--text);
+  display:flex;
+  align-items:center;
+  gap:var(--sp-6);
+  transition:background var(--ease-fast), border-color var(--ease-fast);
+}
+.ms-bulk-chip:hover { background:var(--al-tint, var(--surface-lav)); }
+.ms-bulk-chip[data-selected="true"] {
+  background:var(--al-tint, var(--surface-lav));
+  border-color:var(--al-tc, var(--lavender));
+  color:var(--al-tc, var(--tc-lav));
+  font-weight:700;
+}
+.ms-bulk-chip-icon { font-size:var(--icon-sm); flex-shrink:0; color:var(--al-tc, var(--mid)); }
+.ms-bulk-submit { margin-top:var(--sp-12); }
+
+/* ── Domain filter chips (Library sub-tab) — reads ACTIVITY_CATEGORIES.
+   Each chip carries data-domain="<key>" so it consumes the canonical
+   cascade — active state shows the chip's OWN domain accent (motor→sage,
+   language→lavender, etc.) rather than uniform lavender. HR-6 + HR-8
+   closure. Dark-mode parity preserved via override at the cascade-value
+   level (theme-specific rgba adjustments). ── */
+.ms-domain-filter { display:flex; gap:var(--sp-6); flex-wrap:wrap; padding:var(--sp-4) 0; }
+.ms-domain-chip {
+  min-height:36px;
+  padding:var(--sp-8) var(--sp-12);
+  border-radius:var(--r-md);
+  background:var(--warm);
+  border:1px solid var(--border-subtle);
+  color:var(--text);
+  font-size:var(--fs-xs);
+  cursor:pointer;
+  display:inline-flex;
+  align-items:center;
+  gap:var(--sp-4);
+  transition:background var(--ease-fast), border-color var(--ease-fast), color var(--ease-fast);
+}
+.ms-domain-chip:hover { background:var(--al-tint, var(--surface-lav)); }
+.ms-domain-chip[data-active="true"] {
+  font-weight:700;
+  background:var(--al-tint, var(--surface-lav));
+  border-color:var(--al-tc, var(--lavender));
+  color:var(--al-tc, var(--tc-lav));
+}
+/* "All" chip has data-domain="all" — no cascade match → falls to the
+   lavender default (the milestones-tab-overall accent per design-table
+   row "Milestones, achievements → lavender"). Explicit rule so the All
+   state reads cohesively rather than as a "missing token" gray. */
+.ms-domain-chip[data-domain="all"][data-active="true"] {
+  background:var(--lav-light);
+  border-color:var(--lavender);
+  color:var(--tc-lav);
+}
+[data-theme="dark"] .ms-domain-chip {
+  background:rgba(255,255,255,0.06);
+  border-color:rgba(255,255,255,0.14);
+  color:var(--text);
+}
+[data-theme="dark"] .ms-domain-chip:hover { background:rgba(255,255,255,0.10); }
+[data-theme="dark"] .ms-domain-chip[data-active="true"] {
+  background:var(--al-active-dk, rgba(201,184,232,0.22));
+  border-color:var(--al-tc, var(--lavender));
+}
+
+/* Domain filter visibility class — class-driven hide for milestoneList items
+   per HR-2 (no inline style mutation). filterMsDomain toggles this class on
+   [data-domain] children of #milestoneList. */
+.ms-domain-hidden { display:none; }
+
+/* ── Trajectory ribbon (Patterns sub-tab) — return-visit surface 2 ──
+   V-V-49 collapse: 2 visual states (filled=confirmed, outlined=hedged).
+   V-K-122: global cap 20 markers post-bucket-merge.
+   V-V-66: ≥9px marker diameter + ≥1.8px stroke at 320px viewport.
+   Lavender domain accent: --surface-lav background. */
+/* ── Trajectory ribbon — MAJOR OVERHAUL post-Architect feedback 2026-05-27.
+   3 visual states (celebrated/practicing/coming-up) + age-axis + current-age
+   indicator + warmer narrative caption. The V-V-49 2-state collapse is
+   rebated per Architect call: live use showed "practicing-or-in-window"
+   merged bucket didn't convey state clarity warmly enough. ── */
+.ms-trajectory-card { padding:var(--sp-12) var(--sp-16); background:var(--surface-lav); }
+.ms-trajectory-svg { width:100%; height:auto; display:block; }
+
+/* Age axis (bottom). Subtle line with periodic ticks + month labels. */
+.ms-traj-axis { stroke:var(--mid); stroke-width:0.6; opacity:0.5; }
+.ms-traj-axis-tick { stroke:var(--mid); stroke-width:0.8; opacity:0.55; }
+.ms-traj-axis-label { font-size:8px; fill:var(--mid); font-family:'Nunito',sans-serif; opacity:0.85; }
+
+/* Lane guide-lines — very low opacity structural cue (no chart-like grid).
+   State identity is conveyed by marker color + matching legend chips. */
+.ms-traj-lane-guide { stroke:var(--mid); stroke-width:0.5; opacity:0.18; stroke-dasharray:1 2; }
+.ms-traj-lane-empty { font-size:9px; fill:var(--mid); opacity:0.4; font-family:'Nunito',sans-serif; }
+
+/* Current-age vertical indicator. Dashed; rose tint so it reads as
+   "you are here" without competing with the markers. */
+.ms-traj-current { stroke:var(--tc-rose); stroke-width:1.1; stroke-dasharray:3 2; opacity:0.65; }
+.ms-traj-current-label { font-size:8px; fill:var(--tc-rose); font-family:'Nunito',sans-serif; font-weight:700; }
+
+/* Markers — 3 distinct states. V-V-66 ≥9px-diameter / ≥1.8px-stroke pixel-
+   scale floor honored at default sizes (markerR:5 → 10px diameter;
+   markerRSmall:4 → 8px borderline, compensated by 1.8px stroke). */
+.ms-trajectory-marker { transition: filter var(--ease-fast); }
+.ms-trajectory-marker[data-state="celebrated"] { fill:var(--sage-deepest); stroke:none; filter:drop-shadow(0 0 1.5px rgba(95,140,120,0.45)); }
+.ms-trajectory-marker[data-state="practicing"] { /* group element — children carry the visual */ }
+.ms-trajectory-marker[data-state="practicing"] .ms-traj-ring { fill:transparent; stroke:var(--amber-deep); stroke-width:1.8; }
+.ms-trajectory-marker[data-state="practicing"] .ms-traj-core { fill:var(--amber-deep); stroke:none; }
+.ms-trajectory-marker[data-state="comingup"]  { fill:transparent; stroke:var(--lavender); stroke-width:1.8; stroke-dasharray:2 1.5; opacity:0.85; }
+.ms-trajectory-marker[data-action="gotoMsRow"] { cursor:pointer; }
+.ms-trajectory-marker[data-action="gotoMsRow"]:hover { filter:brightness(1.15) drop-shadow(0 0 2px rgba(95,140,120,0.55)); }
+
+/* Legend swatches use the SAME styling as the markers so the visual key
+   on the page matches the markers exactly. */
+.ms-trajectory-legend { display:flex; gap:var(--sp-12); justify-content:center; padding:var(--sp-8) 0 var(--sp-4); font-size:var(--fs-2xs); color:var(--mid); flex-wrap:wrap; }
+.ms-traj-legend-item { display:inline-flex; align-items:center; gap:var(--sp-4); }
+.ms-traj-legend-item[data-state="celebrated"] { color:var(--tc-sage); font-weight:600; }
+.ms-traj-legend-item[data-state="practicing"] { color:var(--tc-amber); font-weight:600; }
+.ms-traj-legend-item[data-state="comingup"]   { color:var(--tc-lav); font-weight:600; }
+.ms-traj-legend-swatch { width:14px; height:14px; flex-shrink:0; }
+.ms-traj-legend-swatch circle[data-state="celebrated"] { fill:var(--sage-deepest); stroke:none; }
+.ms-traj-legend-swatch circle[data-state="comingup"]   { fill:transparent; stroke:var(--lavender); stroke-width:1.8; stroke-dasharray:2 1.5; }
+
+.ms-trajectory-label { font-size:var(--fs-xs); color:var(--mid); margin-top:var(--sp-6); text-align:center; line-height:1.4; padding:0 var(--sp-8); }
+
+/* Brief landing-confirmation highlight for milestone rows scrolled into view
+   by trajectory ribbon tap. Fades over 1.8s; class is removed by JS. */
+.ms-row-highlight { animation: msRowHighlight 1.8s ease-out; }
+@keyframes msRowHighlight {
+  0%   { background-color: var(--surface-lav); }
+  100% { background-color: transparent; }
+}
+
+/* ── Pediatric-visit prep card (Patterns sub-tab) — return-visit surface 3 ──
+   V-V-53: narrated-only v1 minimum (no copy-as-text + no PDF; deferred to R-3).
+   V-M-109 + V-M-122: visible register-tag "for visit-prep only — not a
+   clinical record" footer with border-top + var(--fs-xs) + var(--tc-rose).
+   V-V-67: register-tag MUST stay within standard phone screenshot viewport
+   (320/375/414px widths) — top-positioned card body, footer at bottom of card
+   with no scroll-clip on standard breakpoints (regression guard verified at IMPL). */
+.ms-pediatric-prep-card { padding:var(--sp-16); }
+.ms-pediatric-prep-narration { font-family:'Fraunces',serif; font-size:var(--fs-md); line-height:1.6; color:var(--text); }
+.ms-pediatric-prep-section { margin-top:var(--sp-12); }
+.ms-pediatric-prep-section-label { font-size:var(--fs-xs); font-weight:700; text-transform:uppercase; letter-spacing:var(--ls-wide); color:var(--mid); margin-bottom:var(--sp-4); }
+.ms-pediatric-prep-tag {
+  margin-top:var(--sp-16);
+  padding-top:var(--sp-8);
+  border-top:1px solid var(--mid);
+  font-size:var(--fs-xs);
+  color:var(--tc-rose);
+  font-weight:600;
+  text-align:center;
+}
+
+/* ── Correlation cross-link teaser (Patterns sub-tab) ──
+   V-V-48 + V-V-63: uses gotoCard('info','infoMilestoneSleepCard') canonical
+   pattern; cardId verified against template.html. */
+.ms-correlation-teaser { min-height:44px; padding:var(--sp-10) var(--sp-12); background:var(--warm); border-radius:var(--r-md); display:flex; align-items:center; justify-content:space-between; gap:var(--sp-8); cursor:pointer; transition:background var(--ease-fast); border:1px solid var(--border-subtle); }
+.ms-correlation-teaser:hover { background:var(--surface-lav); }
+.ms-correlation-teaser-text { font-size:var(--fs-sm); color:var(--text); flex:1; }
+.ms-correlation-teaser-chev { font-size:var(--icon-sm); color:var(--light); flex-shrink:0; }
+
+[data-theme="dark"] .ms-inwindow-card { background:rgba(255,255,255,0.03); }
+[data-theme="dark"] .ms-al-chip { background:rgba(255,255,255,0.03); border-color:rgba(255,255,255,0.06); }
+[data-theme="dark"] .ms-tap-btn { background:rgba(255,255,255,0.03); border-color:rgba(255,255,255,0.06); }
+[data-theme="dark"] .ms-bulk-chip { background:rgba(255,255,255,0.03); border-color:rgba(255,255,255,0.06); }
+[data-theme="dark"] .ms-correlation-teaser { background:rgba(255,255,255,0.03); }
+
+[data-theme="dark"] .ai-dot { background:rgba(255,255,255,0.06); }
+[data-theme="dark"] .ai-domain-track { background:rgba(255,255,255,0.06); }
+.al-undo-btn { background:none; border:none; color:inherit; text-decoration:underline; cursor:pointer; font-size:inherit; padding:0 var(--sp-4); }
+
+/* ── Cross-Domain Intelligence Cards ── */
+.cd-bar-row { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-4) 0; }
+.cd-bar-label { font-size:var(--fs-xs); color:var(--mid); min-width:70px; text-align:right; }
+.cd-bar-track { flex:1; height:var(--sp-12); background:var(--warm); border-radius:var(--r-md); overflow:hidden; position:relative; }
+.cd-bar-fill { height:100%; border-radius:var(--r-md); transition:width 0.4s ease; }
+.cd-bar-val { font-size:var(--fs-2xs); font-weight:600; min-width:36px; text-align:right; }
+.cd-pill { display:inline-flex; align-items:center; gap:var(--sp-4); padding:var(--sp-2) var(--sp-8); border-radius:var(--r-md); font-size:var(--fs-xs); font-weight:600; }
+.cd-pill-pos { background:rgba(58,112,96,0.1); color:var(--tc-sage); }
+.cd-pill-neg { background:rgba(200,80,80,0.1); color:var(--tc-rose); }
+.cd-pill-neutral { background:var(--warm); color:var(--light); }
+.cd-food-item { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-6) 0; border-bottom:1px solid var(--border-subtle); }
+.cd-food-item:last-child { border-bottom:none; }
+.cd-food-name { flex:1; font-size:var(--fs-sm); font-weight:600; min-width:0; }
+.cd-food-meta { font-size:var(--fs-2xs); color:var(--light); }
+.cd-section-label { font-size:var(--fs-xs); font-weight:700; text-transform:uppercase; letter-spacing:var(--ls-wide); color:var(--mid); margin:var(--sp-12) 0 var(--sp-6) 0; }
+.cd-section-label:first-child { margin-top:0; }
+.cd-episode { padding:var(--sp-8); border-radius:var(--r-md); background:var(--warm); margin-bottom:var(--sp-8); }
+.cd-episode-title { font-size:var(--fs-sm); font-weight:700; margin-bottom:var(--sp-4); }
+.cd-episode-row { display:flex; align-items:center; gap:var(--sp-6); padding:var(--sp-2) 0; font-size:var(--fs-xs); }
+.cd-episode-domain { min-width:50px; font-weight:600; color:var(--mid); }
+.cd-episode-vals { flex:1; display:flex; align-items:center; gap:var(--sp-4); }
+.cd-episode-delta { font-weight:700; font-size:var(--fs-2xs); }
+.cd-timeline-row { display:grid; grid-template-columns:40px 50px 50px 40px 40px; gap:var(--sp-4); padding:var(--sp-2) 0; font-size:var(--fs-2xs); align-items:center; text-align:center; }
+.cd-timeline-hdr { font-weight:700; color:var(--mid); text-transform:uppercase; letter-spacing:var(--ls-wide); border-bottom:1px solid var(--border-subtle); padding-bottom:var(--sp-4); margin-bottom:var(--sp-2); }
+.cd-burst { color:var(--tc-amber); font-weight:700; }
+.cd-regr { color:var(--tc-rose); font-weight:700; }
+.cd-meta { font-size:var(--fs-xs); color:var(--light); margin-top:var(--sp-4); }
+.cd-capitalize { text-transform:capitalize; }
+.cd-align-end { text-align:right; margin-top:var(--sp-4); }
+.cd-episode-date { font-weight:400; color:var(--light); }
+.cd-burst-note-pos { font-size:var(--fs-xs); color:var(--tc-sage); }
+.cd-burst-note-neg { font-size:var(--fs-xs); color:var(--tc-rose); }
+.cd-tl-week { font-weight:600; }
+[data-theme="dark"] .cd-bar-track { background:rgba(255,255,255,0.06); }
+[data-theme="dark"] .cd-episode { background:var(--base); }
+
+/* ── Tomorrow's Prep (tp-*) ── */
+.tp-meal-section { font-size:var(--fs-xs); font-weight:700; text-transform:uppercase; letter-spacing:var(--ls-wide); color:var(--mid); margin-top:var(--sp-20); margin-bottom:var(--sp-8); display:flex; align-items:center; gap:var(--sp-6); }
+.tp-meal-section:first-child { margin-top:var(--sp-8); }
+.tp-meal-section .zi { width:var(--icon-sm); height:var(--icon-sm); }
+.tp-meal-options { display:flex; flex-direction:column; gap:var(--sp-8); }
+.tp-option { border-radius:var(--r-xl); padding:var(--sp-12) var(--sp-16); cursor:pointer; transition:all var(--ease-fast); border:1.5px solid transparent; }
+.tp-option:active { opacity:0.9; }
+.tp-option.tp-starred { border-left:3px solid var(--tc-sage); }
+/* Meal-type tinted backgrounds */
+.tp-option[data-tp-meal="breakfast"] { background:var(--peach-light); border-color:rgba(250,212,180,0.3); }
+.tp-option[data-tp-meal="lunch"]     { background:var(--sage-light); border-color:rgba(181,213,197,0.3); }
+.tp-option[data-tp-meal="dinner"]    { background:var(--lav-light); border-color:rgba(201,184,232,0.3); }
+.tp-option[data-tp-meal="snack"]     { background:var(--amber-light); border-color:rgba(240,200,120,0.3); }
+.tp-option-foods { font-size:var(--fs-sm); font-weight:700; color:var(--text); display:flex; align-items:center; gap:var(--sp-4); }
+.tp-option-star { color:var(--tc-sage); font-size:var(--fs-sm); }
+.tp-option-reason { font-size:var(--fs-xs); color:var(--mid); margin-top:var(--sp-4); line-height:1.5; }
+.tp-activity-row { display:flex; gap:var(--sp-10); align-items:flex-start; padding:var(--sp-10) 0; }
+.tp-activity-icon { flex-shrink:0; margin-top:var(--sp-2); }
+.tp-activity-icon .zi { width:var(--icon-sm); height:var(--icon-sm); }
+.tp-activity-body { flex:1; }
+.tp-activity-title { font-size:var(--fs-sm); font-weight:600; color:var(--text); }
+.tp-activity-reason { font-size:var(--fs-xs); color:var(--mid); margin-top:var(--sp-2); line-height:1.4; }
+.tp-sleep-note { display:flex; gap:var(--sp-10); align-items:flex-start; padding:var(--sp-12) var(--sp-16); background:var(--indigo-light); border-radius:var(--r-xl); border:1px solid rgba(155,168,216,0.2); }
+.tp-sleep-icon { flex-shrink:0; margin-top:var(--sp-2); }
+.tp-sleep-icon .zi { width:var(--icon-sm); height:var(--icon-sm); color:var(--tc-indigo); }
+.tp-sleep-body { flex:1; }
+.tp-sleep-title { font-size:var(--fs-sm); font-weight:600; color:var(--text); }
+.tp-sleep-reason { font-size:var(--fs-xs); color:var(--mid); margin-top:var(--sp-2); line-height:1.4; }
+.tp-headsup-row { display:flex; gap:var(--sp-10); align-items:center; padding:var(--sp-8) 0; }
+.tp-headsup-icon { font-size:var(--fs-md); flex-shrink:0; }
+.tp-headsup-text { font-size:var(--fs-sm); color:var(--text); flex:1; }
+.tp-section-divider { border:none; border-top:1px solid var(--border-subtle); margin:var(--sp-16) 0; }
+.tp-section-label { font-size:var(--fs-xs); font-weight:700; text-transform:uppercase; letter-spacing:var(--ls-wide); color:var(--mid); text-align:center; margin-bottom:var(--sp-10); }
+.tp-option-planned { border-color:var(--tc-sage); background:rgba(140,190,160,0.12); }
+.tp-planned-check { font-size:var(--fs-xs); color:var(--tc-sage); margin-top:var(--sp-4); font-weight:600; }
+[data-theme="dark"] .tp-option { border-color:rgba(255,255,255,0.06); }
+[data-theme="dark"] .tp-option[data-tp-meal="breakfast"] { background:rgba(250,212,180,0.06); border-color:rgba(250,212,180,0.1); }
+[data-theme="dark"] .tp-option[data-tp-meal="lunch"]     { background:rgba(181,213,197,0.06); border-color:rgba(181,213,197,0.1); }
+[data-theme="dark"] .tp-option[data-tp-meal="dinner"]    { background:rgba(201,184,232,0.06); border-color:rgba(201,184,232,0.1); }
+[data-theme="dark"] .tp-option[data-tp-meal="snack"]     { background:rgba(240,200,120,0.06); border-color:rgba(240,200,120,0.1); }
+[data-theme="dark"] .tp-option.tp-starred { border-left-color:var(--tc-sage); }
+[data-theme="dark"] .tp-option-planned { background:rgba(140,190,160,0.08); }
+[data-theme="dark"] .tp-sleep-note { background:rgba(155,168,216,0.06); border-color:rgba(155,168,216,0.1); }
+
+/* ── Quick Log Modal ── */
+.ql-modal-overlay {
+  position:fixed; inset:0; z-index:1003;
+  background:var(--overlay-bg);
+  display:flex; align-items:flex-end; justify-content:center;
+  opacity:0; pointer-events:none;
+  transition:opacity var(--ease-med);
+}
+.ql-modal-overlay.open { opacity:1; pointer-events:auto; }
+.ql-modal-overlay.ql-keyboard-open { align-items:flex-start; padding-top:10vh; }
+
+.ql-modal {
+  width:100%; max-width:440px;
+  background:var(--surface);
+  border-radius:var(--r-2xl) 24px 0 0;
+  padding:var(--sp-20) var(--sp-24) var(--sp-24);
+  box-shadow:0 -8px 40px rgba(0,0,0,0.15);
+  transform:translateY(40px);
+  transition:transform var(--ease-slow);
+  max-height:85vh; overflow-y:auto;
+  padding-bottom:max(var(--sp-24), env(safe-area-inset-bottom, var(--sp-24)));
+}
+.ql-modal-overlay.ql-keyboard-open .ql-modal { border-radius:var(--r-2xl); }
+.ql-modal-overlay.open .ql-modal { transform:translateY(0); }
+[data-theme="dark"] .ql-modal { box-shadow:0 -8px 40px rgba(0,0,0,0.5); }
+
+.ql-modal-header {
+  display:flex; align-items:center; justify-content:space-between;
+  margin-bottom:var(--sp-16);
+}
+.ql-modal-title {
+  font-family:'Fraunces',serif; font-size:var(--fs-xl);
+  font-weight:600; color:var(--text);
+  display:flex; align-items:center; gap:var(--sp-8);
+}
+.ql-modal-close {
+  width:32px; height:32px; border-radius:50%; border:none;
+  background:var(--warm); color:var(--mid); cursor:pointer;
+  font-size:var(--icon-base); display:flex; align-items:center; justify-content:center;
+  transition:all var(--ease-fast);
+}
+.ql-modal-close:hover { background:var(--rose-light); color:var(--tc-rose); }
+
+.ql-form { display:flex; flex-direction:column; gap:var(--sp-12); }
+/* Backfill date pills */
+.ql-bf-row { display:flex; gap:var(--sp-4); flex-wrap:wrap; }
+.ql-bf-pill {
+  font-size:var(--fs-xs); padding:var(--sp-4) var(--sp-10); border-radius:var(--r-full);
+  background:var(--lav-light); border:1px solid rgba(201,184,232,0.3);
+  color:var(--tc-lav); cursor:pointer; transition:transform var(--ease-fast);
+}
+.ql-bf-pill.active { background:#7e66b4; color:white; border-color:#7e66b4; }
+.ql-bf-pill:active { transform:scale(0.95); }
+/* Meal progress strip */
+.meal-progress { display:flex; gap:var(--sp-8); min-width:0; flex-wrap:wrap;}
+.meal-prog-slot {
+  flex:1; display:flex; flex-direction:column; align-items:center; gap:var(--sp-4);
+  padding:var(--sp-8) var(--sp-4); border-radius:var(--r-lg); border:1px solid var(--card-border);
+  background:var(--white); font-size:var(--fs-xs); transition:background var(--ease-fast);
+}
+.meal-prog-slot.mps-done { background:var(--sage-light); border-color:rgba(181,213,197,0.4); }
+.meal-prog-slot.mps-empty { cursor:pointer; }
+.meal-prog-slot.mps-empty:active { background:var(--peach-light); }
+.meal-prog-label { font-weight:600; color:var(--mid); }
+.meal-prog-icon { font-size:var(--icon-base); }
+.meal-prog-food { color:var(--tc-sage); font-size:var(--fs-2xs); max-width:90px; text-align:center; }
+.ql-row { display:flex; gap:var(--sp-12); }
+.ql-row > * { flex:1; }
+
+/* Quick log meal pills */
+.ql-meal-pills { display:flex; gap:var(--sp-8); }
+.ql-meal-pill {
+  flex:1; padding:var(--sp-10) var(--sp-6); border-radius:var(--r-lg); border:1.5px solid var(--border-subtle);
+  background:var(--warm); cursor:pointer; text-align:center;
+  font-size:var(--fs-base); font-weight:700; color:var(--mid);
+  transition:all var(--ease-fast); min-height:44px;
+  display:flex; align-items:center; justify-content:center; gap:var(--sp-4);
+}
+.ql-meal-pill.active { background:var(--tc-peach); color:white; border-color:var(--tc-peach); }
+.ql-intake-pill {
+  flex:1 1 0; min-width:0; padding:var(--sp-8) var(--sp-4); border-radius:var(--r-lg); border:1.5px solid var(--border-subtle);
+  background:var(--warm); cursor:pointer; text-align:center;
+  font-size:var(--fs-xs); font-weight:600; color:var(--mid);
+  transition:all var(--ease-fast); min-height:40px;
+  display:flex; align-items:center; justify-content:center; gap:var(--sp-4);
+  white-space:nowrap;
+}
+.ql-intake-pill .zi { width:var(--icon-sm); height:var(--icon-sm); }
+.ql-intake-pill.active { background:var(--tc-sage); color:white; border-color:var(--tc-sage); }
+[data-theme="dark"] .ql-intake-pill { background:rgba(255,255,255,0.04); border-color:rgba(255,255,255,0.08); }
+[data-theme="dark"] .ql-intake-pill.active { background:var(--tc-sage); color:white; border-color:var(--tc-sage); }
+
+/* Quick log poop colour dots — compact row */
+.ql-color-row { display:flex; gap:var(--sp-8); flex-wrap:wrap; }
+.ql-color-dot {
+  width:36px; height:36px; border-radius:50%; border:2px solid transparent;
+  cursor:pointer; transition:all var(--ease-fast);
+  display:flex; align-items:center; justify-content:center;
+  font-size:var(--icon-xs); color:transparent;
+}
+.ql-color-dot:hover { transform:scale(1.1); }
+.ql-color-dot.active { border-color:var(--text); box-shadow:0 0 0 2px var(--surface), 0 0 0 4px var(--text); transform:scale(1.1); }
+.ql-color-dot.active { color:white; font-weight:700; }
+[data-theme="dark"] .ql-color-dot.active { border-color:var(--text); box-shadow:0 0 0 2px var(--surface), 0 0 0 4px var(--mid); }
+
+/* Quick log consistency pills — compact */
+.ql-con-pills { display:flex; gap:var(--sp-8); flex-wrap:wrap; }
+.ql-con-pill {
+  padding:var(--sp-8) var(--sp-12); border-radius:var(--r-2xl); border:1.5px solid var(--border-subtle);
+  background:var(--warm); cursor:pointer;
+  font-size:var(--fs-base); font-weight:600; color:var(--mid);
+  transition:all var(--ease-fast); min-height:36px;
+  display:flex; align-items:center; justify-content:center;
+}
+.ql-con-pill.active { background:#8a6520; color:white; border-color:#8a6520; }
+
+/* Quick log save button */
+.ql-save {
+  width:100%; padding:var(--sp-12); border-radius:var(--r-xl); border:none;
+  font-family:'Nunito',sans-serif; font-size:var(--fs-md); font-weight:700;
+  color:white; cursor:pointer; transition:all var(--ease-fast);
+  min-height:48px; margin-top:var(--sp-4); letter-spacing:var(--ls-tight);
+}
+.ql-save:hover { filter:brightness(1.05); transform:translateY(-1px); }
+.ql-save:active { transform:scale(0.98); }
+.ql-save-feed  { background:linear-gradient(135deg, var(--tc-peach), var(--tc-amber)); }
+.ql-save-sleep { background:linear-gradient(135deg, #5a6498, #606a98); }
+.ql-save-nap   { background:linear-gradient(135deg, #7e66b4, #7060a8); }
+.ql-save-poop  { background:linear-gradient(135deg, #8a6520, #946225); }
+
+/* ═══════════════════════════════════════════════════════════════
+   F-2 — FOB Feed sheet (autofill-first redesign)
+   Spec: docs/specs/food-sub-tab-v1.md §F-2
+   Four rail surfaces (L1 repeat / L2 combo / items / L3 next-item)
+   + per-food qty steppers + skip-meal button. Tokens-only per HR-4.
+   ═══════════════════════════════════════════════════════════════ */
+
+/* Rail wrapper — same vertical rhythm as other ql-form sections */
+.ql-feed-rail-wrap { display:flex; flex-direction:column; gap:var(--sp-4); }
+.ql-feed-rail { display:flex; flex-direction:column; gap:var(--sp-6); }
+
+/* L1 Repeat chips — sage outlined; primary chip emphasized */
+.ql-feed-repeat-chip {
+  background:var(--white);
+  border:1.5px solid var(--sage);
+  border-radius:var(--r-xl);
+  padding:var(--sp-10) var(--sp-12);
+  cursor:pointer;
+  min-height:36px;
+  transition:transform var(--ease-fast), background-color var(--ease-fast);
+  box-shadow:0 1px 3px rgba(60,40,40,0.04);
+}
+.ql-feed-repeat-chip:active { transform:scale(0.985); }
+.ql-feed-repeat-chip.primary {
+  background:var(--sage-light);
+  border-width:2px;
+}
+.ql-feed-repeat-head {
+  display:flex; align-items:center; gap:var(--sp-6);
+  font-weight:700; color:var(--tc-sage);
+  font-size:var(--fs-sm);
+}
+.ql-feed-repeat-head .zi { width:var(--icon-base); height:var(--icon-base); }
+.ql-feed-repeat-sub {
+  font-size:var(--fs-xs);
+  color:var(--mid);
+  margin-top:var(--sp-4);
+  font-weight:500;
+  line-height:var(--lh-snug);
+}
+
+/* L2 Combo chips — lavender outlined; freq badge inline */
+.ql-feed-combo-chip {
+  background:var(--lav-light);
+  border:1.5px solid var(--lavender);
+  border-radius:var(--r-xl);
+  padding:var(--sp-10) var(--sp-12);
+  cursor:pointer;
+  min-height:36px;
+  transition:transform var(--ease-fast);
+}
+.ql-feed-combo-chip:active { transform:scale(0.985); }
+.ql-feed-combo-head {
+  display:flex; align-items:center; gap:var(--sp-6);
+  font-weight:700; color:var(--tc-lav);
+  font-size:var(--fs-sm);
+}
+.ql-feed-combo-head .zi { width:var(--icon-base); height:var(--icon-base); }
+.ql-feed-combo-conf {
+  margin-left:auto;
+  font-size:var(--fs-2xs);
+  background:var(--lavender); color:var(--text);
+  padding:var(--sp-2) var(--sp-6);
+  border-radius:var(--r-full);
+  font-weight:700;
+}
+.ql-feed-combo-sub {
+  font-size:var(--fs-xs);
+  color:var(--mid);
+  margin-top:var(--sp-4);
+  font-weight:500;
+  line-height:var(--lh-snug);
+}
+
+/* Items list — current meal being built */
+.ql-feed-items-list {
+  background:var(--white);
+  border:1px solid #ece4dd;
+  border-radius:var(--r-xl);
+  overflow:hidden;
+}
+.ql-feed-items-empty {
+  text-align:center;
+  color:var(--light);
+  padding:var(--sp-16);
+  font-style:italic;
+  font-size:var(--fs-sm);
+}
+.ql-feed-item-row {
+  display:flex; align-items:center; gap:var(--sp-8);
+  padding:var(--sp-8) var(--sp-10);
+  border-bottom:1px solid #f4ece6;
+  min-height:48px;
+}
+.ql-feed-item-row:last-of-type { border-bottom:none; }
+.ql-feed-item-icon {
+  width:28px; height:28px;
+  background:var(--sage-light); color:var(--tc-sage);
+  border-radius:var(--r-full);
+  display:inline-flex; align-items:center; justify-content:center;
+  font-size:var(--fs-sm); font-weight:700;
+  flex-shrink:0;
+}
+.ql-feed-item-name {
+  flex:1; font-weight:600; font-size:var(--fs-base);
+  display:flex; flex-direction:column;
+  line-height:var(--lh-snug);
+}
+.ql-feed-item-meta {
+  font-size:var(--fs-2xs);
+  color:var(--light);
+  text-transform:uppercase;
+  letter-spacing:var(--ls-wide);
+  font-weight:500;
+  margin-top:var(--sp-2);
+}
+.ql-feed-item-x {
+  width:32px; height:32px;
+  display:inline-flex; align-items:center; justify-content:center;
+  border-radius:var(--r-full);
+  background:var(--rose-light); color:var(--tc-rose);
+  font-weight:700; font-size:var(--fs-md);
+  border:none; cursor:pointer;
+  flex-shrink:0;
+  margin-left:var(--sp-2);
+  transition:transform var(--ease-fast);
+}
+.ql-feed-item-x:active { transform:scale(0.9); }
+
+/* Per-food quantity stepper — [− qty unit +] */
+.ql-feed-qty-stepper {
+  display:inline-flex; align-items:center;
+  background:var(--warm);
+  border-radius:var(--r-full);
+  padding:var(--sp-2);
+  flex-shrink:0;
+}
+.ql-feed-qty-step {
+  width:32px; height:32px;
+  display:inline-flex; align-items:center; justify-content:center;
+  border-radius:var(--r-full);
+  background:var(--white); color:var(--tc-sage);
+  font-weight:700; font-size:var(--fs-base);
+  border:1px solid #ece4dd;
+  cursor:pointer;
+  font-family:'Nunito', sans-serif;
+  transition:transform var(--ease-fast);
+}
+.ql-feed-qty-step:active { transform:scale(0.92); background:var(--sage-light); }
+.ql-feed-qty-val {
+  padding:0 var(--sp-8);
+  font-weight:700;
+  min-width:52px; text-align:center;
+  font-size:var(--fs-sm);
+  color:var(--text);
+}
+.ql-feed-qty-unit {
+  font-size:var(--fs-2xs);
+  color:var(--mid);
+  letter-spacing:0;
+  font-weight:500;
+}
+
+/* L3 Next-item ribbon — horizontal scroll; confidence % per chip */
+.ql-feed-next-ribbon {
+  display:flex; gap:var(--sp-6);
+  overflow-x:auto;
+  padding:var(--sp-4) 0;
+  -webkit-overflow-scrolling:touch;
+}
+.ql-feed-next-chip {
+  display:inline-flex; align-items:center; gap:var(--sp-4);
+  background:var(--sage-light);
+  color:var(--tc-sage);
+  font-weight:700; font-size:var(--fs-sm);
+  padding:var(--sp-6) var(--sp-12);
+  border-radius:var(--r-full);
+  border:1px solid var(--sage);
+  flex-shrink:0;
+  min-height:36px;
+  cursor:pointer;
+  font-family:'Nunito', sans-serif;
+  transition:transform var(--ease-fast);
+}
+.ql-feed-next-chip:active { transform:scale(0.94); }
+.ql-feed-next-conf {
+  font-size:var(--fs-2xs);
+  background:var(--white); color:var(--tc-sage);
+  border-radius:var(--r-full);
+  padding:1px var(--sp-6);
+  margin-left:var(--sp-2);
+  font-weight:700;
+  letter-spacing:0;
+}
+
+/* L4 Typeahead dropdown rows — qty hint inlined */
+.ql-feed-ta-row {
+  display:flex; align-items:center; gap:var(--sp-8);
+  padding:var(--sp-8) var(--sp-10);
+  border-bottom:1px solid #f4ece6;
+  cursor:pointer;
+  min-height:36px;
+}
+.ql-feed-ta-row:last-of-type { border-bottom:none; }
+.ql-feed-ta-row:active { background:var(--sage-light); }
+.ql-feed-ta-name {
+  flex:1;
+  font-weight:600; font-size:var(--fs-base);
+  color:var(--text);
+}
+.ql-feed-ta-meta {
+  font-size:var(--fs-2xs);
+  color:var(--mid);
+  text-transform:uppercase;
+  letter-spacing:var(--ls-wide);
+  font-weight:500;
+}
+
+/* Skip meal button — neutral chrome; pairs visually with Save Feed */
+.ql-save-skip {
+  background:var(--warm);
+  color:var(--mid);
+  border:1.5px solid #d8ccc4;
+  border-radius:var(--r-full);
+  padding:var(--sp-10) var(--sp-16);
+  font-weight:600; font-size:var(--fs-sm);
+  font-family:'Nunito', sans-serif;
+  cursor:pointer;
+  min-height:44px;
+  transition:transform var(--ease-fast), background-color var(--ease-fast);
+}
+.ql-save-skip:active { transform:scale(0.97); background:#f0e8e0; }
+.ql-save-skip:hover { background:#f8f0e8; }
+
+/* Dark mode — preserve domain identity; deepen backgrounds */
+[data-theme="dark"] .ql-feed-repeat-chip { background:var(--surface-alt); border-color:var(--tc-sage); }
+[data-theme="dark"] .ql-feed-repeat-chip.primary { background:#1e3028; }
+[data-theme="dark"] .ql-feed-repeat-head { color:#7ac0a0; }
+[data-theme="dark"] .ql-feed-combo-chip { background:#2a2240; border-color:var(--tc-lav); }
+[data-theme="dark"] .ql-feed-combo-head { color:#b8a8e0; }
+/* Deep-lavender badge with light text so the combo frequency/confidence
+   number stays legible in dark mode — the prior var(--text) flipped light
+   over the unchanged light-lavender fill (~1.42:1). (V-M-210 / V-V-210) */
+[data-theme="dark"] .ql-feed-combo-conf { background:#3a2f55; color:#e6dcf5; }
+[data-theme="dark"] .ql-feed-items-list { background:var(--surface); border-color:#3a2e3e; }
+[data-theme="dark"] .ql-feed-item-row { border-bottom-color:#3a2e3e; }
+[data-theme="dark"] .ql-feed-qty-stepper { background:#221c28; }
+[data-theme="dark"] .ql-feed-qty-step { background:var(--surface); border-color:#3a2e3e; color:#7ac0a0; }
+[data-theme="dark"] .ql-feed-next-chip { background:#1e3028; color:#7ac0a0; border-color:var(--tc-sage); }
+[data-theme="dark"] .ql-feed-next-conf { background:var(--surface); color:#7ac0a0; }
+[data-theme="dark"] .ql-save-skip { background:#221c28; color:var(--mid); border-color:#3a2e3e; }
+
+/* ═══════════════════════════════════════════════════════════════
+   F-6a — FEEDING COMPOSER (.fc-*)
+   Spec: docs/specs/food-sub-tab-v1-f6-feeding-composer.md §Visual refresh.
+   One shared component, two mounts. The Log-tab cards adopt the Receded
+   register (Law 2): domain --*-light wash + a border-left rail in the slot's
+   domain ACCENT token + the slot label in the matching --tc-*. Dark mode
+   hue-swaps to the deep --tc hue (Law 1), never the pale accent over dark.
+   Slot→domain: breakfast→peach, lunch→sage, dinner→lavender, snack→amber.
+   ═══════════════════════════════════════════════════════════════ */
+
+.fc-hidden { display:none !important; }
+
+/* Undo affordance inside the QL toast (HR-2 — was an inline style span). */
+.ql-toast-undo { text-decoration:underline; font-weight:700; cursor:pointer; margin-left:var(--sp-8); }
+
+/* ── Mount B — per-slot composer cards ── */
+.fc-cards { display:flex; flex-direction:column; gap:var(--sp-8); margin-top:var(--sp-12); }
+.fc-card {
+  border-radius:var(--r-xl);
+  padding:var(--sp-12);
+  border:1px solid transparent;
+  border-left:3px solid var(--mid);
+  overflow:visible;
+}
+/* Receded register — light wash + domain accent rail (border-left). */
+.fc-card-breakfast { background:var(--peach-light); border-left-color:var(--peach); }
+.fc-card-lunch     { background:var(--sage-light);  border-left-color:var(--sage); }
+.fc-card-dinner    { background:var(--lav-light);   border-left-color:var(--lavender); }
+.fc-card-snack     { background:var(--amber-light); border-left-color:var(--amber); }
+.fc-card.fc-skipped { opacity:0.72; }
+
+.fc-card-head { display:flex; align-items:center; gap:var(--sp-8); margin-bottom:var(--sp-8); }
+.fc-slot-label {
+  font-size:var(--fs-sm); font-weight:700; text-transform:uppercase;
+  letter-spacing:var(--ls-wide); display:flex; align-items:center; gap:var(--sp-6);
+}
+.fc-card-breakfast .fc-slot-label { color:var(--tc-peach); }
+.fc-card-lunch     .fc-slot-label { color:var(--tc-sage); }
+.fc-card-dinner    .fc-slot-label { color:var(--tc-lav); }
+.fc-card-snack     .fc-slot-label { color:var(--tc-caution); }
+.fc-slot-label .zi { width:var(--icon-base); height:var(--icon-base); }
+.fc-head-right { margin-left:auto; display:flex; align-items:center; gap:var(--sp-6); }
+.fc-time {
+  width:84px; padding:var(--sp-2) var(--sp-6);
+  border:1px solid var(--border-subtle); border-radius:var(--r-md);
+  font-family:'Nunito',sans-serif; font-size:var(--fs-xs); font-weight:500;
+  color:var(--mid); background:transparent; outline:none;
+}
+.fc-time:focus { border-color:var(--tc-peach); color:var(--text); }
+.fc-mic {
+  width:32px; height:32px; border-radius:var(--r-full); border:1px solid var(--border-subtle);
+  background:var(--surface); cursor:pointer; display:inline-flex; align-items:center; justify-content:center;
+}
+.fc-skip-pill {
+  font-size:var(--fs-xs); font-weight:500; color:var(--light); cursor:pointer;
+  padding:var(--sp-4) var(--sp-8); border-radius:var(--r-md);
+  background:var(--surface); border:1px solid var(--border-subtle);
+  transition:all var(--ease-fast); display:inline-flex; align-items:center; gap:var(--sp-4);
+}
+.fc-skip-pill:hover { background:var(--peach-light); color:var(--tc-caution); }
+.fc-skip-pill.skipped { background:var(--peach-light); color:var(--tc-caution); }
+.fc-skipped-note { font-size:var(--fs-sm); font-style:italic; color:var(--light); padding:var(--sp-8) 0; }
+.fc-show-suggest {
+  display:inline-flex; align-items:center; gap:var(--sp-6);
+  background:transparent; border:1px dashed var(--border-subtle); border-radius:var(--r-full);
+  color:var(--mid); font-weight:600; font-size:var(--fs-sm); font-family:'Nunito',sans-serif;
+  padding:var(--sp-6) var(--sp-12); cursor:pointer; min-height:40px; margin-top:var(--sp-4);
+}
+.fc-show-suggest .zi { width:var(--icon-sm); height:var(--icon-sm); }
+
+/* ── Prefill offer (V-V-219) — interrogative ghost/dashed + explicit Add verb;
+   shape-distinct from committed items (which are 48px rows, never chips). ── */
+.fc-prefill {
+  display:flex; align-items:center; gap:var(--sp-8); flex-wrap:wrap;
+  background:transparent; border:1.5px dashed var(--peach);
+  border-radius:var(--r-lg); padding:var(--sp-8) var(--sp-10); margin-bottom:var(--sp-8);
+}
+.fc-prefill-q { flex:1; min-width:0; font-weight:600; font-size:var(--fs-sm); color:var(--mid); }
+.fc-prefill-actions { display:flex; gap:var(--sp-6); }
+.fc-prefill-add {
+  background:var(--tc-peach); color:white; border:none; border-radius:var(--r-full);
+  font-weight:700; font-size:var(--fs-sm); font-family:'Nunito',sans-serif;
+  padding:var(--sp-6) var(--sp-14); cursor:pointer; min-height:36px;
+}
+.fc-prefill-edit {
+  background:transparent; color:var(--mid); border:1px solid var(--border-subtle);
+  border-radius:var(--r-full); font-weight:600; font-size:var(--fs-sm); font-family:'Nunito',sans-serif;
+  padding:var(--sp-6) var(--sp-12); cursor:pointer; min-height:36px;
+}
+
+/* ── Rails (shared by both variants) ── */
+.fc-rail-wrap { display:flex; flex-direction:column; gap:var(--sp-4); margin-bottom:var(--sp-8); }
+.fc-rail { display:flex; flex-direction:column; gap:var(--sp-6); }
+.fc-repeat-chip {
+  background:var(--white); border:1.5px solid var(--sage); border-radius:var(--r-xl);
+  padding:var(--sp-10) var(--sp-12); cursor:pointer; min-height:36px;
+  transition:transform var(--ease-fast), background-color var(--ease-fast);
+  box-shadow:0 1px 3px rgba(60,40,40,0.04);
+}
+.fc-repeat-chip:active { transform:scale(0.985); }
+.fc-repeat-chip.primary { background:var(--sage-light); border-width:2px; }
+.fc-repeat-head { display:flex; align-items:center; gap:var(--sp-6); font-weight:700; color:var(--tc-sage); font-size:var(--fs-sm); }
+.fc-repeat-head .zi { width:var(--icon-base); height:var(--icon-base); }
+.fc-repeat-sub { font-size:var(--fs-xs); color:var(--mid); margin-top:var(--sp-4); font-weight:500; line-height:var(--lh-snug); }
+.fc-combo-chip {
+  background:var(--lav-light); border:1.5px solid var(--lavender); border-radius:var(--r-xl);
+  padding:var(--sp-10) var(--sp-12); cursor:pointer; min-height:36px; transition:transform var(--ease-fast);
+}
+.fc-combo-chip:active { transform:scale(0.985); }
+.fc-combo-head { display:flex; align-items:center; gap:var(--sp-6); font-weight:700; color:var(--tc-lav); font-size:var(--fs-sm); }
+.fc-combo-head .zi { width:var(--icon-base); height:var(--icon-base); }
+.fc-combo-conf { margin-left:auto; font-size:var(--fs-2xs); background:var(--lavender); color:var(--text); padding:var(--sp-2) var(--sp-6); border-radius:var(--r-full); font-weight:700; }
+.fc-combo-sub { font-size:var(--fs-xs); color:var(--mid); margin-top:var(--sp-4); font-weight:500; line-height:var(--lh-snug); }
+
+/* ── Items list ── */
+.fc-items-wrap { display:flex; flex-direction:column; gap:var(--sp-4); margin-bottom:var(--sp-8); }
+.fc-items-list { background:var(--white); border:1px solid var(--border-subtle); border-radius:var(--r-xl); overflow:hidden; }
+.fc-items-empty { text-align:center; color:var(--light); padding:var(--sp-16); font-style:italic; font-size:var(--fs-sm); }
+.fc-item-row { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-8) var(--sp-10); border-bottom:1px solid var(--border-subtle); min-height:48px; }
+.fc-item-row:last-of-type { border-bottom:none; }
+.fc-item-icon { width:28px; height:28px; background:var(--sage-light); color:var(--tc-sage); border-radius:var(--r-full); display:inline-flex; align-items:center; justify-content:center; font-size:var(--fs-sm); font-weight:700; flex-shrink:0; }
+.fc-item-name { flex:1; font-weight:600; font-size:var(--fs-base); line-height:var(--lh-snug); }
+.fc-qty-stepper { display:inline-flex; align-items:center; background:var(--warm); border-radius:var(--r-full); padding:var(--sp-2); flex-shrink:0; }
+.fc-qty-step { width:32px; height:32px; display:inline-flex; align-items:center; justify-content:center; border-radius:var(--r-full); background:var(--white); color:var(--tc-sage); font-weight:700; font-size:var(--fs-base); border:1px solid var(--border-subtle); cursor:pointer; font-family:'Nunito',sans-serif; transition:transform var(--ease-fast); }
+.fc-qty-step:active { transform:scale(0.92); background:var(--sage-light); }
+.fc-qty-val { padding:0 var(--sp-8); font-weight:700; min-width:52px; text-align:center; font-size:var(--fs-sm); color:var(--text); }
+.fc-qty-unit { font-size:var(--fs-2xs); color:var(--mid); letter-spacing:0; font-weight:500; }
+.fc-item-x { width:32px; height:32px; display:inline-flex; align-items:center; justify-content:center; border-radius:var(--r-full); background:var(--rose-light); color:var(--tc-rose); font-weight:700; font-size:var(--fs-md); border:none; cursor:pointer; flex-shrink:0; margin-left:var(--sp-2); transition:transform var(--ease-fast); }
+.fc-item-x:active { transform:scale(0.9); }
+
+/* ── L3 next-item ribbon ── */
+.fc-next-ribbon { display:flex; gap:var(--sp-6); overflow-x:auto; padding:var(--sp-4) 0; -webkit-overflow-scrolling:touch; }
+.fc-next-chip { display:inline-flex; align-items:center; gap:var(--sp-4); background:var(--sage-light); color:var(--tc-sage); font-weight:700; font-size:var(--fs-sm); padding:var(--sp-6) var(--sp-12); border-radius:var(--r-full); border:1px solid var(--sage); flex-shrink:0; min-height:36px; cursor:pointer; font-family:'Nunito',sans-serif; transition:transform var(--ease-fast); }
+.fc-next-chip:active { transform:scale(0.94); }
+.fc-next-conf { font-size:var(--fs-2xs); background:var(--white); color:var(--tc-sage); border-radius:var(--r-full); padding:1px var(--sp-6); margin-left:var(--sp-2); font-weight:700; letter-spacing:0; }
+
+/* ── L4 typeahead + dropdown ── */
+.fc-add-wrap { display:flex; flex-direction:column; gap:var(--sp-4); }
+.fc-input-wrap { position:relative; z-index:30; }
+.fc-ta-input { width:100%; }
+.fc-dropdown {
+  position:absolute; left:0; right:0; top:100%; z-index:50;
+  background:var(--card-bg); border-radius:0 0 var(--r-lg) var(--r-lg);
+  border:1.5px solid var(--peach); border-top:none;
+  box-shadow:0 8px 24px rgba(180,120,120,0.15);
+  max-height:200px; overflow-y:auto; display:none;
+}
+.fc-dropdown.open { display:block; }
+/* C3 — card-variant dropdown stacking (the :511 fix reborn deliberately):
+   an open dropdown must clear the next slot card below. Raise the open card
+   above its lower siblings. */
+.fc-card:has(.fc-dropdown.open) { z-index:10; position:relative; }
+.fc-ta-row { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-8) var(--sp-10); border-bottom:1px solid var(--border-subtle); cursor:pointer; min-height:36px; }
+.fc-ta-row:last-of-type { border-bottom:none; }
+.fc-ta-row:active { background:var(--sage-light); }
+.fc-ta-name { flex:1; font-weight:600; font-size:var(--fs-base); color:var(--text); }
+.fc-ta-meta { font-size:var(--fs-2xs); color:var(--mid); text-transform:uppercase; letter-spacing:var(--ls-wide); font-weight:500; }
+/* C1 — no-match add-as-new-food row (the .meal-dd-add pattern reborn). */
+.fc-dd-add { font-size:var(--fs-base); padding:var(--sp-8) var(--sp-12); cursor:pointer; color:var(--sage); font-weight:700; display:flex; align-items:center; gap:var(--sp-8); transition:background var(--ease-fast); }
+.fc-dd-add:hover { background:var(--sage-light); }
+
+/* ── Card footer — intake editor + insight + saved cue ── */
+.fc-card-foot { display:flex; flex-direction:column; gap:var(--sp-6); margin-top:var(--sp-8); }
+.fc-intake { margin:0; }
+.fc-insight { display:flex; align-items:center; gap:var(--sp-6); font-size:var(--fs-xs); color:var(--mid); line-height:var(--lh-snug); }
+.fc-saved-cue { display:flex; align-items:center; gap:var(--sp-4); font-size:var(--fs-2xs); color:var(--tc-sage); font-weight:600; }
+.fc-saved-cue .zi { width:var(--icon-xs); height:var(--icon-xs); }
+
+/* ── Mount A — sheet mount (rails render directly into the sheet body) ── */
+.fc-mount-sheet { display:flex; flex-direction:column; gap:var(--sp-8); }
+
+/* ── Dark mode — preserve domain identity; deepen backgrounds (Law 1) ── */
+[data-theme="dark"] .fc-card-breakfast { background:rgba(250,212,180,0.10); }
+[data-theme="dark"] .fc-card-lunch     { background:rgba(181,213,197,0.10); }
+[data-theme="dark"] .fc-card-dinner    { background:rgba(201,184,232,0.10); }
+[data-theme="dark"] .fc-card-snack     { background:rgba(240,200,120,0.10); }
+[data-theme="dark"] .fc-repeat-chip { background:var(--surface-alt); border-color:var(--tc-sage); }
+[data-theme="dark"] .fc-repeat-chip.primary { background:#1e3028; }
+[data-theme="dark"] .fc-repeat-head { color:#7ac0a0; }
+[data-theme="dark"] .fc-combo-chip { background:#2a2240; border-color:var(--tc-lav); }
+[data-theme="dark"] .fc-combo-head { color:#b8a8e0; }
+[data-theme="dark"] .fc-combo-conf { background:#3a2f55; color:#e6dcf5; }
+[data-theme="dark"] .fc-items-list { background:var(--surface); border-color:#3a2e3e; }
+[data-theme="dark"] .fc-item-row { border-bottom-color:#3a2e3e; }
+[data-theme="dark"] .fc-qty-stepper { background:#221c28; }
+[data-theme="dark"] .fc-qty-step { background:var(--surface); border-color:#3a2e3e; color:#7ac0a0; }
+[data-theme="dark"] .fc-next-chip { background:#1e3028; color:#7ac0a0; border-color:var(--tc-sage); }
+[data-theme="dark"] .fc-next-conf { background:var(--surface); color:#7ac0a0; }
+[data-theme="dark"] .fc-skip-pill { background:#221c28; color:var(--mid); border-color:#3a2e3e; }
+[data-theme="dark"] .fc-time { border-color:rgba(255,255,255,0.1); color:var(--mid); }
+[data-theme="dark"] .fc-dropdown { border-color:var(--tc-peach); }
+
+/* ── Quick Log Toast ── */
+.ql-toast {
+  position:fixed; bottom:90px; left:50%; transform:translateX(-50%) translateY(20px);
+  z-index:1010; padding:var(--sp-10) var(--sp-20); border-radius:var(--r-2xl);
+  background:var(--text); color:var(--cream);
+  font-size:var(--fs-md); font-weight:600;
+  box-shadow:0 4px 20px rgba(0,0,0,0.2);
+  opacity:0; pointer-events:none;
+  transition:all var(--ease-med);
+}
+.ql-toast.show { opacity:1; transform:translateX(-50%) translateY(0); }
+[data-theme="dark"] .ql-toast { background:var(--mid); color:var(--body-bg); }
+
+/* ── Post-Save Nutrition Flash ── */
+.psf-overlay {
+  position:fixed; inset:0; z-index:1050;
+  display:flex; align-items:flex-end; justify-content:center;
+  background:rgba(0,0,0,0.25);
+  opacity:0; pointer-events:none;
+  transition:opacity 0.25s ease;
+  padding:0 var(--sp-12) 100px;
+}
+.psf-overlay.open { opacity:1; pointer-events:auto; }
+.psf-card {
+  width:100%; max-width:400px;
+  background:var(--card-bg); border-radius:var(--r-2xl);
+  box-shadow:0 8px 32px rgba(0,0,0,0.18);
+  transform:translateY(40px);
+  transition:transform 0.3s var(--ease-spring, cubic-bezier(0.34,1.56,0.64,1));
+  overflow:hidden;
+}
+.psf-overlay.open .psf-card { transform:translateY(0); }
+.psf-header {
+  display:flex; align-items:center; gap:var(--sp-8);
+  padding:var(--sp-12) var(--sp-16) var(--sp-10);
+}
+.psf-check {
+  width:28px; height:28px; border-radius:50%;
+  background:var(--sage); color:#fff;
+  display:flex; align-items:center; justify-content:center;
+  font-size:15px; font-weight:700; flex-shrink:0;
+}
+.psf-title {
+  font-family:'Nunito',sans-serif; font-weight:700;
+  font-size:var(--fs-md); color:var(--text); line-height:1.2;
+}
+.psf-subtitle {
+  font-size:var(--fs-xs); color:var(--light); margin-top:1px;
+}
+.psf-body { padding:0 var(--sp-16) var(--sp-12); }
+.psf-nutrients {
+  display:flex; flex-wrap:wrap; gap:var(--sp-6); margin-bottom:var(--sp-10);
+}
+.psf-nut {
+  display:inline-flex; align-items:center; gap:var(--sp-4);
+  font-size:var(--fs-xs); font-weight:600;
+  padding:var(--sp-4) var(--sp-8); border-radius:var(--r-full);
+  background:rgba(58,112,96,0.08); color:var(--tc-sage);
+}
+.psf-nut.missed {
+  background:rgba(200,120,80,0.08); color:var(--tc-amber);
+  font-weight:500;
+}
+.psf-tip {
+  font-size:var(--fs-sm); color:var(--mid);
+  line-height:var(--lh-relaxed);
+  padding:var(--sp-8) var(--sp-10); border-radius:var(--r-lg);
+  background:var(--sage-light);
+}
+.psf-tip strong { color:var(--text); }
+.psf-synergy {
+  font-size:var(--fs-xs); color:var(--tc-sage);
+  margin-top:var(--sp-6); font-weight:600;
+}
+.psf-dismiss {
+  display:block; width:100%; padding:var(--sp-10);
+  text-align:center; font-size:var(--fs-xs);
+  color:var(--light); border:none; background:none;
+  border-top:1px solid var(--sage-light); cursor:pointer;
+  font-family:'Nunito',sans-serif;
+}
+[data-theme="dark"] .psf-card { background:var(--card-bg); box-shadow:0 8px 32px rgba(0,0,0,0.4); }
+[data-theme="dark"] .psf-nut { background:rgba(181,213,197,0.1); }
+[data-theme="dark"] .psf-nut.missed { background:rgba(200,160,100,0.1); }
+[data-theme="dark"] .psf-tip { background:rgba(255,255,255,0.04); }
+[data-theme="dark"] .psf-dismiss { border-top-color:var(--card-border); }
+.psf-home-wrap {
+  margin-top:var(--sp-10); padding:var(--sp-10) var(--sp-12); border-radius:var(--r-lg);
+  background:var(--sage-light); cursor:pointer;
+  transition:background var(--ease-fast);
+}
+.psf-home-wrap:active { background:rgba(58,112,96,0.12); }
+[data-theme="dark"] .psf-home-wrap { background:rgba(255,255,255,0.04); }
+[data-theme="dark"] .psf-home-wrap:active { background:rgba(181,213,197,0.1); }
+
+/* ── Diet Intelligence Banner ── */
+.dib-card {
+  padding:var(--sp-10) var(--sp-12); border-radius:var(--r-lg); margin-bottom:var(--sp-10);
+  font-size:var(--fs-xs); line-height:var(--lh-relaxed);
+}
+.dib-reaction {
+  background:rgba(250,212,180,0.15); border:1px solid rgba(250,212,180,0.3);
+  color:var(--mid);
+}
+.dib-reaction strong { color:var(--tc-caution); }
+.dib-synergy {
+  background:var(--sage-light); border:1px solid rgba(140,190,160,0.2);
+  color:var(--mid);
+}
+.dib-synergy-pill {
+  display:inline-flex; align-items:center; gap:var(--sp-4);
+  padding:var(--sp-4) var(--sp-10); border-radius:var(--r-2xl);
+  font-size:var(--fs-xs); font-weight:600;
+  background:rgba(58,112,96,0.08); color:var(--tc-sage);
+  cursor:pointer; transition:all var(--ease-fast);
+  margin:var(--sp-2) var(--sp-2) var(--sp-2) 0;
+}
+.dib-synergy-pill:active { background:var(--sage); color:white; }
+[data-theme="dark"] .dib-reaction { background:rgba(250,212,180,0.06); border-color:rgba(250,212,180,0.15); }
+[data-theme="dark"] .dib-synergy { background:rgba(58,112,96,0.08); border-color:rgba(181,213,197,0.1); }
+[data-theme="dark"] .dib-synergy-pill { background:rgba(181,213,197,0.1); }
+
+/* ── Symptom Checker ── */
+.sc-result { border-radius:var(--r-lg); padding:var(--sp-12); margin-bottom:var(--sp-10); position:relative; }
+.sc-emergency { background:rgba(220,60,60,0.08); border:1.5px solid rgba(220,60,60,0.3); }
+.sc-warning { background:rgba(240,180,80,0.08); border:1.5px solid rgba(240,180,80,0.25); }
+.sc-mild { background:rgba(58,112,96,0.06); border:1.5px solid rgba(58,112,96,0.2); }
+.sc-sev-badge {
+  display:inline-flex; align-items:center; gap:var(--sp-4);
+  padding:var(--sp-4) var(--sp-10); border-radius:var(--r-full);
+  font-size:var(--fs-xs); font-weight:700; margin-bottom:var(--sp-8);
+}
+.sc-emergency .sc-sev-badge { background:rgba(220,60,60,0.12); color:#c0392b; }
+.sc-warning .sc-sev-badge { background:rgba(240,180,80,0.15); color:#b8860b; }
+.sc-mild .sc-sev-badge { background:rgba(58,112,96,0.1); color:var(--tc-sage); }
+.sc-title { font-weight:700; font-size:var(--fs-md); color:var(--text); margin-bottom:var(--sp-6); }
+.sc-section { margin-top:var(--sp-10); }
+.sc-section-title { font-size:var(--fs-xs); font-weight:700; text-transform:uppercase; letter-spacing:var(--ls-wide); color:var(--light); margin-bottom:var(--sp-4); }
+.sc-section-body { font-size:var(--fs-sm); color:var(--mid); line-height:var(--lh-relaxed); }
+.sc-doctor-card {
+  margin-top:var(--sp-12); padding:var(--sp-12); border-radius:var(--r-lg);
+  background:rgba(220,60,60,0.05); border:1px solid rgba(220,60,60,0.15);
+  display:flex; align-items:center; gap:var(--sp-12); flex-wrap:wrap;
+}
+.sc-doctor-card a { color:#c0392b; font-weight:700; text-decoration:none; }
+.sc-quick-chip {
+  padding:var(--sp-6) var(--sp-12); border-radius:var(--r-2xl);
+  font-size:var(--fs-xs); font-weight:600;
+  background:var(--warm); color:var(--mid);
+  border:1px solid var(--border-subtle);
+  cursor:pointer; transition:all var(--ease-fast);
+}
+.sc-quick-chip:active { background:var(--sage-light); color:var(--tc-sage); }
+[data-theme="dark"] .sc-result { border-color:rgba(255,255,255,0.1); }
+[data-theme="dark"] .sc-emergency { background:rgba(220,60,60,0.06); border-color:rgba(220,60,60,0.2); }
+[data-theme="dark"] .sc-warning { background:rgba(240,180,80,0.06); border-color:rgba(240,180,80,0.15); }
+[data-theme="dark"] .sc-mild { background:rgba(58,112,96,0.05); border-color:rgba(58,112,96,0.15); }
+[data-theme="dark"] .sc-mild .sc-sev-badge { background:rgba(58,112,96,0.22); color:var(--tc-sage-light); border:1px solid rgba(58,112,96,0.35); }
+[data-theme="dark"] .sc-doctor-card { background:rgba(220,60,60,0.04); border-color:rgba(220,60,60,0.12); }
+[data-theme="dark"] .sc-doctor-card a { color:#e74c3c; }
+[data-theme="dark"] .sc-quick-chip { background:rgba(255,255,255,0.05); border-color:rgba(255,255,255,0.08); }
+
+/* ── Symptom Checker — D1 Polish (lyra-spec-2026-05-13-symptom-checker-d1-polish.md v3.1) ── */
+/* D1 §2.1 — severity rail. .sc-result gets position:relative above (line ~5990) to anchor. */
+.sc-rail {
+  position:absolute; top:var(--sp-8); bottom:var(--sp-8); left:var(--sp-4);
+  width:4px; border-radius:2px; pointer-events:none;
+}
+.sc-emergency .sc-rail { background:var(--tc-rose); }
+.sc-warning   .sc-rail { background:var(--amber-deep); }
+.sc-mild      .sc-rail { background:var(--accent-sage-deep); }
+.sc-emergency .sc-rail { animation:sc-rail-pulse 1.5s ease-out 1; }
+@keyframes sc-rail-pulse {
+  0%   { box-shadow:0 0 0 0 rgba(220,60,60,0); }
+  50%  { box-shadow:0 0 8px 2px rgba(220,60,60,0.5); }
+  100% { box-shadow:0 0 0 0 rgba(220,60,60,0); }
+}
+[data-theme="dark"] .sc-warning .sc-rail { background:var(--tc-warn); }
+[data-theme="dark"] .sc-mild    .sc-rail { background:var(--tc-sage-light); }
+
+/* D1 §2.2 — sticky doctor-CTA footer (Home overlay path only; #symptomResult Medical-tab
+   path has no scroll container so position:sticky no-ops there — surface asymmetry per V-K8). */
+.sc-sticky-footer {
+  position:sticky; bottom:0; z-index:2;
+  margin:var(--sp-8) calc(-1 * var(--sp-12)) calc(-1 * var(--sp-12));
+  padding:var(--sp-10) var(--sp-12);
+  background:var(--blush);
+  border-top:1px solid rgba(220,60,60,0.2);
+  box-shadow:0 -2px 8px rgba(0,0,0,0);
+  transition:box-shadow 200ms ease-out;
+}
+.sc-sticky-footer.is-pinned { box-shadow:0 -2px 8px rgba(0,0,0,0.12); }
+#homeSymptomOverlay > .modal { padding-bottom:60px; } /* V-M1 #5 — sticky-CTA never covers content */
+
+/* D1 §2.3 — severity-aware doctor-card variants + call-CTA tiers */
+.sc-doctor-card-emergency { display:flex; flex-direction:column; gap:var(--sp-4); }
+.sc-doctor-card-warning   { display:flex; flex-direction:column; gap:var(--sp-4); }
+.sc-doctor-card-mild      { display:flex; flex-direction:column; gap:var(--sp-4); }
+.sc-call-primary {
+  display:flex; align-items:center; justify-content:center;
+  min-height:60px; min-width:60px; padding:var(--sp-10) var(--sp-12);
+  font-weight:700; font-size:var(--fs-md); border-radius:var(--r-lg);
+  background:rgba(220,60,60,0.12); color:var(--tc-danger); text-decoration:none;
+}
+.sc-call-secondary {
+  display:inline-flex; align-items:center; min-height:44px;
+  padding:var(--sp-6) var(--sp-10); font-weight:600; font-size:var(--fs-base);
+  color:var(--tc-rose); text-decoration:none;
+}
+.sc-call-tertiary {
+  display:inline-flex; align-items:center; min-height:44px; min-width:44px;
+  padding:var(--sp-6) var(--sp-8); font-size:var(--fs-sm); font-weight:500;
+  color:var(--mid); text-decoration:none;
+}
+.sc-doctor-name { font-weight:700; color:var(--text); font-size:var(--fs-sm); }
+.sc-doctor-name-mild { font-weight:500; }
+.sc-doctor-address { font-size:var(--fs-xs); color:var(--light); }
+/* D1 §2.3.2 — no-doctor severity-aware fallback */
+.sc-doctor-empty { font-size:var(--fs-sm); color:var(--mid); }
+.sc-doctor-add-link {
+  display:inline-flex; align-items:center; justify-content:center;
+  min-height:44px; min-width:44px; padding:var(--sp-4) var(--sp-8);
+  text-decoration:underline; font-weight:600; color:var(--tc-sage);
+}
+.sc-doctor-empty-nudge { margin-top:var(--sp-6); font-size:var(--fs-xs); color:var(--mid); font-style:italic; }
+.sc-emergency-fallback {
+  margin-top:var(--sp-6); padding:var(--sp-6) var(--sp-8);
+  background:rgba(220,60,60,0.12); border-radius:var(--r-md);
+  font-size:var(--fs-xs); font-weight:600; color:var(--tc-danger);
+}
+[data-theme="dark"] .sc-emergency-fallback { background:rgba(220,60,60,0.2); color:var(--tc-danger); }
+
+/* D1 §8 — prefers-reduced-motion override for every D1-introduced animation */
+@media (prefers-reduced-motion: reduce) {
+  .sc-emergency .sc-rail { animation:none; }
+  .sc-sticky-footer { transition:none; }
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   D2 STRUCTURAL — DO-NOT callout, numbered/bulleted, progressive disclosure,
+   footer-triad, back-channel, lifeThreat CTA. Phase-spec §2.3-§2.11.
+   ───────────────────────────────────────────────────────────────── */
+
+/* §2.10 — HR-2 sweep: replace inline style="color:..." on .sc-section-title
+   with modifier classes (carried-forward violation from D1 — Cipher pre-empt). */
+.sc-section-title-danger  { color:var(--tc-danger); }
+.sc-section-title-caution { color:var(--tc-caution); }
+
+/* §2.3 / §2.4 — DO-NOT callout. 2px solid --rose-deep border (SG-D2-DONOT-BORDER
+   ratified). Per-item zi-no-entry prefix on EVERY line per V-M3 #2.
+
+   MAREN-LOCKED ALPHA: rgba(220,60,60,0.06) composes to 4.51:1 against
+   --tc-danger on light --body-bg (Maren [11a] fixture R2; only 0.01
+   above WCAG AA-normal 4.5:1). Any change to this alpha — or to
+   --body-bg / --tc-danger — requires re-running the Maren contrast
+   fixture. Dark theme uses rgba(220,60,60,0.12) at L6147 with comfortable headroom. */
+.sc-donot-callout {
+  margin-top:var(--sp-12);
+  padding:var(--sp-10) var(--sp-12);
+  border-left:2px solid var(--rose-deep);
+  background:rgba(220,60,60,0.06);
+  border-radius:0 var(--r-md) var(--r-md) 0;
+}
+.sc-donot-callout-title {
+  display:inline-flex; align-items:center; gap:var(--sp-4);
+  font-size:var(--fs-xs); font-weight:800;
+  text-transform:uppercase; letter-spacing:var(--ls-wide);
+  color:var(--tc-danger);
+  margin-bottom:var(--sp-6);
+}
+.sc-donot-list { list-style:none; padding:0; margin:0; }
+.sc-donot-item {
+  display:flex; align-items:flex-start; gap:var(--sp-6);
+  padding:var(--sp-4) 0;
+  font-size:var(--fs-sm); font-weight:500;
+  color:var(--tc-danger);
+  line-height:var(--lh-relaxed);
+}
+.sc-donot-item.sc-donot-critical {
+  /* §2.4 — critical DO-NOT typography per V-M3 #3. */
+  font-size:var(--fs-base); font-weight:800;
+  text-decoration:underline;
+  padding:var(--sp-6) 0;
+}
+[data-theme="dark"] .sc-donot-callout { background:rgba(220,60,60,0.12); }
+
+/* §2.5 — numbered/bulleted lists for whatToDo / precautions / emergency arrays */
+.sc-numbered-steps { padding-left:var(--sp-20); margin:var(--sp-6) 0; }
+.sc-step {
+  margin-bottom:var(--sp-6);
+  font-size:var(--fs-sm); color:var(--mid); line-height:var(--lh-relaxed);
+}
+.sc-step::marker { font-weight:800; color:var(--text); }
+.sc-bullet-list { padding-left:var(--sp-16); margin:var(--sp-6) 0; }
+.sc-bullet {
+  margin-bottom:var(--sp-4);
+  font-size:var(--fs-sm); color:var(--mid); line-height:var(--lh-relaxed);
+}
+
+/* §2.6 — progressive disclosure. Emergency tier force-expands per
+   SG-D2-PROGRESSIVE-DISCLOSURE-EMERGENCY-OVERRIDE. */
+.sc-disclosure { margin-top:var(--sp-8); }
+.sc-disclosure-summary {
+  list-style:none;
+  display:flex; align-items:flex-start; gap:var(--sp-8);
+  cursor:pointer;
+  padding:var(--sp-6) 0;
+  font-size:var(--fs-sm); color:var(--mid);
+  line-height:var(--lh-relaxed);
+}
+.sc-disclosure-summary::-webkit-details-marker { display:none; }
+.sc-summary-text { flex:1; }
+.sc-disclosure-toggle {
+  flex:0 0 24px;
+  transition:transform 200ms ease;
+}
+details[open] .sc-disclosure-toggle { transform:rotate(180deg); }
+.sc-disclosure-body { margin-top:var(--sp-8); }
+
+/* §2.8 — footer-triad. Save-only slot on emergency; full triad on warning/mild.
+   All three actions are STUBS in D2 (SG-D2-FOOTER-SAVE-WIRING ratified). */
+.sc-footer-triad {
+  display:flex; gap:var(--sp-8);
+  margin-top:var(--sp-12); padding-top:var(--sp-10);
+  border-top:1px solid rgba(0,0,0,0.06);
+}
+.sc-footer-triad.sc-footer-emergency { justify-content:flex-start; }
+.sc-footer-action {
+  flex:1;
+  display:inline-flex; align-items:center; justify-content:center;
+  gap:var(--sp-6);
+  min-height:44px; padding:var(--sp-8) var(--sp-10);
+  border-radius:var(--r-md);
+  border:1px solid rgba(0,0,0,0.08);
+  background:transparent;
+  font-size:var(--fs-sm); font-weight:600;
+  color:var(--mid);
+  cursor:pointer;
+}
+.sc-footer-action:active { background:rgba(0,0,0,0.04); }
+.sc-footer-emergency .sc-footer-action { flex:0 0 auto; min-width:120px; }
+[data-theme="dark"] .sc-footer-triad { border-top-color:rgba(255,255,255,0.08); }
+[data-theme="dark"] .sc-footer-action { border-color:rgba(255,255,255,0.12); }
+
+/* §2.9 — back-channel callout. Tiered copy per severity (Maren C-D2-M-7). */
+.sc-back-channel {
+  margin-top:var(--sp-10);
+  padding:var(--sp-6) var(--sp-10);
+  border-radius:var(--r-md);
+  background:rgba(220,60,60,0.08);
+  font-size:var(--fs-sm); font-weight:600;
+  color:var(--tc-rose);
+  display:flex; align-items:center; gap:var(--sp-6);
+}
+.sc-back-channel-warning {
+  /* sharper visual weight matches sharper copy */
+  font-weight:700;
+}
+.sc-back-channel-mild {
+  /* Cipher E-D2-6 fold: explicit rule for symmetry / future-edit safety.
+     Currently equivalent to base; future refinements (softer color, etc.)
+     land here without altering the class-emit contract. */
+}
+[data-theme="dark"] .sc-back-channel { background:rgba(220,60,60,0.16); }
+
+/* §2.11 — lifeThreat CTA + hospital list. Touch targets ≥60×60 per D1 §9. */
+.sc-lifethreat-cta {
+  display:flex; flex-direction:column; gap:var(--sp-6);
+  margin:var(--sp-10) 0;
+}
+.sc-call-emergency {
+  display:flex; align-items:center; justify-content:center; gap:var(--sp-6);
+  min-height:60px; min-width:60px;
+  padding:var(--sp-10) var(--sp-12);
+  font-weight:800; font-size:var(--fs-md);
+  border-radius:var(--r-lg);
+  background:var(--tc-danger); color:#fff;
+  text-decoration:none;
+}
+/* Maren-[11a] PRE-Edict V finding: white-on-#f09090 dark-theme = 2.31:1 (WCAG AA fail).
+   Emergency CTAs stay theme-invariant red; semantic colour for the highest-stakes
+   action — Maren ruling on PR #72 fixture. Fixed bg = light-theme --tc-danger. */
+[data-theme="dark"] .sc-call-emergency { background:#c44040; color:#fff; }
+.sc-call-fallback {
+  display:inline-flex; align-items:center; justify-content:center;
+  min-height:44px; padding:var(--sp-6) var(--sp-10);
+  font-size:var(--fs-xs); color:var(--tc-danger);
+  text-decoration:none; font-weight:600;
+}
+.sc-hospital-list {
+  list-style:none; padding:0; margin:var(--sp-8) 0 0;
+  display:flex; flex-direction:column; gap:var(--sp-4);
+}
+.sc-hospital-list li { font-size:var(--fs-xs); }
+.sc-hospital-list a { color:var(--mid); text-decoration:none; }
+
+/* D2 §2.6 / §2.8 — prefers-reduced-motion parity for new transitions */
+@media (prefers-reduced-motion: reduce) {
+  .sc-disclosure-toggle { transition:none; }
+}
+[data-theme="dark"] .ql-bf-pill { background:rgba(201,184,232,0.1); border-color:rgba(201,184,232,0.15); }
+[data-theme="dark"] .ql-bf-pill.active { background:rgba(184,168,224,0.2); color:var(--tc-lav); border-color:rgba(184,168,224,0.35); }
+[data-theme="dark"] .meal-prog-slot { background:var(--card-bg); border-color:var(--card-border); }
+[data-theme="dark"] .meal-prog-slot.mps-done { background:rgba(58,112,96,0.1); border-color:rgba(181,213,197,0.2); }
+[data-theme="dark"] .meal-prog-slot.mps-empty:active { background:rgba(250,212,180,0.1); }
+/* Dark mode QL pill active states */
+[data-theme="dark"] .ql-meal-pill.active { background:rgba(212,168,72,0.18); color:var(--tc-amber); border-color:rgba(212,168,72,0.35); }
+[data-theme="dark"] .ql-con-pill.active { background:rgba(212,168,72,0.18); color:var(--tc-amber); border-color:rgba(212,168,72,0.35); }
+/* ── Quick Log: Suggest Card ── */
+.ql-suggest-wrap { margin:var(--sp-4) var(--sp-12) var(--sp-8); }
+.ql-suggest-hidden { display:none; }
+.ql-suggest { border-radius:var(--r-lg); padding:var(--sp-12); background:var(--glass-strong); border:1px solid rgba(0,0,0,0.06); }
+.ql-suggest .card-header { display:flex; align-items:center; gap:var(--sp-8); margin-bottom:var(--sp-10); }
+.ql-suggest .card-title { font-family:'Nunito',sans-serif; font-size:var(--fs-sm); font-weight:600; flex:1; min-width:0; }
+.ql-suggest .card-icon { width:22px; height:22px; border-radius:var(--r-md); display:flex; align-items:center; justify-content:center; flex-shrink:0; }
+.ql-suggest .card-icon svg.zi { width:14px; height:14px; }
+.ql-suggest .card-body { display:flex; flex-direction:column; gap:var(--sp-8); }
+.ql-suggest-foods { font-size:var(--fs-xs); color:var(--mid); }
+.ql-suggest-actions { display:flex; gap:var(--sp-8); margin-top:var(--sp-4); }
+.ql-suggest-actions .btn-primary { font-size:var(--fs-xs); padding:var(--sp-6) var(--sp-12); border-radius:var(--r-lg); min-height:var(--chip-min-h-compact); }
+.ql-suggest-actions .btn-ghost { font-size:var(--fs-xs); padding:var(--sp-6) var(--sp-12); border-radius:var(--r-lg); min-height:var(--chip-min-h-compact); }
+.ql-suggest .chip-row-scroll { margin-bottom:var(--sp-8); }
+[data-theme="dark"] .ql-suggest { background:rgba(255,255,255,0.04); border-color:rgba(255,255,255,0.06); }
+/* ── Food Favorites Star ── */
+.food-fav-star { background:none; border:none; cursor:pointer; padding:var(--sp-4); min-width:36px; min-height:36px; display:inline-flex; align-items:center; justify-content:center; color:var(--light); transition:color var(--anim-fast) ease; }
+.food-fav-star svg.zi { width:16px; height:16px; }
+.food-fav-star.active { color:var(--tc-amber); }
+.food-fav-star:active { transform:scale(0.9); }
+[data-theme="dark"] .food-fav-star { color:var(--light); }
+[data-theme="dark"] .food-fav-star.active { color:var(--tc-amber); }
+/* ── Dark mode: Ziva Score + Cards ── */
+[data-theme="dark"] .zs-score-excellent .zs-ring { background:linear-gradient(135deg, rgba(111,207,151,0.15), rgba(45,134,89,0.15)); border-color:rgba(111,207,151,0.4); }
+[data-theme="dark"] .zs-score-excellent .zs-number { color:#6fcf97; }
+[data-theme="dark"] .zs-score-excellent .zs-label,
+[data-theme="dark"] .zs-score-excellent .zs-trend { color:#6fcf97; }
+[data-theme="dark"] .zs-score-great .zs-ring { background:linear-gradient(135deg, rgba(127,184,216,0.15), rgba(80,140,180,0.15)); border-color:rgba(127,184,216,0.4); }
+[data-theme="dark"] .zs-score-great .zs-number { color:#7fb8d8; }
+[data-theme="dark"] .zs-score-great .zs-label,
+[data-theme="dark"] .zs-score-great .zs-trend { color:#7fb8d8; }
+[data-theme="dark"] .zs-score-good .zs-ring { background:linear-gradient(135deg, rgba(232,200,109,0.12), rgba(200,170,80,0.12)); border-color:rgba(232,200,109,0.35); }
+[data-theme="dark"] .zs-score-good .zs-number { color:#e8c86d; }
+[data-theme="dark"] .zs-score-good .zs-label,
+[data-theme="dark"] .zs-score-good .zs-trend { color:#e8c86d; }
+[data-theme="dark"] .zs-score-fair .zs-ring { background:linear-gradient(135deg, rgba(232,160,80,0.12), rgba(200,130,60,0.12)); border-color:rgba(232,160,80,0.35); }
+[data-theme="dark"] .zs-score-fair .zs-number { color:#e8a050; }
+[data-theme="dark"] .zs-score-fair .zs-label,
+[data-theme="dark"] .zs-score-fair .zs-trend { color:#e8a050; }
+[data-theme="dark"] .zs-score-attention .zs-ring { background:linear-gradient(135deg, rgba(224,112,112,0.12), rgba(176,72,94,0.12)); border-color:rgba(224,112,112,0.35); }
+[data-theme="dark"] .zs-score-attention .zs-number { color:var(--tc-danger); }
+[data-theme="dark"] .zs-score-attention .zs-label,
+[data-theme="dark"] .zs-score-attention .zs-trend { color:var(--tc-danger); }
+[data-theme="dark"] .zs-domain-pill.zsd-excellent { background:rgba(111,207,151,0.08); border-color:rgba(111,207,151,0.25); }
+[data-theme="dark"] .zs-domain-pill.zsd-excellent .zsd-score { color:#6fcf97; }
+[data-theme="dark"] .zs-domain-pill.zsd-great { background:rgba(127,184,216,0.08); border-color:rgba(127,184,216,0.25); }
+[data-theme="dark"] .zs-domain-pill.zsd-great .zsd-score { color:#7fb8d8; }
+[data-theme="dark"] .zs-domain-pill.zsd-good { background:rgba(232,200,109,0.08); border-color:rgba(232,200,109,0.2); }
+[data-theme="dark"] .zs-domain-pill.zsd-good .zsd-score { color:#e8c86d; }
+[data-theme="dark"] .zs-domain-pill.zsd-fair { background:rgba(232,160,80,0.08); border-color:rgba(232,160,80,0.2); }
+[data-theme="dark"] .zs-domain-pill.zsd-fair .zsd-score { color:#e8a050; }
+[data-theme="dark"] .zs-domain-pill.zsd-attention { background:rgba(224,112,112,0.08); border-color:rgba(224,112,112,0.2); }
+[data-theme="dark"] .zs-domain-pill.zsd-attention .zsd-score { color:var(--tc-danger); }
+[data-theme="dark"] .zs-domain-header:active { background:rgba(255,255,255,0.04); }
+[data-theme="dark"] .zs-comp-bar { background:rgba(255,255,255,0.08); }
+[data-theme="dark"] .zs-comp-val { color:#e8d8d8; }
+[data-theme="dark"] .zs-domain-name { color:#e8d8d8; }
+[data-theme="dark"] .zs-domain-score-label { color:#e8d8d8; }
+[data-theme="dark"] .zs-score-excellent .zs-ring { background:linear-gradient(135deg, rgba(111,207,151,0.12), rgba(45,134,89,0.12)); }
+[data-theme="dark"] .zs-score-fair .zs-ring { background:linear-gradient(135deg, rgba(232,184,109,0.12), rgba(250,212,180,0.12)); }
+[data-theme="dark"] .zs-score-attention .zs-ring { background:linear-gradient(135deg, rgba(224,112,112,0.12), rgba(176,72,94,0.12)); }
+[data-theme="dark"] .variety-bar { background:rgba(255,255,255,0.08); }
+[data-theme="dark"] .variety-gap { background:rgba(232,184,109,0.08); border:1px solid rgba(232,184,109,0.15); }
+[data-theme="dark"] .nutrient-bar-wrap { background:rgba(255,255,255,0.08); }
+[data-theme="dark"] .corr-item { background:rgba(255,255,255,0.04); }
+[data-theme="dark"] .ai-item { background:var(--card-bg); border-color:var(--card-border); }
+[data-theme="dark"] .ai-badge-active { background:rgba(224,112,112,0.12); color:var(--tc-danger); }
+[data-theme="dark"] .ai-badge-recurring { background:rgba(232,184,109,0.12); color:var(--amber); }
+[data-theme="dark"] .ai-badge-resolved { background:rgba(111,207,151,0.12); color:#6fcf97; }
+[data-theme="dark"] .ai-ss-concern { background:rgba(224,112,112,0.1); color:var(--tc-danger); }
+[data-theme="dark"] .ai-ss-recurring { background:rgba(232,184,109,0.1); color:var(--amber); }
+[data-theme="dark"] .ai-ss-resolved { background:rgba(111,207,151,0.1); color:#6fcf97; }
+[data-theme="dark"] .corr-evidence-trail { background:rgba(255,255,255,0.03); }
+[data-theme="dark"] .corr-ev-row { border-bottom-color:rgba(255,255,255,0.05); }
+[data-theme="dark"] .sb-excellent { background:rgba(45,134,89,0.15); color:#6fcf97; }
+[data-theme="dark"] .sb-great { background:rgba(242,168,184,0.12); color:var(--rose); }
+[data-theme="dark"] .sb-good { background:rgba(168,207,224,0.12); color:var(--sky); }
+[data-theme="dark"] .sb-fair { background:rgba(232,184,109,0.12); color:var(--amber); }
+[data-theme="dark"] .sb-attention { background:rgba(224,112,112,0.10); color:var(--tc-danger); }
+
+/* ── Dark mode: Contextual Alerts ── */
+[data-theme="dark"] .ctx-alert          { background:rgba(58,112,96,0.10); border-color:rgba(181,213,197,0.15); }
+[data-theme="dark"] .ctx-alert.ca-watch { background:rgba(232,184,109,0.10); border-color:rgba(232,184,109,0.25); }
+[data-theme="dark"] .ctx-alert.ca-action{ background:rgba(224,112,112,0.10); border-color:rgba(224,112,112,0.25); }
+[data-theme="dark"] .ctx-alert.ca-info  { background:rgba(58,112,96,0.10); border-color:rgba(181,213,197,0.20); }
+[data-theme="dark"] .ctx-alert.ca-positive { background:rgba(111,207,151,0.08); border-color:rgba(111,207,151,0.20); }
+[data-theme="dark"] .ctx-alert-sev.sev-positive { background:rgba(45,134,89,0.15); border-color:rgba(45,134,89,0.25); color:#6fcf97; }
+[data-theme="dark"] .ca-synthesis-narrative { background:rgba(232,184,109,0.10); border-color:rgba(232,184,109,0.15); color:var(--tc-amber); }
+[data-theme="dark"] .plan-item { background:var(--card-bg); border-color:var(--card-border); }
+[data-theme="dark"] .plan-item:active { background:rgba(255,255,255,0.03); }
+[data-theme="dark"] .sidebar { background:var(--body-bg); box-shadow:4px 0 24px rgba(0,0,0,0.4); }
+[data-theme="dark"] .sidebar-header { border-bottom-color:rgba(255,255,255,0.06); }
+[data-theme="dark"] .sidebar-close:hover { background:rgba(255,255,255,0.08); }
+[data-theme="dark"] .sidebar-tabs { background:rgba(255,255,255,0.03); }
+[data-theme="dark"] .sidebar-save-btn { background:rgba(58,112,96,0.12); }
+[data-theme="dark"] .sidebar-save-btn:active { background:var(--accent-sage-deep); }
+[data-theme="dark"] .sidebar-overlay { background:rgba(0,0,0,0.55); }
+[data-theme="dark"] .zoom-slider { background:rgba(255,255,255,0.08); }
+[data-theme="dark"] .zoom-preview { background:var(--base); }
+[data-theme="dark"] .insights-fab { background:linear-gradient(135deg, #c09030, #a07828); box-shadow:0 4px 16px rgba(0,0,0,0.4); }
+[data-theme="dark"] .insights-fab.fab-active { background:var(--light); }
+[data-theme="dark"] .insights-popup { background:var(--body-bg); box-shadow:0 -8px 32px rgba(0,0,0,0.5); }
+[data-theme="dark"] .insights-popup-close:hover { background:rgba(255,255,255,0.08); }
+[data-theme="dark"] .insights-popup-overlay { background:rgba(0,0,0,0.55); }
+[data-theme="dark"] .insights-popup-footer { border-top-color:rgba(255,255,255,0.06); }
+[data-theme="dark"] .insights-popup-footer:hover { background:rgba(168,207,224,0.1); }
+[data-theme="dark"] .score-popup { background:var(--body-bg); box-shadow:0 -8px 32px rgba(0,0,0,0.5); }
+[data-theme="dark"] .score-popup-overlay { background:rgba(0,0,0,0.55); }
+[data-theme="dark"] .score-popup-close:hover { background:rgba(255,255,255,0.08); }
+[data-theme="dark"] .sp-tab-bar { border-bottom-color:rgba(255,255,255,0.06); }
+[data-theme="dark"] .sp-tab.active { background:rgba(242,168,184,0.1); border-color:rgba(242,168,184,0.2); }
+[data-theme="dark"] .sp-comp { border-bottom-color:rgba(255,255,255,0.06); }
+[data-theme="dark"] .sp-comp-bar { background:rgba(255,255,255,0.08); }
+[data-theme="dark"] .sp-trend-line { background:rgba(51,101,128,0.12); }
+[data-theme="dark"] .sp-overview-item { background:rgba(255,255,255,0.03); border-color:rgba(255,255,255,0.06); }
+[data-theme="dark"] .sp-tip { background:rgba(168,207,224,0.08); border-color:rgba(168,207,224,0.15); }
+[data-theme="dark"] .domain-score-hero { border-bottom-color:rgba(255,255,255,0.06); }
+[data-theme="dark"] .dsh-comp-pill { background:var(--card-bg); border-color:var(--card-border); }
+[data-theme="dark"] .dsh-diet .dsh-comp-pill { background:linear-gradient(135deg, var(--warm), rgba(58,112,96,0.12)); border-color:rgba(181,213,197,0.15); }
+[data-theme="dark"] .dsh-sleep .dsh-comp-pill { background:linear-gradient(135deg, var(--warm), rgba(74,80,128,0.12)); border-color:rgba(155,168,216,0.15); }
+[data-theme="dark"] .dsh-poop .dsh-comp-pill { background:linear-gradient(135deg, var(--warm), rgba(138,101,32,0.12)); border-color:rgba(232,184,109,0.15); }
+[data-theme="dark"] .dsh-medical .dsh-comp-pill { background:linear-gradient(135deg, var(--warm), rgba(158,62,82,0.12)); border-color:rgba(242,168,184,0.15); }
+[data-theme="dark"] .dsh-milestones .dsh-comp-pill { background:linear-gradient(135deg, var(--warm), rgba(110,94,154,0.12)); border-color:rgba(201,184,232,0.15); }
+
+/* ── Dark mode: domain-tinted card backgrounds ── */
+[data-theme="dark"] #tab-diet .card { background:linear-gradient(135deg, var(--warm), rgba(58,112,96,0.08)); }
+[data-theme="dark"] #tab-sleep .card { background:linear-gradient(135deg, var(--warm), rgba(74,80,128,0.08)); }
+[data-theme="dark"] #tab-poop .card { background:linear-gradient(135deg, var(--warm), rgba(138,101,32,0.08)); }
+[data-theme="dark"] #tab-medical .card { background:linear-gradient(135deg, var(--warm), rgba(158,62,82,0.08)); }
+[data-theme="dark"] #tab-milestones .card { background:linear-gradient(135deg, var(--warm), rgba(110,94,154,0.08)); }
+[data-theme="dark"] .dsh-ring-excellent { background:linear-gradient(135deg, rgba(58,112,96,0.25), rgba(58,112,96,0.15)); border-color:rgba(111,207,151,0.4); color:#7ac0a0; }
+[data-theme="dark"] .dsh-ring-great { background:linear-gradient(135deg, rgba(42,106,138,0.25), rgba(42,106,138,0.15)); border-color:rgba(127,184,216,0.4); color:#80b8d8; }
+[data-theme="dark"] .dsh-ring-good { background:linear-gradient(135deg, rgba(138,101,32,0.25), rgba(138,101,32,0.15)); border-color:rgba(232,200,109,0.4); color:#d4a848; }
+[data-theme="dark"] .dsh-ring-fair { background:linear-gradient(135deg, rgba(138,80,32,0.25), rgba(138,80,32,0.15)); border-color:rgba(232,160,80,0.4); color:#e0a060; }
+[data-theme="dark"] .dsh-ring-attention { background:linear-gradient(135deg, rgba(160,48,48,0.25), rgba(160,48,48,0.15)); border-color:rgba(224,112,112,0.4); color:#e090a8; }
+[data-theme="dark"] .dsh-comp-pill .dcp-bar.dcb-high { background:rgba(111,207,151,0.1); color:#6fcf97; }
+[data-theme="dark"] .dsh-comp-pill .dcp-bar.dcb-mid  { background:rgba(232,200,109,0.1); color:var(--amber); }
+[data-theme="dark"] .dsh-comp-pill .dcp-bar.dcb-low  { background:rgba(224,112,112,0.1); color:var(--tc-danger); }
+[data-theme="dark"] .dsh-comp-pill .dcp-name { color:#e8d8d8; }
+[data-theme="dark"] .dsh-comp-pill.dcp-high::before { background:linear-gradient(180deg, #4aba7a, #3a9a6a); }
+[data-theme="dark"] .dsh-comp-pill.dcp-mid::before  { background:linear-gradient(180deg, #d4a040, #c09030); }
+[data-theme="dark"] .dsh-comp-pill.dcp-low::before  { background:linear-gradient(180deg, #c85050, #b04040); }
+[data-theme="dark"] .popup-plan-item { background:var(--card-bg); border-color:var(--card-border); }
+[data-theme="dark"] .popup-plan-item:active { background:rgba(255,255,255,0.03); }
+[data-theme="dark"] .ctx-alert-title    { color:var(--text); }
+[data-theme="dark"] .ctx-alert-msg      { color:var(--mid); }
+[data-theme="dark"] .ctx-alert-tip      { background:rgba(255,255,255,0.04); border-color:rgba(255,255,255,0.08); }
+[data-theme="dark"] .ctx-alert-sev.sev-info   { background:rgba(58,112,96,0.15); border-color:rgba(58,112,96,0.25); }
+[data-theme="dark"] .ctx-alert-sev.sev-watch  { background:rgba(138,101,32,0.15); border-color:rgba(138,101,32,0.25); }
+[data-theme="dark"] .ctx-alert-sev.sev-action { background:rgba(176,72,94,0.15); border-color:rgba(176,72,94,0.25); }
+[data-theme="dark"] .ctx-alert-btn.cab-primary { background:var(--mid); }
+[data-theme="dark"] .ctx-alert-btn.cab-secondary { border-color:rgba(255,255,255,0.12); color:var(--light); }
+[data-theme="dark"] .ctx-alert-btn.cab-snooze { border-color:rgba(255,255,255,0.12); color:var(--light); }
+[data-theme="dark"] .ctx-alert-btn.cab-ack { background:rgba(181,213,197,0.14); border-color:rgba(181,213,197,0.3); }
+[data-theme="dark"] .ctx-alert-dismiss:hover { background:rgba(255,255,255,0.08); }
+[data-theme="dark"] .ca-view-all:hover { background:rgba(168,207,224,0.1); }
+[data-theme="dark"] .alert-hist-item { border-bottom-color:rgba(255,255,255,0.05); }
+
+/* ═══ MEAL INTAKE ═══ */
+.mi-prompt {
+  padding:var(--sp-12) var(--sp-16) var(--sp-8);
+  border-top:1px solid var(--card-border);
+}
+.mi-prompt-label {
+  font-size:var(--fs-xs); color:var(--mid); font-weight:600;
+  margin-bottom:var(--sp-8); text-align:center;
+}
+.mi-buttons {
+  display:flex; gap:var(--sp-8); justify-content:center;
+}
+.mi-btn {
+  flex:1; max-width:80px; padding:var(--sp-8) var(--sp-4);
+  border:1.5px solid var(--card-border); border-radius:var(--r-md);
+  background:var(--card-bg); cursor:pointer; text-align:center;
+  transition:border-color 0.15s, background 0.15s;
+}
+.mi-btn:active { background:rgba(155,168,216,0.1); }
+.mi-btn-icon { font-size:var(--fs-md); line-height:1.2; }
+.mi-btn-icon .zi { width:var(--icon-md); height:var(--icon-md); }
+.mi-btn-label { font-size:var(--fs-2xs); color:var(--mid); margin-top:var(--sp-2); }
+.mi-btn.mi-selected {
+  border-color:var(--tc-indigo); background:rgba(155,168,216,0.08);
+}
+.mi-btn.mi-selected .mi-btn-label { color:var(--tc-indigo); font-weight:700; }
+.mi-skip {
+  display:block; margin:var(--sp-8) auto 0; padding:var(--sp-4) var(--sp-12);
+  background:none; border:none; color:var(--light); font-size:var(--fs-xs);
+  cursor:pointer; font-family:inherit;
+}
+.mi-skip:active { color:var(--mid); }
+.mi-chip {
+  display:inline-flex; align-items:center; gap:var(--sp-4);
+  padding:var(--sp-2) var(--sp-8); border-radius:var(--r-md);
+  font-size:var(--fs-2xs); font-weight:600; cursor:pointer;
+  border:1px solid transparent; transition:background 0.15s;
+}
+.mi-chip-100 { background:rgba(58,112,96,0.1); color:var(--tc-sage); border-color:rgba(58,112,96,0.2); }
+.mi-chip-75  { background:rgba(58,112,96,0.06); color:var(--tc-sage); border-color:rgba(58,112,96,0.12); }
+.mi-chip-50  { background:rgba(232,200,109,0.1); color:var(--tc-amber); border-color:rgba(232,200,109,0.2); }
+.mi-chip-25  { background:rgba(240,150,100,0.1); color:var(--tc-caution); border-color:rgba(240,150,100,0.2); }
+.mi-chip:active { filter:brightness(0.95); }
+.mi-bar {
+  display:flex; gap:1px; height:var(--sp-4); border-radius:var(--r-sm); overflow:hidden;
+  background:var(--card-border); min-width:var(--sp-32);
+}
+.mi-bar-seg {
+  flex:1; border-radius:var(--r-sm);
+}
+.mi-bar-seg.filled-100 { background:var(--tc-sage); }
+.mi-bar-seg.filled-75  { background:var(--tc-sage); }
+.mi-bar-seg.filled-50  { background:var(--tc-amber); }
+.mi-bar-seg.filled-25  { background:var(--tc-caution); }
+.mi-inline {
+  display:flex; gap:var(--sp-6); margin-top:var(--sp-8);
+}
+.mi-prog-row {
+  display:flex; align-items:center; gap:var(--sp-4);
+  margin-top:var(--sp-2);
+}
+.mi-prog-label { font-size:var(--fs-2xs); color:var(--mid); }
+.mi-inline-btn {
+  flex:1 1 0; min-width:0; padding:var(--sp-6) var(--sp-4); border-radius:var(--r-lg);
+  font-size:var(--fs-xs); border:1.5px solid var(--glass-strong);
+  background:var(--glass); color:var(--mid); cursor:pointer;
+  transition:all 0.15s; font-family:inherit; font-weight:500;
+  display:flex; align-items:center; justify-content:center; gap:var(--sp-4);
+  white-space:nowrap;
+}
+.mi-inline-btn .zi { width:var(--icon-sm); height:var(--icon-sm); flex-shrink:0; }
+.mi-inline-btn:active { opacity:0.8; }
+.mi-inline-btn.mi-active {
+  border-color:var(--tc-sage); background:rgba(58,112,96,0.1);
+  color:var(--tc-sage); font-weight:700;
+}
+
+/* Dark mode */
+[data-theme="dark"] .mi-prompt { border-top-color:rgba(255,255,255,0.06); }
+[data-theme="dark"] .mi-btn { background:var(--surface); border-color:var(--card-border); }
+[data-theme="dark"] .mi-btn:active { background:rgba(155,168,216,0.12); }
+[data-theme="dark"] .mi-btn.mi-selected { background:rgba(155,168,216,0.1); }
+[data-theme="dark"] .mi-inline-btn { background:rgba(255,255,255,0.06); border-color:rgba(255,255,255,0.1); }
+[data-theme="dark"] .mi-inline-btn:active { opacity:0.8; }
+[data-theme="dark"] .mi-inline-btn.mi-active { background:rgba(58,112,96,0.15); border-color:rgba(58,112,96,0.3); }
+
+/* ═══ SMART Q&A ═══ */
+.qa-card {
+  /* Invisible container — the input-wrap IS the visual element */
+  padding:0; background:none; border:none; box-shadow:none;
+}
+.qa-input-wrap {
+  display:flex; align-items:center; gap:var(--sp-12);
+  background:var(--white); border:1px solid rgba(155,168,216,0.15);
+  border-radius:var(--r-full); padding:var(--sp-10) var(--sp-16);
+  box-shadow:0 1px 8px rgba(155,168,216,0.08);
+  transition:border-color var(--ease-fast), box-shadow var(--ease-fast);
+}
+.qa-input-wrap:focus-within {
+  border-color:rgba(155,168,216,0.4);
+  box-shadow:0 2px 12px rgba(155,168,216,0.12);
+}
+.qa-input-icon { color:var(--tc-indigo); flex-shrink:0; opacity:0.45; }
+.qa-input-icon .zi { width:var(--icon-sm); height:var(--icon-sm); }
+.qa-input {
+  flex:1; border:none; background:none; outline:none;
+  font-size:var(--fs-base); color:var(--text); font-family:inherit;
+  min-width:0;
+}
+.qa-input::placeholder { color:var(--light); font-style:italic; }
+.qa-clear {
+  background:none; border:none; cursor:pointer;
+  color:var(--light); font-size:var(--fs-md); padding:var(--sp-4);
+  border-radius:var(--r-full); display:none; line-height:1;
+}
+.qa-clear:active { background:rgba(0,0,0,0.05); }
+/* Chips: hidden by default, revealed on qa-active */
+.qa-chips {
+  display:flex; gap:var(--sp-8); overflow-x:auto;
+  -webkit-overflow-scrolling:touch; scrollbar-width:none;
+  max-height:0; opacity:0; padding-top:0; overflow:hidden;
+  transition:max-height var(--ease-med), opacity var(--ease-med), padding-top var(--ease-med);
+}
+.qa-card.qa-active .qa-chips {
+  max-height:50px; opacity:1; padding-top:var(--sp-12); overflow-x:auto;
+}
+.qa-chips::-webkit-scrollbar { display:none; }
+.qa-chip {
+  flex-shrink:0; padding:var(--sp-8) var(--sp-12);
+  border-radius:var(--r-full); font-size:var(--fs-xs);
+  cursor:pointer; white-space:nowrap;
+  transition:background 0.15s, border-color 0.15s;
+  font-weight:500;
+  background:var(--glass-strong); border:1px solid rgba(155,168,216,0.15);
+  color:var(--mid);
+}
+.qa-chip-rose   { background:var(--rose-light); border-color:rgba(242,168,184,0.3); color:var(--tc-rose); }
+.qa-chip-peach  { background:var(--peach-light); border-color:rgba(250,212,180,0.4); color:var(--tc-caution); }
+.qa-chip-sage   { background:var(--sage-light); border-color:rgba(181,213,197,0.4); color:var(--tc-sage); }
+.qa-chip-indigo { background:var(--indigo-light); border-color:rgba(155,168,216,0.3); color:var(--tc-indigo); }
+.qa-chip-amber  { background:var(--amber-light); border-color:rgba(240,200,120,0.4); color:var(--tc-amber); }
+.qa-chip-lav    { background:var(--lav-light); border-color:rgba(201,184,232,0.3); color:var(--tc-lav); }
+.qa-chip-sky    { background:var(--sky-light); border-color:rgba(168,207,224,0.3); color:var(--tc-sky); }
+.qa-chip:active { opacity:0.8; }
+.qa-chip-context { font-weight:700; }
+.qa-suggest {
+  display:none; padding:var(--sp-4) var(--sp-8) var(--sp-8);
+}
+.qa-suggest.active { display:flex; flex-direction:column; gap:var(--sp-4); }
+.qa-suggest-item {
+  font-family:inherit; font-size:var(--fs-sm); font-weight:500;
+  padding:var(--sp-6) var(--sp-12); border-radius:var(--r-lg);
+  border:1px solid var(--card-border); background:var(--glass);
+  color:var(--text); cursor:pointer; text-align:left;
+  transition:all 0.12s ease; line-height:1.4;
+}
+.qa-suggest-item:active { opacity:0.8; transform:scale(0.98); }
+.qa-answer {
+  margin:var(--sp-12) 0 0;
+  border-radius:var(--r-xl); overflow:hidden;
+  animation:qaSlideIn 0.2s ease-out;
+  padding:var(--sp-4) 0;
+  /* Default: neutral white card */
+  background:linear-gradient(135deg, var(--white) 60%, var(--warm));
+  border:1px solid var(--card-border);
+  box-shadow:0 2px 12px rgba(180,120,120,0.08);
+}
+.qa-answer-indigo {
+  background:linear-gradient(135deg, var(--white) 50%, var(--indigo-light));
+  border-color:rgba(155,168,216,0.2);
+  box-shadow:0 2px 16px rgba(155,168,216,0.1);
+}
+.qa-answer-peach {
+  background:linear-gradient(135deg, var(--white) 50%, var(--peach-light));
+  border-color:rgba(250,212,180,0.3);
+  box-shadow:0 2px 16px rgba(250,212,180,0.1);
+}
+.qa-answer-rose {
+  background:linear-gradient(135deg, var(--white) 50%, var(--rose-light));
+  border-color:rgba(242,168,184,0.2);
+  box-shadow:0 2px 16px rgba(242,168,184,0.08);
+}
+.qa-answer-amber {
+  background:linear-gradient(135deg, var(--white) 50%, var(--amber-light));
+  border-color:rgba(240,200,120,0.3);
+  box-shadow:0 2px 16px rgba(240,200,120,0.08);
+}
+.qa-answer-sage {
+  background:linear-gradient(135deg, var(--white) 50%, var(--sage-light));
+  border-color:rgba(181,213,197,0.3);
+  box-shadow:0 2px 16px rgba(181,213,197,0.1);
+}
+.qa-answer-lav {
+  background:linear-gradient(135deg, var(--white) 50%, var(--lav-light));
+  border-color:rgba(201,184,232,0.2);
+  box-shadow:0 2px 16px rgba(201,184,232,0.08);
+}
+.qa-answer-sky {
+  background:linear-gradient(135deg, var(--white) 50%, var(--sky-light));
+  border-color:rgba(168,207,224,0.3);
+  box-shadow:0 2px 16px rgba(168,207,224,0.08);
+}
+@keyframes qaSlideIn { from { opacity:0; transform:translateY(8px); } to { opacity:1; transform:translateY(0); } }
+.qa-answer-header {
+  display:flex; align-items:center; gap:var(--sp-12);
+  padding:var(--sp-12) var(--sp-16) var(--sp-8);
+}
+.qa-answer-header .icon {
+  width:32px; height:32px; border-radius:var(--r-md);
+  display:flex; align-items:center; justify-content:center;
+  flex-shrink:0;
+}
+.qa-answer-header .icon svg.zi { width:18px; height:18px; }
+.qa-answer-title-group { flex:1; min-width:0; }
+.qa-answer-title {
+  font-size:var(--fs-md); font-weight:700; color:var(--text);
+  line-height:1.3;
+}
+.qa-answer-headline {
+  font-size:var(--fs-sm); color:var(--mid);
+  margin-top:var(--sp-2); line-height:1.4;
+}
+.qa-answer-close {
+  background:none; border:none; cursor:pointer;
+  color:var(--light); font-size:var(--fs-lg);
+  padding:var(--sp-4); border-radius:var(--r-full);
+  line-height:1; flex-shrink:0;
+}
+.qa-answer-close:active { background:rgba(0,0,0,0.05); }
+.qa-section { padding:var(--sp-4) var(--sp-16) var(--sp-12); }
+.qa-section-label {
+  font-size:var(--fs-xs); font-weight:700; color:var(--mid);
+  text-transform:uppercase; letter-spacing:var(--ls-wide);
+  margin-bottom:var(--sp-8);
+  display:flex; align-items:center; gap:var(--sp-6);
+}
+.qa-section-label-icon { font-size:var(--fs-sm); line-height:1; }
+.qa-item {
+  display:flex; align-items:flex-start; gap:var(--sp-8);
+  padding:var(--sp-4) 0; font-size:var(--fs-sm); color:var(--text);
+  line-height:1.5;
+}
+.qa-item-signal { flex-shrink:0; font-size:var(--fs-sm); line-height:1.5; width:var(--sp-16); text-align:center; }
+.qa-item-text { flex:1; min-width:0; }
+.qa-item-good .qa-item-signal { color:var(--tc-sage); }
+.qa-item-warn .qa-item-signal { color:var(--tc-caution); }
+.qa-item-action .qa-item-signal { color:var(--tc-indigo); }
+.qa-item-info .qa-item-signal { color:var(--tc-sky); }
+.qa-item-neutral .qa-item-signal { color:var(--mid); }
+/* food-effects v2 R2 (V-R2-N1/N2): the Q&A emergency-floor section must carry the
+   weight of the .cons-severe log-time floor a parent has already learned — not the
+   muted nutrition-section chrome. Amber surface + amber-deep bold label/siren (V-3:
+   serious-without-alarm; rose reserved for the acute-toxin seek-care line). Applied
+   via sec.tone==='floor' in qaRenderAnswer; reachability/order are unchanged. */
+.qa-section-floor { background:var(--surface-amber); border-left:3px solid var(--amber-deep); border-radius:var(--r-md); margin:var(--sp-4) var(--sp-16) var(--sp-12); padding:var(--sp-12); }
+.qa-section-floor .qa-section-label { color:var(--amber-deep); }
+.qa-section-floor .qa-section-label-icon { color:var(--amber-deep); }
+/* watch-fors inside a floor read at warn weight, not the calm 'info' sky-blue (V-R2-N2) */
+.qa-section-floor .qa-item-info .qa-item-signal { color:var(--amber-deep); }
+/* the seek-care line carries the rose-deep alarm in its TEXT, not just its icon */
+.qa-section-floor .qa-item-seek { color:var(--rose-deep); font-weight:600; }
+.qa-section-floor .qa-item-seek .qa-item-signal { color:var(--rose-deep); }
+.qa-confidence {
+  padding:var(--sp-8) var(--sp-16) var(--sp-12);
+  font-size:var(--fs-2xs); color:var(--light);
+  border-top:1px solid var(--card-border);
+  text-align:center;
+}
+.qa-data-gap {
+  padding:var(--sp-8) var(--sp-16);
+  font-size:var(--fs-xs); color:var(--tc-sky);
+  background:rgba(168,207,224,0.06);
+  border-top:1px solid rgba(168,207,224,0.12);
+  text-align:center;
+}
+.qa-actions {
+  display:flex; flex-wrap:wrap; gap:var(--sp-8);
+  padding:var(--sp-8) var(--sp-16) var(--sp-12);
+  border-top:1px solid var(--card-border);
+}
+.qa-action-btn {
+  flex:1; min-width:0;
+  font-family:inherit; font-size:var(--fs-sm); font-weight:700;
+  padding:var(--sp-10) var(--sp-16); border-radius:var(--r-lg);
+  border:1px solid rgba(242,168,184,0.3); background:var(--rose-light);
+  color:var(--tc-rose); cursor:pointer; transition:all 0.15s ease;
+  display:flex; align-items:center; justify-content:center; gap:var(--sp-6);
+  line-height:1.3;
+}
+.qa-action-btn:active { opacity:0.8; transform:scale(0.98); }
+.qa-action-btn:disabled { opacity:0.5; cursor:default; }
+.qa-action-btn .qa-action-icon { flex-shrink:0; }
+.qa-action-btn .qa-action-icon .zi { width:var(--sp-16); height:var(--sp-16); }
+.qa-action-sage { background:var(--sage-light); border-color:rgba(181,213,197,0.4); color:var(--tc-sage); }
+.qa-action-rose { background:var(--rose-light); border-color:rgba(242,168,184,0.3); color:var(--tc-rose); }
+.qa-action-done { background:var(--sage-light); border-color:rgba(181,213,197,0.4); color:var(--tc-sage); }
+.qa-action-indigo { background:var(--indigo-light); border-color:rgba(155,168,216,0.3); color:var(--tc-indigo); }
+.qa-action-sky { background:var(--sky-light); border-color:rgba(168,207,224,0.3); color:var(--tc-sky); }
+.qa-action-amber { background:var(--amber-light); border-color:rgba(240,200,120,0.3); color:var(--tc-amber); }
+.qa-action-lav { background:var(--lav-light); border-color:rgba(201,184,232,0.3); color:var(--tc-lav); }
+.qa-no-match {
+  padding:var(--sp-16);
+  text-align:center; font-size:var(--fs-sm); color:var(--mid);
+}
+.qa-no-match-label { margin-bottom:var(--sp-12); }
+.qa-cat-chips {
+  display:flex; flex-wrap:wrap; gap:var(--sp-8);
+  justify-content:center;
+}
+
+/* Dark mode */
+[data-theme="dark"] .qa-card { background:none; border:none; box-shadow:none; }
+[data-theme="dark"] .qa-input-wrap { background:rgba(255,255,255,0.06); border-color:rgba(155,168,216,0.12); box-shadow:0 1px 8px rgba(0,0,0,0.15); }
+[data-theme="dark"] .qa-input-wrap:focus-within { border-color:rgba(155,168,216,0.4); box-shadow:0 2px 12px rgba(155,168,216,0.1); }
+[data-theme="dark"] .qa-clear:active { background:rgba(255,255,255,0.08); }
+[data-theme="dark"] .qa-chip { background:rgba(255,255,255,0.04); border-color:rgba(255,255,255,0.08); }
+[data-theme="dark"] .qa-chip-rose   { background:rgba(242,168,184,0.08); border-color:rgba(242,168,184,0.15); color:var(--tc-rose); }
+[data-theme="dark"] .qa-chip-peach  { background:rgba(250,212,180,0.08); border-color:rgba(250,212,180,0.15); color:var(--tc-caution); }
+[data-theme="dark"] .qa-chip-sage   { background:rgba(181,213,197,0.08); border-color:rgba(181,213,197,0.15); color:var(--tc-sage); }
+[data-theme="dark"] .qa-chip-indigo { background:rgba(155,168,216,0.08); border-color:rgba(155,168,216,0.15); color:var(--tc-indigo); }
+[data-theme="dark"] .qa-chip-amber  { background:rgba(240,200,120,0.08); border-color:rgba(240,200,120,0.15); color:var(--tc-amber); }
+[data-theme="dark"] .qa-chip-lav    { background:rgba(201,184,232,0.08); border-color:rgba(201,184,232,0.15); color:var(--tc-lav); }
+[data-theme="dark"] .qa-chip-sky    { background:rgba(168,207,224,0.08); border-color:rgba(168,207,224,0.15); color:var(--tc-sky); }
+[data-theme="dark"] .qa-chip:active { opacity:0.8; }
+[data-theme="dark"] .qa-chip-context { font-weight:700; }
+[data-theme="dark"] .qa-suggest-item { background:var(--surface-alt); border-color:rgba(255,255,255,0.08); }
+[data-theme="dark"] .qa-answer { background:linear-gradient(135deg, var(--surface) 60%, var(--surface-alt)); border-color:var(--card-border); box-shadow:0 2px 12px rgba(0,0,0,0.2); }
+[data-theme="dark"] .qa-answer-indigo { background:linear-gradient(135deg, var(--surface) 50%, rgba(155,168,216,0.08)); border-color:rgba(155,168,216,0.12); }
+[data-theme="dark"] .qa-answer-peach  { background:linear-gradient(135deg, var(--surface) 50%, rgba(250,212,180,0.06)); border-color:rgba(250,212,180,0.1); }
+[data-theme="dark"] .qa-answer-rose   { background:linear-gradient(135deg, var(--surface) 50%, rgba(242,168,184,0.06)); border-color:rgba(242,168,184,0.1); }
+[data-theme="dark"] .qa-answer-amber  { background:linear-gradient(135deg, var(--surface) 50%, rgba(240,200,120,0.06)); border-color:rgba(240,200,120,0.1); }
+[data-theme="dark"] .qa-answer-sage   { background:linear-gradient(135deg, var(--surface) 50%, rgba(181,213,197,0.06)); border-color:rgba(181,213,197,0.1); }
+[data-theme="dark"] .qa-answer-lav    { background:linear-gradient(135deg, var(--surface) 50%, rgba(201,184,232,0.06)); border-color:rgba(201,184,232,0.1); }
+[data-theme="dark"] .qa-answer-sky    { background:linear-gradient(135deg, var(--surface) 50%, rgba(168,207,224,0.06)); border-color:rgba(168,207,224,0.1); }
+[data-theme="dark"] .qa-answer-close:active { background:rgba(255,255,255,0.08); }
+[data-theme="dark"] .qa-confidence { border-top-color:rgba(255,255,255,0.06); }
+[data-theme="dark"] .qa-data-gap { background:rgba(168,207,224,0.05); border-top-color:rgba(168,207,224,0.08); }
+[data-theme="dark"] .qa-actions { border-top-color:rgba(255,255,255,0.06); }
+[data-theme="dark"] .qa-action-btn { background:rgba(242,168,184,0.1); border-color:rgba(242,168,184,0.15); }
+[data-theme="dark"] .qa-action-sage { background:rgba(181,213,197,0.1); border-color:rgba(181,213,197,0.15); }
+[data-theme="dark"] .qa-action-rose { background:rgba(242,168,184,0.1); border-color:rgba(242,168,184,0.15); }
+[data-theme="dark"] .qa-action-done { background:rgba(181,213,197,0.1); border-color:rgba(181,213,197,0.15); }
+[data-theme="dark"] .qa-action-indigo { background:rgba(155,168,216,0.1); border-color:rgba(155,168,216,0.15); }
+[data-theme="dark"] .qa-action-sky { background:rgba(168,207,224,0.1); border-color:rgba(168,207,224,0.15); }
+[data-theme="dark"] .qa-action-amber { background:rgba(240,200,120,0.1); border-color:rgba(240,200,120,0.15); }
+[data-theme="dark"] .qa-action-lav { background:rgba(201,184,232,0.1); border-color:rgba(201,184,232,0.15); }
+
+/* ═══ UNIFIED INTELLIGENCE BAR (UIB) ═══ */
+.qa-mode-indicator {
+  display:flex; align-items:center; gap:var(--sp-8);
+  padding:var(--sp-6) var(--sp-12); margin-top:var(--sp-4);
+  font-size:var(--fs-xs); font-weight:600; letter-spacing:var(--ls-wide);
+  color:var(--tc-indigo); opacity:0; max-height:0; overflow:hidden;
+  transition:opacity 0.25s ease, max-height 0.25s ease;
+}
+.qa-mode-indicator.active { opacity:1; max-height:var(--sp-32); }
+.qa-mode-indicator .icon { width:var(--sp-16); height:var(--sp-16); flex-shrink:0; }
+.iq-picker {
+  background:var(--glass); border:1px solid rgba(155,168,216,0.12);
+  border-radius:var(--r-lg); padding:var(--sp-12) var(--sp-16);
+  margin-top:var(--sp-8); display:none;
+}
+.iq-picker.active { display:block; }
+.iq-picker-title {
+  font-size:var(--fs-xs); font-weight:700; letter-spacing:var(--ls-wide);
+  text-transform:uppercase; color:var(--tc-indigo); margin-bottom:var(--sp-10);
+  display:flex; align-items:center; gap:var(--sp-6);
+}
+.iq-picker-title .icon { width:var(--sp-16); height:var(--sp-16); }
+.iq-group { margin-bottom:var(--sp-10); }
+.iq-group-label {
+  font-size:var(--fs-2xs); font-weight:700; letter-spacing:var(--ls-wide);
+  text-transform:uppercase; color:var(--mid); margin-bottom:var(--sp-4);
+}
+.iq-group-chips { display:flex; flex-wrap:wrap; gap:var(--sp-4); }
+.iq-food-chip {
+  font-family:inherit; font-size:var(--fs-xs); font-weight:500;
+  padding:var(--sp-4) var(--sp-10); border-radius:var(--r-full);
+  border:1px solid rgba(155,168,216,0.15); background:var(--warm);
+  color:var(--text); cursor:pointer; transition:all 0.15s ease;
+  line-height:1.4;
+}
+.iq-food-chip:active { transform:scale(0.96); }
+.iq-food-chip.selected {
+  background:var(--sage-light); border-color:var(--tc-sage);
+  color:var(--tc-sage); font-weight:700;
+}
+/* Per-group colored chips */
+.iq-chip-peach  { background:var(--peach-light); border-color:rgba(250,212,180,0.4); color:var(--tc-caution); }
+.iq-chip-amber  { background:var(--amber-light); border-color:rgba(240,200,120,0.4); color:var(--tc-amber); }
+.iq-chip-sage   { background:var(--sage-light); border-color:rgba(181,213,197,0.4); color:var(--tc-sage); }
+.iq-chip-rose   { background:var(--rose-light); border-color:rgba(242,168,184,0.3); color:var(--tc-rose); }
+.iq-chip-lav    { background:var(--lav-light); border-color:rgba(201,184,232,0.3); color:var(--tc-lav); }
+.iq-chip-sky    { background:var(--sky-light); border-color:rgba(168,207,224,0.3); color:var(--tc-sky); }
+.iq-label-peach { color:var(--tc-caution); }
+.iq-label-amber { color:var(--tc-amber); }
+.iq-label-sage  { color:var(--tc-sage); }
+.iq-label-rose  { color:var(--tc-rose); }
+.iq-label-lav   { color:var(--tc-lav); }
+.iq-label-sky   { color:var(--tc-sky); }
+.iq-submit-row { display:flex; justify-content:flex-end; margin-top:var(--sp-10); }
+.iq-submit-btn {
+  font-family:inherit; font-size:var(--fs-sm); font-weight:700;
+  padding:var(--sp-8) var(--sp-20); border-radius:var(--r-full);
+  border:none; background:var(--tc-sage); color:white;
+  cursor:pointer; transition:opacity 0.15s ease;
+  display:flex; align-items:center; gap:var(--sp-6);
+}
+.iq-submit-btn:disabled { opacity:0.35; cursor:default; }
+.iq-submit-btn:active:not(:disabled) { opacity:0.8; }
+.iq-search-wrap {
+  margin-bottom:var(--sp-10); position:relative;
+}
+.iq-search-input {
+  width:100%; box-sizing:border-box;
+  font-family:inherit; font-size:var(--fs-sm); font-weight:500;
+  padding:var(--sp-8) var(--sp-12); border-radius:var(--r-lg);
+  border:1px solid rgba(155,168,216,0.2); background:var(--warm);
+  color:var(--text); outline:none; transition:border-color 0.15s ease;
+}
+.iq-search-input:focus { border-color:rgba(155,168,216,0.5); }
+.iq-search-input::placeholder { color:var(--light); }
+.iq-new-section { margin-top:var(--sp-8); }
+.iq-new-label {
+  font-size:var(--fs-2xs); font-weight:700; letter-spacing:var(--ls-wide);
+  text-transform:uppercase; color:var(--tc-indigo); margin-bottom:var(--sp-4);
+  display:flex; align-items:center; gap:var(--sp-4);
+}
+.iq-new-label .icon { width:var(--sp-12); height:var(--sp-12); }
+.iq-chip-new {
+  font-family:inherit; font-size:var(--fs-xs); font-weight:500;
+  padding:var(--sp-4) var(--sp-10); border-radius:var(--r-full);
+  border:1px dashed rgba(155,168,216,0.3); background:var(--indigo-light);
+  color:var(--tc-indigo); cursor:pointer; transition:all 0.15s ease;
+  line-height:1.4;
+}
+.iq-chip-new:active { transform:scale(0.96); }
+.iq-chip-new.selected {
+  background:var(--sage-light); border-color:var(--tc-sage);
+  border-style:solid; color:var(--tc-sage); font-weight:700;
+}
+.iq-combo-history-label {
+  font-size:var(--fs-2xs); font-weight:700; letter-spacing:var(--ls-wide);
+  text-transform:uppercase; color:var(--mid); margin:var(--sp-8) 0 var(--sp-4);
+}
+.iq-combo-card {
+  background:var(--warm); border-radius:var(--r-md);
+  padding:var(--sp-8) var(--sp-12); margin-bottom:var(--sp-6);
+  border:1px solid rgba(155,168,216,0.08);
+}
+.iq-combo-card.starred { border-left:3px solid var(--tc-sage); }
+.iq-combo-name { font-size:var(--fs-sm); font-weight:700; color:var(--text); }
+.iq-combo-meta {
+  font-size:var(--fs-2xs); color:var(--mid); margin-top:var(--sp-2);
+  display:flex; flex-wrap:wrap; gap:var(--sp-6); align-items:center;
+}
+.iq-combo-reason {
+  font-size:var(--fs-xs); color:var(--tc-sage); margin-top:var(--sp-4);
+  font-style:italic; line-height:1.4;
+}
+.iq-warning {
+  margin-top:var(--sp-8); padding:var(--sp-8) var(--sp-12);
+  background:var(--amber-light); border-radius:var(--r-md);
+  font-size:var(--fs-xs); color:var(--tc-amber);
+  display:flex; align-items:flex-start; gap:var(--sp-6);
+}
+.iq-warning .icon { width:var(--sp-16); height:var(--sp-16); flex-shrink:0; margin-top:1px; }
+/* Dark mode — UIB */
+[data-theme="dark"] .qa-mode-indicator { color:var(--tc-indigo); }
+[data-theme="dark"] .iq-picker { background:var(--surface); border-color:rgba(155,168,216,0.1); }
+[data-theme="dark"] .iq-food-chip { background:var(--surface-alt); border-color:rgba(255,255,255,0.08); color:var(--text); }
+[data-theme="dark"] .iq-food-chip.selected { background:rgba(181,213,197,0.15); border-color:var(--tc-sage); color:var(--tc-sage); }
+[data-theme="dark"] .iq-chip-peach  { background:rgba(250,212,180,0.08); border-color:rgba(250,212,180,0.15); color:var(--tc-caution); }
+[data-theme="dark"] .iq-chip-amber  { background:rgba(240,200,120,0.08); border-color:rgba(240,200,120,0.15); color:var(--tc-amber); }
+[data-theme="dark"] .iq-chip-sage   { background:rgba(181,213,197,0.08); border-color:rgba(181,213,197,0.15); color:var(--tc-sage); }
+[data-theme="dark"] .iq-chip-rose   { background:rgba(242,168,184,0.08); border-color:rgba(242,168,184,0.12); color:var(--tc-rose); }
+[data-theme="dark"] .iq-chip-lav    { background:rgba(201,184,232,0.08); border-color:rgba(201,184,232,0.12); color:var(--tc-lav); }
+[data-theme="dark"] .iq-chip-sky    { background:rgba(168,207,224,0.08); border-color:rgba(168,207,224,0.12); color:var(--tc-sky); }
+[data-theme="dark"] .iq-combo-card { background:var(--surface-alt); border-color:rgba(255,255,255,0.06); }
+[data-theme="dark"] .iq-search-input { background:var(--surface-alt); border-color:rgba(155,168,216,0.12); color:var(--text); }
+[data-theme="dark"] .iq-search-input:focus { border-color:rgba(155,168,216,0.35); }
+[data-theme="dark"] .iq-chip-new { background:rgba(155,168,216,0.08); border-color:rgba(155,168,216,0.2); color:var(--tc-indigo); }
+[data-theme="dark"] .iq-chip-new.selected { background:rgba(181,213,197,0.15); border-color:var(--tc-sage); color:var(--tc-sage); }
+[data-theme="dark"] .iq-combo-card.starred { border-left-color:var(--tc-sage); }
+[data-theme="dark"] .iq-warning { background:rgba(240,200,120,0.08); }
+
+/* ═══ UIB Session 2: Outing Planner ═══ */
+.outing-form {
+  display:none; padding:var(--sp-16); border-radius:var(--r-lg);
+  background:var(--sage-light); border:1.5px solid rgba(58,112,96,0.12);
+  margin-top:var(--sp-8);
+}
+.outing-form.active { display:block; }
+.outing-form-title {
+  display:flex; align-items:center; gap:var(--sp-6);
+  font-size:var(--fs-base); font-weight:700; color:var(--tc-sage);
+  margin-bottom:var(--sp-12);
+}
+.outing-form-title .icon { width:var(--sp-16); height:var(--sp-16); }
+.outing-row { display:flex; flex-direction:column; gap:var(--sp-6); margin-bottom:var(--sp-12); }
+.outing-row-label { font-size:var(--fs-xs); font-weight:600; color:var(--tc-sage); text-transform:uppercase; letter-spacing:0.04em; }
+.outing-chips { display:flex; gap:var(--sp-8); flex-wrap:wrap; }
+.outing-chip {
+  padding:var(--sp-8) var(--sp-16); border-radius:var(--r-full);
+  border:1.5px solid rgba(58,112,96,0.18); background:rgba(232,245,239,0.6);
+  font-size:var(--fs-sm); font-family:'Nunito',sans-serif; color:var(--tc-sage);
+  font-weight:500; cursor:pointer; transition:all 0.15s ease;
+  line-height:1.4; white-space:nowrap;
+}
+.outing-chip:active { transform:scale(0.96); }
+.outing-chip.selected {
+  background:var(--sage-light); border-color:var(--tc-sage);
+  color:var(--tc-sage); font-weight:700;
+  box-shadow:0 0 0 1.5px rgba(58,112,96,0.1);
+}
+.outing-submit-btn {
+  width:100%; padding:var(--sp-10); border:none; border-radius:var(--r-lg);
+  background:var(--tc-sage); color:#fff; font-family:'Nunito',sans-serif;
+  font-size:var(--fs-sm); font-weight:700; cursor:pointer; transition:opacity 0.15s;
+  margin-top:var(--sp-4);
+}
+.outing-submit-btn:active { opacity:0.85; }
+.outing-active-badge {
+  display:inline-flex; align-items:center; gap:var(--sp-4);
+  padding:var(--sp-4) var(--sp-8); border-radius:var(--r-md);
+  background:var(--sage-light); font-size:var(--fs-xs);
+  font-weight:600; color:var(--tc-sage);
+}
+.outing-active-badge .icon { width:var(--sp-12); height:var(--sp-12); }
+.outing-clear-btn {
+  border:none; background:none; color:var(--tc-sage);
+  font-family:'Nunito',sans-serif; font-size:var(--fs-xs);
+  cursor:pointer; text-decoration:underline; padding:0;
+}
+
+/* ═══ TP Outing Toggle ═══ */
+.tp-outing-toggle {
+  display:flex; align-items:center; justify-content:space-between;
+  padding:var(--sp-8) var(--sp-12); border-radius:var(--r-lg);
+  background:var(--sage-light); border:1.5px solid rgba(58,112,96,0.1);
+  margin-bottom:var(--sp-10);
+}
+.tp-outing-toggle-label {
+  display:flex; align-items:center; gap:var(--sp-6);
+  font-size:var(--fs-sm); font-weight:600; color:var(--tc-sage);
+}
+.tp-outing-toggle-label .icon { width:var(--sp-16); height:var(--sp-16); }
+.tp-outing-toggle-sub { font-size:var(--fs-xs); color:var(--light); margin-top:var(--sp-2); }
+.tp-outing-toggle.active { border-color:var(--tc-sage); }
+.tp-outing-config {
+  display:none; padding-top:var(--sp-8);
+}
+.tp-outing-config.open { display:flex; flex-direction:column; gap:var(--sp-8); }
+
+/* ═══ TP Hydration Section ═══ */
+.tp-hydration-section {
+  padding:var(--sp-10); border-radius:var(--r-lg);
+  background:var(--sky-light); border:1.5px solid rgba(51,101,128,0.1);
+  margin-top:var(--sp-8); margin-bottom:var(--sp-8);
+}
+.tp-hydration-title {
+  display:flex; align-items:center; gap:var(--sp-6);
+  font-size:var(--fs-sm); font-weight:700; color:var(--tc-sky);
+  margin-bottom:var(--sp-6);
+}
+.tp-hydration-title .icon { width:var(--sp-16); height:var(--sp-16); }
+.tp-hydration-items { display:flex; flex-direction:column; gap:var(--sp-4); }
+.tp-hydration-item { font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-relaxed); display:flex; align-items:flex-start; gap:var(--sp-6); }
+.tp-hydration-item .icon { width:var(--sp-16); height:var(--sp-16); flex-shrink:0; margin-top:var(--sp-2); }
+.tp-hydration-section.prominent {
+  background:var(--rose-light); border-color:rgba(158,62,82,0.12);
+}
+.tp-hydration-section.prominent .tp-hydration-title { color:var(--tc-danger); }
+
+/* ═══ Power outage toggle (settings) ═══ */
+.power-outage-row {
+  display:flex; align-items:center; justify-content:space-between;
+}
+.power-outage-label { font-size:var(--fs-base); }
+.power-outage-sub { font-size:var(--fs-xs); color:var(--light); }
+
+/* ═══ Dark mode: UIB Session 2 ═══ */
+[data-theme="dark"] .outing-form { background:rgba(58,112,96,0.08); border-color:rgba(58,112,96,0.15); }
+[data-theme="dark"] .outing-chip { background:rgba(181,213,197,0.08); border-color:rgba(58,112,96,0.2); color:var(--tc-sage); }
+[data-theme="dark"] .outing-chip.selected { background:rgba(181,213,197,0.15); border-color:var(--tc-sage); color:var(--tc-sage); }
+[data-theme="dark"] .outing-submit-btn { background:var(--tc-sage); }
+[data-theme="dark"] .outing-active-badge { background:rgba(181,213,197,0.1); }
+[data-theme="dark"] .tp-outing-toggle { background:rgba(58,112,96,0.08); border-color:rgba(58,112,96,0.15); }
+[data-theme="dark"] .tp-outing-toggle.active { border-color:var(--tc-sage); }
+[data-theme="dark"] .tp-hydration-section { background:rgba(51,101,128,0.08); border-color:rgba(51,101,128,0.15); }
+[data-theme="dark"] .tp-hydration-section.prominent { background:rgba(158,62,82,0.08); border-color:rgba(158,62,82,0.15); }
+
+/* ═══ Outing Briefing Popup (ob-*) ═══ */
+.ob-overlay {
+  position:fixed; inset:0; z-index:1010;
+  background:var(--overlay-bg);
+  display:flex; align-items:flex-end; justify-content:center;
+  opacity:0; pointer-events:none;
+  transition:opacity var(--ease-med);
+}
+.ob-overlay.open { opacity:1; pointer-events:auto; }
+.ob-overlay.open .ob-card { transform:translateY(0); }
+.ob-card {
+  width:100%; max-width:440px;
+  background:var(--warm);
+  border-radius:var(--r-2xl) var(--r-2xl) 0 0;
+  box-shadow:0 -8px 40px rgba(0,0,0,0.15);
+  max-height:90vh; overflow-y:auto;
+  transform:translateY(40px);
+  transition:transform var(--ease-slow);
+  padding-bottom:max(var(--sp-24), env(safe-area-inset-bottom, var(--sp-24)));
+}
+.ob-header {
+  position:sticky; top:0; z-index:2;
+  display:flex; align-items:center; justify-content:space-between;
+  padding:var(--sp-16) var(--sp-20) var(--sp-10);
+  background:var(--sage-light);
+  border-radius:var(--r-2xl) var(--r-2xl) 0 0;
+}
+.ob-header-left { display:flex; flex-direction:column; gap:var(--sp-2); }
+.ob-title {
+  display:flex; align-items:center; gap:var(--sp-8);
+  font-family:'Fraunces',serif; font-size:var(--fs-xl);
+  font-weight:600; color:var(--tc-sage);
+}
+.ob-title .icon { width:var(--sp-20); height:var(--sp-20); }
+.ob-subtitle { font-size:var(--fs-xs); color:var(--tc-sage); opacity:0.8; }
+.ob-close {
+  width:var(--sp-32); height:var(--sp-32); border-radius:50%; border:none;
+  background:rgba(255,255,255,0.6); color:var(--tc-sage); cursor:pointer;
+  font-size:var(--fs-lg); display:flex; align-items:center; justify-content:center;
+  transition:all var(--ease-fast); flex-shrink:0;
+}
+.ob-close:hover { background:rgba(255,255,255,0.9); }
+.ob-body { padding:var(--sp-12) var(--sp-16); display:flex; flex-direction:column; gap:var(--sp-10); }
+.ob-section {
+  padding:var(--sp-12); border-radius:var(--r-lg);
+  background:var(--glass);
+}
+.ob-section-title {
+  font-size:var(--fs-xs); font-weight:700; letter-spacing:var(--ls-wide);
+  text-transform:uppercase; color:var(--mid);
+  margin-bottom:var(--sp-8);
+  display:flex; align-items:center; gap:var(--sp-6);
+}
+.ob-section-title .icon { width:var(--sp-12); height:var(--sp-12); }
+.ob-weather-grid {
+  display:grid; grid-template-columns:repeat(2, 1fr); gap:var(--sp-6) var(--sp-12);
+}
+.ob-weather-stat {
+  font-size:var(--fs-sm); color:var(--text);
+  display:flex; align-items:center; gap:var(--sp-4);
+}
+.ob-weather-stat .icon { width:var(--sp-12); height:var(--sp-12); }
+.ob-weather-stat strong { font-weight:700; }
+.ob-weather-advisory {
+  margin-top:var(--sp-8); padding:var(--sp-8) var(--sp-10);
+  border-radius:var(--r-md);
+  background:var(--amber-light); color:var(--tc-amber);
+  font-size:var(--fs-sm); font-weight:600;
+  display:flex; align-items:flex-start; gap:var(--sp-6);
+}
+.ob-weather-advisory .icon { width:var(--sp-12); height:var(--sp-12); flex-shrink:0; margin-top:var(--sp-2); }
+.ob-weather-advisory.severe { background:var(--rose-light); color:var(--tc-danger); }
+.ob-pack-progress {
+  display:flex; align-items:center; gap:var(--sp-8);
+  margin-bottom:var(--sp-8);
+  font-size:var(--fs-xs); color:var(--light); font-weight:600;
+}
+.ob-pack-bar {
+  flex:1; height:var(--sp-4); border-radius:var(--r-full);
+  background:var(--glass-strong);
+}
+.ob-pack-bar-fill {
+  height:100%; border-radius:var(--r-full);
+  background:var(--tc-sage);
+  transition:width var(--ease-fast);
+  width:0%;
+}
+.ob-pack-list { display:flex; flex-direction:column; gap:var(--sp-4); }
+.ob-pack-item {
+  display:flex; align-items:center; gap:var(--sp-8);
+  padding:var(--sp-6) var(--sp-8); border-radius:var(--r-md);
+  cursor:pointer; transition:background var(--ease-fast);
+  -webkit-user-select:none; user-select:none;
+}
+.ob-pack-item:active { background:var(--sage-light); }
+.ob-pack-check {
+  width:var(--sp-20); height:var(--sp-20); border-radius:var(--r-sm);
+  border:1.5px solid var(--card-border); background:var(--white);
+  display:flex; align-items:center; justify-content:center;
+  flex-shrink:0; transition:all var(--ease-fast);
+  color:transparent;
+}
+.ob-pack-check .icon { width:var(--sp-12); height:var(--sp-12); }
+.ob-pack-item.checked .ob-pack-check {
+  background:var(--tc-sage); border-color:var(--tc-sage); color:#fff;
+}
+.ob-pack-item.checked .ob-pack-label { text-decoration:line-through; opacity:0.5; }
+.ob-pack-label { font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-snug); }
+.ob-meal-pick { margin-bottom:var(--sp-8); }
+.ob-meal-star {
+  display:flex; align-items:center; gap:var(--sp-6);
+  font-size:var(--fs-base); font-weight:700; color:var(--tc-sage);
+}
+.ob-meal-star .icon { width:var(--sp-16); height:var(--sp-16); color:var(--tc-amber); }
+.ob-meal-reason { font-size:var(--fs-xs); color:var(--light); margin-top:var(--sp-2); margin-left:var(--sp-24); }
+.ob-meal-alt {
+  font-size:var(--fs-sm); color:var(--text); padding:var(--sp-4) 0;
+  display:flex; align-items:center; gap:var(--sp-6);
+}
+.ob-meal-alt .icon { width:var(--sp-12); height:var(--sp-12); flex-shrink:0; }
+.ob-meal-tip {
+  margin-top:var(--sp-6); padding:var(--sp-8) var(--sp-10);
+  border-radius:var(--r-md); background:var(--sage-light);
+  font-size:var(--fs-xs); color:var(--tc-sage); line-height:var(--lh-relaxed);
+  display:flex; align-items:flex-start; gap:var(--sp-6);
+}
+.ob-meal-tip .icon { width:var(--sp-12); height:var(--sp-12); flex-shrink:0; margin-top:var(--sp-2); }
+.ob-hydration-schedule { display:flex; flex-direction:column; gap:var(--sp-4); }
+.ob-hydration-item {
+  font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-relaxed);
+  display:flex; align-items:flex-start; gap:var(--sp-6);
+}
+.ob-hydration-item .icon { width:var(--sp-12); height:var(--sp-12); flex-shrink:0; margin-top:var(--sp-2); }
+.ob-section.ob-hydration-prominent { background:var(--rose-light); }
+.ob-section.ob-hydration-prominent .ob-section-title { color:var(--tc-danger); }
+.ob-section.ob-hydration-full { background:var(--sky-light); }
+.ob-section.ob-hydration-full .ob-section-title { color:var(--tc-sky); }
+.ob-dress-code {
+  font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-relaxed);
+}
+.ob-activity-note {
+  font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-relaxed);
+}
+.ob-medical-item {
+  font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-relaxed);
+  display:flex; align-items:flex-start; gap:var(--sp-6);
+  padding:var(--sp-4) 0;
+}
+.ob-medical-item .icon { width:var(--sp-12); height:var(--sp-12); flex-shrink:0; margin-top:var(--sp-2); }
+.ob-clear-btn {
+  display:block; margin:var(--sp-6) auto 0;
+  padding:var(--sp-8) var(--sp-24); border-radius:var(--r-lg);
+  border:1.5px solid var(--tc-amber); background:var(--amber-light);
+  color:var(--tc-amber); font-family:'Nunito',sans-serif;
+  font-size:var(--fs-sm); font-weight:700; cursor:pointer;
+  transition:all var(--ease-fast);
+}
+.ob-clear-btn:active { opacity:0.8; }
+.ob-loading { text-align:center; padding:var(--sp-24); }
+.ob-loading .icon { width:var(--sp-24); height:var(--sp-24); }
+.outing-active-badge { cursor:pointer; }
+.tp-outing-toggle.active { cursor:pointer; }
+
+/* ═══ Dark mode: Outing Briefing ═══ */
+[data-theme="dark"] .ob-card { background:var(--warm); box-shadow:0 -8px 40px rgba(0,0,0,0.5); }
+[data-theme="dark"] .ob-header { background:rgba(58,112,96,0.15); }
+[data-theme="dark"] .ob-close { background:rgba(255,255,255,0.08); color:var(--tc-sage); }
+[data-theme="dark"] .ob-section { background:var(--glass); }
+[data-theme="dark"] .ob-weather-advisory { background:rgba(138,101,32,0.1); }
+[data-theme="dark"] .ob-weather-advisory.severe { background:rgba(158,62,82,0.1); }
+[data-theme="dark"] .ob-pack-check { background:rgba(255,255,255,0.05); border-color:rgba(255,255,255,0.15); }
+[data-theme="dark"] .ob-pack-item.checked .ob-pack-check { background:var(--tc-sage); border-color:var(--tc-sage); }
+[data-theme="dark"] .ob-pack-item:active { background:rgba(58,112,96,0.1); }
+[data-theme="dark"] .ob-meal-tip { background:rgba(58,112,96,0.1); }
+[data-theme="dark"] .ob-section.ob-hydration-prominent { background:rgba(158,62,82,0.1); }
+[data-theme="dark"] .ob-section.ob-hydration-full { background:rgba(51,101,128,0.1); }
+[data-theme="dark"] .ob-clear-btn { background:rgba(138,101,32,0.1); border-color:var(--tc-amber); }
+
+/* ═══════════════════════════════════════════
+   Bug Capture System — bug-* class family
+   Domain color: amber (caution/attention)
+   ═══════════════════════════════════════════ */
+
+/* ── Bug Reporter Overlay (bottom sheet) ── */
+.bug-overlay {
+  position:fixed; inset:0; z-index:1050;
+  background:var(--overlay-bg);
+  display:flex; align-items:flex-end; justify-content:center;
+  opacity:0; pointer-events:none;
+  transition:opacity var(--ease-med);
+}
+.bug-overlay.open { opacity:1; pointer-events:auto; }
+.bug-overlay.open .bug-card { transform:translateY(0); }
+.bug-card {
+  width:100%; max-width:440px;
+  background:var(--warm);
+  border-radius:var(--r-2xl) var(--r-2xl) 0 0;
+  box-shadow:0 -8px 40px rgba(0,0,0,0.15);
+  max-height:90vh; overflow-y:auto;
+  transform:translateY(40px);
+  transition:transform var(--ease-slow);
+  padding-bottom:max(var(--sp-24), env(safe-area-inset-bottom, var(--sp-24)));
+}
+.bug-header {
+  position:sticky; top:0; z-index:2;
+  display:flex; align-items:center; justify-content:space-between;
+  padding:var(--sp-16) var(--sp-20) var(--sp-10);
+  background:var(--amber-light);
+  border-radius:var(--r-2xl) var(--r-2xl) 0 0;
+}
+.bug-header-left { display:flex; flex-direction:column; gap:var(--sp-4); }
+.bug-title {
+  display:flex; align-items:center; gap:var(--sp-8);
+  font-family:'Fraunces',serif; font-size:var(--fs-xl);
+  font-weight:600; color:var(--tc-amber);
+}
+.bug-title .icon { width:var(--sp-20); height:var(--sp-20); }
+.bug-title .icon svg.zi { width:var(--sp-16); height:var(--sp-16); }
+.bug-subtitle { font-size:var(--fs-xs); color:var(--tc-amber); opacity:0.8; }
+.bug-close {
+  width:var(--sp-32); height:var(--sp-32); border-radius:50%; border:none;
+  background:rgba(255,255,255,0.6); color:var(--tc-amber); cursor:pointer;
+  font-size:var(--fs-lg); display:flex; align-items:center; justify-content:center;
+  transition:all var(--ease-fast); flex-shrink:0;
+}
+.bug-close:hover { background:rgba(255,255,255,0.9); }
+.bug-body { padding:var(--sp-12) var(--sp-16); display:flex; flex-direction:column; gap:var(--sp-12); }
+
+/* ── Description textarea ── */
+.bug-textarea {
+  width:100%; min-height:80px; resize:vertical;
+  border:1.5px solid rgba(138,101,32,0.25); border-radius:var(--r-lg);
+  padding:var(--sp-10) var(--sp-12);
+  font-family:'Nunito',sans-serif; font-size:var(--fs-base);
+  color:var(--text); background:var(--glass);
+  outline:none; transition:border-color var(--ease-fast);
+}
+.bug-textarea:focus { border-color:var(--tc-amber); }
+.bug-desc-label {
+  font-size:var(--fs-sm); font-weight:700; color:var(--tc-amber);
+  margin-bottom:var(--sp-4);
+}
+
+/* ── Context section ── */
+.bug-context {
+  padding:var(--sp-10) var(--sp-12); border-radius:var(--r-lg);
+  background:var(--glass); display:flex; flex-direction:column; gap:var(--sp-6);
+}
+.bug-context-title {
+  font-size:var(--fs-xs); font-weight:700; letter-spacing:var(--ls-wide);
+  text-transform:uppercase; color:var(--mid);
+  display:flex; align-items:center; gap:var(--sp-6);
+  margin-bottom:var(--sp-4);
+}
+.bug-context-title .icon { width:var(--sp-12); height:var(--sp-12); }
+.bug-context-title .icon svg.zi { width:var(--sp-12); height:var(--sp-12); }
+.bug-context-row {
+  font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-relaxed);
+}
+.bug-context-row .bug-context-label { font-weight:600; color:var(--mid); }
+
+.bug-context-action { padding-left:var(--sp-12); }
+
+/* ── Error section ── */
+.bug-error {
+  padding:var(--sp-10) var(--sp-12); border-radius:var(--r-lg);
+  background:var(--rose-light); display:flex; flex-direction:column; gap:var(--sp-4);
+}
+.bug-error-title {
+  font-size:var(--fs-xs); font-weight:700; letter-spacing:var(--ls-wide);
+  text-transform:uppercase; color:var(--tc-rose);
+  display:flex; align-items:center; gap:var(--sp-6);
+  margin-bottom:var(--sp-4);
+}
+.bug-error-title .icon { width:var(--sp-12); height:var(--sp-12); }
+.bug-error-title .icon svg.zi { width:var(--sp-12); height:var(--sp-12); }
+.bug-error-msg {
+  font-size:var(--fs-sm); color:var(--tc-rose); font-weight:600;
+  word-break:break-word;
+}
+.bug-error-meta { font-size:var(--fs-xs); color:var(--tc-rose); opacity:0.7; }
+
+/* ── Action buttons ── */
+.bug-actions { display:flex; flex-direction:column; gap:var(--sp-8); }
+.bug-btn {
+  display:flex; align-items:center; justify-content:center; gap:var(--sp-8);
+  padding:var(--sp-12) var(--sp-16); border-radius:var(--r-lg);
+  font-family:'Nunito',sans-serif; font-size:var(--fs-base); font-weight:700;
+  border:none; cursor:pointer; transition:all var(--ease-fast);
+}
+.bug-btn-whatsapp {
+  background:linear-gradient(135deg, #25d366 0%, #128c7e 100%);
+  color:#fff;
+}
+.bug-btn-whatsapp:active { transform:scale(0.97); }
+.bug-btn-clipboard {
+  background:var(--glass-strong); color:var(--tc-amber);
+  border:1.5px solid rgba(138,101,32,0.2);
+}
+.bug-btn-clipboard:active { transform:scale(0.97); }
+
+/* ── Auto-prompt banner (Path C) ── */
+.bug-auto-prompt {
+  position:fixed; top:0; left:0; right:0; z-index:1060;
+  padding:var(--sp-12) var(--sp-16);
+  background:var(--amber-light);
+  border-bottom:1.5px solid rgba(138,101,32,0.2);
+  display:flex; align-items:center; justify-content:space-between; gap:var(--sp-10);
+  transform:translateY(-100%);
+  transition:transform var(--ease-med);
+  box-shadow:0 4px 20px rgba(0,0,0,0.08);
+}
+.bug-auto-prompt.open { transform:translateY(0); }
+.bug-auto-prompt-text {
+  display:flex; align-items:center; gap:var(--sp-6);
+  font-size:var(--fs-sm); font-weight:600; color:var(--tc-amber); flex:1;
+}
+.bug-auto-prompt-text .icon { width:var(--sp-16); height:var(--sp-16); }
+.bug-auto-prompt-text .icon svg.zi { width:var(--sp-16); height:var(--sp-16); }
+.bug-auto-prompt-actions { display:flex; gap:var(--sp-8); flex-shrink:0; }
+.bug-auto-prompt-btn {
+  padding:var(--sp-6) var(--sp-12); border-radius:var(--r-md);
+  font-family:'Nunito',sans-serif; font-size:var(--fs-xs); font-weight:700;
+  border:none; cursor:pointer; transition:all var(--ease-fast);
+}
+.bug-auto-prompt-report { background:var(--tc-amber); color:#fff; }
+.bug-auto-prompt-dismiss { background:var(--glass-strong); color:var(--tc-amber); }
+
+/* ── FAB tooltip ── */
+.bug-tooltip {
+  position:fixed; z-index:1005;
+  bottom:calc(68px + var(--sp-12));
+  left:50%; transform:translateX(-50%);
+  background:var(--sage-light); color:var(--tc-sage);
+  padding:var(--sp-8) var(--sp-12);
+  border-radius:var(--r-lg);
+  font-size:var(--fs-xs); font-weight:600;
+  display:flex; align-items:center; gap:var(--sp-8);
+  box-shadow:0 4px 16px rgba(0,0,0,0.1);
+  opacity:0; pointer-events:none;
+  transition:opacity var(--ease-med);
+}
+.bug-tooltip.open { opacity:1; pointer-events:auto; }
+.bug-tooltip-close {
+  background:none; border:none; color:var(--tc-sage); cursor:pointer;
+  font-size:var(--fs-sm); font-weight:700; padding:0; line-height:1;
+}
+.bug-tooltip-arrow {
+  position:absolute; bottom:-6px; left:50%; transform:translateX(-50%);
+  width:0; height:0;
+  border-left:6px solid transparent; border-right:6px solid transparent;
+  border-top:6px solid var(--sage-light);
+}
+
+/* ── Settings row ── */
+.bug-settings-row {
+  display:flex; align-items:center; justify-content:space-between;
+  padding:var(--sp-10) var(--sp-12); border-radius:var(--r-lg);
+  background:var(--amber-light); cursor:pointer;
+  transition:all var(--ease-fast);
+  border:1.5px solid rgba(138,101,32,0.15);
+}
+.bug-settings-row:active { transform:scale(0.98); }
+.bug-settings-left { display:flex; flex-direction:column; gap:var(--sp-2); }
+.bug-settings-title {
+  font-size:var(--fs-base); font-weight:700; color:var(--tc-amber);
+  display:flex; align-items:center; gap:var(--sp-6);
+}
+.bug-settings-title .icon { width:var(--sp-16); height:var(--sp-16); }
+.bug-settings-title .icon svg.zi { width:var(--sp-16); height:var(--sp-16); }
+.bug-settings-sub { font-size:var(--fs-xs); color:var(--tc-amber); opacity:0.7; }
+.bug-settings-arrow { font-size:var(--fs-lg); color:var(--tc-amber); opacity:0.5; }
+
+/* ═══ Dark mode: Bug Capture ═══ */
+[data-theme="dark"] .bug-card { background:var(--warm); box-shadow:0 -8px 40px rgba(0,0,0,0.5); }
+[data-theme="dark"] .bug-header { background:rgba(138,101,32,0.15); }
+[data-theme="dark"] .bug-close { background:rgba(255,255,255,0.08); color:var(--tc-amber); }
+[data-theme="dark"] .bug-textarea { background:rgba(255,255,255,0.05); border-color:rgba(138,101,32,0.25); }
+[data-theme="dark"] .bug-context { background:var(--glass); }
+[data-theme="dark"] .bug-error { background:rgba(158,62,82,0.12); }
+[data-theme="dark"] .bug-btn-clipboard { background:rgba(255,255,255,0.06); border-color:rgba(138,101,32,0.2); }
+[data-theme="dark"] .bug-auto-prompt { background:rgba(138,101,32,0.15); border-bottom-color:rgba(138,101,32,0.25); box-shadow:0 4px 20px rgba(0,0,0,0.3); }
+[data-theme="dark"] .bug-auto-prompt-dismiss { background:rgba(255,255,255,0.08); }
+[data-theme="dark"] .bug-tooltip { background:rgba(58,112,96,0.2); box-shadow:0 4px 16px rgba(0,0,0,0.3); }
+[data-theme="dark"] .bug-tooltip-arrow { border-top-color:rgba(58,112,96,0.2); }
+[data-theme="dark"] .bug-settings-row { background:rgba(138,101,32,0.1); border-color:rgba(138,101,32,0.2); }
+
+/* ── Today So Far (tsf-*) ── */
+.tsf-header-count { font-size:var(--fs-xs); color:var(--mid); font-weight:400; }
+.tsf-caught-up { font-size:var(--fs-xs); color:var(--tc-sage); font-weight:600; display:inline-flex; align-items:center; gap:var(--sp-4); }
+.tsf-caught-up .icon { width:var(--sp-12); height:var(--sp-12); display:inline-flex; align-items:center; justify-content:center; }
+.tsf-caught-up .icon svg.zi { width:12px; height:12px; }
+.tsf-warmth-bar { width:100%; height:var(--sp-6); border-radius:var(--r-full); background:var(--glass); overflow:hidden; margin-top:var(--sp-8); margin-bottom:var(--sp-12); }
+.tsf-warmth-fill { height:100%; border-radius:var(--r-full); transition:width 0.4s ease, background 0.4s ease; min-width:var(--sp-4); }
+.tsf-warmth-fill[data-level="1"] { background:var(--glass-strong); }
+.tsf-warmth-fill[data-level="2"] { background:var(--peach-light); }
+.tsf-warmth-fill[data-level="3"] { background:var(--sage-light); }
+.tsf-warmth-fill[data-level="4"] { background:var(--tc-sage); opacity:0.5; }
+.tsf-warmth-fill[data-level="5"] { background:var(--tc-sage); opacity:0.7; }
+.tsf-event-list { display:flex; flex-direction:column; gap:var(--sp-2); }
+.tsf-event-wrap { border-radius:var(--r-md); }
+.tsf-event-wrap.tsf-event-expanded { background:var(--glass); }
+.tsf-event { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-6) var(--sp-4); border-radius:var(--r-md); cursor:pointer; transition:background 0.15s ease; }
+.tsf-event:active { background:var(--glass); }
+.tsf-event-time { font-size:var(--fs-xs); color:var(--mid); min-width:var(--sp-32); text-align:right; flex-shrink:0; font-variant-numeric:tabular-nums; }
+.tsf-event-icon { flex-shrink:0; }
+.tsf-event-icon .icon { width:var(--sp-24); height:var(--sp-24); display:flex; align-items:center; justify-content:center; border-radius:var(--r-md); }
+.tsf-event-icon .icon svg.zi { width:14px; height:14px; }
+.tsf-event-body { flex:1; min-width:0; }
+.tsf-event-label { font-size:var(--fs-sm); color:var(--text); line-height:1.3; }
+.tsf-event-detail { font-size:var(--fs-xs); color:var(--light); }
+/* ═══════════════════════════════════════════════════════════════════════
+   v3-5 — Unified chip-state taxonomy registry (single source of truth).
+   Spec: docs/specs/v3-5-chip-taxonomy-tsf-story.md §The 8-state chip-state
+   registry. Charter axis primarily served: Architectural Extensibility
+   (CV3-006) — one attribute per chip, mutual-exclusion enforced by the
+   attribute model. Adding a state = one CSS variant here + one branch
+   in _tsfDeriveChipState in intelligence-quicklog.js.
+
+   State precedence in the deriver (highest wins, single value resolved):
+   urgent > live > calm > skipped > late > inferred > pending > done
+
+   V-V-31 collision concern (T2-A.3 era) resolved by the attribute model:
+   the previous class-based system allowed `tsf-event-inferred` AND
+   `data-state="skipped"` to co-occur on the same wrapper; under v3-5
+   each chip carries exactly one data-state and the deriver picks one
+   per precedence. The V-V-31 / V-V-32 wisdom carries forward — see the
+   `data-state="skipped"` block below for the legacy precedent. */
+
+/* done — default for any logged event without a more-specific state.
+   Visual contract: clean — the per-event icon-color class already carries
+   the sage affirmation; no extra chip-level decoration. */
+.tsf-event[data-state="done"] { /* clean — icon carries the affirmation */ }
+
+/* skipped — T2-A.3 (V-V-25) precedent. Strikethrough label + warn-color
+   time slot + faded icon. V-V-32: dark-theme variant intentionally absent
+   — --tc-warn and --light cascade theme-aware via the [data-theme="dark"]
+   overrides further down this file, so the strikethrough + dimmed label
+   read correctly in both themes without explicit override.
+   V-M-86 (Maren synth-fold): icon selector tightened to
+   `.tsf-event-icon .icon` to prevent bleed if `.icon` ever appears bare
+   elsewhere inside a chip. */
+.tsf-event[data-state="skipped"] .tsf-event-label { text-decoration:line-through; text-decoration-color:var(--tc-warn); color:var(--light); }
+.tsf-event[data-state="skipped"] .tsf-event-time  { color:var(--tc-warn); opacity:0.7; }
+.tsf-event[data-state="skipped"] .tsf-event-icon .icon { opacity:0.6; }
+
+/* late — retroactive Done log; amber-tinted time slot.
+   Token-bound to --tc-amber; cascades theme-aware. */
+.tsf-event[data-state="late"] .tsf-event-time { color:var(--tc-amber); font-weight:600; }
+
+/* inferred — pattern-fallback time (not a logged event). Italic time +
+   0.7 opacity on the wrapper. Migrated from class-based `.tsf-event-inferred`. */
+.tsf-event[data-state="inferred"] .tsf-event-time { font-style:italic; opacity:0.7; }
+
+/* live — recent log under the TSF refresh window; pulse the detail slot.
+   Migrated from class-based `.tsf-event-live`. */
+.tsf-event[data-state="live"] .tsf-event-detail { animation:tsfPulse 2s ease-in-out infinite; }
+
+/* calm — explicit opt-out of pulse for a long-running live event
+   (existing precedent: night sleep elapsed >= 120m). Migrated from
+   class-based `.tsf-event-live[data-calm="true"]`. */
+.tsf-event[data-state="calm"] .tsf-event-detail { animation:none; }
+
+/* urgent — safety-tier escalation. Rose-accent border + bold rose time slot.
+   Producer (v3-1 recommendation pipeline) wires the state when an unmet
+   recommendation reaches severityLevel === 'urgent'; v3-5 ratifies the
+   visual contract. Maren pair-note: urgent must never be visually
+   outranked by done — the rose-accent border + bold time slot carry
+   that floor per spec §Cross-Region pair-notes.
+   V-M-87 (Maren synth-fold): border uses --rose-deep (not --tc-rose) so
+   the dark-theme cascade amplifies rather than dilutes — --rose-deep is
+   the token D2 phase-spec §2.3 reserved for "DO-NOT callout border,
+   dark theme, brighter than --tc-rose dark for amplification on dark
+   surfaces." Time-slot text remains --tc-rose because the time is text
+   on background, not the attention-grab signal. */
+.tsf-event[data-state="urgent"] { border-left:3px solid var(--rose-deep); padding-left:calc(var(--sp-4) - 3px); }
+.tsf-event[data-state="urgent"] .tsf-event-time { color:var(--tc-rose); font-weight:700; }
+
+/* pending — domain-specific "expected but not yet logged". Outline-only,
+   light text, dashed border. Producer (reminder pipeline / D3 not-yet-given
+   today / scheduled feed window) wires the state when a chip should appear
+   before its corresponding logged event lands. */
+.tsf-event[data-state="pending"] { border:1px dashed var(--glass-strong); }
+.tsf-event[data-state="pending"] .tsf-event-label { color:var(--light); }
+.tsf-event[data-state="pending"] .tsf-event-time { color:var(--light); }
+
+@keyframes tsfPulse { 0%,100%{ opacity:1; } 50%{ opacity:0.5; } }
+
+/* prefers-reduced-motion — disable tsfPulse for users who opt out
+   (Charter Warmth cross-check, HR-5 a11y cascade). */
+@media (prefers-reduced-motion: reduce) {
+  .tsf-event[data-state="live"] .tsf-event-detail { animation:none; }
+}
+
+/* ─── v3-5 story-arc summary (vela-arc-2) ─────────────────────────────
+   Single-sentence narrative summary line above the event list on Today
+   So Far. Renders a passage, not a ledger (CV3-002 Narrate-vs-List).
+   Generated by _tsfGenerateSummary (Kael pair-note region; data-side
+   primitive owned by Kael, render owned by Vela per spec §Cross-Region
+   pair-notes). ────────────────────────────────────────────────────── */
+.tsf-story-arc { font-family:Fraunces, serif; font-size:var(--fs-md); line-height:1.45; color:var(--text); padding:var(--sp-4) 0 var(--sp-8) 0; }
+.tsf-story-arc[data-empty="true"] { color:var(--mid); font-style:italic; }
+.tsf-expand-timeline { text-align:center; font-size:var(--fs-xs); color:var(--tc-indigo); padding:var(--sp-8) 0 var(--sp-4) 0; cursor:pointer; font-weight:600; }
+.tsf-expand-timeline:active { opacity:0.6; }
+.tsf-event-expanded-detail { padding:var(--sp-4) var(--sp-4) var(--sp-8) calc(var(--sp-32) + var(--sp-8) + var(--sp-24) + var(--sp-8) + var(--sp-4)); font-size:var(--fs-xs); color:var(--mid); line-height:1.5; border-top:1px solid var(--glass-strong); margin-top:0; }
+.tsf-show-earlier { text-align:center; font-size:var(--fs-xs); color:var(--tc-indigo); padding:var(--sp-6) 0; cursor:pointer; font-weight:600; }
+.tsf-show-earlier:active { opacity:0.6; }
+.tsf-now { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-8) 0; font-size:var(--fs-xs); color:var(--tc-indigo); font-weight:600; }
+.tsf-now::before, .tsf-now::after { content:''; flex:1; height:1px; background:var(--tc-indigo); opacity:0.25; }
+.tsf-nudges { display:flex; flex-direction:column; gap:var(--sp-6); margin-top:var(--sp-4); }
+.tsf-nudge { display:flex; align-items:center; gap:var(--sp-8); padding:var(--sp-10) var(--sp-10); background:var(--glass); border-radius:var(--r-lg); cursor:pointer; border-left:3px solid transparent; transition:background 0.15s ease; }
+.tsf-nudge:active { background:var(--glass-strong); }
+.tsf-nudge-lav { border-left-color:var(--tc-lav); }
+.tsf-nudge-sky { border-left-color:var(--tc-sky); }
+.tsf-nudge-peach { border-left-color:var(--tc-caution); }
+.tsf-nudge-sage { border-left-color:var(--tc-sage); }
+.tsf-nudge-amber { border-left-color:var(--tc-amber); }
+.tsf-nudge-indigo { border-left-color:var(--tc-indigo); }
+.tsf-nudge-icon { flex-shrink:0; }
+.tsf-nudge-icon .icon { width:var(--sp-24); height:var(--sp-24); display:flex; align-items:center; justify-content:center; border-radius:var(--r-md); }
+.tsf-nudge-icon .icon svg.zi { width:14px; height:14px; }
+.tsf-nudge-body { flex:1; min-width:0; }
+.tsf-nudge-text { font-size:var(--fs-sm); color:var(--text); }
+.tsf-nudge-action { font-size:var(--fs-xs); color:var(--tc-indigo); font-weight:600; margin-top:var(--sp-2); }
+.tsf-no-time { margin-top:var(--sp-8); }
+.tsf-no-time-label { font-size:var(--fs-xs); color:var(--light); margin-bottom:var(--sp-4); }
+.tsf-complete { font-size:var(--fs-xs); color:var(--tc-sage); text-align:center; padding:var(--sp-8) 0; }
+.tsf-empty { font-size:var(--fs-sm); color:var(--light); text-align:center; padding:var(--sp-16) 0; }
+.tsf-empty-action { color:var(--tc-indigo); font-weight:600; cursor:pointer; margin-top:var(--sp-4); display:inline-block; }
+
+/* TSF dark mode */
+[data-theme="dark"] .tsf-warmth-bar { background:rgba(255,255,255,0.06); }
+[data-theme="dark"] .tsf-warmth-fill[data-level="1"] { background:rgba(58,112,96,0.08); }
+[data-theme="dark"] .tsf-warmth-fill[data-level="2"] { background:rgba(58,112,96,0.15); }
+[data-theme="dark"] .tsf-warmth-fill[data-level="3"] { background:rgba(58,112,96,0.25); }
+[data-theme="dark"] .tsf-warmth-fill[data-level="4"] { background:rgba(58,112,96,0.35); }
+[data-theme="dark"] .tsf-warmth-fill[data-level="5"] { background:rgba(58,112,96,0.45); }
+[data-theme="dark"] .tsf-event:active { background:rgba(255,255,255,0.05); }
+[data-theme="dark"] .tsf-event-wrap.tsf-event-expanded { background:rgba(255,255,255,0.04); }
+[data-theme="dark"] .tsf-event-expanded-detail { border-top-color:rgba(255,255,255,0.08); }
+[data-theme="dark"] .tsf-nudge { background:rgba(255,255,255,0.04); }
+[data-theme="dark"] .tsf-nudge:active { background:rgba(255,255,255,0.08); }
+[data-theme="dark"] .tsf-now::before, [data-theme="dark"] .tsf-now::after { background:var(--tc-indigo); opacity:0.35; }
+/* ═══════════════════════════════════════════════════════════════
+   ACTIVITY UPGRADE — Time Slots + Duration Chips (Session A)
+   Domain: sage | Prefix: al-
+   Append this to styles.css
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Time Slots ── */
+.al-slot-row {
+  margin: var(--sp-12) 0 var(--sp-4);
+}
+
+.al-slot-label {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--mid);
+  margin-bottom: var(--sp-8);
+}
+
+.al-slot-label .zi {
+  width: var(--sp-16);
+  height: var(--sp-16);
+  color: var(--tc-sage);
+}
+
+.al-slot-chips {
+  display: flex;
+  gap: var(--sp-8);
+}
+
+.al-slot {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--sp-4);
+  padding: var(--sp-8) var(--sp-4);
+  border-radius: var(--r-lg);
+  border: 1.5px solid var(--sage-light);
+  background: var(--sage-light);
+  color: var(--mid);
+  font-family: 'Nunito', sans-serif;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.al-slot:active {
+  transform: scale(0.96);
+}
+
+.al-slot.active {
+  background: var(--sage);
+  border-color: var(--sage);
+  color: white;
+}
+
+.al-slot-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.al-slot-icon .zi {
+  width: var(--sp-16);
+  height: var(--sp-16);
+}
+
+.al-slot.active .al-slot-icon .zi {
+  color: white;
+}
+
+.al-slot-text {
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  line-height: 1;
+}
+
+/* ── Duration Chips ── */
+.al-dur-row {
+  margin: var(--sp-12) 0 var(--sp-4);
+}
+
+.al-dur-label {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-4);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--mid);
+  margin-bottom: var(--sp-8);
+}
+
+.al-dur-label .zi {
+  width: var(--sp-16);
+  height: var(--sp-16);
+  color: var(--tc-sage);
+}
+
+.al-dur-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-8);
+}
+
+.al-dur-chip {
+  padding: var(--sp-8) var(--sp-12);
+  border-radius: var(--r-lg);
+  border: 1.5px solid var(--sage-light);
+  background: var(--sage-light);
+  color: var(--mid);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  font-family: 'Nunito', sans-serif;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  -webkit-tap-highlight-color: transparent;
+  white-space: nowrap;
+}
+
+.al-dur-chip:active {
+  transform: scale(0.96);
+}
+
+.al-dur-chip.active {
+  background: var(--sage);
+  border-color: var(--sage);
+  color: white;
+}
+
+.al-dur-chip-skip {
+  border-color: rgba(168, 207, 224, 0.3);
+  background: transparent;
+}
+
+.al-dur-chip-skip.active {
+  background: var(--sage);
+  border-color: var(--sage);
+  color: white;
+}
+
+.al-dur-chip-other {
+  border-style: dashed;
+}
+
+.al-dur-chip-other.active {
+  background: var(--sage);
+  border-color: var(--sage);
+  border-style: solid;
+  color: white;
+}
+
+/* ── Custom duration inline input ── */
+.al-dur-custom-row {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-8);
+  margin-top: var(--sp-8);
+}
+
+.al-dur-custom {
+  flex: 1;
+  max-width: calc(var(--sp-16) * 8);
+  padding: var(--sp-8) var(--sp-12);
+  border-radius: var(--r-lg);
+  border: 1.5px solid var(--sage);
+  background: var(--sage-light);
+  font-size: 16px !important; /* BN-3: prevent iOS zoom */
+  font-family: 'Nunito', sans-serif;
+  font-weight: 600;
+  color: var(--text);
+  outline: none;
+}
+
+.al-dur-custom:focus {
+  border-color: var(--tc-sage);
+  box-shadow: 0 0 0 2px rgba(58, 112, 96, 0.15);
+}
+
+.al-dur-custom-go {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--sp-8);
+  border-radius: var(--r-md);
+  background: var(--sage);
+  border: none;
+  color: white;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.al-dur-custom-go .zi {
+  width: var(--sp-16);
+  height: var(--sp-16);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   DARK MODE
+   ═══════════════════════════════════════════════════════════════ */
+
+[data-theme="dark"] .al-slot {
+  border-color: rgba(58, 112, 96, 0.35);
+  background: rgba(58, 112, 96, 0.12);
+  color: var(--mid);
+}
+
+[data-theme="dark"] .al-slot.active {
+  background: var(--sage);
+  border-color: var(--sage);
+  color: white;
+}
+
+[data-theme="dark"] .al-dur-chip {
+  border-color: rgba(58, 112, 96, 0.35);
+  background: rgba(58, 112, 96, 0.12);
+  color: var(--mid);
+}
+
+[data-theme="dark"] .al-dur-chip.active {
+  background: var(--sage);
+  border-color: var(--sage);
+  color: white;
+}
+
+[data-theme="dark"] .al-dur-chip-skip {
+  border-color: rgba(168, 207, 224, 0.2);
+  background: transparent;
+}
+
+[data-theme="dark"] .al-dur-chip-skip.active {
+  background: var(--sage);
+  border-color: var(--sage);
+  color: white;
+}
+
+[data-theme="dark"] .al-dur-chip-other {
+  border-color: rgba(58, 112, 96, 0.35);
+  background: transparent;
+}
+
+[data-theme="dark"] .al-dur-chip-other.active {
+  background: var(--sage);
+  border-color: var(--sage);
+  color: white;
+}
+
+[data-theme="dark"] .al-dur-custom {
+  background: rgba(58, 112, 96, 0.12);
+  border-color: rgba(58, 112, 96, 0.4);
+  color: var(--text);
+}
+
+[data-theme="dark"] .al-dur-custom:focus {
+  border-color: var(--tc-sage);
+  box-shadow: 0 0 0 2px rgba(58, 112, 96, 0.25);
+}
+
+[data-theme="dark"] .al-dur-custom-go {
+  background: var(--sage);
+}
+/* ═══════════════════════════════════════════════════════════════
+   ACTIVITY LOG: Session B — Suggestions, Yesterday, Nudge, Upgrade
+   Domain color: sage · Chip system compliant · Design token-only
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Separator ── */
+.al-separator {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-6);
+  justify-content: center;
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-xs);
+  color: var(--mid);
+  padding: var(--sp-6) 0;
+  letter-spacing: var(--ls-normal);
+}
+.al-separator svg { width: 14px; height: 14px; opacity: 0.5; }
+
+/* ── Yesterday Section ── */
+.al-yesterday-section { margin-bottom: var(--sp-12); }
+.al-yesterday-label {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-6);
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-xs);
+  font-weight: 700;
+  color: var(--mid);
+  text-transform: uppercase;
+  letter-spacing: var(--ls-wide);
+  margin-bottom: var(--sp-8);
+}
+.al-yesterday-label svg { width: 14px; height: 14px; color: var(--tc-sage); }
+
+.al-yesterday-items {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-6);
+  margin-bottom: var(--sp-8);
+}
+.al-yesterday-item {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-8);
+  background: var(--sage-light);
+  border: 1.5px solid rgba(58,112,96, 0.25);
+  border-radius: var(--r-lg);
+  padding: var(--sp-8) var(--sp-12);
+  min-height: var(--chip-min-h);
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-sm);
+  color: var(--tc-sage);
+  cursor: pointer;
+  transition: transform 0.1s ease, background var(--anim-fast) ease;
+}
+.al-yesterday-item:active {
+  transform: scale(0.97);
+  background: rgba(58,112,96, 0.15);
+}
+.al-yesterday-icon svg { width: 16px; height: 16px; color: var(--tc-sage); flex-shrink: 0; }
+.al-yesterday-text { line-height: 1.3; }
+
+.al-yesterday-repeat {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-6);
+  background: rgba(58,112,96, 0.12);
+  border: 1.5px solid rgba(58,112,96, 0.35);
+  border-radius: var(--r-full);
+  padding: var(--sp-6) var(--sp-16);
+  min-height: var(--chip-min-h);
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-xs);
+  font-weight: 700;
+  color: var(--tc-sage);
+  cursor: pointer;
+  letter-spacing: var(--ls-tight);
+  transition: transform 0.1s ease, background var(--anim-fast) ease;
+}
+.al-yesterday-repeat:active {
+  transform: scale(0.96);
+  background: rgba(58,112,96, 0.22);
+}
+.al-yesterday-repeat svg { width: 14px; height: 14px; }
+
+/* ── Suggestion Groups ── */
+.al-suggest-section { margin-bottom: var(--sp-8); }
+.al-suggest-group { margin-bottom: var(--sp-12); }
+.al-suggest-group-label {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-6);
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-xs);
+  font-weight: 700;
+  color: var(--tc-sage);
+  letter-spacing: var(--ls-normal);
+  margin-bottom: var(--sp-6);
+}
+.al-suggest-group-label svg { width: 14px; height: 14px; color: var(--tc-sage); }
+.al-suggest-stage {
+  font-weight: 400;
+  color: var(--mid);
+  font-size: var(--fs-2xs);
+  letter-spacing: var(--ls-tight);
+}
+.al-suggest-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-8);
+}
+
+/* Milestone suggestion cards — warm tappable cards with sage domain */
+.al-suggest-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--sp-4);
+  background: var(--sage-light);
+  border: 1.5px solid rgba(58,112,96, 0.2);
+  border-radius: var(--r-xl);
+  padding: var(--sp-10) var(--sp-12);
+  max-width: calc(50% - var(--sp-4));
+  flex: 1 1 calc(50% - var(--sp-4));
+  cursor: pointer;
+  transition: transform 0.1s ease, background var(--anim-fast) ease, border-color var(--anim-fast) ease;
+  text-align: left;
+}
+.al-suggest-card:active {
+  transform: scale(0.96);
+  background: rgba(58,112,96, 0.15);
+  border-color: var(--tc-sage);
+}
+
+/* Fallback preset chips — horizontal pill row */
+.al-suggest-card-fallback {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--sp-6);
+  max-width: none;
+  flex: 0 0 auto;
+  padding: var(--sp-6) var(--sp-12);
+  border-radius: var(--r-full);
+  min-height: var(--chip-min-h);
+}
+
+.al-suggest-icon svg { width: 18px; height: 18px; color: var(--tc-sage); }
+.al-suggest-text {
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--tc-sage);
+  line-height: 1.3;
+}
+.al-suggest-dur {
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-2xs);
+  color: var(--mid);
+  font-weight: 600;
+  letter-spacing: var(--ls-tight);
+}
+
+/* ── Tip Line ── */
+.al-suggest-tip {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--sp-8);
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-sm);
+  color: var(--tc-sage);
+  background: var(--sage-light);
+  border-left: 3px solid var(--tc-sage);
+  border-radius: var(--r-md);
+  padding: var(--sp-8) var(--sp-12);
+  margin-top: var(--sp-8);
+  line-height: 1.4;
+}
+.al-suggest-tip svg { width: 14px; height: 14px; color: var(--tc-sage); flex-shrink: 0; margin-top: var(--sp-2); }
+
+/* ── Domain Nudge ── */
+.al-domain-nudge-section { margin-bottom: var(--sp-8); }
+.al-domain-nudge {
+  background: var(--glass);
+  border: 1.5px solid rgba(58,112,96, 0.15);
+  border-radius: var(--r-lg);
+  padding: var(--sp-10) var(--sp-12);
+}
+.al-domain-nudge-text {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-6);
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: var(--sp-4);
+}
+.al-domain-nudge-text svg { width: 16px; height: 16px; }
+.al-domain-nudge-links {
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-sm);
+  color: var(--mid);
+}
+.al-nudge-link {
+  background: none;
+  border: none;
+  color: var(--tc-sage);
+  font-weight: 700;
+  text-decoration: underline;
+  text-decoration-color: rgba(58,112,96, 0.3);
+  text-underline-offset: 3px;
+  cursor: pointer;
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-sm);
+  padding: var(--sp-2) 0;
+  min-height: var(--chip-min-h);
+}
+.al-nudge-link:active { color: var(--tc-sage); text-decoration-color: var(--tc-sage); }
+
+/* ── Upgrade Toast (fixed, outside modal, on document.body) ── */
+.al-upgrade-toast {
+  position: fixed;
+  bottom: var(--sp-24);
+  left: var(--sp-16);
+  right: var(--sp-16);
+  background: var(--warm);
+  border: 1.5px solid rgba(58,112,96, 0.2);
+  border-radius: var(--r-xl);
+  padding: var(--sp-12) var(--sp-16);
+  z-index: 2000;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.18);
+  transform: translateY(120%);
+  opacity: 0;
+  transition: transform var(--anim-normal) ease, opacity var(--anim-normal) ease;
+  pointer-events: none;
+}
+.al-upgrade-toast.show {
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+.al-upgrade-text {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-6);
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: var(--sp-4);
+}
+.al-upgrade-text svg { width: 16px; height: 16px; color: var(--tc-sage); }
+.al-upgrade-sub {
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-xs);
+  color: var(--mid);
+  margin-bottom: var(--sp-10);
+}
+.al-upgrade-actions {
+  display: flex;
+  gap: var(--sp-8);
+}
+.al-upgrade-yes {
+  background: var(--tc-sage);
+  color: #fff;
+  border: none;
+  border-radius: var(--r-full);
+  padding: var(--sp-8) var(--sp-16);
+  min-height: var(--chip-min-h);
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-sm);
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.1s ease, opacity var(--anim-fast) ease;
+}
+.al-upgrade-yes:active { transform: scale(0.96); opacity: 0.85; }
+.al-upgrade-dismiss {
+  background: var(--glass);
+  color: var(--mid);
+  border: 1.5px solid rgba(58,112,96, 0.25);
+  border-radius: var(--r-full);
+  padding: var(--sp-8) var(--sp-16);
+  min-height: var(--chip-min-h);
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.1s ease;
+}
+.al-upgrade-dismiss:active { transform: scale(0.96); color: var(--text); }
+
+/* ── Dark Mode ──
+   Most tokens (--sage-light, --tc-sage, --warm, --glass, --text, --mid)
+   are theme-aware and switch automatically. Only override where the
+   automatic switch isn't sufficient (active states, border alphas). */
+
+[data-theme="dark"] .al-yesterday-item {
+  border-color: rgba(58,112,96, 0.35);
+}
+[data-theme="dark"] .al-yesterday-item:active {
+  background: rgba(58,112,96, 0.25);
+}
+[data-theme="dark"] .al-yesterday-repeat {
+  background: rgba(58,112,96, 0.18);
+  border-color: rgba(58,112,96, 0.4);
+}
+[data-theme="dark"] .al-yesterday-repeat:active {
+  background: rgba(58,112,96, 0.3);
+}
+
+[data-theme="dark"] .al-suggest-card {
+  border-color: rgba(58,112,96, 0.3);
+}
+[data-theme="dark"] .al-suggest-card:active {
+  background: rgba(58,112,96, 0.25);
+  border-color: var(--tc-sage);
+}
+
+[data-theme="dark"] .al-suggest-tip {
+  border-left-color: rgba(58,112,96, 0.5);
+}
+
+[data-theme="dark"] .al-domain-nudge {
+  border-color: rgba(58,112,96, 0.25);
+}
+
+[data-theme="dark"] .al-upgrade-toast {
+  border-color: rgba(58,112,96, 0.3);
+  box-shadow: 0 4px 24px rgba(0,0,0,0.4);
+}
+[data-theme="dark"] .al-upgrade-dismiss {
+  border-color: rgba(58,112,96, 0.3);
+}
+[data-theme="dark"] .al-upgrade-dismiss:active {
+  color: var(--text);
+}
+/* ═══════════════════════════════════════════════════════════════
+   ACTIVITY LOG: Session B — Suggestions, Yesterday, Nudge, Upgrade
+   Domain-color-coded · Chip system compliant · Design token-only
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Domain Color Cascade ──
+   Parent elements set data-domain="motor|language|cognitive|social|sensory"
+   These custom properties cascade to all children automatically.
+   Motor=sage, Language=lavender, Cognitive=sky, Social=peach, Sensory=amber */
+
+[data-domain="motor"]     { --al-tint: var(--sage-light);  --al-tc: var(--tc-sage);    --al-border: rgba(58,112,96,0.25);  --al-active: rgba(58,112,96,0.15);  --al-active-dk: rgba(58,112,96,0.25);  }
+[data-domain="language"]  { --al-tint: var(--lav-light);   --al-tc: var(--tc-lav);     --al-border: rgba(110,94,154,0.25); --al-active: rgba(110,94,154,0.15); --al-active-dk: rgba(110,94,154,0.25); }
+[data-domain="cognitive"] { --al-tint: var(--sky-light);   --al-tc: var(--tc-sky);     --al-border: rgba(51,101,128,0.25); --al-active: rgba(51,101,128,0.15); --al-active-dk: rgba(51,101,128,0.25); }
+[data-domain="social"]    { --al-tint: var(--peach-light); --al-tc: var(--tc-caution);  --al-border: rgba(135,90,32,0.25);  --al-active: rgba(135,90,32,0.15);  --al-active-dk: rgba(135,90,32,0.25);  }
+[data-domain="sensory"]   { --al-tint: var(--amber-light); --al-tc: var(--tc-amber);   --al-border: rgba(138,101,32,0.25); --al-active: rgba(138,101,32,0.15); --al-active-dk: rgba(138,101,32,0.25); }
+
+/* ── Separator ── */
+.al-separator {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-6);
+  justify-content: center;
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-xs);
+  color: var(--mid);
+  padding: var(--sp-6) 0;
+  letter-spacing: var(--ls-normal);
+}
+.al-separator svg { width: 14px; height: 14px; opacity: 0.5; }
+
+/* ── Yesterday Section ── */
+.al-yesterday-section { margin-bottom: var(--sp-12); }
+.al-yesterday-label {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-6);
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-xs);
+  font-weight: 700;
+  color: var(--mid);
+  text-transform: uppercase;
+  letter-spacing: var(--ls-wide);
+  margin-bottom: var(--sp-8);
+}
+.al-yesterday-label svg { width: 14px; height: 14px; color: var(--tc-sage); }
+
+.al-yesterday-items {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-6);
+  margin-bottom: var(--sp-8);
+}
+/* Yesterday items pick up domain color from data-domain attr */
+.al-yesterday-item {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--sp-8);
+  background: var(--al-tint, var(--sage-light));
+  border: 1.5px solid var(--al-border, rgba(58,112,96,0.25));
+  border-radius: var(--r-lg);
+  padding: var(--sp-10) var(--sp-12);
+  min-height: var(--chip-min-h);
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-sm);
+  color: var(--al-tc, var(--tc-sage));
+  cursor: pointer;
+  transition: transform 0.1s ease, background var(--anim-fast) ease;
+}
+.al-yesterday-item:active {
+  transform: scale(0.97);
+  background: var(--al-active, rgba(58,112,96,0.15));
+}
+.al-yesterday-icon svg { width: 16px; height: 16px; color: var(--al-tc, var(--tc-sage)); flex-shrink: 0; margin-top: var(--sp-2); }
+.al-yesterday-text { line-height: 1.3; }
+
+.al-yesterday-repeat {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-6);
+  background: rgba(58,112,96, 0.12);
+  border: 1.5px solid rgba(58,112,96, 0.35);
+  border-radius: var(--r-full);
+  padding: var(--sp-8) var(--sp-16);
+  min-height: var(--chip-min-h);
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-xs);
+  font-weight: 700;
+  color: var(--tc-sage);
+  cursor: pointer;
+  letter-spacing: var(--ls-tight);
+  transition: transform 0.1s ease, background var(--anim-fast) ease;
+}
+.al-yesterday-repeat:active {
+  transform: scale(0.96);
+  background: rgba(58,112,96, 0.22);
+}
+.al-yesterday-repeat svg { width: 14px; height: 14px; }
+
+/* ── Suggestion Groups (domain-colored via parent data-domain) ── */
+.al-suggest-section { margin-bottom: var(--sp-8); }
+.al-suggest-group { margin-bottom: var(--sp-16); }
+.al-suggest-group-label {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: var(--sp-4) var(--sp-6);
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-xs);
+  font-weight: 700;
+  color: var(--al-tc, var(--tc-sage));
+  letter-spacing: var(--ls-normal);
+  margin-bottom: var(--sp-8);
+}
+.al-suggest-group-label svg { width: 14px; height: 14px; color: var(--al-tc, var(--tc-sage)); }
+.al-suggest-stage {
+  font-weight: 400;
+  color: var(--mid);
+  font-size: var(--fs-2xs);
+  letter-spacing: var(--ls-tight);
+  margin-left: var(--sp-4);
+}
+.al-suggest-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-8);
+}
+
+/* Suggestion cards inherit domain color from parent [data-domain] */
+.al-suggest-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--sp-6);
+  background: var(--al-tint, var(--sage-light));
+  border: 1.5px solid var(--al-border, rgba(58,112,96,0.2));
+  border-radius: var(--r-xl);
+  padding: var(--sp-12) var(--sp-12);
+  max-width: calc(50% - var(--sp-4));
+  flex: 1 1 calc(50% - var(--sp-4));
+  cursor: pointer;
+  transition: transform 0.1s ease, background var(--anim-fast) ease, border-color var(--anim-fast) ease;
+  text-align: left;
+}
+.al-suggest-card:active {
+  transform: scale(0.96);
+  background: var(--al-active, rgba(58,112,96,0.15));
+  border-color: var(--al-tc, var(--tc-sage));
+}
+
+/* Fallback preset chips — no domain, defaults to sage */
+.al-suggest-card-fallback {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--sp-6);
+  max-width: none;
+  flex: 0 0 auto;
+  padding: var(--sp-6) var(--sp-12);
+  border-radius: var(--r-full);
+  min-height: var(--chip-min-h);
+  background: var(--sage-light);
+  border-color: rgba(58,112,96,0.25);
+  color: var(--tc-sage);
+}
+
+.al-suggest-icon svg { width: 18px; height: 18px; color: var(--al-tc, var(--tc-sage)); }
+.al-suggest-text {
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--al-tc, var(--tc-sage));
+  line-height: 1.3;
+}
+.al-suggest-dur {
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-2xs);
+  color: var(--mid);
+  font-weight: 600;
+  letter-spacing: var(--ls-tight);
+}
+
+/* ── Tip Line ── */
+.al-suggest-tip {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--sp-8);
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-sm);
+  color: var(--tc-sage);
+  background: var(--sage-light);
+  border-left: 3px solid var(--tc-sage);
+  border-radius: var(--r-md);
+  padding: var(--sp-8) var(--sp-12);
+  margin-top: var(--sp-8);
+  line-height: 1.4;
+}
+.al-suggest-tip svg { width: 14px; height: 14px; color: var(--tc-sage); flex-shrink: 0; margin-top: var(--sp-2); }
+
+/* ── Domain Nudge (domain-colored via data-domain) ── */
+.al-domain-nudge-section { margin-bottom: var(--sp-8); }
+.al-domain-nudge {
+  background: var(--glass);
+  border: 1.5px solid var(--al-border, rgba(58,112,96,0.15));
+  border-radius: var(--r-lg);
+  padding: var(--sp-10) var(--sp-12);
+}
+.al-domain-nudge-text {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-6);
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--al-tc, var(--text));
+  margin-bottom: var(--sp-4);
+}
+.al-domain-nudge-text svg { width: 16px; height: 16px; color: var(--al-tc, var(--text)); }
+.al-domain-nudge-links {
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-sm);
+  color: var(--mid);
+}
+.al-nudge-link {
+  background: none;
+  border: none;
+  color: var(--al-tc, var(--tc-sage));
+  font-weight: 700;
+  text-decoration: underline;
+  text-decoration-color: var(--al-border, rgba(58,112,96,0.3));
+  text-underline-offset: 3px;
+  cursor: pointer;
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-sm);
+  padding: var(--sp-2) 0;
+  min-height: var(--chip-min-h);
+}
+.al-nudge-link:active { text-decoration-color: var(--al-tc, var(--tc-sage)); }
+
+/* ── Upgrade Toast ── */
+.al-upgrade-toast {
+  position: fixed;
+  bottom: var(--sp-24);
+  left: var(--sp-16);
+  right: var(--sp-16);
+  background: var(--warm);
+  border: 1.5px solid rgba(58,112,96, 0.2);
+  border-radius: var(--r-xl);
+  padding: var(--sp-12) var(--sp-16);
+  z-index: 2000;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.18);
+  transform: translateY(120%);
+  opacity: 0;
+  transition: transform var(--anim-normal) ease, opacity var(--anim-normal) ease;
+  pointer-events: none;
+}
+.al-upgrade-toast.show {
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+.al-upgrade-text {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-6);
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: var(--sp-4);
+}
+.al-upgrade-text svg { width: 16px; height: 16px; color: var(--tc-sage); }
+.al-upgrade-sub {
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-xs);
+  color: var(--mid);
+  margin-bottom: var(--sp-10);
+}
+.al-upgrade-actions {
+  display: flex;
+  gap: var(--sp-8);
+}
+.al-upgrade-yes {
+  background: var(--tc-sage);
+  color: #fff;
+  border: none;
+  border-radius: var(--r-full);
+  padding: var(--sp-8) var(--sp-16);
+  min-height: var(--chip-min-h);
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-sm);
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.1s ease, opacity var(--anim-fast) ease;
+}
+.al-upgrade-yes:active { transform: scale(0.96); opacity: 0.85; }
+.al-upgrade-dismiss {
+  background: var(--glass);
+  color: var(--mid);
+  border: 1.5px solid rgba(58,112,96, 0.25);
+  border-radius: var(--r-full);
+  padding: var(--sp-8) var(--sp-16);
+  min-height: var(--chip-min-h);
+  font-family: 'Nunito', sans-serif;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.1s ease;
+}
+.al-upgrade-dismiss:active { transform: scale(0.96); color: var(--text); }
+
+/* ── Dark Mode ──
+   Theme-aware tokens auto-switch. Only override rgba active opacities
+   (0.15 → 0.25 per chip system dark-mode spec). */
+
+[data-theme="dark"] .al-yesterday-item:active { background: var(--al-active-dk, rgba(58,112,96,0.25)); }
+[data-theme="dark"] .al-yesterday-repeat { background: rgba(58,112,96, 0.18); border-color: rgba(58,112,96, 0.4); }
+[data-theme="dark"] .al-yesterday-repeat:active { background: rgba(58,112,96, 0.3); }
+[data-theme="dark"] .al-suggest-card:active { background: var(--al-active-dk, rgba(58,112,96,0.25)); }
+[data-theme="dark"] .al-suggest-tip { border-left-color: rgba(58,112,96, 0.5); }
+[data-theme="dark"] .al-upgrade-toast { border-color: rgba(58,112,96, 0.3); box-shadow: 0 4px 24px rgba(0,0,0,0.4); }
+[data-theme="dark"] .al-upgrade-dismiss:active { color: var(--text); }
+
+/* ═══════════════════════════════════════════════════════════════
+   CARETICKETS — Phase B Styles
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Cards ── */
+.card.ct-card {
+  background: var(--lav-light);
+  border-radius: var(--r-2xl);
+  padding: var(--sp-16);
+  box-shadow: 0 4px 20px var(--shadow);
+  cursor: pointer;
+  margin-bottom: var(--sp-12);
+  position: relative;
+}
+.card.ct-card.ct-incident { background: var(--rose-light); }
+.card.ct-card.ct-goal { background: var(--lav-light); }
+
+.card.ct-card.ct-escalated {
+  background: var(--rose-light);
+  border: 1px solid rgba(200,180,190,0.12);
+  border-left: var(--accent-w) solid var(--rose);
+  box-shadow: 0 4px 20px var(--shadow);
+}
+.card.ct-card.ct-overdue {
+  border: 1px solid rgba(200,180,190,0.12);
+  border-left: var(--accent-w) solid var(--rose);
+  box-shadow: 0 4px 20px var(--shadow);
+}
+.card.ct-card.ct-approaching {
+  border: 1px solid rgba(200,180,190,0.12);
+  border-left: var(--accent-w) solid var(--sage);
+}
+
+.card.ct-card .card-title {
+  font-size: var(--fs-md);
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-8);
+}
+
+/* ── Chips ── */
+.chip.ct-entry-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-8);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  padding: var(--sp-10) var(--sp-16);
+  border-radius: var(--r-2xl);
+  background: var(--lav-light);
+  color: var(--tc-lav);
+  border: 1.5px solid var(--lavender);
+  cursor: pointer;
+  min-height: 44px;
+  transition: all var(--ease-fast);
+}
+.chip.ct-entry-chip:active { filter: brightness(0.92); }
+.chip.ct-entry-chip.ct-dimmed {
+  opacity: 0.5;
+  pointer-events: none;
+  cursor: default;
+}
+
+.chip.ct-banner-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-6);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  padding: var(--sp-8) var(--sp-16);
+  border-radius: var(--r-2xl);
+  background: var(--rose-light);
+  color: var(--tc-rose);
+  border: 1.5px solid var(--rose);
+  cursor: pointer;
+  min-height: 36px;
+  transition: all var(--ease-fast);
+}
+.chip.ct-banner-btn:active { filter: brightness(0.92); }
+
+/* ── Text / Layout ── */
+.ct-card-meta {
+  font-size: var(--fs-sm);
+  color: var(--light);
+  margin-top: var(--sp-4);
+  line-height: 1.4;
+}
+
+.ct-overdue-dot {
+  display: inline-block;
+  width: var(--sp-8);
+  height: var(--sp-8);
+  border-radius: var(--r-full);
+  background: var(--rose);
+  vertical-align: middle;
+  margin-right: var(--sp-4);
+  animation: ct-pulse 1.5s var(--ease-med) infinite;
+}
+
+@keyframes ct-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.ct-zone-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--sp-8) 0;
+  font-size: var(--fs-md);
+  font-weight: 700;
+  color: var(--dark);
+}
+.ct-zone-header .ct-zone-add {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--r-full);
+  background: var(--lav-light);
+  color: var(--tc-lav);
+  font-size: var(--fs-lg);
+  font-weight: 700;
+  cursor: pointer;
+  border: none;
+  transition: all var(--ease-fast);
+}
+.ct-zone-header .ct-zone-add:active { filter: brightness(0.9); }
+
+.ct-hidden { display: none; }
+
+.ct-storage-warn {
+  background: var(--amber-light);
+  color: var(--tc-amber);
+  font-size: var(--fs-sm);
+  padding: var(--sp-10) var(--sp-16);
+  border-radius: var(--r-lg);
+  margin-bottom: var(--sp-12);
+}
+
+.ct-toast {
+  position: fixed;
+  bottom: 80px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--dark);
+  color: var(--white);
+  font-size: var(--fs-sm);
+  padding: var(--sp-10) var(--sp-20);
+  border-radius: var(--r-2xl);
+  z-index: 9999;
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.3s ease;
+}
+.ct-toast-fade { opacity: 0; }
+
+.ct-banner {
+  background: var(--rose-light);
+  border-radius: var(--r-2xl);
+  padding: var(--sp-12) var(--sp-16);
+  margin-bottom: var(--sp-12);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-12);
+}
+.ct-banner-text {
+  font-size: var(--fs-sm);
+  color: var(--tc-rose);
+  font-weight: 600;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-8);
+}
+
+.ct-card-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: var(--sp-8);
+}
+.ct-card-actions .chip {
+  min-height: 36px;
+}
+
+.ct-view-all {
+  display: block;
+  text-align: center;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--tc-lav);
+  padding: var(--sp-8);
+  cursor: pointer;
+}
+.ct-view-all:active { opacity: 0.7; }
+
+/* ── Dark mode — all via existing token overrides ── */
+[data-theme="dark"] .card.ct-card { box-shadow: 0 4px 20px var(--shadow); }
+[data-theme="dark"] .card.ct-card.ct-escalated { border-color: rgba(255,255,255,0.06); }
+[data-theme="dark"] .card.ct-card.ct-overdue { border-color: rgba(255,255,255,0.06); }
+[data-theme="dark"] .card.ct-card.ct-approaching { border-color: rgba(255,255,255,0.06); }
+[data-theme="dark"] .ct-toast { background: var(--white); color: var(--dark); }
+
+.ct-zone-wrap {
+  padding: 0 var(--sp-16);
+  margin-top: var(--sp-12);
+}
+
+/* ═══ CareTickets — Overlay Styles (Phase C) ═══ */
+
+/* ── Overlay Scrims ── */
+.ct-picker-scrim,
+.ct-checkin-scrim,
+.ct-detail-scrim {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: var(--overlay-bg);
+  z-index: 9000;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+/* ── Overlay Bodies ── */
+.ct-picker-body,
+.ct-checkin-body,
+.ct-detail-body {
+  background: var(--cream);
+  border-radius: var(--r-2xl) var(--r-2xl) 0 0;
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: var(--sp-20);
+  width: 100%;
+}
+
+/* ── Check-In Header ── */
+.ct-checkin-header {
+  position: sticky;
+  top: 0;
+  background: var(--cream);
+  padding-bottom: var(--sp-12);
+  border-bottom: 1px solid var(--border-subtle);
+  z-index: 1;
+}
+
+/* ── Sticky Submit ── */
+.ct-submit-area {
+  position: sticky;
+  bottom: 0;
+  background: var(--cream);
+  padding: var(--sp-12) 0;
+  border-top: 1px solid var(--border-subtle);
+  z-index: 1;
+}
+.ct-submit-area .chip {
+  width: 100%;
+  min-height: 44px;
+  border-radius: var(--r-2xl);
+  background: var(--sage);
+  color: var(--white);
+  font-weight: 700;
+  font-size: var(--fs-base);
+  justify-content: center;
+  cursor: pointer;
+  border: none;
+  transition: all var(--ease-fast);
+}
+.ct-submit-area .chip[disabled] {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+/* ── Template Chips ── */
+.chip.ct-template-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-8);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  padding: var(--sp-8) var(--sp-16);
+  border-radius: var(--r-2xl);
+  background: var(--surface);
+  color: var(--text);
+  border: 1.5px solid var(--border-subtle);
+  cursor: pointer;
+  min-height: 44px;
+  transition: all var(--ease-fast);
+}
+.chip.ct-template-chip.active {
+  background: var(--lavender);
+  color: var(--white);
+  border-color: var(--lavender);
+}
+.chip.ct-template-chip.ct-incident-tpl.active {
+  background: var(--rose);
+  color: var(--white);
+  border-color: var(--rose);
+}
+
+/* ── Bool Chips ── */
+.ct-bool-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  padding: var(--sp-8) var(--sp-16);
+  border-radius: var(--r-2xl);
+  background: var(--surface);
+  color: var(--text);
+  border: 1.5px solid var(--border-subtle);
+  cursor: pointer;
+  min-height: 44px;
+  transition: all var(--ease-fast);
+}
+.ct-bool-chip[data-value="true"].active.ct-incident-bool {
+  background: var(--rose);
+  color: var(--white);
+  border-color: var(--rose);
+}
+.ct-bool-chip[data-value="false"].active.ct-incident-bool {
+  background: var(--sage);
+  color: var(--white);
+  border-color: var(--sage);
+}
+.ct-bool-chip.active.ct-goal-bool {
+  background: var(--lavender);
+  color: var(--white);
+  border-color: var(--lavender);
+}
+
+/* ── Answer Chips (select options) ── */
+.chip.ct-answer-chip {
+  display: inline-flex;
+  align-items: center;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  padding: var(--sp-8) var(--sp-16);
+  border-radius: var(--r-2xl);
+  background: var(--surface);
+  color: var(--text);
+  border: 1.5px solid var(--border-subtle);
+  cursor: pointer;
+  min-height: 44px;
+  transition: all var(--ease-fast);
+}
+.chip.ct-answer-chip.active {
+  background: var(--lavender);
+  color: var(--white);
+  border-color: var(--lavender);
+}
+.chip.ct-answer-chip.active.ct-incident-ans {
+  background: var(--rose);
+  color: var(--white);
+  border-color: var(--rose);
+}
+
+/* ── Text Input ── */
+.ct-text-input {
+  width: 100%;
+  border-radius: var(--r-lg);
+  font-size: var(--fs-base);
+  font-family: 'Nunito', sans-serif;
+  padding: var(--sp-12);
+  border: 1px solid var(--border-subtle);
+  min-height: 44px;
+  resize: vertical;
+  background: var(--surface);
+  color: var(--text);
+  box-sizing: border-box;
+}
+
+/* ── Questions ── */
+.ct-question { margin-bottom: var(--sp-16); }
+.ct-question-label {
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  margin-bottom: var(--sp-8);
+  color: var(--text);
+}
+.ct-chips-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-8);
+}
+
+/* ── Disclaimer & Age Note ── */
+.ct-disclaimer {
+  font-size: var(--fs-xs);
+  color: var(--tc-amber);
+  padding: var(--sp-12);
+  background: var(--amber-light);
+  border-radius: var(--r-lg);
+  margin-bottom: var(--sp-12);
+  line-height: var(--lh-relaxed);
+}
+.ct-age-note {
+  font-size: var(--fs-xs);
+  color: var(--tc-rose);
+  padding: var(--sp-12);
+  background: var(--rose-light);
+  border-radius: var(--r-lg);
+  margin-bottom: var(--sp-12);
+  line-height: var(--lh-relaxed);
+}
+
+/* ── Read-only Strip (onceOnly) ── */
+.ct-readonly-strip {
+  background: var(--surface-alt);
+  padding: var(--sp-8) var(--sp-12);
+  border-radius: var(--r-md);
+  font-size: var(--fs-sm);
+  margin-bottom: var(--sp-8);
+  color: var(--mid);
+  line-height: var(--lh-relaxed);
+}
+
+/* ── Auto Data (goal metrics) ── */
+.ct-auto-data {
+  padding: var(--sp-12);
+  background: var(--lav-light);
+  border-radius: var(--r-lg);
+  font-size: var(--fs-sm);
+  margin-bottom: var(--sp-12);
+  color: var(--tc-lav);
+  line-height: var(--lh-relaxed);
+}
+
+/* ── Preamble ── */
+.ct-preamble {
+  font-size: var(--fs-sm);
+  color: var(--mid);
+  margin-bottom: var(--sp-12);
+  font-weight: 600;
+}
+
+/* ── Quick Clear ── */
+.chip.ct-quick-clear {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-8);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  padding: var(--sp-8) var(--sp-16);
+  border-radius: var(--r-2xl);
+  background: var(--sage-light);
+  color: var(--tc-sage);
+  border: 1.5px solid var(--sage);
+  cursor: pointer;
+  min-height: 44px;
+  margin-bottom: var(--sp-12);
+  transition: all var(--ease-fast);
+}
+.chip.ct-quick-clear:active { filter: brightness(0.92); }
+
+/* ── Escalation Card ── */
+.ct-escalation-card {
+  background: var(--rose-light);
+  padding: var(--sp-16);
+  border-radius: var(--r-2xl);
+  border-left: var(--accent-w) solid var(--rose);
+  margin-bottom: var(--sp-12);
+}
+
+/* ── Phone Number ── */
+.ct-phone-number {
+  font-size: var(--fs-lg);
+  font-weight: 700;
+  color: var(--tc-rose);
+  cursor: pointer;
+  padding: var(--sp-8) 0;
+  display: block;
+}
+
+/* ── De-escalation Prompt ── */
+.ct-deescalate-prompt {
+  padding: var(--sp-16);
+  text-align: center;
+}
+
+/* ── Resolve Prompt ── */
+.ct-resolve-prompt { padding: var(--sp-16); }
+.chip.ct-resolve-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-8);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  padding: var(--sp-8) var(--sp-16);
+  border-radius: var(--r-2xl);
+  background: var(--sage-light);
+  color: var(--tc-sage);
+  border: 1.5px solid var(--sage);
+  cursor: pointer;
+  min-height: 44px;
+  transition: all var(--ease-fast);
+}
+.chip.ct-reason-chip {
+  display: inline-flex;
+  align-items: center;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  padding: var(--sp-8) var(--sp-16);
+  border-radius: var(--r-2xl);
+  background: var(--surface);
+  color: var(--text);
+  border: 1.5px solid var(--border-subtle);
+  cursor: pointer;
+  min-height: 44px;
+  transition: all var(--ease-fast);
+}
+.chip.ct-reason-chip.active {
+  background: var(--sage);
+  color: var(--white);
+  border-color: var(--sage);
+}
+
+/* ── Confirmation ── */
+.ct-confirmation {
+  padding: var(--sp-12);
+  border-radius: var(--r-lg);
+  text-align: center;
+  font-weight: 600;
+  font-size: var(--fs-sm);
+  margin-bottom: var(--sp-12);
+}
+.ct-confirmation.ct-sage {
+  background: var(--sage-light);
+  color: var(--tc-sage);
+}
+.ct-confirmation.ct-amber {
+  background: var(--amber-light);
+  color: var(--tc-amber);
+}
+
+/* ── Status Badge ── */
+.ct-status-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: var(--fs-xs);
+  padding: var(--sp-4) var(--sp-8);
+  border-radius: var(--r-full);
+  font-weight: 600;
+}
+.ct-status-badge.ct-rose {
+  background: var(--rose-light);
+  color: var(--tc-rose);
+}
+.ct-status-badge.ct-amber {
+  background: var(--amber-light);
+  color: var(--tc-amber);
+}
+.ct-status-badge.ct-sage {
+  background: var(--sage-light);
+  color: var(--tc-sage);
+}
+
+/* ── Divider / Older Hidden / Reopen Note ── */
+.ct-divider {
+  height: 1px;
+  background: var(--border-subtle);
+  margin: var(--sp-12) 0;
+}
+.ct-older-hidden { display: none; }
+.ct-reopen-note {
+  font-size: var(--fs-xs);
+  color: var(--tc-amber);
+  padding: var(--sp-8);
+  background: var(--amber-light);
+  border-radius: var(--r-md);
+  margin-bottom: var(--sp-12);
+  line-height: var(--lh-relaxed);
+}
+.ct-entry-divider {
+  margin: var(--sp-16) 0;
+  border: none;
+  border-top: 1px solid var(--border-subtle);
+}
+
+/* ── Escalation header inside overlay ── */
+.ct-esc-header {
+  font-weight: 600;
+  color: var(--tc-rose);
+  margin-bottom: var(--sp-4);
+}
+
+/* ── Timeline verdict colors ── */
+.ct-verdict-clear { color: var(--tc-sage); }
+.ct-verdict-watch { color: var(--tc-amber); }
+.ct-verdict-escalate { color: var(--tc-rose); }
+
+/* ── Overlay close button ── */
+.ct-close-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  min-height: 36px;
+  border-radius: var(--r-full);
+  cursor: pointer;
+  font-size: var(--fs-lg);
+  color: var(--mid);
+  background: none;
+  border: none;
+  flex-shrink: 0;
+}
+
+/* ── Overlay header row ── */
+.ct-overlay-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-8);
+  margin-bottom: var(--sp-16);
+}
+.ct-overlay-title {
+  font-family: 'Fraunces', serif;
+  font-size: var(--fs-lg);
+  font-weight: 700;
+  color: var(--dark);
+  flex: 1;
+}
+
+/* ── Section labels inside overlays ── */
+.ct-section-label {
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: var(--ls-wide);
+  color: var(--light);
+  margin-bottom: var(--sp-8);
+  margin-top: var(--sp-16);
+}
+
+/* ── Duplicate warning ── */
+.ct-dupe-warn {
+  font-size: var(--fs-xs);
+  color: var(--tc-amber);
+  padding: var(--sp-8) var(--sp-12);
+  background: var(--amber-light);
+  border-radius: var(--r-md);
+  margin-top: var(--sp-8);
+  line-height: var(--lh-relaxed);
+}
+
+/* ── Title input helper ── */
+.ct-title-area { margin-top: var(--sp-12); }
+.ct-helper-text {
+  font-size: var(--fs-xs);
+  color: var(--light);
+  margin-top: var(--sp-4);
+}
+
+/* ── Detail timeline ── */
+.ct-timeline-entry {
+  padding: var(--sp-8) 0;
+}
+.ct-timeline-time {
+  font-size: var(--fs-xs);
+  color: var(--light);
+  margin-bottom: var(--sp-4);
+}
+.ct-timeline-verdict {
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  margin-bottom: var(--sp-4);
+}
+.ct-timeline-answers {
+  font-size: var(--fs-xs);
+  color: var(--mid);
+  line-height: var(--lh-relaxed);
+}
+
+/* ── Detail action buttons ── */
+.ct-detail-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-8);
+  margin-top: var(--sp-16);
+  padding-top: var(--sp-12);
+  border-top: 1px solid var(--border-subtle);
+}
+
+/* ═══ Device Sync (sync-*) ═══ */
+.sync-settings-section { padding:var(--sp-12) var(--sp-12) 0; }
+.sync-card {
+  padding:var(--sp-12) 14px;
+  border-radius:var(--r-lg);
+  background:var(--sky-light);
+  border:1.5px solid rgba(168,207,224,0.3);
+}
+.sync-card-hdr {
+  display:flex;
+  align-items:center;
+  gap:var(--sp-8);
+  margin-bottom:var(--sp-8);
+}
+.sync-card-hdr .icon { width:var(--sp-20); height:var(--sp-20); }
+.sync-card-hdr .icon svg.zi { width:var(--icon-sm); height:var(--icon-sm); }
+.sync-card-title {
+  font-family:'Nunito',sans-serif;
+  font-size:var(--fs-base);
+  font-weight:600;
+  color:var(--tc-sky);
+}
+.sync-card-body {
+  font-size:var(--fs-sm);
+  color:var(--mid);
+  line-height:var(--lh-relaxed);
+  margin-bottom:var(--sp-12);
+}
+.sync-card-actions { display:flex; flex-direction:column; gap:var(--sp-8); }
+.sync-user-email {
+  font-size:var(--fs-xs);
+  color:var(--mid);
+  opacity:0.7;
+}
+.sync-members { margin-bottom:var(--sp-8); }
+.sync-section-label {
+  font-size:var(--fs-xs);
+  font-weight:600;
+  text-transform:uppercase;
+  letter-spacing:var(--ls-wide);
+  color:var(--mid);
+  margin-bottom:var(--sp-4);
+}
+.sync-member {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  padding:var(--sp-4) 0;
+}
+.sync-member-name { font-size:var(--fs-sm); color:var(--text); font-weight:500; }
+.sync-member-role { font-size:var(--fs-xs); color:var(--mid); }
+.sync-code-row {
+  display:flex;
+  align-items:center;
+  gap:var(--sp-8);
+  padding:var(--sp-8) 0;
+  border-top:1px solid rgba(168,207,224,0.2);
+  margin-bottom:var(--sp-8);
+}
+.sync-code-label { font-size:var(--fs-xs); color:var(--mid); font-weight:600; }
+.sync-code-value {
+  font-family:'Nunito',sans-serif;
+  font-size:var(--fs-sm);
+  font-weight:700;
+  color:var(--tc-sky);
+  letter-spacing:var(--ls-wide);
+}
+.sync-code-used { font-size:var(--fs-xs); color:var(--mid); opacity:0.5; }
+.sync-status-badge {
+  font-size:var(--fs-2xs);
+  font-weight:700;
+  text-transform:uppercase;
+  letter-spacing:var(--ls-normal);
+  padding:var(--sp-2) var(--sp-8);
+  border-radius:var(--r-full);
+  margin-left:auto;
+}
+.sync-status-connected { background:var(--sage-light); color:var(--tc-sage); }
+.sync-modal-overlay {
+  position:fixed; inset:0; z-index:9999;
+  background:var(--overlay-bg);
+  display:flex; align-items:center; justify-content:center;
+  padding:var(--sp-16);
+}
+.sync-modal {
+  background:var(--surface);
+  border-radius:var(--r-xl);
+  width:100%; max-width:360px;
+  overflow:hidden;
+}
+.sync-modal-label {
+  font-size:var(--fs-sm);
+  font-weight:600;
+  color:var(--text);
+}
+.sync-modal-input {
+  width:100%;
+  padding:var(--sp-10) var(--sp-12);
+  border:1.5px solid rgba(168,207,224,0.3);
+  border-radius:var(--r-lg);
+  font-family:'Nunito',sans-serif;
+  font-size:var(--fs-base);
+  background:var(--surface);
+  color:var(--text);
+  outline:none;
+  box-sizing:border-box;
+}
+.sync-modal-input:focus { border-color:var(--sky); }
+
+.sync-toast {
+  position:fixed;
+  bottom:calc(var(--nav-h) + var(--sp-12));
+  left:50%; transform:translateX(-50%);
+  background:var(--tc-sky);
+  color:#fff;
+  padding:var(--sp-10) var(--sp-16);
+  border-radius:var(--r-full);
+  font-size:var(--fs-sm);
+  font-weight:600;
+  font-family:'Nunito',sans-serif;
+  z-index:9998;
+  cursor:default;
+  box-shadow:0 4px 16px rgba(0,0,0,0.2);
+  animation:syncToastIn 0.3s ease-out;
+  white-space:nowrap;
+}
+/* Phase 3 PR-9: success-path toast is auto-dismiss-only (no click handler;
+   `cursor:default`). Fallback path adds `.is-tappable` to restore the prior
+   tap-to-reload affordance — the click handler is wired in JS at toast
+   creation time, gated on the same flag. */
+.sync-toast.is-tappable { cursor:pointer; }
+@keyframes syncToastIn {
+  from { opacity:0; transform:translateX(-50%) translateY(10px); }
+  to   { opacity:1; transform:translateX(-50%) translateY(0); }
+}
+
+/* ═══ Dark mode: Device Sync ═══ */
+[data-theme="dark"] .sync-card { background:rgba(51,101,128,0.1); border-color:rgba(51,101,128,0.2); }
+[data-theme="dark"] .sync-card-title { color:var(--tc-sky); }
+[data-theme="dark"] .sync-status-connected { background:rgba(58,112,96,0.15); }
+[data-theme="dark"] .sync-code-row { border-top-color:rgba(51,101,128,0.15); }
+[data-theme="dark"] .sync-modal { background:var(--surface); }
+[data-theme="dark"] .sync-modal-input { background:rgba(255,255,255,0.05); border-color:rgba(51,101,128,0.25); }
+
+/* ═══ Sync Visibility Indicator (Phase 1 — sl-1-2, r2) ═══
+   Five logical states mapped to three visual colors per the gap audit.
+   Copy + aria-label disambiguate the two reds (offline vs halted) for AT. */
+.sync-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-6);
+  padding: var(--sp-2) var(--sp-8);
+  border: 1px solid transparent;
+  border-radius: var(--r-full);
+  background: transparent;
+  color: var(--light);
+  font: inherit;
+  font-size: var(--fs-xs);
+  line-height: 1.1;
+  cursor: default;
+  transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+.sync-indicator[hidden] { display: none !important; }
+.sync-indicator:focus-visible { outline: 2px solid var(--tc-sky); outline-offset: 2px; }
+.sync-indicator__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--r-full);
+  background: currentColor;
+  flex-shrink: 0;
+}
+.sync-indicator__label { white-space: nowrap; font-weight: 600; }
+.sync-indicator[data-state="connecting"] { color: var(--tc-amber); }
+.sync-indicator[data-state="online"]     { color: var(--tc-sage); }
+.sync-indicator[data-state="syncing"]    { color: var(--tc-amber); }
+.sync-indicator[data-state="offline"]    { color: var(--tc-danger); }
+.sync-indicator[data-state="halted"]     { color: var(--tc-danger); cursor: pointer; }
+.sync-indicator[data-state="connecting"] .sync-indicator__dot,
+.sync-indicator[data-state="syncing"]    .sync-indicator__dot {
+  animation: sync-indicator-pulse 1.4s ease-in-out infinite;
+}
+@keyframes sync-indicator-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.35; transform: scale(0.85); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .sync-indicator[data-state="connecting"] .sync-indicator__dot,
+  .sync-indicator[data-state="syncing"]    .sync-indicator__dot { animation: none; }
+}
+
+/* ═══ Offline / Halted Persistent Badge (Phase 1 — sl-1-3) ═══
+   Matches the existing home-banner pattern (fe-home-banner etc.) — left
+   border accent via --tc-danger, tinted background, rounded corners,
+   single row on wide viewports, wraps on narrow. Tokens only (HR-5), no
+   inline styles (HR-2); reload routed through data-action (HR-3/HR-6). */
+.offline-badge {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-10);
+  padding: var(--sp-10) var(--sp-12);
+  margin: var(--sp-8) 0;
+  border-left: 4px solid var(--tc-danger);
+  border-radius: var(--r-lg);
+  background: rgba(224, 112, 112, 0.10);
+  color: var(--text);
+  font-size: var(--fs-sm);
+  line-height: 1.35;
+  flex-wrap: wrap;
+}
+.offline-badge[hidden] { display: none !important; }
+.offline-badge__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  color: var(--tc-danger);
+  flex-shrink: 0;
+}
+.offline-badge__icon .zi { width: 18px; height: 18px; }
+.offline-badge__copy {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-weight: 600;
+}
+.offline-badge__action {
+  flex-shrink: 0;
+  padding: var(--sp-4) var(--sp-10);
+  border: 1px solid var(--tc-danger);
+  border-radius: var(--r-md);
+  background: transparent;
+  color: var(--tc-danger);
+  font: inherit;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.offline-badge__action[hidden] { display: none !important; }
+.offline-badge__action:hover,
+.offline-badge__action:focus-visible {
+  background: var(--tc-danger);
+  color: var(--white);
+}
+.offline-badge__action:focus-visible {
+  outline: 2px solid var(--tc-sky);
+  outline-offset: 2px;
+}
+[data-theme="dark"] .offline-badge { background: rgba(224, 112, 112, 0.08); }
+
+/* ═══════════════════════════════════════════════════════════════════════
+   v3-6 — Card-priority registry (single source of truth, card tier).
+   Spec: docs/specs/v3-6-card-priority.md §The three-tier card-priority
+   registry + §Visual contract per tier. Charter axis primarily served:
+   Linguistic + visual warmth (CV3-006 Axis 3) — gestalt-lift on the
+   Info tab via a three-tier mutex hierarchy. Architectural extensibility
+   (Axis 2) — one attribute per card, mutual exclusion enforced by the
+   attribute model. Adding a tier = one CSS variant here + one constant
+   in window._CARD_PRIORITY_TIERS + one branch in _setCardPriority +
+   canon-cc-027 amendment.
+
+   Tier precedence (mutex, highest first): urgent > notable > ambient.
+
+   The three sync sites the meta-audit test
+   regression-guard-v3-6-tier-registry-sync watches:
+     1. window._CARD_PRIORITY_TIERS constant (intelligence-cards.js)
+     2. The data-card-priority CSS variants in this block
+     3. The deriver branches in _setCardPriority (intelligence-cards.js)
+
+   v3-5 cipher-extensibility-2 dormant gate is closed by that meta-audit
+   — the three-site sync pattern v3-5 surfaced is enforced at v3-6.
+
+   F1 + F2 IMPL-note (review-pass amendment 2026-05-27): two derived
+   tokens compose from existing design-system tokens. No inline rgba
+   composition, no inline box-shadow values. Maren second-round audit
+   picks the dark-theme bindings. ────────────────────────────────────── */
+
+/* Derived tokens — compose from existing tokens; no ad-hoc hex */
+:root {
+  /* Ambient surface tint binds to the existing glass token whose alpha
+     already encodes the warm-light overlay. Maren second-round audit may
+     refine to a dedicated value if the contrast floor demands it. */
+  --card-surface-ambient: var(--glass);
+  /* Urgent elevation composes from the existing --shadow token at a deeper
+     radius/offset than the default --shadow (which the base .card uses at
+     4px 20px). The 6px 24px values widen the rose-domain salience without
+     introducing a new color token. */
+  --shadow-card-urgent: 0 6px 24px var(--shadow);
+}
+[data-theme="dark"] {
+  /* Dark-theme bindings — Maren picks the final value at triple-jurisdiction
+     audit time per spec §IMPL-note. Sensible defaults: same composition
+     pattern as light-theme, the dark-theme --glass / --shadow already
+     cascade. */
+  --card-surface-ambient: var(--glass);
+  --shadow-card-urgent: 0 6px 24px var(--shadow);
+}
+
+/* urgent — actionable card-internal insight the parent should see now.
+   Rose-deep border-left 3px (mirrors the v3-5 chip-tier urgent contract
+   one tier larger) + --text title color + bold title font-weight + the
+   --shadow-card-urgent derived elevation. Maren severity-floor honor
+   (V-M-87 echo): --rose-deep is the D2 phase-spec §2.3 token reserved
+   for DO-NOT callout border amplification — never softens below the
+   safety threshold across themes.
+
+   Per spec §Tier-deriver patterns: trend cards and composite cards
+   NEVER urgent. This visual contract activates only when an adherence
+   or reaction card's data deriver returns the urgent signal.
+
+   Selector specificity note: .card.card-daily already defines a
+   border-left:3px solid var(--border-subtle) at line 2521; the
+   .card[data-card-priority="..."] block here recolors / re-widths via
+   higher attribute-selector specificity so the priority chrome wins
+   the cascade. */
+.card[data-card-priority="urgent"] {
+  border-left: 3px solid var(--rose-deep);
+  box-shadow: var(--shadow-card-urgent);
+}
+.card[data-card-priority="urgent"] .card-title {
+  color: var(--text);
+  font-weight: 600;
+}
+
+/* notable — default tier (trends with data, computable correlations).
+   Clean chrome — explicit no-op preserves the base .card visual contract.
+   This block exists so the registry has a CSS site per tier (the three
+   sync sites the meta-audit reads). The deriver leaves the collapse body
+   alone for notable, preserving the user's last tap state per spec. */
+.card[data-card-priority="notable"] { /* clean — base .card carries the chrome */ }
+
+/* ambient — no actionable signal (si-nodata branch or baseline historical
+   data with no recent delta). --glass-strong border-left 2px + --mid title
+   color + --card-surface-ambient surface tint. Body forced collapsed by
+   _setCardPriority (mirrors toggleHistoryCard close outcome).
+
+   Per spec §Tier-deriver patterns: every si-nodata branch always routes
+   ambient — CV3-003 honest-empty-state cross-cut. The card-header (title
+   + chevron) remains visible and tappable; the card announces itself. */
+.card[data-card-priority="ambient"] {
+  border-left: 2px solid var(--glass-strong);
+  background: var(--card-surface-ambient);
+}
+.card[data-card-priority="ambient"] .card-title {
+  color: var(--mid);
+}
+
+
+/* ═══ food-sub-tab-v1 F-3 — Library search + filter + detail sheet ═══ */
+.food-lib-controls { display:flex; flex-direction:column; gap:var(--sp-8); margin:var(--sp-12) 0; }
+.food-lib-search {
+  width:100%; padding:var(--sp-8) var(--sp-12); border-radius:var(--r-lg);
+  border:1.5px solid var(--sky-light); background:var(--glass); color:var(--text);
+  font-size:var(--fs-base); font-family:'Nunito',sans-serif;
+}
+.food-lib-search:focus { outline:none; border-color:var(--sky); }
+.food-lib-filter-rail { display:flex; flex-wrap:wrap; gap:var(--sp-4); }
+.food-lib-chip {
+  padding:var(--sp-4) var(--sp-12); border-radius:var(--r-2xl);
+  border:1.5px solid var(--sage-light); background:var(--glass);
+  color:var(--mid); font-size:var(--fs-sm); font-weight:600; cursor:pointer;
+  transition:all var(--ease-fast); min-height:44px;
+}
+.food-lib-chip:active { transform:scale(0.96); }
+.food-lib-chip.active { background:var(--sage-light); border-color:var(--sage); color:var(--tc-sage); }
+.food-lib-results { margin-top:var(--sp-8); }
+.food-lib-count { font-size:var(--fs-xs); color:var(--light); margin-bottom:var(--sp-8); }
+.food-lib-cards { display:flex; flex-direction:column; gap:var(--sp-6); }
+.food-lib-card {
+  display:flex; align-items:center; justify-content:space-between; gap:var(--sp-8);
+  width:100%; text-align:left; padding:var(--sp-12); border-radius:var(--r-lg);
+  border:1.5px solid var(--glass-strong); background:var(--glass);
+  color:var(--text); cursor:pointer; transition:all var(--ease-fast); min-height:44px;
+}
+.food-lib-card:hover { filter:brightness(0.97); }
+.food-lib-card.tried { border-color:var(--sage-light); background:var(--sage-light); }
+.flc-name { font-size:var(--fs-base); font-weight:600; text-transform:capitalize; }
+.flc-flags { display:flex; flex-wrap:wrap; gap:var(--sp-4); align-items:center; }
+.flc-flag { display:inline-flex; align-items:center; gap:var(--sp-2); font-size:var(--fs-xs); font-weight:700; padding:var(--sp-2) var(--sp-6); border-radius:var(--r-md); }
+.flc-tried { background:var(--sage-light); color:var(--tc-sage); }
+.flc-allergen { background:var(--rose-light); color:var(--tc-rose); }
+.flc-aged { background:var(--peach-light); color:var(--tc-caution); }
+.food-lib-empty { padding:var(--sp-12); text-align:center; color:var(--light); font-size:var(--fs-base); }
+
+/* detail sheet */
+.fd-tried-row { display:flex; align-items:center; justify-content:space-between; gap:var(--sp-8); margin-bottom:var(--sp-12); }
+.fd-tried-state { font-size:var(--fs-base); font-weight:600; color:var(--mid); display:inline-flex; align-items:center; gap:var(--sp-4); }
+.fd-tried-btn { white-space:nowrap; }
+.fd-flag { display:flex; align-items:flex-start; gap:var(--sp-6); padding:var(--sp-8) var(--sp-12); border-radius:var(--r-lg); margin-bottom:var(--sp-8); font-size:var(--fs-sm); line-height:var(--lh-relaxed); }
+.fd-flag-allergen { background:var(--rose-light); color:var(--tc-rose); }
+/* encourage polarity (food-effects-v2): introduce-early allergens read sage/calm,
+   NOT rose/alarm. Rose (.fd-flag-allergen) is reserved for true "avoid". The
+   severe-reaction floor below the banner stays serious regardless. */
+.fd-flag-encourage { background:var(--sage-light); color:var(--tc-sage); }
+/* food-effects-v2 P1c (K-6): the four-polarity flag set on the Food Library detail
+   surface, switched off _effPolarity. conditional (drink-timing, cow milk) reads
+   amber/clock; inform (substitute-caveat, plant milk) reads sky/info — never the rose
+   .fd-flag-allergen siren (rose stays reserved for true acute-toxin "avoid"). */
+.fd-flag-conditional { background:var(--amber-light); color:var(--tc-amber); }
+.fd-flag-inform { background:var(--sky-light); color:var(--tc-sky); }
+.fd-flag-aged { background:var(--peach-light); color:var(--tc-caution); }
+.fd-flag-neutral { background:var(--glass-strong); color:var(--mid); }
+.fd-section { margin-top:var(--sp-12); }
+.fd-section-title { font-size:var(--fs-sm); font-weight:700; color:var(--text); margin-bottom:var(--sp-6); }
+.fd-chips { display:flex; flex-wrap:wrap; gap:var(--sp-4); }
+.fd-chip { font-size:var(--fs-xs); padding:var(--sp-2) var(--sp-8); border-radius:var(--r-md); background:var(--glass-strong); color:var(--mid); text-transform:capitalize; }
+.fd-chem-row { display:flex; justify-content:space-between; gap:var(--sp-8); padding:var(--sp-4) 0; border-bottom:1px solid var(--glass-strong); }
+.fd-chem-k { font-size:var(--fs-sm); font-weight:600; color:var(--mid); }
+.fd-chem-v { font-size:var(--fs-sm); color:var(--text); text-align:right; text-transform:capitalize; }
+.fd-note { font-size:var(--fs-xs); color:var(--light); line-height:var(--lh-relaxed); margin-top:var(--sp-6); }
+[data-theme="dark"] .food-lib-search { background:rgba(255,255,255,0.06); }
+[data-theme="dark"] .food-lib-chip { background:rgba(255,255,255,0.06); }
+[data-theme="dark"] .food-lib-card { background:rgba(255,255,255,0.04); }
+[data-theme="dark"] .fd-chip { background:rgba(255,255,255,0.08); }
+
+/* ════════════════════════════════════════════════════════════════════════
+   Diet → Library redesign (food-effects-v2) — the living shelf.
+   Two wings (Browse foods / Safety guides), collapsible polarity shelves of
+   living books (journey + EP voice + food-domain whisper), expand-in-place
+   detail (reuses .enc-form / .cons-severe / .enc-emergency for content), and
+   the Emergency Deck. Detail floor renders via _libBuildGuide. Design record:
+   docs/design/library-redesign/ (S4–S8). All tokens; no raw hex.
+   ════════════════════════════════════════════════════════════════════════ */
+
+/* wing control */
+.lib-wings { display:flex; gap:var(--sp-4); background:var(--surface-alt); border-radius:var(--r-2xl); padding:var(--sp-4); margin-bottom:var(--sp-16); }
+.lib-wing { flex:1; padding:var(--sp-10) var(--sp-8); min-height:36px; border:none; border-radius:var(--r-2xl); background:transparent; cursor:pointer; font-family:'Nunito',sans-serif; font-size:var(--fs-sm); font-weight:700; color:var(--mid); display:flex; align-items:center; justify-content:center; gap:var(--sp-6); white-space:nowrap; transition:all var(--ease-fast); }
+.lib-wing--active { background:var(--card-bg); color:var(--tc-sage); box-shadow:0 2px 10px var(--shadow); }
+.lib-wing .zi { width:var(--icon-base); height:var(--icon-base); }
+.lib-wing-in { animation:fadeUp var(--ease-med) both; }
+
+/* emergency entry — pinned, loud-but-calm; opens the deck */
+.emerg-entry { display:flex; align-items:center; gap:var(--sp-12); width:100%; text-align:left; cursor:pointer; background:var(--rose-light); border:none; border-left:3px solid var(--rose); border-radius:var(--r-2xl); padding:var(--sp-12) var(--sp-16); min-height:44px; box-shadow:0 3px 14px var(--shadow); margin-bottom:var(--sp-20); }
+.emerg-entry-icon { flex:0 0 auto; width:40px; height:40px; border-radius:var(--r-full); background:var(--tc-rose); color:var(--card-bg); display:flex; align-items:center; justify-content:center; }
+.emerg-entry-icon .zi { width:var(--icon-lg); height:var(--icon-lg); }
+.emerg-entry-txt { flex:1; min-width:0; }
+.emerg-entry-title { display:block; font-family:'Fraunces',serif; font-weight:600; font-size:var(--fs-md); color:var(--tc-rose); line-height:var(--lh-snug); }
+.emerg-entry-sub { display:block; font-size:var(--fs-xs); color:var(--mid); margin-top:var(--sp-2); line-height:var(--lh-normal); }
+.emerg-entry-go { flex:0 0 auto; align-self:center; color:var(--tc-rose); }
+.emerg-entry-go .zi { width:var(--icon-md); height:var(--icon-md); }
+
+/* collapsible section header (shared by Browse shelves + Safety guides) */
+.lib-group { margin-bottom:var(--sp-16); }
+.lib-group-label { display:flex; align-items:center; gap:var(--sp-8); width:100%; border:none; background:transparent; cursor:pointer; text-align:left; font-family:'Fraunces',serif; font-weight:600; font-size:var(--fs-md); line-height:var(--lh-snug); margin:var(--sp-12) 0 var(--sp-10); padding:var(--sp-4); min-height:36px; color:var(--text); }
+.lib-group-label .zi { width:var(--icon-md); height:var(--icon-md); flex:0 0 auto; }
+.lib-group-count { margin-left:auto; font-family:'Nunito',sans-serif; font-weight:700; font-size:var(--fs-2xs); opacity:0.7; }
+.lib-group-chev { display:inline-flex; color:var(--light); transition:transform var(--ease-fast); }
+.lib-group-chev .zi { width:var(--icon-base); height:var(--icon-base); }
+.lib-group.open .lib-group-chev { transform:rotate(90deg); }
+.lib-group--guide .lib-group-chev { margin-left:auto; }
+.lib-group--encourage .lib-group-label, .lib-group--sage  .lib-group-label { color:var(--tc-sage); }
+.lib-group--conditional .lib-group-label, .lib-group--amber .lib-group-label { color:var(--tc-amber); }
+.lib-group--warn .lib-group-label, .lib-group--rose .lib-group-label { color:var(--tc-rose); }
+.lib-group--inform .lib-group-label, .lib-group--sky .lib-group-label { color:var(--tc-sky); }
+.lib-group--lav .lib-group-label { color:var(--tc-lav); }
+.lib-shelf-row { display:flex; flex-direction:column; gap:var(--sp-10); }
+.lib-group:not(.open) .lib-shelf-row { display:none; }
+.lib-group.open .lib-shelf-row { animation:fadeUp var(--ease-med) both; }
+
+/* the living book row */
+.lib-book-wrap { display:flex; flex-direction:column; }
+.lib-book { display:flex; align-items:center; gap:var(--sp-12); width:100%; text-align:left; border-radius:var(--r-lg); padding:var(--sp-12) var(--sp-16); min-height:44px; box-shadow:0 1px 8px var(--shadow); cursor:pointer; background-color:var(--card-bg); border:none; border-left:3px solid var(--mid); transition:box-shadow var(--ease-fast); }
+.lib-book:hover, .lib-book.expanded { box-shadow:0 3px 18px var(--shadow); }
+.lib-book--encourage   { border-left-color:var(--sage); }
+.lib-book--conditional { border-left-color:var(--amber); }
+.lib-book--warn        { border-left-color:var(--rose); }
+.lib-book--inform      { border-left-color:var(--sky); }
+.lib-book--lav         { border-left-color:var(--lavender); }
+.lib-book-body { flex:1; min-width:0; }
+.lib-book-title { display:block; font-family:'Fraunces',serif; font-weight:600; font-size:var(--fs-md); color:var(--text); line-height:var(--lh-snug); }
+.lib-book-reg { font-weight:400; color:var(--tc-sage); font-size:var(--fs-sm); }
+.lib-book-voice { display:block; font-family:'Fraunces',serif; font-style:italic; font-weight:400; font-size:var(--fs-sm); color:var(--mid); line-height:var(--lh-snug); margin-top:1px; }
+.lib-book-glance { font-size:var(--fs-sm); color:var(--mid); margin-top:var(--sp-6); display:flex; align-items:center; gap:var(--sp-6); }
+.lib-book-glance .zi { width:var(--icon-sm); height:var(--icon-sm); flex:0 0 auto; color:var(--tc-amber); }
+/* V-V-2 (Vela): a warn book's at-a-glance triangle is a STOP cue — rose, not amber-caution. */
+.lib-book--warn .lib-book-glance .zi { color:var(--tc-rose); }
+.lib-book-siren { flex:0 0 auto; color:var(--rose); display:flex; align-items:center; align-self:center; }
+.lib-book-siren .zi { width:var(--icon-sm); height:var(--icon-sm); }
+.lib-book-go { flex:0 0 auto; color:var(--light); align-self:center; transition:transform var(--ease-fast); }
+.lib-book-go .zi { width:var(--icon-base); height:var(--icon-base); }
+.lib-book.expanded .lib-book-go { transform:rotate(90deg); }
+
+/* food-domain whisper (#217/#218) — light */
+.dt-grains { background-image:linear-gradient(135deg, transparent 40%, rgba(181,213,197,0.22)); }
+.dt-fruits { background-image:linear-gradient(135deg, transparent 40%, rgba(242,168,184,0.22)); }
+.dt-nonveg { background-image:linear-gradient(135deg, transparent 40%, rgba(242,168,184,0.22)); }
+.dt-dairy  { background-image:linear-gradient(135deg, transparent 40%, rgba(168,207,224,0.22)); }
+.dt-nuts   { background-image:linear-gradient(135deg, transparent 40%, rgba(201,184,232,0.22)); }
+.dt-spices { background-image:linear-gradient(135deg, transparent 40%, rgba(232,184,109,0.22)); }
+.dt-vegs   { background-image:linear-gradient(135deg, transparent 40%, rgba(250,212,180,0.22)); }
+/* whisper — dark (hue-swap to deep --tc tones) */
+[data-theme="dark"] .dt-grains { background-image:linear-gradient(135deg, transparent 30%, rgba(58,112,96,0.16)); }
+[data-theme="dark"] .dt-fruits { background-image:linear-gradient(135deg, transparent 30%, rgba(158,62,82,0.18)); }
+[data-theme="dark"] .dt-nonveg { background-image:linear-gradient(135deg, transparent 30%, rgba(158,62,82,0.18)); }
+[data-theme="dark"] .dt-dairy  { background-image:linear-gradient(135deg, transparent 30%, rgba(58,112,144,0.16)); }
+[data-theme="dark"] .dt-nuts   { background-image:linear-gradient(135deg, transparent 30%, rgba(110,94,154,0.18)); }
+[data-theme="dark"] .dt-spices { background-image:linear-gradient(135deg, transparent 30%, rgba(138,101,32,0.18)); }
+[data-theme="dark"] .dt-vegs   { background-image:linear-gradient(135deg, transparent 30%, rgba(138,101,32,0.18)); }
+
+/* journey channel — Receded register, a second channel beside the safety rail/siren */
+.lib-untried { display:inline-flex; align-items:center; gap:var(--sp-6); margin-top:var(--sp-8); font-family:'Nunito',sans-serif; font-weight:600; font-size:var(--fs-2xs); color:var(--light); }
+.lib-untried .lib-dot { width:6px; height:6px; border-radius:var(--r-full); border:1.5px solid var(--light); }
+.lib-journey { display:inline-flex; align-items:center; gap:var(--sp-6); margin-top:var(--sp-8); padding:var(--sp-4) var(--sp-10); border-radius:var(--r-2xl); width:fit-content; font-family:'Nunito',sans-serif; font-weight:700; font-size:var(--fs-2xs); line-height:1; }
+.lib-journey .zi { width:var(--icon-sm); height:var(--icon-sm); flex:0 0 auto; }
+.lib-journey .lib-go { width:var(--icon-xs); height:var(--icon-xs); margin-left:var(--sp-2); opacity:0.8; }
+.lib-journey--settled, .lib-journey--regular { background:var(--sage-light); color:var(--tc-sage); }
+.lib-journey--watching { background:var(--amber-light); color:var(--tc-amber); }
+.lib-book-nudge { font-size:var(--fs-sm); color:var(--tc-sage); margin-top:var(--sp-6); display:flex; align-items:center; gap:var(--sp-6); font-weight:600; }
+.lib-book-nudge .zi { width:var(--icon-sm); height:var(--icon-sm); flex:0 0 auto; }
+.lib-book-nudge .lib-go { width:var(--icon-xs); height:var(--icon-xs); opacity:0.8; }
+
+/* expand-in-place detail (content reuses .enc-form / .cons-severe / .enc-emergency) */
+.lib-why { font-size:var(--fs-sm); color:var(--mid); line-height:var(--lh-normal); margin:0; }
+/* Suggested-for-Ziva lead card — the entry point the eye lands on */
+.lib-lead { background:var(--sage-light); border-radius:var(--r-lg); padding:var(--sp-12) var(--sp-16); margin-bottom:var(--sp-16); border-left:3px solid var(--sage); }
+.lib-lead-h { display:flex; align-items:center; gap:var(--sp-6); font-family:'Fraunces',serif; font-weight:600; font-size:var(--fs-md); color:var(--tc-sage); }
+.lib-lead-h .zi { width:var(--icon-base); height:var(--icon-base); }
+.lib-lead-sub { font-size:var(--fs-xs); color:var(--mid); margin-top:var(--sp-2); line-height:var(--lh-normal); }
+.lib-lead-chips { display:flex; flex-wrap:wrap; gap:var(--sp-8); margin-top:var(--sp-10); }
+.lib-lead-chip { display:inline-flex; align-items:center; gap:var(--sp-4); padding:var(--sp-6) var(--sp-12); min-height:36px; border:1.5px solid var(--sage); border-radius:var(--r-2xl); background:var(--card-bg); color:var(--tc-sage); font-family:'Nunito',sans-serif; font-weight:700; font-size:var(--fs-sm); cursor:pointer; }
+.lib-lead-chip .zi { width:var(--icon-sm); height:var(--icon-sm); }
+
+/* Emergency Deck — overlay of the four never-cross floors (both faces stacked) */
+.lib-deck { position:fixed; inset:0; background:rgba(20,12,16,0.55); display:none; align-items:center; justify-content:center; padding:var(--sp-32) var(--sp-12); overflow:auto; z-index:1200; }
+.lib-deck.open { display:flex; }
+.lib-deck-sheet { width:100%; max-width:460px; max-height:calc(100vh - var(--sp-32) * 2); overflow-y:auto; box-sizing:border-box; background:var(--cream); border-radius:var(--r-2xl); padding:var(--sp-16); box-shadow:0 12px 50px rgba(0,0,0,0.5); }
+.lib-deck-head { position:sticky; top:0; z-index:1; background:var(--cream); display:flex; align-items:center; gap:var(--sp-10); padding-bottom:var(--sp-8); margin-bottom:var(--sp-8); }
+/* hide the quick-log FAB while a Library overlay is open so it can't clutter or
+   intercept the pinned pop-up / deck footer (the overlay sits above it at z-1200). */
+.lib-overlay-open .ql-fab { display:none; }
+.lib-deck-head .zi { width:var(--icon-lg); height:var(--icon-lg); color:var(--tc-rose); }
+.lib-deck-title { font-family:'Fraunces',serif; font-weight:600; font-size:var(--fs-lg); color:var(--text); flex:1; }
+.lib-deck-close { flex:0 0 auto; width:32px; height:32px; border:none; border-radius:var(--r-full); background:var(--surface-alt); color:var(--mid); cursor:pointer; display:flex; align-items:center; justify-content:center; }
+.lib-deck-close .zi { width:var(--icon-base); height:var(--icon-base); }
+
+/* ═══ Nutrient colour system — tint-fade chips, one per nutrient-domain (§10.4 DESIGN_PRINCIPLES).
+   6 nutrient-domains mapped onto 6 of the 7 house domains (peach reserved for food-domain veg). ═══ */
+.nutri-chip { display:inline-flex; align-items:center; padding:var(--sp-4) var(--sp-10); border-radius:var(--r-2xl); font-family:'Nunito',sans-serif; font-weight:700; font-size:var(--fs-2xs); }
+.nutri-chip--growth   { background-image:linear-gradient(135deg, transparent 28%, rgba(181,213,197,0.34)); color:var(--tc-sage); }
+.nutri-chip--blood    { background-image:linear-gradient(135deg, transparent 28%, rgba(242,168,184,0.34)); color:var(--tc-rose); }
+.nutri-chip--bones    { background-image:linear-gradient(135deg, transparent 28%, rgba(168,207,224,0.34)); color:var(--tc-sky); }
+.nutri-chip--brain    { background-image:linear-gradient(135deg, transparent 28%, rgba(201,184,232,0.34)); color:var(--tc-lav); }
+.nutri-chip--immunity { background-image:linear-gradient(135deg, transparent 28%, rgba(232,184,109,0.34)); color:var(--tc-amber); }
+.nutri-chip--energy   { background-image:linear-gradient(135deg, transparent 28%, rgba(155,168,216,0.34)); color:var(--tc-indigo); }
+[data-theme="dark"] .nutri-chip--growth   { background-image:linear-gradient(135deg, transparent 20%, rgba(58,112,96,0.30)); }
+[data-theme="dark"] .nutri-chip--blood    { background-image:linear-gradient(135deg, transparent 20%, rgba(158,62,82,0.30)); }
+[data-theme="dark"] .nutri-chip--bones    { background-image:linear-gradient(135deg, transparent 20%, rgba(58,112,144,0.30)); }
+[data-theme="dark"] .nutri-chip--brain    { background-image:linear-gradient(135deg, transparent 20%, rgba(110,94,154,0.30)); }
+[data-theme="dark"] .nutri-chip--immunity { background-image:linear-gradient(135deg, transparent 20%, rgba(138,101,32,0.32)); }
+[data-theme="dark"] .nutri-chip--energy   { background-image:linear-gradient(135deg, transparent 20%, rgba(74,80,128,0.34)); }
+
+/* ═══ Food-domain chips (§10.5) — tint-fade coloured by FOOD_TAX domain. The chip variant of
+   the .dt-* whisper. grains→sage · fruits & nonveg→rose · vegs→peach · dairy→sky · nuts→lavender · spices→amber. ═══ */
+.fdom-chip { display:inline-flex; align-items:center; padding:var(--sp-4) var(--sp-10); border-radius:var(--r-2xl); font-family:'Nunito',sans-serif; font-weight:700; font-size:var(--fs-2xs); }
+.fdom-chip--grains { background-image:linear-gradient(135deg, transparent 28%, rgba(181,213,197,0.34)); color:var(--tc-sage); }
+.fdom-chip--fruits { background-image:linear-gradient(135deg, transparent 28%, rgba(242,168,184,0.34)); color:var(--tc-rose); }
+.fdom-chip--nonveg { background-image:linear-gradient(135deg, transparent 28%, rgba(242,168,184,0.34)); color:var(--tc-rose); }
+.fdom-chip--vegs   { background-image:linear-gradient(135deg, transparent 28%, rgba(250,212,180,0.40)); color:var(--tc-peach); }
+.fdom-chip--dairy  { background-image:linear-gradient(135deg, transparent 28%, rgba(168,207,224,0.34)); color:var(--tc-sky); }
+.fdom-chip--nuts   { background-image:linear-gradient(135deg, transparent 28%, rgba(201,184,232,0.34)); color:var(--tc-lav); }
+.fdom-chip--spices { background-image:linear-gradient(135deg, transparent 28%, rgba(232,184,109,0.34)); color:var(--tc-amber); }
+[data-theme="dark"] .fdom-chip--grains { background-image:linear-gradient(135deg, transparent 20%, rgba(58,112,96,0.30)); }
+[data-theme="dark"] .fdom-chip--fruits { background-image:linear-gradient(135deg, transparent 20%, rgba(158,62,82,0.30)); }
+[data-theme="dark"] .fdom-chip--nonveg { background-image:linear-gradient(135deg, transparent 20%, rgba(158,62,82,0.30)); }
+[data-theme="dark"] .fdom-chip--vegs   { background-image:linear-gradient(135deg, transparent 20%, rgba(138,101,32,0.32)); }
+[data-theme="dark"] .fdom-chip--dairy  { background-image:linear-gradient(135deg, transparent 20%, rgba(58,112,144,0.30)); }
+[data-theme="dark"] .fdom-chip--nuts   { background-image:linear-gradient(135deg, transparent 20%, rgba(110,94,154,0.30)); }
+[data-theme="dark"] .fdom-chip--spices { background-image:linear-gradient(135deg, transparent 20%, rgba(138,101,32,0.32)); }
+
+/* ═══ Food info pop-up (Read overlay) — records 09/10. Domain-whisper head + EP voice + journey,
+   safety-first body, a single Quick-Act footer, and a 3D card flip to a history/analysis face. ═══ */
+.lib-pop-ov { position:fixed; inset:0; background:rgba(20,12,16,0.5); display:none; align-items:center; justify-content:center; padding:var(--sp-24) var(--sp-12); overflow:auto; z-index:1200; }
+.lib-pop-ov.open { display:flex; }
+/* Bound the card to the viewport: head + foot pin, the body scrolls inside — so a tall
+   pop-up (cow's milk / choking) never buries the footer action below the fold. */
+.food-pop { width:100%; max-width:372px; max-height:calc(100vh - var(--sp-24) * 2); box-sizing:border-box; background:var(--cream); border-radius:var(--r-2xl); box-shadow:0 18px 60px rgba(0,0,0,0.4); overflow:hidden; perspective:1400px; display:flex; flex-direction:column; }
+/* 3D flip — both faces share one grid cell so the card sizes to the taller face (no clip) */
+.fp-flip { flex:1 1 auto; min-height:0; display:grid; transform-style:preserve-3d; transition:transform var(--ease-slow); }
+.fp-flip > .fp-face { grid-area:1 / 1; min-height:0; min-width:0; display:flex; flex-direction:column; backface-visibility:hidden; -webkit-backface-visibility:hidden; }
+.fp-back { transform:rotateY(180deg); }
+.fp-flip.flipped { transform:rotateY(180deg); }
+/* backface-visibility fallback (PR#235): some browsers/GPUs bleed the away-facing face
+   THROUGH the visible one — doubling the close-× and slicing the header (the mirrored
+   front × lands top-left, over the name). Don't trust backface-visibility alone: swap
+   each face's visibility at the 0.175s edge-on midpoint of the 0.35s flip, so exactly
+   one face is ever visible — in every browser. Shared by the food-room + emergency flip. */
+.fp-flip > .fp-face { transition:visibility 0s linear 0.175s; }
+.fp-flip:not(.flipped) > .fp-front { visibility:visible; }
+.fp-flip:not(.flipped) > .fp-back  { visibility:hidden; }
+.fp-flip.flipped > .fp-front { visibility:hidden; }
+.fp-flip.flipped > .fp-back  { visibility:visible; }
+/* Reduced-motion: suppress the 3D flip rotation (Vela PR#235, V-V-1) — the back doc-prep
+   face still arrives, only the spin is removed. The visibility swap goes instant too,
+   to match the no-spin flip. Shared with the food-room flip. */
+@media (prefers-reduced-motion: reduce) { .fp-flip { transition:none; } .fp-flip > .fp-face { transition:none; } }
+
+.fp-head { position:relative; flex:0 0 auto; padding:var(--sp-20) var(--sp-16) var(--sp-16); }
+.fp-name { font-family:'Fraunces',serif; font-weight:600; font-size:var(--fs-xl); color:var(--text); line-height:var(--lh-snug); padding-right:36px; }
+.fp-voice { font-family:'Fraunces',serif; font-style:italic; font-weight:400; font-size:var(--fs-md); color:var(--mid); line-height:var(--lh-snug); margin-top:var(--sp-2); }
+.fp-close { position:absolute; top:var(--sp-12); right:var(--sp-12); width:32px; height:32px; border:none; border-radius:var(--r-full); background:var(--card-bg); color:var(--mid); font-size:18px; line-height:1; cursor:pointer; box-shadow:0 1px 6px var(--shadow); }
+.fp-journey { display:inline-flex; align-items:center; gap:var(--sp-6); margin-top:var(--sp-10); padding:var(--sp-4) var(--sp-10); border-radius:var(--r-2xl); font-family:'Nunito',sans-serif; font-weight:700; font-size:var(--fs-2xs); line-height:1; }
+.fp-journey .zi { width:var(--icon-sm); height:var(--icon-sm); flex:0 0 auto; }
+.fp-journey--settled, .fp-journey--regular { background:var(--sage-light); color:var(--tc-sage); }
+.fp-journey--watching { background:var(--amber-light); color:var(--tc-amber); }
+.fp-journey--untried { background:var(--surface-alt); color:var(--light); }
+/* V-V-1 (Vela): untried uses a hollow dot (matching the shelf), not the eye that means "watching". */
+.fp-dot { width:7px; height:7px; border-radius:var(--r-full); border:1.5px solid currentColor; display:inline-block; flex:0 0 auto; }
+
+.fp-body { flex:1 1 auto; min-height:0; overflow-y:auto; padding:var(--sp-16); }
+.fp-body > * + * { margin-top:var(--sp-16); }
+.fp-sec-h { font-family:'Nunito',sans-serif; font-weight:800; font-size:var(--fs-2xs); letter-spacing:0.06em; text-transform:uppercase; color:var(--light); margin:0 0 var(--sp-8); }
+
+.fp-flag { display:flex; align-items:flex-start; gap:var(--sp-8); border-radius:var(--r-md); padding:var(--sp-10) var(--sp-12); font-size:var(--fs-sm); line-height:var(--lh-normal); }
+.fp-flag + .fp-flag { margin-top:var(--sp-8); }
+.fp-flag .zi { width:var(--icon-base); height:var(--icon-base); flex:0 0 auto; margin-top:1px; }
+.fp-flag b { font-weight:800; }
+.fp-flag--encourage { background:var(--sage-light); color:var(--tc-sage); }
+.fp-flag--conditional { background:var(--amber-light); color:var(--tc-amber); }
+.fp-flag--warn { background:var(--rose-light); color:var(--tc-rose); }
+.fp-flag--inform { background:var(--sky-light); color:var(--tc-sky); }
+.fp-flag--age { background:var(--amber-light); color:var(--tc-amber); }
+
+.fp-chips { display:flex; flex-wrap:wrap; gap:var(--sp-6); }
+.fp-chip { display:inline-flex; align-items:center; gap:var(--sp-4); padding:var(--sp-4) var(--sp-10); border-radius:var(--r-2xl); font-family:'Nunito',sans-serif; font-size:var(--fs-2xs); font-weight:700; line-height:var(--lh-snug); }
+.fp-chip .zi { width:11px; height:11px; flex:0 0 auto; }
+.fp-chip--ok { background:var(--sage-light); color:var(--tc-sage); }
+.fp-chip--never { background:var(--rose-light); color:var(--tc-rose); }
+
+.fp-insight { display:flex; align-items:flex-start; gap:var(--sp-8); background:var(--sky-light); color:var(--tc-sky); border-radius:var(--r-md); padding:var(--sp-10) var(--sp-12); font-size:var(--fs-sm); line-height:var(--lh-normal); }
+.fp-insight .zi { width:var(--icon-base); height:var(--icon-base); flex:0 0 auto; margin-top:1px; }
+.fp-empty { display:flex; flex-direction:column; align-items:center; text-align:center; gap:var(--sp-10); padding:var(--sp-24) var(--sp-16); color:var(--light); }
+.fp-empty .zi { width:30px; height:30px; }
+.fp-empty p { margin:0; font-size:var(--fs-sm); line-height:var(--lh-normal); }
+
+.fp-foot { flex:0 0 auto; display:flex; align-items:center; gap:var(--sp-10); padding:var(--sp-12) var(--sp-16); border-top:1px solid var(--surface-alt); }
+.fp-foot-btn { flex:1; display:inline-flex; align-items:center; justify-content:center; gap:var(--sp-6); min-height:44px; border:none; border-radius:var(--r-2xl); background:var(--sage); color:var(--tc-sage); font-family:'Nunito',sans-serif; font-weight:800; font-size:var(--fs-sm); cursor:pointer; }
+.fp-foot-btn .zi { width:var(--icon-base); height:var(--icon-base); }
+.fp-foot-btn--ghost { background:var(--surface-alt); color:var(--mid); }
+.fp-foot-link { display:inline-flex; align-items:center; gap:var(--sp-4); color:var(--tc-lav); font-family:'Nunito',sans-serif; font-weight:700; font-size:var(--fs-sm); cursor:pointer; white-space:nowrap; }
+.fp-foot-link .zi { width:var(--icon-sm); height:var(--icon-sm); }
+.fp-back-arrow { transform:scaleX(-1); }
+
+/* ═══ 6-second card — verdict band + progressive-disclosure rows (S11) ═══ */
+.fp-body--rows { padding:0; }
+.fp-verdict { display:flex; align-items:flex-start; gap:var(--sp-10); margin:var(--sp-16) var(--sp-16) var(--sp-12); padding:var(--sp-12) var(--sp-14); border-radius:var(--r-lg); }
+.fp-verdict .zi { width:var(--icon-md); height:var(--icon-md); flex:0 0 auto; margin-top:var(--sp-2); }
+.fp-verdict-tx { display:flex; flex-direction:column; min-width:0; }
+.fp-verdict-t { font-family:'Nunito',sans-serif; font-weight:800; font-size:var(--fs-md); letter-spacing:-0.01em; line-height:var(--lh-snug); }
+.fp-verdict-s { font-family:'Nunito',sans-serif; font-weight:700; font-size:var(--fs-xs); opacity:.9; margin-top:var(--sp-2); line-height:var(--lh-snug); }
+.fp-verdict--yes { background:var(--sage-light); color:var(--tc-sage); }
+.fp-verdict--wait { background:var(--amber-light); color:var(--tc-amber); }
+.fp-verdict--no { background:var(--rose-light); color:var(--tc-rose); }
+.fp-verdict--info { background:var(--sky-light); color:var(--tc-sky); }
+
+.lib-prows { margin-top:var(--sp-6); }
+.lib-prow { border-bottom:1px solid var(--surface-alt); }
+.lib-prow:first-child { border-top:1px solid var(--surface-alt); }
+.lib-prow-head { display:flex; align-items:center; gap:var(--sp-10); width:100%; border:none; background:none; cursor:pointer; text-align:left; padding:var(--sp-12) var(--sp-16); font-family:'Nunito',sans-serif; min-height:44px; }
+.lib-prow-ic { flex:0 0 auto; width:28px; height:28px; border-radius:var(--r-full); display:flex; align-items:center; justify-content:center; background:var(--surface-alt); color:var(--mid); }
+.lib-prow-ic .zi { width:var(--icon-sm); height:var(--icon-sm); }
+.lib-prow--why .lib-prow-ic, .lib-prow--forms .lib-prow-ic { background:var(--sage-light); color:var(--tc-sage); }
+.lib-prow--floor .lib-prow-ic { background:var(--rose-light); color:var(--tc-rose); }
+.lib-prow--nutri .lib-prow-ic { background:var(--lav-light); color:var(--tc-lav); }
+.lib-prow-txt { flex:1; min-width:0; }
+.lib-prow-t { display:block; font-weight:800; font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-snug); }
+.lib-prow--floor .lib-prow-t { color:var(--tc-rose); }
+.lib-prow-d { display:block; font-size:var(--fs-xs); color:var(--mid); margin-top:1px; }
+.lib-prow-chev { flex:0 0 auto; color:var(--light); display:inline-flex; transition:transform var(--ease-fast); }
+.lib-prow-chev .zi { width:var(--icon-base); height:var(--icon-base); }
+.lib-prow.open .lib-prow-chev { transform:rotate(90deg); }
+.lib-prow-body { max-height:0; overflow:hidden; transition:max-height var(--ease-slow); }
+/* V-V-10: headroom so a long severeSigns list at large text-zoom can't clip the Deck button. */
+.lib-prow.open .lib-prow-body { max-height:2400px; }
+.lib-prow-inner { padding:0 var(--sp-16) var(--sp-16) 54px; }
+.lib-prow-p { margin:0; font-size:var(--fs-sm); color:var(--mid); line-height:var(--lh-normal); }
+.lib-prow-signs { margin:0 0 var(--sp-8); padding-left:var(--sp-16); }
+.lib-prow-signs li { font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-normal); margin-bottom:var(--sp-2); }
+.lib-prow-act { margin:0 0 var(--sp-10); font-size:var(--fs-xs); color:var(--tc-rose); font-weight:700; line-height:var(--lh-normal); }
+.lib-prow-deck { display:flex; align-items:center; gap:var(--sp-6); width:100%; border:none; cursor:pointer; background:var(--rose-light); color:var(--tc-rose); border-radius:var(--r-md); padding:var(--sp-8) var(--sp-10); font-family:'Nunito',sans-serif; font-weight:800; font-size:var(--fs-xs); }
+.lib-prow-deck > span { flex:1; text-align:left; }
+.lib-prow-deck .zi { width:var(--icon-sm); height:var(--icon-sm); flex:0 0 auto; }
+/* Caution floor (V-M-224): choking + sub-acute watch lists carry AMBER chrome, not the
+   anaphylaxis rose — choking is mechanical/conditional, honey's botulism watch is sub-acute. */
+.lib-prow--caution .lib-prow-ic { background:var(--amber-light); color:var(--tc-amber); }
+.lib-prow--caution .lib-prow-t { color:var(--tc-amber); }
+.lib-prow--caution .lib-prow-act { color:var(--tc-amber); }
+.lib-prow--caution .lib-prow-deck { background:var(--amber-light); color:var(--tc-amber); }
+
+/* ═══ "Look up any food" search — the gateway to the pop-up for any food (#3, record 10) ═══ */
+.lib-search { margin-top:var(--sp-20); }
+.lib-search-h { font-family:'Fraunces',serif; font-weight:600; font-size:var(--fs-md); color:var(--mid); margin:0 0 var(--sp-8); }
+.lib-search-input { width:100%; box-sizing:border-box; border:1.5px solid var(--border-subtle); background:var(--card-bg); color:var(--text); border-radius:var(--r-2xl); padding:var(--sp-10) var(--sp-16); min-height:44px; font-family:'Nunito',sans-serif; font-size:var(--fs-sm); }
+.lib-search-input::placeholder { color:var(--light); }
+.lib-search-input:focus { outline:none; border-color:var(--sage); }
+.lib-search-results { display:flex; flex-direction:column; gap:var(--sp-10); margin-top:var(--sp-10); }
+.lib-search-results:empty { margin-top:0; }
+.lib-search-empty { font-size:var(--fs-sm); color:var(--light); padding:var(--sp-8) var(--sp-4); }
+.lib-book--lookup { border-left-color:var(--light); }
+
+/* ═══ Safety-guides reference cards (#5b) — light collapsible lib-group bodies. The
+   .lib-group--guide / label-colour rules already ship above; these style the body. ═══ */
+.lib-guide-inner { margin:var(--sp-6) 0 var(--sp-2); padding:var(--sp-12) var(--sp-16) var(--sp-16); border-radius:var(--r-lg); background:var(--surface-alt); }
+.lib-guide-inner > * + * { margin-top:var(--sp-12); }
+.lib-guide-h { font-family:'Nunito',sans-serif; font-weight:800; font-size:var(--fs-2xs); letter-spacing:0.06em; text-transform:uppercase; color:var(--light); margin:0 0 var(--sp-6); }
+.lib-guide-why { font-size:var(--fs-sm); color:var(--mid); line-height:var(--lh-normal); margin:0; }
+.lib-guide-why b { font-weight:800; color:var(--text); }
+.lib-guide-chips { display:flex; flex-wrap:wrap; gap:var(--sp-6); }
+.lib-guide-deck { display:flex; align-items:center; gap:var(--sp-8); width:100%; text-align:left; cursor:pointer; background:var(--rose-light); border:none; border-left:3px solid var(--rose); border-radius:var(--r-md); padding:var(--sp-10) var(--sp-12); color:var(--tc-rose); font-family:'Nunito',sans-serif; font-weight:700; font-size:var(--fs-sm); line-height:var(--lh-normal); }
+.lib-guide-deck > span { flex:1; }
+.lib-guide-deck b { font-weight:800; }
+.lib-guide-deck .zi { width:var(--icon-base); height:var(--icon-base); flex:0 0 auto; }
+
+/* ═══ Emergency Cards (emergency-protocol-v1) — deep-linked per-hazard protocol cards
+   rendered in the Deck; per-hazard chrome (anaphylaxis rose / choking·botulism amber). ═══ */
+.ecard { background:var(--cream); border-radius:var(--r-2xl); box-shadow:0 6px 26px var(--shadow); overflow:hidden; margin-bottom:var(--sp-16); scroll-margin-top:64px; }
+.ecard-flip { perspective:1400px; }  /* food card → flip host (front=first aid, back=doc-prep) */
+.ecard:last-child { margin-bottom:0; }
+.ecard.ec-focus { box-shadow:0 0 0 3px var(--rose), 0 6px 26px var(--shadow); }
+.ecard--amber.ec-focus { box-shadow:0 0 0 3px var(--amber), 0 6px 26px var(--shadow); }
+.ec-head { padding:var(--sp-16) var(--sp-16) var(--sp-12); background:var(--rose-light); border-bottom:3px solid var(--rose); }
+.ecard--amber .ec-head { background:var(--amber-light); border-bottom-color:var(--amber); }
+.ec-name { font-family:'Fraunces',serif; font-weight:600; font-size:var(--fs-lg); color:var(--text); line-height:var(--lh-snug); }
+.ec-sub { font-family:'Nunito',sans-serif; font-weight:700; font-size:var(--fs-sm); color:var(--tc-rose); margin-top:var(--sp-2); }
+.ecard--amber .ec-sub { color:var(--tc-amber); }
+.ec-body { padding:var(--sp-16); }
+.ec-sec { margin-bottom:var(--sp-16); } .ec-sec:last-child { margin-bottom:0; }
+.ec-sec-h { font-family:'Nunito',sans-serif; font-weight:800; font-size:var(--fs-2xs); letter-spacing:0.07em; text-transform:uppercase; color:var(--light); margin:0 0 var(--sp-8); }
+.ec-tempo { display:flex; align-items:flex-start; gap:var(--sp-8); background:var(--sky-light); color:var(--tc-sky); border-radius:var(--r-md); padding:var(--sp-10) var(--sp-12); font-size:var(--fs-sm); font-weight:700; line-height:var(--lh-normal); margin-bottom:var(--sp-16); }
+.ec-tempo .zi { width:var(--icon-base); height:var(--icon-base); flex:0 0 auto; margin-top:1px; }
+.ec-do { background:var(--card-bg); border-radius:var(--r-lg); border-left:3px solid var(--rose); box-shadow:0 2px 12px var(--shadow); padding:var(--sp-16); }
+.ecard--amber .ec-do { border-left-color:var(--amber); }
+.ec-do-h { display:flex; align-items:center; gap:var(--sp-8); font-family:'Nunito',sans-serif; font-weight:800; font-size:var(--fs-sm); letter-spacing:0.04em; text-transform:uppercase; color:var(--tc-rose); margin-bottom:var(--sp-14); }
+.ecard--amber .ec-do-h { color:var(--tc-amber); }
+.ec-do-h .zi { width:var(--icon-md); height:var(--icon-md); }
+.ec-step { display:flex; gap:var(--sp-12); margin-bottom:var(--sp-14); }
+.ec-step:last-of-type { margin-bottom:0; }
+.ec-step-n { flex:0 0 auto; width:24px; height:24px; border-radius:var(--r-full); background:var(--rose); color:#fff; font-weight:800; font-size:var(--fs-sm); display:flex; align-items:center; justify-content:center; margin-top:1px; }
+.ecard--amber .ec-step-n { background:var(--tc-amber); color:#fff; }  /* V-V-1: filled badge, step order must not blur */
+.ec-step-t { font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-normal); font-weight:600; }
+.ec-step-t b { font-weight:800; } .ec-step-t i { font-style:italic; color:var(--mid); font-weight:600; }
+/* Call — the fade flow: a continuously flowing rose gradient + soft pulse */
+.ec-call { display:flex; align-items:center; justify-content:center; gap:var(--sp-8); width:100%; min-height:50px; margin-top:var(--sp-16); border:none; border-radius:var(--r-2xl); text-decoration:none; color:#fff; font-family:'Nunito',sans-serif; font-weight:800; font-size:var(--fs-md); cursor:pointer;
+  background:linear-gradient(110deg, #c0607a 0%, var(--tc-rose) 28%, var(--rose-deep) 50%, var(--tc-rose) 72%, #c0607a 100%); background-size:280% 100%;
+  animation:ecCallFlow 3.4s ease-in-out infinite, ecCallPulse 2.2s ease-in-out infinite; }
+.ec-call .zi { width:var(--icon-md); height:var(--icon-md); }
+@keyframes ecCallFlow { 0%{background-position:0% 50%;} 50%{background-position:100% 50%;} 100%{background-position:0% 50%;} }
+@keyframes ecCallPulse { 0%,100%{box-shadow:0 6px 18px rgba(158,62,82,0.30);} 50%{box-shadow:0 8px 30px rgba(158,62,82,0.55);} }
+@media (prefers-reduced-motion:reduce) { .ec-call { animation:none; background-position:0 50%; } }
+.ec-signs, .ec-next { margin:0; padding-left:var(--sp-16); }
+.ec-signs li { font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-normal); margin-bottom:var(--sp-4); }
+.ec-next li { font-size:var(--fs-sm); color:var(--mid); line-height:var(--lh-normal); margin-bottom:var(--sp-6); }
+.ec-next li b { color:var(--text); font-weight:800; }
+.ec-xlink { display:inline-flex; align-items:center; gap:var(--sp-6); margin-top:var(--sp-8); border:none; background:none; cursor:pointer; font-family:'Nunito',sans-serif; font-size:var(--fs-xs); font-weight:700; color:var(--tc-amber); padding:0; }
+.ec-xlink .zi { width:var(--icon-sm); height:var(--icon-sm); }
+.ec-docprep { display:flex; align-items:center; gap:var(--sp-10); width:100%; text-align:left; cursor:pointer; background:var(--sky-light); border:none; border-left:3px solid var(--sky); border-radius:var(--r-lg); padding:var(--sp-12) var(--sp-16); }
+.ec-docprep-ic { flex:0 0 auto; width:34px; height:34px; border-radius:var(--r-full); background:var(--tc-sky); color:var(--card-bg); display:flex; align-items:center; justify-content:center; }
+.ec-docprep-ic .zi { width:var(--icon-base); height:var(--icon-base); }
+.ec-docprep-tx { flex:1; min-width:0; display:flex; flex-direction:column; gap:var(--sp-2); }
+.ec-docprep-t { font-family:'Nunito',sans-serif; font-weight:800; font-size:var(--fs-sm); color:var(--tc-sky); line-height:var(--lh-snug); }
+.ec-docprep-d { font-size:var(--fs-xs); color:var(--mid); line-height:var(--lh-normal); }
+.ec-docprep-go { flex:0 0 auto; color:var(--tc-sky); } .ec-docprep-go .zi { width:var(--icon-base); height:var(--icon-base); }
+
+/* (The old #emDocOv doc-prep overlay styles were retired in emergency-room-v2 M2 —
+   doc-prep now renders on the card flip-back via the container-neutral .docface set.) */
+@media print {
+  /* Doc-prep print (emSaveDoc): isolate the flipped card's .docface and lay it
+     flat (neutralise the flip transform). Scoped to the .doc-printing body flag
+     so it never affects an ordinary "Print Dashboard". */
+  body.doc-printing * { visibility:hidden; }
+  body.doc-printing .doc-print .fp-back, body.doc-printing .doc-print .fp-back * { visibility:visible; }
+  body.doc-printing .doc-print { position:absolute; inset:0; }
+  body.doc-printing .doc-print .fp-flip, body.doc-printing .doc-print .fp-back { transform:none !important; position:static !important; backface-visibility:visible !important; }
+  body.doc-printing .doc-print .docface, body.doc-printing .doc-print .docface .doc { box-shadow:none; max-width:100%; }
+  body.doc-printing .doc-print .docface .doc-actions { display:none; }
+  /* A printout is always white paper — re-force the paper tokens even when the app is
+     in dark mode (data-theme="dark" stays set during print). PR#235 dark-mode fix. */
+  body.doc-printing .doc-print .docface {
+    --doc-paper:#fff; --doc-ink:#2a2020; --doc-ink-soft:#3a2c2c;
+    --doc-line:#ecdfe2; --doc-line-soft:#f0e6e9; --doc-muted:#7a6a6a;
+    --doc-placeholder:#9a8a8a; --doc-dash:#d8b9c2; --doc-note-bg:#fdeef1;
+    --doc-foot-bg:#faf2f4; --doc-btn-bg:#fff; --doc-btn-ghost-border:#e6dcdf;
+    --doc-btn-copy-border:#e6b9c4;
+    /* Maren safety-tier (PR#235): the field labels and the stamped adrenaline/reaction
+       TIME render directly off --tc-rose. Re-force it to the paper-safe light rose so a
+       dark-mode printout shows the time at 6.4:1, not a faint 2.4:1 pink. */
+    --tc-rose:#9e3e52;
+  }
+}
+/* ═══════════════════════════════════════════════════════════════════════
+   Diet → Recipes sub-tab (WIRING_PLAN docs/design/recipes-tab/, LOCKED.md
+   05-meal-rows). Two-channel colour (DESIGN_PRINCIPLES §Tint System):
+   a DOMAIN LEFT-RAIL (border-left in the primary ingredient's FOOD_TAX
+   domain) + a FOOD-DOMAIN WHISPER FADE (.dt-*, transparent→accent, never a
+   flat fill). Featured "Suggested for Ziva" hero on top; browsable catalog
+   grouped by meal slot as full-width .recipe-row rows; expand-in-place detail
+   reuses .combo-*/.fd-flag*. Light + dark first-class (dark hue-swaps).
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* Food-domain WHISPER FADE — verbatim from the ratified design record
+   (transparent 40% -> domain accent). Keyed by FOOD_TAX domain pid. */
+.dt-grains { background-image:linear-gradient(135deg,transparent 40%,rgba(181,213,197,0.22)); }
+.dt-fruits { background-image:linear-gradient(135deg,transparent 40%,rgba(242,168,184,0.22)); }
+.dt-vegs   { background-image:linear-gradient(135deg,transparent 40%,rgba(250,212,180,0.30)); }
+.dt-dairy  { background-image:linear-gradient(135deg,transparent 40%,rgba(168,207,224,0.22)); }
+.dt-nuts   { background-image:linear-gradient(135deg,transparent 40%,rgba(201,184,232,0.22)); }
+.dt-spices { background-image:linear-gradient(135deg,transparent 40%,rgba(232,184,109,0.24)); }
+.dt-nonveg { background-image:linear-gradient(135deg,transparent 40%,rgba(242,168,184,0.22)); }
+[data-theme="dark"] .dt-grains { background-image:linear-gradient(135deg,transparent 30%,rgba(58,112,96,0.18)); }
+[data-theme="dark"] .dt-fruits { background-image:linear-gradient(135deg,transparent 30%,rgba(158,62,82,0.20)); }
+[data-theme="dark"] .dt-vegs   { background-image:linear-gradient(135deg,transparent 30%,rgba(138,101,32,0.20)); }
+[data-theme="dark"] .dt-dairy  { background-image:linear-gradient(135deg,transparent 30%,rgba(58,112,144,0.18)); }
+[data-theme="dark"] .dt-nuts   { background-image:linear-gradient(135deg,transparent 30%,rgba(110,94,154,0.20)); }
+[data-theme="dark"] .dt-spices { background-image:linear-gradient(135deg,transparent 30%,rgba(150,110,40,0.20)); }
+[data-theme="dark"] .dt-nonveg { background-image:linear-gradient(135deg,transparent 30%,rgba(158,62,82,0.20)); }
+
+/* zif food-icon — full-colour sibling of .zi; consumer sets hue via --zif-c
+   (the established diet.js --dyn-* idiom). Falls back to currentColor. */
+.zif { width:var(--icon-sm); height:var(--icon-sm); flex:0 0 auto; color:var(--zif-c, currentColor); }
+
+/* Section labels inside the Recipes panel */
+.recipes-sec-label { font-family:'Fraunces', serif; font-size:var(--fs-lg); font-weight:600; color:var(--text); margin:var(--sp-4) 0 var(--sp-8); }
+.recipes-sub-note { font-size:var(--fs-sm); color:var(--mid); margin:0 0 var(--sp-12); line-height:var(--lh-relaxed); }
+
+/* Featured "Suggested for Ziva" hero card */
+.recipe-hero { position:relative; overflow:hidden; border-radius:var(--r-2xl); padding:var(--sp-20) var(--sp-20) var(--sp-16); box-shadow:0 8px 32px var(--shadow); margin-bottom:var(--sp-10); background:var(--card-bg); border:1px solid var(--card-border); border-left:4px solid var(--rc-rail, var(--tc-sage)); cursor:pointer; }
+.recipe-hero-eyebrow { display:inline-flex; align-items:center; gap:var(--sp-6); font-size:var(--fs-2xs); font-weight:800; text-transform:uppercase; letter-spacing:var(--ls-wide); color:var(--tc-sage); margin-bottom:var(--sp-6); }
+.recipe-hero-eyebrow .zi { width:15px; height:15px; }
+.recipe-hero-title { font-family:'Fraunces', serif; font-weight:700; font-size:var(--fs-2xl); line-height:1.08; color:var(--text); margin:0 0 2px; text-wrap:balance; }
+.recipe-hero-tag { font-family:'Fraunces', serif; font-style:italic; font-weight:400; font-size:var(--fs-lg); line-height:1.25; color:var(--mid); margin:0 0 var(--sp-8); }
+.recipe-hero-why { font-size:var(--fs-sm); color:var(--mid); line-height:var(--lh-relaxed); margin:0 0 var(--sp-8); }
+/* Panel header (LOCKED 05-meal-rows) */
+.recipes-header { margin-bottom:var(--sp-8); }
+.recipes-h1 { font-family:'Fraunces', serif; font-weight:600; font-size:var(--fs-2xl); color:var(--text); margin:0 0 2px; }
+.recipes-subtitle { font-size:var(--fs-sm); color:var(--mid); margin:0; line-height:var(--lh-relaxed); }
+
+/* ── Generative "Suggested for Ziva" hero (§9.3/§9.4) ──
+   grams-weighted wavelength FADE body (--rc-fl light / --rc-fd dark) + a 4px
+   warm-wave STRIPE (--rc-stripe) with a sheen sweep (reuses @keyframes ld-wave)
+   + a corner zif watermark. Two-channel colour: the domain left-rail leads,
+   the fingerprint fade rides under. */
+.recipe-hero-gen { background:var(--rc-fl, var(--card-bg)); }
+[data-theme="dark"] .recipe-hero-gen { background:var(--rc-fd, var(--surface)); }
+.recipe-hero-gen > * { position:relative; z-index:1; }
+.recipe-hero-gen::before {
+  content:''; position:absolute; top:0; left:0; right:0; height:4px; z-index:2; border-radius:var(--r-2xl) var(--r-2xl) 0 0;
+  background-image:linear-gradient(100deg, transparent 35%, rgba(255,255,255,0.5) 50%, transparent 65%), var(--rc-stripe, var(--tc-sage));
+  background-size:35% 100%, 100% 100%; background-repeat:no-repeat; background-position:-35% 0, 0 0;
+  animation:ld-wave 4.4s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) { .recipe-hero-gen::before { animation:none; background-position:0 0, 0 0; } }
+/* corner watermark — dominant ingredient gets the big slot, non-overlapping */
+/* watermark — center-right faded-ingredient motif, vertically centered and
+   hugging the right edge so it clears the bottom foot/CTA (was bottom-right,
+   colliding with the "See recipe" pill). Behind text (z-index 0, low opacity). */
+.recipe-hero-wm { position:absolute; right:0; top:50%; transform:translateY(-50%); width:184px; height:92px; pointer-events:none; z-index:0; }
+.recipe-hero-wm .recipe-wm { position:absolute; }
+.recipe-hero-wm .recipe-wm svg.zif { width:100%; height:100%; opacity:0.28; }
+[data-theme="dark"] .recipe-hero-wm .recipe-wm svg.zif { opacity:0.38; }
+.recipe-hero-wm .wm-1 { width:74px; height:74px; right:-2px; top:9px; }
+.recipe-hero-wm .wm-2 { width:44px; height:44px; right:70px; top:0; }
+.recipe-hero-wm .wm-3 { width:32px; height:32px; right:128px; top:30px; }
+.recipe-hero-head { display:flex; align-items:center; justify-content:space-between; gap:var(--sp-8); margin-bottom:var(--sp-6); }
+.recipe-hero-head .recipe-hero-eyebrow { margin-bottom:0; }
+.recipe-hero-badge { flex:0 0 auto; display:inline-flex; align-items:center; background:var(--tc-sage); color:var(--card-bg); border-radius:var(--r-full); padding:var(--sp-4) var(--sp-10); font-size:var(--fs-2xs); font-weight:800; }
+/* strict no's lead the tagline (rose, never folded) */
+.recipe-strict { font-family:'Nunito', sans-serif; font-style:normal; font-weight:800; font-size:var(--fs-2xs); text-transform:uppercase; letter-spacing:var(--ls-normal); color:var(--tc-rose); }
+.recipe-hero-foot { display:flex; align-items:center; justify-content:space-between; gap:var(--sp-8); flex-wrap:wrap; }
+.recipe-hero-meta { display:flex; align-items:center; gap:var(--sp-8); flex-wrap:wrap; }
+.recipe-hero-meta span { display:inline-flex; align-items:center; gap:var(--sp-4); font-size:var(--fs-xs); color:var(--mid); }
+.recipe-hero-meta span:not(:first-child)::before { content:'·'; margin-right:var(--sp-4); color:var(--light); }
+.recipe-hero-meta .zi { width:13px; height:13px; }
+.recipe-hero-cta { display:inline-flex; align-items:center; gap:var(--sp-4); min-height:36px; background:var(--tc-sage); color:var(--card-bg); border-radius:var(--r-full); padding:var(--sp-6) var(--sp-12); font-size:var(--fs-xs); font-weight:700; }
+.recipe-hero-cta .zi { width:14px; height:14px; transition:transform var(--ease-med); }
+.recipe-hero[aria-expanded="true"] .recipe-hero-cta .zi { transform:rotate(90deg); }
+
+/* Meal-slot groups + full-width recipe rows (.lib-book idiom) */
+.recipe-group { margin-bottom:var(--sp-16); }
+.recipe-group-head { display:flex; align-items:center; gap:var(--sp-8); margin:var(--sp-8) 0 var(--sp-8); }
+.recipe-group-head .zi { width:var(--icon-sm); height:var(--icon-sm); color:var(--tc-sage); }
+.recipe-group-title { font-family:'Fraunces', serif; font-size:var(--fs-lg); font-weight:600; color:var(--text); }
+.recipe-group-count { font-size:var(--fs-xs); color:var(--light); font-weight:600; }
+
+/* background-COLOR (not the `background` shorthand) so the .dt-* domain whisper
+   background-image layers over the card base in BOTH themes — the shorthand reset
+   background-image:none, which (at equal specificity, source-order winning) killed
+   the whisper in light mode while dark survived on [data-theme] specificity. */
+.recipe-row { position:relative; overflow:hidden; display:block; width:100%; text-align:left; background-color:var(--card-bg); border:1px solid var(--card-border); border-left:4px solid var(--rc-rail, var(--tc-sage)); border-radius:var(--r-xl); padding:var(--sp-12) var(--sp-12); margin-bottom:var(--sp-8); cursor:pointer; transition:box-shadow var(--ease-med), transform var(--ease-med); }
+.recipe-row:hover, .recipe-row:focus-visible { box-shadow:0 4px 18px var(--shadow); }
+.recipe-row[aria-expanded="true"] { box-shadow:0 6px 22px var(--shadow); }
+/* Generative row (§9.3) — brings the hero's quantity-weighted multi-domain
+   fingerprint to the catalog/suggested rows so every card shares one generative
+   language: a grams-weighted FADE body (--rc-fl light / --rc-fd dark) + a static
+   wavelength top-stripe (--rc-stripe). The animated sheen sweep + corner watermark
+   stay HERO-ONLY (the featured pick leads; the list stays calm). Rows with no
+   classifiable primary ingredient fall back to the flat .dt-* whisper. */
+.recipe-row-gen { background:var(--rc-fl, var(--card-bg)); }
+[data-theme="dark"] .recipe-row-gen { background:var(--rc-fd, var(--surface)); }
+.recipe-row-gen::before {
+  content:''; position:absolute; top:0; left:0; right:0; height:3px; z-index:2;
+  border-radius:var(--r-xl) var(--r-xl) 0 0; background-image:var(--rc-stripe, var(--tc-sage));
+}
+.recipe-row-top { position:relative; z-index:1; display:flex; align-items:center; gap:var(--sp-10); }
+.recipe-row-icon { width:34px; height:34px; flex:0 0 auto; display:flex; align-items:center; justify-content:center; }
+.recipe-row-icon .zif { width:30px; height:30px; }
+.recipe-row-main { flex:1; min-width:0; }
+.recipe-row-title { font-family:'Fraunces', serif; font-weight:600; font-size:var(--fs-base); color:var(--text); line-height:1.15; }
+.recipe-row-meta { display:flex; align-items:center; gap:var(--sp-8); margin-top:var(--sp-4); flex-wrap:wrap; }
+.recipe-row-meta span { display:inline-flex; align-items:center; gap:var(--sp-4); font-size:var(--fs-xs); color:var(--mid); }
+.recipe-row-meta span:not(:first-child)::before { content:'·'; margin-right:var(--sp-4); color:var(--light); }
+.recipe-row-meta .zi { width:13px; height:13px; }
+.recipe-row-rel { color:var(--tc-sage); font-weight:700; }
+.recipe-row-chev { flex:0 0 auto; color:var(--light); transition:transform var(--ease-med); }
+.recipe-row[aria-expanded="true"] .recipe-row-chev { transform:rotate(180deg); }
+
+/* age-gate badge on a catalog row (withheld from Suggested) */
+.recipe-age-badge { display:inline-flex; align-items:center; gap:var(--sp-4); font-size:var(--fs-2xs); font-weight:700; color:var(--tc-caution); background:var(--amber-light); border-radius:var(--r-full); padding:2px var(--sp-8); }
+.recipe-age-badge .zi { width:12px; height:12px; }
+
+/* Ingredient chips */
+.recipe-chips { display:flex; flex-wrap:wrap; gap:var(--sp-6); margin:var(--sp-8) 0 0; }
+/* background-COLOR longhand (not the shorthand) so the per-ingredient .dt-*
+   domain whisper background-image layers over the pill base in both themes —
+   same cascade fix as .recipe-row (the shorthand reset background-image:none). */
+.recipe-chip { display:inline-flex; align-items:center; gap:var(--sp-4); background-color:var(--card-bg); border:1px solid var(--card-border); border-radius:var(--r-full); padding:var(--sp-4) var(--sp-10); font-size:var(--fs-xs); font-weight:600; color:var(--text); }
+.recipe-chip .zif { width:15px; height:15px; }
+
+/* Expand-in-place detail — the 6-second recipe template: an at-a-glance
+   ingredient row + an always-visible safety summary, then progressive-disclosure
+   rows (content invited, not dumped). */
+.recipe-detail { position:relative; z-index:1; margin-top:var(--sp-12); padding-top:var(--sp-12); border-top:1px solid var(--card-border); }
+.recipe-steps { margin:0; padding-left:var(--sp-16); }
+.recipe-steps li { font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-relaxed); margin-bottom:var(--sp-4); }
+.recipe-warn { font-family:'Nunito', sans-serif; font-weight:800; font-size:var(--fs-xs); text-transform:uppercase; letter-spacing:0.04em; color:var(--tc-rose); }
+
+/* Safety summary — the 6-second LEAD, always visible (never collapsed, §9.7). */
+.rcp-safe { display:flex; align-items:flex-start; gap:var(--sp-8); margin:var(--sp-12) 0 var(--sp-4); padding:var(--sp-10) var(--sp-12); border-radius:var(--r-lg); font-family:'Nunito',sans-serif; font-weight:700; font-size:var(--fs-sm); line-height:var(--lh-snug); }
+.rcp-safe .zi { width:var(--icon-sm); height:var(--icon-sm); flex:0 0 auto; margin-top:1px; }
+.rcp-safe--safe { background:var(--sage-light); color:var(--tc-sage); }
+.rcp-safe--caution { background:var(--amber-light); color:var(--tc-amber); }
+.rcp-safe--flag { background:var(--rose-light); color:var(--tc-rose); }
+
+/* Serving guidance — calm, informational (responsive feeding: a guide, not an alarm). */
+.rcp-serving { display:flex; align-items:flex-start; gap:var(--sp-8); margin:var(--sp-8) 0 var(--sp-4); font-size:var(--fs-sm); color:var(--mid); line-height:var(--lh-normal); }
+.rcp-serving .zi { width:var(--icon-sm); height:var(--icon-sm); flex:0 0 auto; margin-top:1px; color:var(--tc-sage); }
+.rcp-serving strong { color:var(--text); font-weight:700; }
+.rcp-serving-src { color:var(--light); font-weight:700; white-space:nowrap; }
+
+/* Progressive-disclosure rows (recipe-namespaced sibling of .lib-prow). */
+.rcp-prows { margin-top:var(--sp-8); }
+.rcp-prow { border-bottom:1px solid var(--card-border); }
+.rcp-prow:first-child { border-top:1px solid var(--card-border); }
+.rcp-prow-head { display:flex; align-items:center; gap:var(--sp-10); width:100%; border:none; background:none; cursor:pointer; text-align:left; padding:var(--sp-10) 0; font-family:'Nunito',sans-serif; min-height:44px; }
+.rcp-prow-ic { flex:0 0 auto; width:28px; height:28px; border-radius:var(--r-full); display:flex; align-items:center; justify-content:center; background:var(--surface-alt); color:var(--mid); }
+.rcp-prow-ic .zi { width:var(--icon-sm); height:var(--icon-sm); }
+.rcp-prow--steps .rcp-prow-ic { background:var(--sage-light); color:var(--tc-sage); }
+.rcp-prow--dos .rcp-prow-ic { background:var(--sky-light); color:var(--tc-sky); }
+/* V-1: the safety prow's disc echoes the summary band (amber caution / rose flag),
+   so a green-summary recipe never meets a fixed-rose safety disc. */
+.rcp-prow--safety-flag .rcp-prow-ic { background:var(--rose-light); color:var(--tc-rose); }
+.rcp-prow--safety-caution .rcp-prow-ic { background:var(--amber-light); color:var(--tc-amber); }
+.rcp-prow--source .rcp-prow-ic { background:var(--lav-light); color:var(--tc-lav); }
+.rcp-prow-txt { flex:1; min-width:0; }
+.rcp-prow-t { display:block; font-weight:800; font-size:var(--fs-sm); color:var(--text); line-height:var(--lh-snug); }
+.rcp-prow-d { display:block; font-size:var(--fs-xs); color:var(--mid); margin-top:1px; }
+.rcp-prow-chev { flex:0 0 auto; color:var(--light); display:inline-flex; transition:transform var(--ease-fast); }
+.rcp-prow-chev .zi { width:var(--icon-base); height:var(--icon-base); }
+.rcp-prow.open .rcp-prow-chev { transform:rotate(90deg); }
+.rcp-prow-body { max-height:0; overflow:hidden; transition:max-height var(--ease-slow); }
+.rcp-prow.open .rcp-prow-body { max-height:2400px; }
+.rcp-prow-inner { padding:0 0 var(--sp-12) 38px; }
+.rcp-prow-p { margin:0; font-size:var(--fs-2xs); font-style:italic; color:var(--light); line-height:var(--lh-relaxed); }
+
+/* empty / cold-start state */
+.recipe-empty { padding:var(--sp-16); text-align:center; color:var(--light); font-size:var(--fs-sm); line-height:var(--lh-relaxed); }
+
+/* compact recipe card on the Home Smart-Q&A answer */
+.qa-recipe-card { display:flex; align-items:center; gap:var(--sp-8); min-height:44px; margin-top:var(--sp-6); padding:var(--sp-8) var(--sp-10); border-radius:var(--r-lg); background:var(--card-bg); border:1px solid var(--card-border); border-left:3px solid var(--rc-rail, var(--tc-sage)); }
+.qa-recipe-card .zif { width:20px; height:20px; }
+.qa-recipe-card-main { flex:1; min-width:0; }
+.qa-recipe-card-title { font-family:'Fraunces', serif; font-weight:600; font-size:var(--fs-sm); color:var(--text); }
+.qa-recipe-card-cta { font-size:var(--fs-xs); font-weight:700; color:var(--tc-sage); }
+
+</style>
+<style>
+/* ── catalog chrome (sc-* only; never collides with app classes) ── */
+body { padding:0; margin:0; }
+.sc-wrap { max-width:1100px; margin:0 auto; padding:var(--sp-24, 24px) var(--sp-16, 16px) 80px; }
+.sc-banner { background:var(--amber-light, #f7ecd6); border:1.5px solid var(--amber, #e8b86d); border-radius:14px; padding:14px 18px; margin-bottom:24px; font-size:14px; line-height:1.5; color:var(--text, #3a2e2e); }
+.sc-h1 { font-family:'Fraunces',serif; font-size:30px; font-weight:700; color:var(--text, #3a2e2e); margin:8px 0 4px; }
+.sc-sub { color:var(--mid, #8a7a72); font-size:15px; margin:0 0 8px; }
+.sc-toolbar { display:flex; gap:8px; align-items:center; flex-wrap:wrap; margin:18px 0 8px; }
+.sc-toolbar .sc-zlabel { font-size:12px; text-transform:uppercase; letter-spacing:.08em; color:var(--mid,#8a7a72); font-weight:700; }
+.sc-zbtn { font-family:'Nunito',sans-serif; font-size:13px; font-weight:700; padding:6px 12px; border-radius:999px; border:1.5px solid var(--border-subtle,#e8ddd5); background:var(--surface,#fff); color:var(--mid,#8a7a72); cursor:pointer; }
+.sc-zbtn.active { background:var(--tc-rose,#c2607a); color:#fff; border-color:var(--tc-rose,#c2607a); }
+.sc-rm { width:100%; border-collapse:collapse; margin:8px 0 28px; font-size:14px; }
+.sc-rm td { padding:8px 10px; border-bottom:1px solid var(--border-subtle,#eee); }
+.sc-badge { font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:.06em; padding:2px 9px; border-radius:999px; }
+.sc-badge-live { background:var(--sage,#b5d5c5); color:#1a4a32; }
+.sc-badge-next { background:var(--amber,#e8b86d); color:#5a3e10; }
+.sc-badge-planned { background:var(--border-subtle,#eee); color:var(--mid,#8a7a72); }
+.sc-rm-live td:first-child { font-weight:800; }
+.sc-surface { margin:0 0 40px; }
+.sc-surface > h3 { font-family:'Fraunces',serif; font-size:21px; font-weight:600; color:var(--text,#3a2e2e); margin:30px 0 4px; padding-top:14px; border-top:2px solid var(--border-subtle,#eee); }
+.sc-surface-note { color:var(--mid,#8a7a72); font-size:14px; line-height:1.5; margin:0 0 14px; }
+.sc-surface-note code, .sc-markup code { font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:.86em; background:var(--warm,#f3ece6); padding:1px 5px; border-radius:5px; }
+.sc-specimen { margin:0 0 22px; }
+.sc-specimen-label { font-size:13px; font-weight:700; color:var(--mid,#8a7a72); margin:0 0 8px; }
+.sc-render-row { display:grid; grid-template-columns:1fr 1fr; gap:14px; }
+@media (max-width:720px){ .sc-render-row { grid-template-columns:1fr; } }
+.sc-panel { position:relative; border-radius:16px; padding:30px 18px 18px; background:var(--cream,#fffaf7); border:1px solid var(--border-subtle,#e8ddd5); overflow:visible; }
+.sc-panel[data-theme="dark"] { background:var(--cream); border-color:#3a2e3e; }
+.sc-mode { position:absolute; top:8px; left:12px; font-size:10px; font-weight:800; text-transform:uppercase; letter-spacing:.1em; color:var(--light,#b0a098); }
+.sc-stage { /* the live surface renders here, on its real token background */ }
+.sc-markup { margin-top:10px; }
+.sc-markup summary { font-size:12px; font-weight:700; color:var(--mid,#8a7a72); cursor:pointer; }
+.sc-markup pre { background:var(--warm,#f6f0ea); border:1px solid var(--border-subtle,#e8ddd5); border-radius:10px; padding:12px; overflow:auto; font-size:11.5px; line-height:1.45; margin:8px 0 0; }
+[data-theme="dark"] .sc-markup pre { background:#221c28; border-color:#3a2e3e; }
+</style>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none;">
+<defs>
+<symbol id="zi-lotus" viewBox="0 0 24 24"><path d="M12 21c0 0-4-3.5-4-8c0-3 1.5-5 4-7c2.5 2 4 4 4 7c0 4.5-4 8-4 8z" fill="currentColor" opacity="0.15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path d="M12 21c0 0-7-2-8-7c-.5-2.5.5-5 3-6c1 2 2.5 4 5 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M12 21c0 0 7-2 8-7c.5-2.5-.5-5-3-6c-1 2-2.5 4-5 5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+<symbol id="zi-sprout" viewBox="0 0 24 24"><path d="M12 22v-8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M7 8c0-3 2.5-5 5-6c2.5 1 5 3 5 6c0 3.5-3 6-5 7c-2-1-5-3.5-5-7z" fill="currentColor" opacity="0.12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path d="M12 14c-3-1-5-4-4-7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zi-target" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="1.5" fill="none"/><circle cx="12" cy="12" r="5" stroke="currentColor" stroke-width="1.5" fill="none"/><circle cx="12" cy="12" r="1.5" fill="currentColor"/></symbol>
+<symbol id="zi-crystal" viewBox="0 0 24 24"><circle cx="12" cy="13" r="7" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.08"/><path d="M9 6.5c0 0 1-2 3-2s3 2 3 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/><path d="M9 13c1-2 3-1 4 0" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" fill="none" opacity="0.4"/><path d="M14 16c-.5-1 .5-2 1.5-1.5" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" fill="none" opacity="0.3"/><line x1="12" y1="20" x2="12" y2="22" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="9" y1="21" x2="15" y2="21" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
+<symbol id="zi-clock" viewBox="0 0 24 24"><rect x="4" y="6" width="16" height="14" rx="3" stroke="currentColor" stroke-width="1.5" fill="none"/><circle cx="12" cy="13" r="5" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M12 10.5v3l2 1.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M9 6V3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M15 6V3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></symbol>
+<symbol id="zi-bowl" viewBox="0 0 24 24"><path d="M3 12c0 4.5 4 8 9 8s9-3.5 9-8" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" fill="none"/><line x1="2" y1="12" x2="22" y2="12" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/><path d="M8 8c0-1.5.5-3 .5-3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none" opacity="0.5"/><path d="M12 7c0-2 .5-3 .5-3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none" opacity="0.5"/><path d="M16 8c0-1.5.5-3 .5-3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none" opacity="0.5"/></symbol>
+<symbol id="zi-moon" viewBox="0 0 24 24"><path d="M20 14.5c-1 3.5-4.5 6-8.5 6C6.5 20.5 3 17 3 12c0-4 2.5-7.5 6-9c-1 2-.5 5 1 7c1.5 2 4 3.5 6.5 3.5c1.5 0 2.8-.3 3.5-1" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" fill-opacity="0.1"/><circle cx="18" cy="6" r="1" fill="currentColor" opacity="0.5"/><circle cx="20" cy="9" r="0.6" fill="currentColor" opacity="0.35"/></symbol>
+<symbol id="zi-diaper" viewBox="0 0 24 24"><path d="M5 7h14c1 0 1.5.5 1.5 1.5v3c0 4-3.5 7-8.5 7s-8.5-3-8.5-7v-3C3.5 7.5 4 7 5 7z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" fill-opacity="0.08"/><path d="M8.5 7v1c0 2 1.5 3 3.5 3s3.5-1 3.5-3V7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/><circle cx="8" cy="14" r="0.8" fill="currentColor" opacity="0.3"/><circle cx="12" cy="15" r="0.8" fill="currentColor" opacity="0.3"/><circle cx="16" cy="14" r="0.8" fill="currentColor" opacity="0.3"/></symbol>
+<symbol id="zi-medical" viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="4" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.08"/><line x1="12" y1="7.5" x2="12" y2="16.5" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/><line x1="7.5" y1="12" x2="16.5" y2="12" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></symbol>
+<symbol id="zi-star" viewBox="0 0 24 24"><path d="M12 3l2.5 5.5L20 9.5l-4 4 1 5.5-5-3-5 3 1-5.5-4-4 5.5-1z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" fill-opacity="0.12"/></symbol>
+<symbol id="zi-chart" viewBox="0 0 24 24"><path d="M3 20L9 13l4 4 8-10" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/><circle cx="9" cy="13" r="1.5" fill="currentColor" opacity="0.3"/><circle cx="21" cy="7" r="1.5" fill="currentColor" opacity="0.3"/></symbol>
+<symbol id="zi-ruler" viewBox="0 0 24 24"><rect x="3" y="8" width="18" height="8" rx="2" stroke="currentColor" stroke-width="1.5" fill="none"/><line x1="7" y1="8" x2="7" y2="12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><line x1="11" y1="8" x2="11" y2="13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><line x1="15" y1="8" x2="15" y2="12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><line x1="19" y1="8" x2="19" y2="11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></symbol>
+<symbol id="zi-balloon" viewBox="0 0 24 24"><path d="M12 3c3 0 5.5 3 5.5 6.5S14.5 16 12 16s-5.5-3.5-5.5-6.5S9 3 12 3z" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.1"/><line x1="12" y1="16" x2="12" y2="21" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M10 21c1 .5 3 .5 4 0" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zi-sparkle" viewBox="0 0 24 24"><path d="M12 2l1.5 4.5L18 8l-4.5 1.5L12 14l-1.5-4.5L6 8l4.5-1.5z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="currentColor" fill-opacity="0.15"/><path d="M18 14l1 2.5 2.5 1-2.5 1-1 2.5-1-2.5L14.5 18l2.5-1z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round" fill="currentColor" fill-opacity="0.1"/></symbol>
+<symbol id="zi-bell" viewBox="0 0 24 24"><path d="M18 8A6 6 0 006 8c0 7-3 9-3 9h18s-3-2-3-9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M13.7 21a2 2 0 01-3.4 0" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></symbol>
+<symbol id="zi-sleep" viewBox="0 0 24 24"><path d="M5 6h5l-5 5h5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M13 3h3.5L13 6.5h3.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.6"/><path d="M4 20c2-2 5-3 8-3s6 1 8 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zi-syringe" viewBox="0 0 24 24"><path d="M19 3l2 2-3 3-2-2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><rect x="7.5" y="8.5" width="9" height="4" rx="1" transform="rotate(-45 12 10.5)" stroke="currentColor" stroke-width="1.5" fill="none"/><line x1="5" y1="17" x2="8.5" y2="13.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><line x1="3" y1="21" x2="5" y2="17" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></symbol>
+<symbol id="zi-pill" viewBox="0 0 24 24"><rect x="5" y="9" width="14" height="6" rx="3" stroke="currentColor" stroke-width="1.5" fill="none"/><line x1="12" y1="9" x2="12" y2="15" stroke="currentColor" stroke-width="1.5"/><rect x="12" y="9" width="7" height="6" rx="3" fill="currentColor" fill-opacity="0.12"/></symbol>
+<symbol id="zi-phone" viewBox="0 0 24 24"><path d="M5 4c0-.5.4-1 1-1h2.5c.5 0 .9.3 1 .8l1 3.2c.1.5-.1 1-.5 1.3l-1.5 1c1 2.5 3 4.5 5.5 5.5l1-1.5c.3-.4.8-.6 1.3-.5l3.2 1c.5.1.8.5.8 1V19c0 .6-.5 1-1 1c-8.8 0-16-7.2-16-16z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="currentColor" fill-opacity="0.1"/></symbol>
+<symbol id="zi-shield" viewBox="0 0 24 24"><path d="M12 3L4 7v5c0 5 3.5 8.5 8 10c4.5-1.5 8-5 8-10V7l-8-4z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="currentColor" fill-opacity="0.08"/><path d="M9 12l2 2 4-4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+<symbol id="zi-eye" viewBox="0 0 24 24"><path d="M2 12s3.6-6.5 10-6.5S22 12 22 12s-3.6 6.5-10 6.5S2 12 2 12z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="currentColor" fill-opacity="0.08"/><circle cx="12" cy="12" r="2.8" stroke="currentColor" stroke-width="1.5" fill="none"/></symbol>
+<symbol id="zi-steth" viewBox="0 0 24 24"><path d="M5.5 4v5.5c0 3.5 2.5 5.5 6.5 5.5s6.5-2 6.5-5.5V4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/><circle cx="5.5" cy="3" r="1.2" fill="currentColor"/><circle cx="18.5" cy="3" r="1.2" fill="currentColor"/><line x1="12" y1="15" x2="12" y2="18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><circle cx="12" cy="19.5" r="1.5" stroke="currentColor" stroke-width="1.5" fill="none"/></symbol>
+<symbol id="zi-chef" viewBox="0 0 24 24"><circle cx="12" cy="7" r="4.5" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.08"/><path d="M7.5 8c-1.5-.5-2.5-2-2-3.5s2-2.5 3.5-2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/><path d="M16.5 8c1.5-.5 2.5-2 2-3.5s-2-2.5-3.5-2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/><path d="M8 12v7c0 1 1 2 4 2s4-1 4-2v-7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+<symbol id="zi-spoon" viewBox="0 0 24 24"><path d="M12 3c2.5 0 4.5 2 4.5 4.5S14.5 12 12 12s-4.5-2-4.5-4.5S9.5 3 12 3z" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.08"/><line x1="12" y1="12" x2="12" y2="21" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
+<symbol id="zi-bulb" viewBox="0 0 24 24"><path d="M9 18h6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M10 21h4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M12 2C8 2 5 5 5 8.5c0 2.5 1.5 4.5 3 6c.8.8 1 1.5 1 3.5h6c0-2 .2-2.7 1-3.5c1.5-1.5 3-3.5 3-6C19 5 16 2 12 2z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" fill-opacity="0.1"/></symbol>
+<symbol id="zi-note" viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="none"/><path d="M14 2v6h6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><line x1="8" y1="13" x2="16" y2="13" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" opacity="0.4"/><line x1="8" y1="17" x2="13" y2="17" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" opacity="0.4"/></symbol>
+<symbol id="zi-camera" viewBox="0 0 24 24"><path d="M23 19a2 2 0 01-2 2H3a2 2 0 01-2-2V8a2 2 0 012-2h4l2-3h6l2 3h4a2 2 0 012 2z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="none"/><circle cx="12" cy="13" r="4" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.08"/></symbol>
+<symbol id="zi-bolt" viewBox="0 0 24 24"><path d="M13 2L4 14h7l-1 8 9-12h-7z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" fill-opacity="0.12"/></symbol>
+<symbol id="zi-book" viewBox="0 0 24 24"><path d="M4 4.5C4 3.1 5.1 2 6.5 2H20v20H6.5A2.5 2.5 0 014 19.5z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="none"/><path d="M4 19.5A2.5 2.5 0 016.5 17H20" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/><line x1="9" y1="7" x2="16" y2="7" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" opacity="0.4"/><line x1="9" y1="11" x2="14" y2="11" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" opacity="0.4"/></symbol>
+<symbol id="zi-brain" viewBox="0 0 24 24"><path d="M12 2c-2 0-3.5 1-4 2.5C6.5 4 5 5 5 7c-1.5.5-2 2-2 3.5s1 3 2.5 3.5c0 1.5 1 3 3 3.5c.5 1.5 2 2.5 3.5 2.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/><path d="M12 2c2 0 3.5 1 4 2.5c1.5-.5 3 .5 3 2.5c1.5.5 2 2 2 3.5s-1 3-2.5 3.5c0 1.5-1 3-3 3.5c-.5 1.5-2 2.5-3.5 2.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/><line x1="12" y1="2" x2="12" y2="22" stroke="currentColor" stroke-width="1" stroke-dasharray="2 2" opacity="0.3"/></symbol>
+<symbol id="zi-link" viewBox="0 0 24 24"><path d="M10 13a5 5 0 007 0l3-3a5 5 0 00-7-7l-1.5 1.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" fill="none"/><path d="M14 11a5 5 0 00-7 0l-3 3a5 5 0 007 7l1.5-1.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zi-scope" viewBox="0 0 24 24"><circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="1.5" fill="none"/><line x1="16" y1="16" x2="21" y2="21" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><circle cx="11" cy="11" r="3" stroke="currentColor" stroke-width="1" fill="none" opacity="0.3"/></symbol>
+<symbol id="zi-list" viewBox="0 0 24 24"><line x1="8" y1="6" x2="21" y2="6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><line x1="8" y1="12" x2="21" y2="12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><line x1="8" y1="18" x2="21" y2="18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><circle cx="4" cy="6" r="1.2" fill="currentColor"/><circle cx="4" cy="12" r="1.2" fill="currentColor"/><circle cx="4" cy="18" r="1.2" fill="currentColor"/></symbol>
+<symbol id="zi-bars" viewBox="0 0 24 24"><rect x="4" y="13" width="4" height="8" rx="1" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.12"/><rect x="10" y="8" width="4" height="13" rx="1" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.12"/><rect x="16" y="3" width="4" height="18" rx="1" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.12"/></symbol>
+<symbol id="zi-party" viewBox="0 0 24 24"><path d="M4 21L2 11l9 9z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="currentColor" fill-opacity="0.1"/><circle cx="15" cy="5" r="1" fill="currentColor"/><circle cx="19" cy="9" r="1" fill="currentColor" opacity="0.6"/><circle cx="10" cy="4" r="0.8" fill="currentColor" opacity="0.4"/><path d="M14 8c1-2 3-2 4-1" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" fill="none"/><path d="M17 5c1-1.5 3-1 3.5.5" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zi-info" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="1.5" fill="none"/><line x1="12" y1="11" x2="12" y2="17" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><circle cx="12" cy="7.5" r="1.2" fill="currentColor"/></symbol>
+<symbol id="zi-timer" viewBox="0 0 24 24"><circle cx="12" cy="13" r="8" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M12 9v4l3 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><line x1="10" y1="2" x2="14" y2="2" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="12" y1="2" x2="12" y2="5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></symbol>
+<symbol id="zi-hourglass" viewBox="0 0 24 24"><path d="M6 2h12M6 22h12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M7 2v5l5 5-5 5v5h10v-5l-5-5 5-5V2" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="currentColor" fill-opacity="0.08"/></symbol>
+<symbol id="zi-halfcircle" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M12 3a9 9 0 010 18" fill="currentColor" fill-opacity="0.15"/></symbol>
+<symbol id="zi-scale" viewBox="0 0 24 24"><line x1="12" y1="3" x2="12" y2="21" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M4 7l8 3 8-3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M4 7c0 3 2.5 5 4 5s-1-5-4-5z" stroke="currentColor" stroke-width="1.2" fill="currentColor" fill-opacity="0.1"/><path d="M20 7c0 3-2.5 5-4 5s1-5 4-5z" stroke="currentColor" stroke-width="1.2" fill="currentColor" fill-opacity="0.1"/></symbol>
+<symbol id="zi-warn" viewBox="0 0 24 24"><path d="M12 3L2 20h20L12 3z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="currentColor" fill-opacity="0.08"/><line x1="12" y1="10" x2="12" y2="14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><circle cx="12" cy="17" r="1" fill="currentColor"/></symbol>
+<symbol id="zi-check" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.08"/><path d="M8 12l3 3 5-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+<symbol id="zi-close" viewBox="0 0 24 24"><path d="M6 6 L18 18 M18 6 L6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zi-rainbow" viewBox="0 0 24 24"><path d="M4 18c0-4.4 3.6-8 8-8s8 3.6 8 8" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M7 18c0-2.8 2.2-5 5-5s5 2.2 5 18" stroke="currentColor" stroke-width="1.5" fill="none" opacity="0.5"/><path d="M10 18c0-1.1.9-2 2-2s2 .9 2 2" stroke="currentColor" stroke-width="1.5" fill="none" opacity="0.3"/></symbol>
+<symbol id="zi-trophy" viewBox="0 0 24 24"><path d="M8 3h8v5c0 2.2-1.8 4-4 4s-4-1.8-4-4V3z" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.1"/><path d="M8 5H5c0 2.5 1.5 4 3 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/><path d="M16 5h3c0 2.5-1.5 4-3 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/><line x1="12" y1="12" x2="12" y2="16" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M8 16h8v2a1 1 0 01-1 1H9a1 1 0 01-1-1v-2z" stroke="currentColor" stroke-width="1.5" fill="none"/></symbol>
+<symbol id="zi-baby" viewBox="0 0 24 24"><circle cx="12" cy="9" r="5" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.08"/><path d="M7.5 7c-.8-1-1-3 .5-3.5" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" fill="none"/><path d="M16.5 7c.8-1 1-3-.5-3.5" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" fill="none"/><circle cx="10" cy="9" r="0.8" fill="currentColor"/><circle cx="14" cy="9" r="0.8" fill="currentColor"/><path d="M10.5 11c.7.5 2.3.5 3 0" stroke="currentColor" stroke-width="1" stroke-linecap="round" fill="none"/><path d="M8 15c1 3 3 5 4 5s3-2 4-5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zi-flame" viewBox="0 0 24 24"><path d="M12 22c-4 0-6-3-6-6c0-4 4-7 4-11c1 2 3 3 3 6c1-1 2-3 2-5c3 3 4 6 4 8c0 4-2.5 8-7 8z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" fill-opacity="0.12"/></symbol>
+<symbol id="zi-dot-red" viewBox="0 0 24 24"><circle cx="12" cy="12" r="6" fill="currentColor" opacity="0.8"/><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="1.5" fill="none" opacity="0.3"/></symbol>
+<symbol id="zi-zzz" viewBox="0 0 24 24"><path d="M7 8h4l-4 4h4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M14 4h3l-3 3h3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.6"/><path d="M5 18c2-2 5-3 7-3s5 1 7 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/><circle cx="10" cy="15.5" r="0.5" fill="currentColor" opacity="0.3"/><circle cx="14" cy="15.5" r="0.5" fill="currentColor" opacity="0.3"/></symbol>
+<symbol id="zi-siren" viewBox="0 0 24 24"><path d="M6 15v-3a6 6 0 0112 0v3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/><rect x="4" y="15" width="16" height="5" rx="2" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.1"/><line x1="12" y1="5" x2="12" y2="3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><line x1="5" y1="8" x2="3.5" y2="6.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><line x1="19" y1="8" x2="20.5" y2="6.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></symbol>
+<symbol id="zi-no-entry" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="1.8" fill="currentColor" fill-opacity="0.1"/><line x1="7" y1="12" x2="17" y2="12" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></symbol>
+<symbol id="zi-emergency" viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="4" stroke="currentColor" stroke-width="1.8" fill="currentColor" fill-opacity="0.12"/><line x1="12" y1="7" x2="12" y2="17" stroke="currentColor" stroke-width="2.8" stroke-linecap="round"/><line x1="7" y1="12" x2="17" y2="12" stroke="currentColor" stroke-width="2.8" stroke-linecap="round"/></symbol>
+<symbol id="zi-chevron-down" viewBox="0 0 24 24"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+<symbol id="zi-save" viewBox="0 0 24 24"><path d="M5 3h11l4 4v13a1 1 0 01-1 1H5a1 1 0 01-1-1V4a1 1 0 011-1z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="currentColor" fill-opacity="0.08"/><rect x="8" y="3" width="8" height="5" rx="1" stroke="currentColor" stroke-width="1.5" fill="none"/><rect x="7" y="13" width="10" height="6" rx="1" stroke="currentColor" stroke-width="1.5" fill="none"/></symbol>
+<symbol id="zi-share" viewBox="0 0 24 24"><circle cx="6" cy="12" r="2.5" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.1"/><circle cx="18" cy="6" r="2.5" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.1"/><circle cx="18" cy="18" r="2.5" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.1"/><line x1="8.2" y1="10.8" x2="15.8" y2="7.2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><line x1="8.2" y1="13.2" x2="15.8" y2="16.8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></symbol>
+<symbol id="zi-track" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.08"/><path d="M12 7v5l3 2" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/><circle cx="12" cy="12" r="1.2" fill="currentColor"/></symbol>
+<symbol id="zi-run" viewBox="0 0 24 24"><circle cx="14" cy="4" r="2" fill="currentColor" opacity="0.7"/><path d="M8 22l3-7 3 1v-6l-4-2-3 4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M14 10l2-1 4 4" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+<symbol id="zi-palette" viewBox="0 0 24 24"><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c1 0 2-.8 2-2 0-.5-.2-1-.5-1.3-.3-.3-.5-.8-.5-1.2 0-1.1.9-2 2-2h2.3c3 0 5.5-2 5.5-5 0-5-4.5-8.5-10.8-8.5z" stroke="currentColor" stroke-width="1.5" fill="none"/><circle cx="8" cy="10" r="1.3" fill="currentColor" opacity="0.5"/><circle cx="12" cy="7" r="1.3" fill="currentColor" opacity="0.4"/><circle cx="16" cy="10" r="1.3" fill="currentColor" opacity="0.6"/></symbol>
+<symbol id="zi-chat" viewBox="0 0 24 24"><path d="M21 12c0 4-4 7-9 7-1.5 0-3-.3-4.2-.8L3 20l1.5-4C3.5 14.8 3 13.5 3 12c0-4 4-7 9-7s9 3 9 7z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" fill-opacity="0.08"/><line x1="8" y1="10" x2="16" y2="10" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" opacity="0.4"/><line x1="8" y1="13" x2="13" y2="13" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" opacity="0.4"/></symbol>
+<symbol id="zi-handshake" viewBox="0 0 24 24"><path d="M7 11l-4-2v6l4 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M17 11l4-2v6l-4 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M7 11c2-1 4-1 5 0s3 1 5 0" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" fill="none"/><path d="M7 15c2-1 4-1 5 0s3 1 5 0" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zi-sun" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.15"/><path d="M12 2v3M12 19v3M4.22 4.22l2.12 2.12M17.66 17.66l2.12 2.12M2 12h3M19 12h3M4.22 19.78l2.12-2.12M17.66 6.34l2.12-2.12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></symbol>
+<symbol id="zi-flask" viewBox="0 0 24 24"><path d="M9 3h6M10 3v5.5L5.5 18a1.5 1.5 0 001.3 2.2h10.4a1.5 1.5 0 001.3-2.2L14 8.5V3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" fill-opacity="0.08"/><path d="M7.5 15h9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></symbol>
+<symbol id="zi-drop" viewBox="0 0 24 24"><path d="M12 2.5C12 2.5 5 10.5 5 15a7 7 0 0014 0c0-4.5-7-12.5-7-12.5z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" fill-opacity="0.08"/></symbol>
+<symbol id="zi-fall" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="4" r="2"/><path d="M9 8l3 3 3-3"/><path d="M12 11v4"/><path d="M8 21l4-6 4 6"/><path d="M12 17v-2"/><path d="M14 14l2 1"/><path d="M10 14l-2 1"/></symbol>
+<symbol id="zi-bump" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="10" r="6"/><path d="M8 8l-2-2"/><path d="M16 8l2-2"/><path d="M6 6l-1.5-1.5"/><path d="M18 6l1.5-1.5"/><path d="M10 20h4"/><path d="M12 16v4"/></symbol>
+<symbol id="zi-alert-circle" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><line x1="12" y1="8" x2="12" y2="13"/><circle cx="12" cy="16.5" r="0.5" fill="currentColor" stroke="none"/></symbol>
+<symbol id="zi-trending-up" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 7 13.5 15.5 8.5 10.5 2 17"/><polyline points="16 7 22 7 22 13"/></symbol>
+<symbol id="zi-trending-down" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 17 13.5 8.5 8.5 13.5 2 7"/><polyline points="16 17 22 17 22 11"/></symbol>
+<symbol id="zi-trending-flat" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="12" x2="21" y2="12"/></symbol>
+<symbol id="zi-trending-mixed" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4v16M8 8l4-4 4 4M8 16l4 4 4-4"/></symbol>
+<symbol id="zi-arrow-right" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></symbol>
+<symbol id="zi-plus" viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="5" y1="12" x2="19" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></symbol>
+<symbol id="zi-leaf" viewBox="0 0 24 24"><path d="M4 20c0-8 6-14 16-14c0 10-6 16-16 14z" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.1" stroke-linejoin="round"/><path d="M9 15c2-3 5-5 8-6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zi-doc" viewBox="0 0 24 24"><path d="M6 3h8l4 4v14H6z" stroke="currentColor" stroke-width="1.6" fill="currentColor" fill-opacity="0.1" stroke-linejoin="round"/><path d="M14 3v4h4M9 12h6M9 16h6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zi-copy" viewBox="0 0 24 24"><rect x="8" y="8" width="12" height="13" rx="2" stroke="currentColor" stroke-width="1.6" fill="currentColor" fill-opacity="0.08"/><path d="M16 8V5a2 2 0 00-2-2H5a2 2 0 00-2 2v9a2 2 0 002 2h3" stroke="currentColor" stroke-width="1.6" fill="none" stroke-linejoin="round"/></symbol>
+<symbol id="zi-goal" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 21V5"/><path d="M5 5l12 4-12 4"/></symbol>
+<symbol id="zi-clipboard" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="3" width="12" height="4" rx="1"/><path d="M6 7h12v13a1 1 0 01-1 1H7a1 1 0 01-1-1V7z"/><line x1="10" y1="12" x2="14" y2="12"/><line x1="10" y1="16" x2="14" y2="16"/></symbol>
+<symbol id="zi-follow-up" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/><path d="M19 15l2 2-2 2"/></symbol>
+<symbol id="zi-resolve" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M9 12l2 2 4-4"/></symbol>
+<symbol id="zi-cloud" viewBox="0 0 24 24"><path d="M7 18a4 4 0 110-8 6 6 0 0111-1 4 4 0 011 9H7z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" fill-opacity="0.08"/></symbol>
+<symbol id="zi-rain" viewBox="0 0 24 24"><path d="M7 14a4 4 0 110-8 6 6 0 0111-1 4 4 0 011 9H7z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" fill-opacity="0.08"/><path d="M8 18l-1 3M12 18l-1 3M16 18l-1 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></symbol>
+<symbol id="zi-snow" viewBox="0 0 24 24"><path d="M12 3v18M5 7l14 10M5 17l14-10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M9 4.5l3 2.5 3-2.5M9 19.5l3-2.5 3 2.5M3.5 10l2.5 2-2.5 2M20.5 10l-2.5 2 2.5 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+<symbol id="zi-moon-new" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.04" stroke-dasharray="1.5 1.5" opacity="0.7"/></symbol>
+<symbol id="zi-moon-waxing-crescent" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8" stroke="currentColor" stroke-width="1.5" fill="none" opacity="0.5"/><path d="M12 4 A8 8 0 0 1 12 20 A6 8 0 0 0 12 4 z" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></symbol>
+<symbol id="zi-moon-first-quarter" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8" stroke="currentColor" stroke-width="1.5" fill="none" opacity="0.5"/><path d="M12 4 A8 8 0 0 1 12 20 z" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></symbol>
+<symbol id="zi-moon-waxing-gibbous" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8" stroke="currentColor" stroke-width="1.5" fill="none" opacity="0.5"/><path d="M12 4 A8 8 0 0 1 12 20 A4 8 0 0 1 12 4 z" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></symbol>
+<symbol id="zi-moon-full" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.22"/><circle cx="9" cy="10" r="1" fill="currentColor" opacity="0.3"/><circle cx="14" cy="13" r="0.8" fill="currentColor" opacity="0.3"/><circle cx="11" cy="14.5" r="0.6" fill="currentColor" opacity="0.3"/></symbol>
+<symbol id="zi-moon-waning-gibbous" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8" stroke="currentColor" stroke-width="1.5" fill="none" opacity="0.5"/><path d="M12 4 A8 8 0 0 0 12 20 A4 8 0 0 0 12 4 z" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></symbol>
+<symbol id="zi-moon-third-quarter" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8" stroke="currentColor" stroke-width="1.5" fill="none" opacity="0.5"/><path d="M12 4 A8 8 0 0 0 12 20 z" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></symbol>
+<symbol id="zi-moon-waning-crescent" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8" stroke="currentColor" stroke-width="1.5" fill="none" opacity="0.5"/><path d="M12 4 A8 8 0 0 0 12 20 A6 8 0 0 1 12 4 z" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></symbol>
+<symbol id="zi-mirror" viewBox="0 0 24 24"><ellipse cx="12" cy="9" rx="6" ry="7" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.1"/><ellipse cx="12" cy="9" rx="3.5" ry="4.5" stroke="currentColor" stroke-width="1" fill="none" opacity="0.4"/><path d="M12 16v5M9 21h6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></symbol>
+<symbol id="zi-flag-in" viewBox="0 0 24 24"><path d="M5 3v18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M5 4h13v12H5z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="currentColor" fill-opacity="0.08"/><line x1="5" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1" opacity="0.5"/><line x1="5" y1="12" x2="18" y2="12" stroke="currentColor" stroke-width="1" opacity="0.5"/><circle cx="11.5" cy="10" r="1.6" stroke="currentColor" stroke-width="1" fill="none"/><path d="M11.5 8.4v3.2M9.9 10h3.2M10.4 8.9l2.2 2.2M10.4 11.1l2.2-2.2" stroke="currentColor" stroke-width="0.6" opacity="0.7"/></symbol>
+<symbol id="zi-flag-eu" viewBox="0 0 24 24"><path d="M5 3v18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M5 4h13v12H5z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="currentColor" fill-opacity="0.12"/><g fill="currentColor"><circle cx="11.5" cy="6.5" r="0.4"/><circle cx="14" cy="7.2" r="0.4"/><circle cx="15.5" cy="9.2" r="0.4"/><circle cx="15.5" cy="11.5" r="0.4"/><circle cx="14" cy="13.4" r="0.4"/><circle cx="11.5" cy="14.1" r="0.4"/><circle cx="9" cy="13.4" r="0.4"/><circle cx="7.5" cy="11.5" r="0.4"/><circle cx="7.5" cy="9.2" r="0.4"/><circle cx="9" cy="7.2" r="0.4"/></g></symbol>
+<symbol id="zi-flag-cn" viewBox="0 0 24 24"><path d="M5 3v18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M5 4h13v12H5z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="currentColor" fill-opacity="0.12"/><path d="M8 7l0.5 1.6 1.7 0-1.4 1 0.5 1.6L8 10.2 6.7 11.2l0.5-1.6-1.4-1 1.7 0z" fill="currentColor"/><circle cx="11.5" cy="6.8" r="0.35" fill="currentColor"/><circle cx="12.5" cy="8.2" r="0.35" fill="currentColor"/><circle cx="12.5" cy="10" r="0.35" fill="currentColor"/><circle cx="11.5" cy="11.4" r="0.35" fill="currentColor"/></symbol>
+<symbol id="zi-diya" viewBox="0 0 24 24"><path d="M4 16c0-1 1-2 3-2h10c2 0 3 1 3 2c0 2-3.5 3.5-8 3.5s-8-1.5-8-3.5z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="currentColor" fill-opacity="0.12"/><path d="M12 14c-1.5-2 0-4 0-5.5c1.2 1.2 2 2.5 1 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" fill-opacity="0.2"/></symbol>
+<symbol id="zi-bubble" viewBox="0 0 24 24"><circle cx="9" cy="14" r="5" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.08"/><circle cx="16" cy="9" r="3" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.08"/><circle cx="18" cy="16" r="2" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.08"/><circle cx="7" cy="12" r="1.2" fill="currentColor" opacity="0.3"/><circle cx="15" cy="8" r="0.7" fill="currentColor" opacity="0.3"/></symbol>
+<symbol id="zi-heart" viewBox="0 0 24 24"><path d="M12 20s-7-4.5-7-10a4 4 0 017-2.5A4 4 0 0119 10c0 5.5-7 10-7 10z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" fill-opacity="0.18"/></symbol>
+<symbol id="zi-progress" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M12 4 A8 8 0 0 1 20 12 L12 12 z" fill="currentColor" fill-opacity="0.25"/></symbol>
+<symbol id="zi-shy" viewBox="0 0 24 24"><circle cx="12" cy="12" r="8" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.08"/><path d="M5 10c2 1 5 2 7 2s5-1 7-2" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round"/><path d="M10 15.5c0.6 0.6 1.3 1 2 1s1.4-0.4 2-1" stroke="currentColor" stroke-width="1.3" fill="none" stroke-linecap="round"/><circle cx="9" cy="10.5" r="0.5" fill="currentColor" opacity="0.5"/><circle cx="15" cy="10.5" r="0.5" fill="currentColor" opacity="0.5"/></symbol>
+<symbol id="zi-legume" viewBox="0 0 24 24"><path d="M4 12c0-4 3-7 8-7s8 3 8 7c0 4-3 7-8 7s-8-3-8-7z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="currentColor" fill-opacity="0.08"/><circle cx="8.5" cy="12" r="1.4" stroke="currentColor" stroke-width="1" fill="currentColor" fill-opacity="0.25"/><circle cx="12" cy="12" r="1.4" stroke="currentColor" stroke-width="1" fill="currentColor" fill-opacity="0.25"/><circle cx="15.5" cy="12" r="1.4" stroke="currentColor" stroke-width="1" fill="currentColor" fill-opacity="0.25"/></symbol>
+<symbol id="zi-pepper" viewBox="0 0 24 24"><path d="M7 12c0-3 2-5 5-5s5 2 5 5v4c0 2.5-2.2 4.5-5 4.5s-5-2-5-4.5z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" fill-opacity="0.12"/><path d="M10 7c0-1.5 0.5-3 2-3s2 1.5 2 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/><path d="M12 4v-1.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></symbol>
+<symbol id="zi-blood-drop" viewBox="0 0 24 24"><path d="M12 2.5C12 2.5 5 10.5 5 15a7 7 0 0014 0c0-4.5-7-12.5-7-12.5z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" fill-opacity="0.22"/><path d="M10 14.5h4M12 12.5v4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" opacity="0.6"/></symbol>
+<symbol id="zi-rice" viewBox="0 0 24 24"><path d="M4 14c0-2 3-4 8-4s8 2 8 4v2c0 2.5-2 4.5-4 4.5H8c-2 0-4-2-4-4.5z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" fill-opacity="0.1"/><ellipse cx="9" cy="11" rx="1" ry="2" fill="currentColor" fill-opacity="0.5"/><ellipse cx="12" cy="10" rx="1" ry="2" fill="currentColor" fill-opacity="0.5"/><ellipse cx="15" cy="11" rx="1" ry="2" fill="currentColor" fill-opacity="0.5"/></symbol>
+<symbol id="zi-grain" viewBox="0 0 24 24"><path d="M12 3v18" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M12 6c-1.5 0-3 1-3 2.5c0 1 1 2 3 2.5c2-0.5 3-1.5 3-2.5C15 7 13.5 6 12 6z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round" fill="currentColor" fill-opacity="0.15"/><path d="M12 11c-1.5 0-3 1-3 2.5c0 1 1 2 3 2.5c2-0.5 3-1.5 3-2.5C15 12 13.5 11 12 11z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round" fill="currentColor" fill-opacity="0.15"/><path d="M12 16c-1.5 0-3 1-3 2.5c0 1 1 2 3 2.5c2-0.5 3-1.5 3-2.5C15 17 13.5 16 12 16z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round" fill="currentColor" fill-opacity="0.15"/></symbol>
+<symbol id="zi-fruit" viewBox="0 0 24 24"><path d="M12 7c-4 0-7 3-7 7c0 4 3 7 7 7s7-3 7-7c0-4-3-7-7-7z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="currentColor" fill-opacity="0.12"/><path d="M12 7c0-1.5 1-3 2.5-3M12 7c-0.5-1.5-2-2.5-3.5-2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zi-carrot" viewBox="0 0 24 24"><path d="M9 9l3 12 3-12c0-1-1.5-1.5-3-1.5S9 8 9 9z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="currentColor" fill-opacity="0.18"/><path d="M10 8c-1-2-2-3-3-4M12 8c0-2 0-3 0-4.5M14 8c1-2 2-3 3-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zi-play" viewBox="0 0 24 24"><path d="M7 5l12 7-12 7z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="currentColor" fill-opacity="0.18"/></symbol>
+<symbol id="zi-pause" viewBox="0 0 24 24"><rect x="6" y="5" width="4" height="14" rx="1" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.18"/><rect x="14" y="5" width="4" height="14" rx="1" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.18"/></symbol>
+<symbol id="zi-skip-forward" viewBox="0 0 24 24"><path d="M5 5l10 7-10 7z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round" fill="currentColor" fill-opacity="0.18"/><rect x="17" y="5" width="3" height="14" rx="1" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.18"/></symbol>
+<symbol id="zi-chevron-up" viewBox="0 0 24 24"><path d="M6 15l6-6 6 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+<symbol id="zi-stop" viewBox="0 0 24 24"><rect x="6" y="6" width="12" height="12" rx="1.5" stroke="currentColor" stroke-width="1.5" fill="currentColor" fill-opacity="0.2"/></symbol>
+<symbol id="zi-dot-empty" viewBox="0 0 24 24"><circle cx="12" cy="12" r="6" stroke="currentColor" stroke-width="1.5" fill="none" opacity="0.5"/><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="1.5" fill="none" opacity="0.2"/></symbol>
+<symbol id="zi-ios-share" viewBox="0 0 24 24"><path d="M7 10v9a1.5 1.5 0 001.5 1.5h7A1.5 1.5 0 0017 19v-9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M12 14V3M8.5 6.5L12 3l3.5 3.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+<symbol id="zi-undo" viewBox="0 0 24 24"><path d="M9 14l-5-5 5-5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M4 9h10a6 6 0 016 6v2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+<!-- Reserved sprites (registered for future use, no current call sites): zi-flag-eu, zi-flag-cn. Authored alongside zi-flag-in for region-picker symmetry — currently inert because <option> tags cannot host SVG (HTML spec); slated for a future non-<option> Settings surface (e.g. region pill, schedule header). Per user mandate "industrial scale for future usage" (2026-05-16). zi-undo was previously reserved but is now wired into 3 surfaces (home.js milestone Move-back, core.js note-toggle, intelligence.js meal-skip toggle) per round-3 strict-pass cleanup. -->
+</defs>
+</svg>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none;"><symbol id="zif-rice" viewBox="0 0 24 24"><path d="M3.5 11.5h17c0 4.8-3.8 8.7-8.5 8.7S3.5 16.3 3.5 11.5z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1.1" stroke-linejoin="round"/><g fill="#fff" stroke="rgba(74,48,22,.18)" stroke-width=".8"><ellipse cx="9" cy="8.7" rx="1.1" ry="2.2" transform="rotate(-20 9 8.7)"/><ellipse cx="12" cy="7.9" rx="1.1" ry="2.2"/><ellipse cx="15" cy="8.7" rx="1.1" ry="2.2" transform="rotate(20 15 8.7)"/></g></symbol>
+<symbol id="zif-millet" viewBox="0 0 24 24"><path d="M12 21v-7" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" fill="none"/><g fill="currentColor"><circle cx="12" cy="4.4" r="1.15"/><circle cx="10.1" cy="6" r="1.15"/><circle cx="13.9" cy="6" r="1.15"/><circle cx="9.5" cy="8" r="1.15"/><circle cx="12" cy="7.7" r="1.15"/><circle cx="14.5" cy="8" r="1.15"/><circle cx="10.4" cy="10" r="1.15"/><circle cx="13.6" cy="10" r="1.15"/><circle cx="12" cy="11.5" r="1.15"/></g></symbol>
+<symbol id="zif-oats" viewBox="0 0 24 24"><path d="M12 21V7.5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" fill="none"/><g fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width=".8"><ellipse cx="8.8" cy="7" rx="1.7" ry="2.7" transform="rotate(33 8.8 7)"/><ellipse cx="15.2" cy="7" rx="1.7" ry="2.7" transform="rotate(-33 15.2 7)"/><ellipse cx="8.4" cy="11.5" rx="1.7" ry="2.7" transform="rotate(33 8.4 11.5)"/><ellipse cx="15.6" cy="11.5" rx="1.7" ry="2.7" transform="rotate(-33 15.6 11.5)"/></g></symbol>
+<symbol id="zif-wheat" viewBox="0 0 24 24"><path d="M12 21V11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/><g stroke="currentColor" stroke-width="1" stroke-linecap="round"><path d="M12 5.5L9.5 3.5M12 5.5l2.5-2M12 8.5l-3-1.6M12 8.5l3-1.6"/></g><g fill="currentColor"><ellipse cx="12" cy="4.6" rx="1.3" ry="2.1"/><ellipse cx="9.8" cy="7.2" rx="1.2" ry="2" transform="rotate(-28 9.8 7.2)"/><ellipse cx="14.2" cy="7.2" rx="1.2" ry="2" transform="rotate(28 14.2 7.2)"/><ellipse cx="9.6" cy="10.2" rx="1.2" ry="2" transform="rotate(-28 9.6 10.2)"/><ellipse cx="14.4" cy="10.2" rx="1.2" ry="2" transform="rotate(28 14.4 10.2)"/></g></symbol>
+<symbol id="zif-suji" viewBox="0 0 24 24"><path d="M4 12h16c0 4.4-3.6 8-8 8s-8-3.6-8-8z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><g fill="rgba(74,48,22,.28)"><circle cx="9" cy="14" r=".5"/><circle cx="12" cy="13" r=".5"/><circle cx="15" cy="14" r=".5"/><circle cx="10.5" cy="16" r=".5"/><circle cx="13.5" cy="16" r=".5"/></g></symbol>
+<symbol id="zif-corn" viewBox="0 0 24 24"><path d="M8 18.5c-2.2.3-4-1-4.8-3 1.6-.8 3.4-.5 4.8.6M16 18.5c2.2.3 4-1 4.8-3-1.6-.8-3.4-.5-4.8.6z" fill="#5f9e42" stroke="rgba(74,48,22,.22)" stroke-width=".9" stroke-linejoin="round"/><path d="M12 4.3c2.9 0 4.6 2.4 4.6 6.7 0 4.6-2 8.2-4.6 8.2s-4.6-3.6-4.6-8.2C7.4 6.7 9.1 4.3 12 4.3z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><g stroke="rgba(74,48,22,.22)" stroke-width=".65" fill="none"><path d="M12 5v13.6M9 8c2 .6 4 .6 6 0M8.5 11c2.3.6 4.7.6 7 0M8.5 14c2.3.6 4.7.6 7 0M10.5 6.4c1 .4 2 .4 3 0M10.3 16.6c1.1.4 2.3.4 3.4 0"/><path d="M9 9.5c2 .5 4 .5 6 0M8.6 12.5c2.3.5 4.8.5 6.8 0M9 15.5c2 .5 4 .5 6 0" opacity=".6"/></g></symbol>
+<symbol id="zif-dalia" viewBox="0 0 24 24"><path d="M4 12h16c0 4.4-3.6 8-8 8s-8-3.6-8-8z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><g fill="rgba(74,48,22,.32)"><rect x="8" y="13" width="1.5" height="1.5" rx=".3"/><rect x="11.2" y="12.6" width="1.5" height="1.5" rx=".3"/><rect x="14" y="13" width="1.5" height="1.5" rx=".3"/><rect x="9.6" y="15.2" width="1.5" height="1.5" rx=".3"/><rect x="12.7" y="15.2" width="1.5" height="1.5" rx=".3"/></g></symbol>
+<symbol id="zif-barley" viewBox="0 0 24 24"><path d="M12 21V11.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" fill="none"/><g stroke="currentColor" stroke-width=".8" stroke-linecap="round" opacity=".75"><path d="M12 9l-3.5-5.5M12 9l3.5-5.5M12 7l-2.8-4.5M12 7l2.8-4.5M12 11l-3.2-4.5M12 11l3.2-4.5"/></g><g fill="currentColor"><ellipse cx="12" cy="10" rx="1.2" ry="2"/><ellipse cx="9.7" cy="11.6" rx="1.1" ry="1.8" transform="rotate(-25 9.7 11.6)"/><ellipse cx="14.3" cy="11.6" rx="1.1" ry="1.8" transform="rotate(25 14.3 11.6)"/></g></symbol>
+<symbol id="zif-quinoa" viewBox="0 0 24 24"><g fill="currentColor"><circle cx="8.5" cy="11" r="1.5"/><circle cx="11.5" cy="10" r="1.5"/><circle cx="14.5" cy="11" r="1.5"/><circle cx="10" cy="13" r="1.5"/><circle cx="13" cy="13" r="1.5"/><circle cx="11.5" cy="15.2" r="1.5"/></g><g fill="none" stroke="rgba(255,255,255,.6)" stroke-width=".6"><path d="M8.5 10.1c.7.4.8 1.3.2 1.9M11.5 9.1c.7.4.8 1.3.2 1.9M14.5 10.1c.7.4.8 1.3.2 1.9M10 12.1c.7.4.8 1.3.2 1.9M13 12.1c.7.4.8 1.3.2 1.9"/></g></symbol>
+<symbol id="zif-dal" viewBox="0 0 24 24"><g fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"><ellipse cx="8.4" cy="9.8" rx="4.1" ry="2.5" transform="rotate(-12 8.4 9.8)"/><ellipse cx="15.2" cy="11.4" rx="4.1" ry="2.5" transform="rotate(14 15.2 11.4)"/><ellipse cx="11" cy="15" rx="4.1" ry="2.5" transform="rotate(-5 11 15)"/></g></symbol>
+<symbol id="zif-chana" viewBox="0 0 24 24"><g fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"><circle cx="9" cy="10" r="3.4"/><circle cx="15" cy="11.5" r="3.4"/><circle cx="11.5" cy="15.2" r="3.4"/></g><g fill="rgba(74,48,22,.25)"><circle cx="9" cy="10" r=".5"/><circle cx="15" cy="11.5" r=".5"/><circle cx="11.5" cy="15.2" r=".5"/></g></symbol>
+<symbol id="zif-rajma" viewBox="0 0 24 24"><g fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"><path d="M9.5 5.5c-3 0-5.3 2.6-5.3 5.8s2.3 5.8 5.3 5.8c1.1 0 2.2-.4 3-1.1.4-.3.3-.9-.2-1.1-1.3-.6-2.1-1.9-2.1-3.6 0-1.9 1-3.2 1-4.7 0-.6-.2-1-.6-1z"/><path d="M16 8c-2.6 0-4.6 2.2-4.6 5s2 5 4.6 5c.9 0 1.8-.3 2.5-.9.4-.3.3-.8-.1-1-1.1-.5-1.8-1.6-1.8-3 0-1.6.9-2.7.9-4 0-.6-.4-1.1-1.4-1.1z"/></g></symbol>
+<symbol id="zif-peanut" viewBox="0 0 24 24"><path d="M12 3.5c-2 0-3.5 1.5-3.5 3.4 0 1.3.7 2.1.7 3.1 0 1-.7 1.8-.7 3.1 0 1.9 1.5 3.4 3.5 3.4s3.5-1.5 3.5-3.4c0-1.3-.7-2.1-.7-3.1 0-1 .7-1.8.7-3.1 0-1.9-1.5-3.4-3.5-3.4z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M9.5 9.5c1.6.7 3.4.7 5 0M9.8 6.5c1.4.5 3 .5 4.4 0M9.8 13.5c1.4.5 3 .5 4.4 0" stroke="rgba(74,48,22,.22)" stroke-width=".7" fill="none"/></symbol>
+<symbol id="zif-sprouts" viewBox="0 0 24 24"><g stroke="#5f9e42" stroke-width="1.4" stroke-linecap="round" fill="none"><path d="M10 14c1-3 3.2-4 2.6-7.6"/><path d="M14 14.2c-.5-2.2 1.2-3.8 3.6-4.4"/><path d="M9.6 14.2C8 12.8 7 10.6 7.7 8.4"/></g><g fill="#5f9e42"><path d="M12 5.6c1.4-.4 2.4.5 2.4 1.8-1.4.4-2.4-.5-2.4-1.8z"/><path d="M7.2 8.1c-1.3-.5-1.7-1.7-1.3-2.9 1.3.5 1.7 1.7 1.3 2.9z"/><path d="M17.6 9.6c1.3-.5 1.7-1.7 1.3-2.9-1.3.5-1.7 1.7-1.3 2.9z"/></g><g fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"><ellipse cx="9.6" cy="16.6" rx="2.5" ry="3.3" transform="rotate(-14 9.6 16.6)"/><ellipse cx="14.4" cy="16.9" rx="2.5" ry="3.3" transform="rotate(12 14.4 16.9)"/></g></symbol>
+<symbol id="zif-carrot" viewBox="0 0 24 24"><path d="M8.4 8.6L11.5 20c.16.6.84.6 1 0L15.6 8.6c.12-.45-.12-.8-.55-.8H8.95c-.43 0-.67.35-.55.8z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><g fill="#5f9e42"><path d="M12 8c-.4-2-1.7-3-3.2-3.2.3 1.9 1.4 3 3.2 3.2z"/><path d="M12 8c.4-2 1.7-3 3.2-3.2-.3 1.9-1.4 3-3.2 3.2z"/><path d="M12 8c0-1.9.05-3.3.05-3.3-1.1.15-1.75 1.8-.05 3.3z"/></g><g stroke="rgba(255,255,255,.5)" stroke-width=".8" stroke-linecap="round"><path d="M10.2 11.5h3.4M10.7 14.5h2.4"/></g></symbol>
+<symbol id="zif-spinach" viewBox="0 0 24 24"><path d="M5 19C5 11.3 11.3 5 19 5c0 7.7-6.3 14-14 14z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><g stroke="rgba(255,255,255,.55)" stroke-width="1" stroke-linecap="round" fill="none"><path d="M6.5 17.5C10 14 13.5 10.5 17 7"/><path d="M11 13l-2 .3M14 10l-1.8.2M9 15l-1.8.3"/></g></symbol>
+<symbol id="zif-beans" viewBox="0 0 24 24"><g stroke="currentColor" stroke-width="3.4" stroke-linecap="round" fill="none"><path d="M5 8.5C9.5 9.5 14.5 14 18 19.5"/><path d="M8 6.5C12.5 7.5 17 12 19.5 17"/></g><g fill="rgba(74,48,22,.25)"><circle cx="9" cy="11.5" r=".5"/><circle cx="12" cy="14" r=".5"/><circle cx="13" cy="10.5" r=".5"/></g></symbol>
+<symbol id="zif-bottlegourd" viewBox="0 0 24 24"><path d="M12 4c-1.2 0-2 .8-1.8 2 .1.6.5 1 .5 1.6 0 1-1 1.6-1.6 2.6-1.5 2.4-1.6 6 .4 8.4C9.3 19.6 10.6 20 12 20s2.7-.4 3.5-1.4c2-2.4 1.9-6 .4-8.4-.6-1-1.6-1.6-1.6-2.6 0-.6.4-1 .5-1.6.2-1.2-.6-2-1.8-2z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M12 4V2.6" stroke="#7a5a36" stroke-width="1.4" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zif-beetroot" viewBox="0 0 24 24"><path d="M12 8.5c-3.3 0-5.3 2.4-5.3 4.7 0 1.7 1 3.2 2.3 4.4l3 2.6 3-2.6c1.3-1.2 2.3-2.7 2.3-4.4 0-2.3-2-4.7-5.3-4.7z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M12 20.2c.5 1 .5 1.8.5 2.3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" fill="none"/><g fill="#5f9e42"><path d="M10 8c-1-2.5-.5-4.5.5-5.5 1 1.5 1.2 3.5.5 5.5zM13.5 8c1.2-2.3 2.8-3.3 4-3.3-.3 2.3-1.8 3.5-4 3.3z"/></g><path d="M11.5 8V4" stroke="#5f9e42" stroke-width="1.3" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zif-pumpkin" viewBox="0 0 24 24"><g fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"><ellipse cx="5.7" cy="14.6" rx="2.4" ry="4.3"/><ellipse cx="18.3" cy="14.6" rx="2.4" ry="4.3"/><ellipse cx="8.5" cy="14.2" rx="3" ry="5.4"/><ellipse cx="15.5" cy="14.2" rx="3" ry="5.4"/><ellipse cx="12" cy="14" rx="3.5" ry="6"/></g><g stroke="rgba(74,48,22,.22)" stroke-width=".8" fill="none" opacity=".5"><path d="M12 8.4v11.4"/></g><path d="M12 8.4c0-2.2 1.1-3.5 3-3.7" stroke="#7a5a36" stroke-width="1.8" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zif-sweetpotato" viewBox="0 0 24 24"><path d="M5.6 13.8c-1.6-3 .8-7 4.9-7.8 4.9-1 8.8 1 8.8 4.4 0 4.3-5.1 7.5-9.4 7.5-1.9 0-3.4-1.5-4.3-4.1z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><g stroke="rgba(74,48,22,.3)" stroke-width="1" stroke-linecap="round"><path d="M6 7l-1.4-1.2M19 11.2l1.6-.4"/></g><g fill="rgba(74,48,22,.22)"><circle cx="10" cy="11" r=".5"/><circle cx="14" cy="12.5" r=".5"/></g></symbol>
+<symbol id="zif-potato" viewBox="0 0 24 24"><ellipse cx="12" cy="13" rx="8" ry="6" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" transform="rotate(-12 12 13)"/><g fill="rgba(74,48,22,.3)"><circle cx="9" cy="11" r=".6"/><circle cx="13" cy="10" r=".6"/><circle cx="14.5" cy="14" r=".6"/><circle cx="10" cy="15" r=".6"/></g></symbol>
+<symbol id="zif-broccoli" viewBox="0 0 24 24"><path d="M10.6 12.5h2.8l1.4 6.5c.12.6-.3 1-1 1h-3.6c-.7 0-1.12-.4-1-1z" fill="#7a9a5a" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><g fill="currentColor" stroke="rgba(74,48,22,.18)" stroke-width=".9"><circle cx="8.4" cy="8" r="3"/><circle cx="12.6" cy="6.4" r="3.3"/><circle cx="15.8" cy="9" r="2.9"/><circle cx="11.4" cy="10.3" r="3"/></g></symbol>
+<symbol id="zif-cauliflower" viewBox="0 0 24 24"><path d="M10.6 12.5h2.8l1.2 6.5c.12.6-.3 1-1 1h-3.2c-.7 0-1.12-.4-1-1z" fill="#e7e2cf" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M6 13c-2-1-2.5-3-1.5-4.5 1.5 0 2.7 1 3 2.5M18 13c2-1 2.5-3 1.5-4.5-1.5 0-2.7 1-3 2.5z" fill="#5f9e42" stroke="rgba(74,48,22,.22)" stroke-width=".8" stroke-linejoin="round"/><g fill="currentColor" stroke="rgba(74,48,22,.18)" stroke-width=".9"><circle cx="8.4" cy="8" r="3"/><circle cx="12.6" cy="6.4" r="3.3"/><circle cx="15.8" cy="9" r="2.9"/><circle cx="11.4" cy="10.3" r="3"/></g></symbol>
+<symbol id="zif-tomato" viewBox="0 0 24 24"><circle cx="12" cy="14" r="6.6" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"/><g fill="#5f9e42"><path d="M12 8.2c0-1.8-1-2.6-1-2.6-.3 1.5.2 2.3 1 2.6zM12 8.2c0-1.8 1-2.6 1-2.6.3 1.5-.2 2.3-1 2.6zM12 8.2l-2.4-1.5c-.3 1.4.9 1.9 2.4 1.5zM12 8.2l2.4-1.5c.3 1.4-.9 1.9-2.4 1.5z"/><rect x="11.4" y="4.8" width="1.2" height="2.6" rx=".6"/></g><ellipse cx="9.5" cy="11.6" rx="1.6" ry="1" fill="rgba(255,255,255,.4)" transform="rotate(-35 9.5 11.6)"/></symbol>
+<symbol id="zif-pepper" viewBox="0 0 24 24"><path d="M7 9.5c0-1.5 1.3-2.5 2.5-2 .8-.8 2.2-.8 3 0 1.2-.6 2.5.4 2.5 2 1.5.5 2.5 2.3 2.5 4.5 0 3.5-2.2 6.5-5 6.5s-5-3-5-6.5c0-2.2 1-4 2.5-4.5z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M12 8V5.4" stroke="#5f9e42" stroke-width="1.8" stroke-linecap="round" fill="none"/><path d="M10.4 6c1-1 2.6-1 3.3-.2" stroke="#5f9e42" stroke-width="1.6" stroke-linecap="round" fill="none"/><ellipse cx="9.7" cy="13" rx="1.3" ry="2.4" fill="rgba(255,255,255,.3)"/></symbol>
+<symbol id="zif-cucumber" viewBox="0 0 24 24"><rect x="3.5" y="9" width="17" height="6" rx="3" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" transform="rotate(38 12 12)"/><g stroke="rgba(255,255,255,.4)" stroke-width=".7" fill="none" transform="rotate(38 12 12)"><path d="M7 10.5v3M10 10v4M13 10v4M16 10.5v3"/></g></symbol>
+<symbol id="zif-zucchini" viewBox="0 0 24 24"><rect x="3.5" y="9.5" width="16" height="5.4" rx="2.7" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" transform="rotate(38 12 12)"/><path d="M17 6.5l1.5-1.5" stroke="#7a5a36" stroke-width="1.6" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zif-peas" viewBox="0 0 24 24"><path d="M3.5 11c4.5-2 9.5-1.5 16 2.5-1 1.8-2.6 2.8-4.5 3-3.5.3-7-.8-9.5-2.8-1.5-1.2-2.2-1.8-2-2.7z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><g fill="rgba(255,255,255,.55)" stroke="rgba(74,48,22,.22)" stroke-width=".7"><circle cx="7.5" cy="12" r="1.8"/><circle cx="11.5" cy="13.2" r="1.8"/><circle cx="15.5" cy="14.2" r="1.8"/></g></symbol>
+<symbol id="zif-onion" viewBox="0 0 24 24"><path d="M12 7.4c-3.6 0-6.2 2.9-6.2 6.4 0 3.6 2.8 6.5 6.2 6.5s6.2-2.9 6.2-6.5C18.2 10.3 15.6 7.4 12 7.4z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><g stroke="rgba(255,255,255,.42)" stroke-width=".8" fill="none"><path d="M12 8v12M9.2 13.6c0 3 1.1 5.1 2.8 6.3M14.8 13.6c0 3-1.1 5.1-2.8 6.3"/></g><path d="M12 7.4c-.5-1.7.1-3.1 1.4-3.9M12 7.4c.5-1.7-.1-3.1-1.4-3.9" stroke="#7a5a36" stroke-width="1.2" stroke-linecap="round" fill="none"/><g stroke="rgba(74,48,22,.32)" stroke-width=".8" stroke-linecap="round"><path d="M11 20.2l-.4 1.4M13 20.2l.4 1.4"/></g></symbol>
+<symbol id="zif-garlic" viewBox="0 0 24 24"><path d="M12 6.4c-.9 0-1.4.7-1.3 1.6-2 .9-3.4 3-3.4 5.6 0 3.6 2.1 6.4 4.7 6.4s4.7-2.8 4.7-6.4c0-2.6-1.4-4.7-3.4-5.6.1-.9-.4-1.6-1.3-1.6z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><g stroke="rgba(74,48,22,.22)" stroke-width=".8" fill="none"><path d="M12 8.6v11.2M9.4 9.6c-1 2-1 6 .3 9M14.6 9.6c1 2 1 6-.3 9"/></g><path d="M12 6.4c0-1 .6-1.8 1.6-2.1" stroke="#7a5a36" stroke-width="1.2" stroke-linecap="round" fill="none"/><g stroke="rgba(74,48,22,.3)" stroke-width=".7" stroke-linecap="round"><path d="M10.6 19.8l-.4 1.2M13.4 19.8l.4 1.2M12 20v1.4"/></g></symbol>
+<symbol id="zif-ginger" viewBox="0 0 24 24"><path d="M4.5 12.5c-.3-1.6 1-3 2.6-2.8.4-1.4 2-2 3.3-1.2 1-1 2.7-.9 3.4.4 1.6-.4 3 .9 2.8 2.5 1.3.6 1.7 2.2.9 3.4.7 1.4-.2 3-1.7 3.1-.3 1.5-2 2.2-3.3 1.4-1 1-2.7.7-3.3-.6-1.5.3-2.9-.9-2.7-2.4-1.4-.4-2.1-1.9-1.3-3.2-.5-.5-.7-1.2-.4-1.8z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><g stroke="rgba(74,48,22,.22)" stroke-width=".6" fill="none"><path d="M9 11c1 1 1.5 3 1 4.5M14 10.5c-.5 1.5 0 3.5 1 4.5"/></g></symbol>
+<symbol id="zif-mushroom" viewBox="0 0 24 24"><path d="M4.5 12.5c0-4.1 3.4-7 7.5-7s7.5 2.9 7.5 7c0 .6-.5 1-1.1 1H5.6c-.6 0-1.1-.4-1.1-1z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M9.5 13.5v3.5c0 1.4 1.1 2.5 2.5 2.5s2.5-1.1 2.5-2.5v-3.5z" fill="#ede4d2" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><g fill="rgba(255,255,255,.45)"><circle cx="9" cy="9.5" r=".9"/><circle cx="14" cy="8.8" r=".7"/><circle cx="12" cy="10.5" r=".6"/></g></symbol>
+<symbol id="zif-brinjal" viewBox="0 0 24 24"><path d="M13.6 7c3 0 5.4 2.8 5.4 6.2 0 3.8-3 6.8-6.6 6.8s-6.4-3-6.4-6.8C6 9.8 9 7 12 7z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M12 7c-.3-1.6.4-3 1.8-3.7M12 7c.6-1.2 1.8-1.6 3-1.2M12 7c-1-.8-2.3-.7-3.2.2" stroke="#5f9e42" stroke-width="1.3" stroke-linecap="round" fill="none"/><path d="M12.6 4.4l1.3-1.3" stroke="#7a5a36" stroke-width="1.4" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zif-okra" viewBox="0 0 24 24"><path d="M12 4.5c-.6 0-1 .5-1 1.1l-.2 1.2c-.8.4-1.3 1-1.5 2l-1.2 8.4c-.2 1.4.8 2.8 2.2 2.8h1.4c1.4 0 2.4-1.4 2.2-2.8l-1.2-8.4c-.2-1-.7-1.6-1.5-2L13 5.6c0-.6-.4-1.1-1-1.1z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><g stroke="rgba(74,48,22,.22)" stroke-width=".55" fill="none" opacity=".6"><path d="M10.2 9v9.5M13.8 9v9.5M12 8.5v11"/></g></symbol>
+<symbol id="zif-drumstick" viewBox="0 0 24 24"><path d="M12 3.5v17" stroke="currentColor" stroke-width="3.2" stroke-linecap="round" fill="none"/><g fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width=".6"><circle cx="12" cy="6" r="2"/><circle cx="12" cy="10" r="2"/><circle cx="12" cy="14" r="2"/><circle cx="12" cy="18" r="2"/></g></symbol>
+<symbol id="zif-cabbage" viewBox="0 0 24 24"><circle cx="12" cy="13" r="8" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"/><g stroke="rgba(255,255,255,.5)" stroke-width=".9" fill="none"><path d="M12 5c-3 2-4 6-3 10M12 5c3 2 4 6 3 10M8 8c-2 2.5-2 6.5 0 9M16 8c2 2.5 2 6.5 0 9M12 5v16"/></g></symbol>
+<symbol id="zif-banana" viewBox="0 0 24 24"><path d="M4 7c1 6.8 6.3 11.8 13.4 11.8 1.1 0 1.9-.5 1.9-1.4 0-.7-.6-1-1.3-1.1C12 15.7 8.1 11 7.3 6.2 7.1 5.4 6.6 5 5.8 5 4.8 5 3.9 5.8 4 7z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M4.9 5.6c.3-.5.9-.8 1.5-.6" stroke="#7a5a36" stroke-width="1.4" stroke-linecap="round" fill="none"/><circle cx="18.6" cy="17" r="1" fill="#7a5a36"/></symbol>
+<symbol id="zif-pear" viewBox="0 0 24 24"><path d="M12 5.6c-1 0-1.6 1-1.3 2.2-.2.2-1.7 1.1-2.2 3.2-.6 2.5.3 5.8 1.6 7.5 1 1.4 3 1.4 4 0 1.3-1.7 2.2-5 1.6-7.5-.5-2.1-2-3-2.2-3.2.3-1.2-.3-2.2-1.3-2.2z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M12 5.6V3.8" stroke="#7a5a36" stroke-width="1.4" stroke-linecap="round" fill="none"/><path d="M12 5c1-1.5 2.6-1.7 3.5-1.4-.2 1.6-1.7 2.1-3.5 1.4z" fill="#5f9e42"/></symbol>
+<symbol id="zif-apple" viewBox="0 0 24 24"><path d="M12 7.5c-1.3-1-3-1.3-4.5-.6C5.5 7.8 4.5 10 4.8 12.5c.4 3.5 2.7 7 4.7 7.5 1 .3 1.7-.3 2.5-.3s1.5.6 2.5.3c2-.5 4.3-4 4.7-7.5.3-2.5-.7-4.7-2.7-5.6-1.5-.7-3.2-.4-4.5.6z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M12 7.5V4.5" stroke="#7a5a36" stroke-width="1.5" stroke-linecap="round" fill="none"/><path d="M12 6c1-2 3-2.3 4-2-.2 2-2 2.6-4 2z" fill="#5f9e42"/><ellipse cx="8.8" cy="11.5" rx="1.3" ry="2.2" fill="rgba(255,255,255,.35)" transform="rotate(-20 8.8 11.5)"/></symbol>
+<symbol id="zif-mango" viewBox="0 0 24 24"><path d="M13.6 5.4c3.3.2 5.9 2.9 5.9 6.5 0 4.6-3.5 8.4-7.7 8.4-3.5 0-6.3-2.4-6.3-5.9 0-4.9 4-9.3 8.1-9z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M13.6 5.4c.2-1 1.1-1.7 2.3-1.8" stroke="#7a5a36" stroke-width="1.3" stroke-linecap="round" fill="none"/><path d="M15.6 3.9c1-.6 2.2-.4 2.9.4-.8.9-2.1.8-2.9-.4z" fill="#5f9e42"/><ellipse cx="10" cy="11.3" rx="1.6" ry="2.7" fill="rgba(255,255,255,.28)" transform="rotate(-28 10 11.3)"/></symbol>
+<symbol id="zif-avocado" viewBox="0 0 24 24"><path d="M12 3.4c3.7 0 5.8 4.1 5.8 9 0 4.9-2.9 8.4-5.8 8.4S6.2 17.3 6.2 12.4c0-4.9 2.1-9 5.8-9z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M12 6.2c2.4 0 3.7 3 3.7 6.4 0 3.5-1.9 6-3.7 6s-3.7-2.5-3.7-6c0-3.4 1.3-6.4 3.7-6.4z" fill="#d3e3a3"/><circle cx="12" cy="14" r="2.7" fill="#9a6b3f"/></symbol>
+<symbol id="zif-blueberry" viewBox="0 0 24 24"><g fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"><circle cx="8.5" cy="13" r="4"/><circle cx="15.5" cy="13" r="4"/><circle cx="12" cy="9.8" r="4"/></g><g stroke="rgba(255,255,255,.6)" stroke-width=".8" stroke-linecap="round" fill="none"><path d="M12 9.8l-1.1-1M12 9.8l1.1-1M12 9.8V8.3"/></g></symbol>
+<symbol id="zif-strawberry" viewBox="0 0 24 24"><path d="M12 20.5c-3-1.5-6.5-5-6.5-9 0-1.8 1.5-2.8 3-2.5 1-.8 2-1.2 3.5-1.2s2.5.4 3.5 1.2c1.5-.3 3 .7 3 2.5 0 4-3.5 7.5-6.5 9z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><g fill="#5f9e42"><path d="M12 8c-1.2-1.2-2.6-1.5-4-1 .8 1.4 2.2 1.8 4 1zM12 8c1.2-1.2 2.6-1.5 4-1-.8 1.4-2.2 1.8-4 1z"/><rect x="11.4" y="5.2" width="1.2" height="2.8" rx=".6"/></g><g fill="rgba(255,255,255,.65)"><circle cx="10" cy="12" r=".5"/><circle cx="13.5" cy="12.5" r=".5"/><circle cx="12" cy="14.5" r=".5"/><circle cx="9.5" cy="15" r=".5"/><circle cx="14" cy="15.5" r=".5"/></g></symbol>
+<symbol id="zif-grapes" viewBox="0 0 24 24"><path d="M12 5.5V8" stroke="#7a5a36" stroke-width="1.3" stroke-linecap="round" fill="none"/><path d="M12 6c1-1.3 2.6-1.5 3.6-1-.2 1.6-1.8 2.1-3.6 1z" fill="#5f9e42"/><g fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width=".8"><circle cx="9.5" cy="11" r="2"/><circle cx="14.5" cy="11" r="2"/><circle cx="12" cy="12.5" r="2"/><circle cx="8.5" cy="14.5" r="2"/><circle cx="15.5" cy="14.5" r="2"/><circle cx="11" cy="15.5" r="2"/><circle cx="13.5" cy="16.5" r="2"/><circle cx="12" cy="19" r="2"/></g></symbol>
+<symbol id="zif-date" viewBox="0 0 24 24"><ellipse cx="12" cy="12.5" rx="3.8" ry="7.4" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"/><g stroke="rgba(255,255,255,.3)" stroke-width=".7" fill="none"><path d="M12 5.5v14M10 6.5c-.7 4-.7 8 0 11M14 6.5c.7 4 .7 8 0 11"/></g><ellipse cx="12" cy="5.4" rx="1.3" ry=".8" fill="#7a5a36"/></symbol>
+<symbol id="zif-papaya" viewBox="0 0 24 24"><path d="M4 10.5c0-2.2 3.6-4 8-4s8 1.8 8 4c0 4.2-3.6 9-8 9s-8-4.8-8-9z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><g fill="rgba(74,48,22,.55)"><circle cx="10" cy="11.5" r=".8"/><circle cx="13.5" cy="11" r=".8"/><circle cx="12" cy="13.5" r=".8"/><circle cx="9.5" cy="14" r=".8"/><circle cx="14" cy="14" r=".8"/><circle cx="11.5" cy="15.8" r=".8"/></g></symbol>
+<symbol id="zif-orange" viewBox="0 0 24 24"><circle cx="12" cy="13" r="7" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"/><g stroke="rgba(255,255,255,.4)" stroke-width=".8" fill="none"><path d="M12 13V6M12 13l6 3.5M12 13l-6 3.5M12 13l6-3.5M12 13l-6-3.5M12 13v7"/></g><circle cx="12" cy="6" r="1" fill="#7a5a36"/><path d="M12.5 6c1-1 2.4-1 3-.4-.4 1.2-1.8 1.4-3 .4z" fill="#5f9e42"/></symbol>
+<symbol id="zif-pomegranate" viewBox="0 0 24 24"><circle cx="12" cy="14" r="6.6" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"/><path d="M12 7.4l-1.6-2.4 1.6 1.2 1.6-1.2-1.6 2.4z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M9.8 5.5l2.2 1.9 2.2-1.9" stroke="rgba(74,48,22,.22)" stroke-width="1" fill="none"/><g fill="rgba(255,255,255,.55)"><circle cx="10" cy="13" r=".7"/><circle cx="13.5" cy="12.5" r=".7"/><circle cx="12" cy="15" r=".7"/><circle cx="14.5" cy="15" r=".7"/><circle cx="9.5" cy="15.5" r=".7"/></g></symbol>
+<symbol id="zif-watermelon" viewBox="0 0 24 24"><path d="M3.5 16C9 19 15 19 20.5 16L12 4z" fill="#5f9e42" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M5.5 15.3C9.7 17.4 14.3 17.4 18.5 15.3L12 6.8z" fill="currentColor"/><g fill="rgba(74,48,22,.6)"><circle cx="12" cy="12" r=".6"/><circle cx="10" cy="14" r=".6"/><circle cx="14" cy="14" r=".6"/><circle cx="12" cy="15.2" r=".6"/></g></symbol>
+<symbol id="zif-kiwi" viewBox="0 0 24 24"><circle cx="12" cy="13" r="7" fill="#8a6a3a" stroke="rgba(74,48,22,.22)" stroke-width="1"/><circle cx="12" cy="13" r="5.4" fill="currentColor"/><circle cx="12" cy="13" r="1.4" fill="rgba(255,255,255,.7)"/><g fill="rgba(74,48,22,.5)"><circle cx="12" cy="9" r=".5"/><circle cx="15.5" cy="11" r=".5"/><circle cx="15" cy="15" r=".5"/><circle cx="12" cy="17" r=".5"/><circle cx="9" cy="15" r=".5"/><circle cx="8.5" cy="11" r=".5"/></g></symbol>
+<symbol id="zif-coconut" viewBox="0 0 24 24"><circle cx="12" cy="12.6" r="8" fill="#8a6a3a" stroke="rgba(74,48,22,.22)" stroke-width="1"/><circle cx="12" cy="12.6" r="6" fill="currentColor"/><circle cx="12" cy="12.6" r="2.9" fill="rgba(74,48,22,.16)"/><g stroke="rgba(74,48,22,.3)" stroke-width=".7" fill="none" stroke-linecap="round"><path d="M5.2 9.6c.9.4 1.4 1.2 1.5 2.2M18.8 15.6c-.9-.4-1.4-1.2-1.5-2.2M6 16.5c.8-.3 1.7-.2 2.3.3"/></g></symbol>
+<symbol id="zif-apricot" viewBox="0 0 24 24"><circle cx="12" cy="13.5" r="6.5" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"/><path d="M12 7.2v12.6" stroke="rgba(74,48,22,.22)" stroke-width=".8" opacity=".5" fill="none"/><path d="M12 7.5c.2-1.2 1.2-2 2.4-2.1" stroke="#5f9e42" stroke-width="1.3" stroke-linecap="round" fill="none"/><path d="M14 5.2c1-.5 2-.2 2.5.6-.8.7-1.9.5-2.5-.6z" fill="#5f9e42"/></symbol>
+<symbol id="zif-fig" viewBox="0 0 24 24"><path d="M12 6.5c-3.3 0-5.8 2.8-5.8 6.3 0 3.8 2.6 6.7 5.8 6.7s5.8-2.9 5.8-6.7c0-3.5-2.5-6.3-5.8-6.3z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M12 6.5V4.4" stroke="#7a5a36" stroke-width="1.3" stroke-linecap="round" fill="none"/><path d="M12 5c1-1.2 2.4-1.4 3.4-1-.3 1.4-1.7 1.8-3.4 1z" fill="#5f9e42"/><g fill="rgba(216,71,73,.35)"><circle cx="10.5" cy="13" r=".5"/><circle cx="13.5" cy="13" r=".5"/><circle cx="12" cy="15" r=".5"/><circle cx="11.5" cy="11.5" r=".5"/></g></symbol>
+<symbol id="zif-prune" viewBox="0 0 24 24"><ellipse cx="12" cy="13" rx="6" ry="7" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"/><g stroke="rgba(0,0,0,.2)" stroke-width=".8" fill="none"><path d="M9 8c-1 3-1 7 .5 10M15 8c1 3 1 7-.5 10M12 6.5v13"/></g></symbol>
+<symbol id="zif-raisin" viewBox="0 0 24 24"><g fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width=".9"><ellipse cx="9.5" cy="11" rx="2.6" ry="3.4" transform="rotate(-15 9.5 11)"/><ellipse cx="14.5" cy="13.5" rx="2.6" ry="3.4" transform="rotate(12 14.5 13.5)"/></g><g stroke="rgba(0,0,0,.22)" stroke-width=".6" fill="none"><path d="M8.6 9c.5 2 .5 3.5 0 5M15.4 11.5c.5 2 .5 3.5 0 5"/></g></symbol>
+<symbol id="zif-custardapple" viewBox="0 0 24 24"><circle cx="12" cy="13" r="7" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"/><g stroke="rgba(74,48,22,.22)" stroke-width=".7" fill="none" opacity=".65"><path d="M8 9.5l2 2M12 7.5v2.5M16 9.5l-2 2M7 13.5h2.5M17 13.5h-2.5M9 17l1.5-1.5M15 17l-1.5-1.5M12 12l-1.5 1.5M12 12l1.5 1.5"/></g><path d="M12 6c0-1 .8-1.8 2-2" stroke="#7a5a36" stroke-width="1.3" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zif-sapota" viewBox="0 0 24 24"><ellipse cx="12" cy="13" rx="6.5" ry="7" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"/><path d="M12 6c0-1 .6-1.8 1.6-2" stroke="#7a5a36" stroke-width="1.3" stroke-linecap="round" fill="none"/><path d="M11 6c-1-.5-2.2-.2-2.8.8 1 .6 2.2.3 2.8-.8z" fill="#5f9e42"/></symbol>
+<symbol id="zif-pineapple" viewBox="0 0 24 24"><ellipse cx="12" cy="15" rx="5.5" ry="6.3" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"/><g stroke="rgba(74,48,22,.22)" stroke-width=".6" fill="none" opacity=".7"><path d="M7.5 12l8 7.5M16.5 12l-8 7.5M8 15.5l4 3.5M16 15.5l-4 3.5"/></g><g fill="#5f9e42"><path d="M12 9.5c-1-2.5-.5-4.5.5-5.7 1 1.6 1.2 3.7.5 5.7zM10 10c-1.5-2-2-4-1.5-5.6 1.5 1 2.3 2.9 1.5 5.6zM14 10c1.5-2 2-4 1.5-5.6-1.5 1-2.3 2.9-1.5 5.6z"/></g></symbol>
+<symbol id="zif-peach" viewBox="0 0 24 24"><circle cx="12" cy="13.5" r="6.5" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"/><path d="M12 7.3c-.6 3-.6 9 0 12.4" stroke="rgba(74,48,22,.22)" stroke-width=".8" opacity=".45" fill="none"/><path d="M12 7.5c.3-1.4 1.4-2.2 2.8-2.2" stroke="#5f9e42" stroke-width="1.3" stroke-linecap="round" fill="none"/><path d="M14.2 5.3c1-.6 2.2-.4 2.8.5-.8.7-2 .6-2.8-.5z" fill="#5f9e42"/></symbol>
+<symbol id="zif-plum" viewBox="0 0 24 24"><ellipse cx="12" cy="13" rx="6" ry="6.8" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"/><path d="M12 6.4c-.6 3-.6 9.6 0 13.2" stroke="rgba(0,0,0,.2)" stroke-width=".9" fill="none"/><path d="M12 6.5c.2-1 1-1.7 2-1.9" stroke="#7a5a36" stroke-width="1.2" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zif-muskmelon" viewBox="0 0 24 24"><circle cx="12" cy="13" r="7" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"/><g stroke="rgba(74,48,22,.3)" stroke-width=".55" fill="none"><path d="M6 11c3-1 9-1 12 0M5.5 14c3.5-.8 9.5-.8 13 0M7 17c2.5-.6 7.5-.6 10 0M8 8.5c2-.5 6-.5 8 0M9 13c1 1 5 1 6 0"/></g></symbol>
+<symbol id="zif-guava" viewBox="0 0 24 24"><circle cx="12" cy="13.5" r="6.5" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"/><circle cx="12" cy="13.5" r="2.6" fill="rgba(216,71,73,.22)"/><g fill="rgba(74,48,22,.4)"><circle cx="11" cy="13" r=".4"/><circle cx="13" cy="13" r=".4"/><circle cx="12" cy="14.6" r=".4"/></g><path d="M12 7c0-1 .8-1.8 2-2" stroke="#5f9e42" stroke-width="1.3" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zif-raspberry" viewBox="0 0 24 24"><g fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width=".7"><circle cx="10" cy="12.5" r="1.9"/><circle cx="14" cy="12.5" r="1.9"/><circle cx="12" cy="11" r="1.9"/><circle cx="11" cy="15" r="1.9"/><circle cx="13" cy="15" r="1.9"/><circle cx="12" cy="17.2" r="1.9"/></g><g fill="#5f9e42"><path d="M12 8c-1-1.5-2.5-1.8-4-1.2.8 1.4 2.3 1.8 4 1.2zM12 8c1-1.5 2.5-1.8 4-1.2-.8 1.4-2.3 1.8-4 1.2z"/></g></symbol>
+<symbol id="zif-cranberry" viewBox="0 0 24 24"><g fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"><circle cx="9.5" cy="13" r="4"/><circle cx="15" cy="12.5" r="3.6"/></g><g fill="rgba(0,0,0,.22)"><circle cx="9.5" cy="9.2" r=".5"/><circle cx="15" cy="9.1" r=".5"/></g></symbol>
+<symbol id="zif-lemon" viewBox="0 0 24 24"><ellipse cx="12" cy="13" rx="7.5" ry="6" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" transform="rotate(-12 12 13)"/><path d="M4.8 11.4l-1.4-.4M19.2 14.6l1.4.4" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" fill="none"/><path d="M12 7.6c1-1 2.5-1 3.2-.2" stroke="#5f9e42" stroke-width="1.3" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zif-paneer" viewBox="0 0 24 24"><path d="M12 3.5l7.5 3.8v9L12 20l-7.5-3.7v-9z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M4.5 7.3L12 11l7.5-3.7M12 11v9" stroke="rgba(74,48,22,.22)" stroke-width="1" fill="none" stroke-linejoin="round"/></symbol>
+<symbol id="zif-milk" viewBox="0 0 24 24"><path d="M8 7h8l-.7 11.5c-.07 1.1-1 2-2.1 2h-2.4c-1.1 0-2-.9-2.1-2z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M9 4.5h6V7H9z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M8.3 11h7.4" stroke="rgba(74,48,22,.22)" stroke-width="1" fill="none"/></symbol>
+<symbol id="zif-ghee" viewBox="0 0 24 24"><rect x="7" y="3.3" width="10" height="2.9" rx=".9" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M6.4 6.2h11.2v9.6a3.7 3.7 0 01-3.7 3.7h-3.8a3.7 3.7 0 01-3.7-3.7z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M6.7 10.4c1.6-1 2.9.8 4.4 0s2.9.8 4.4 0l.8-.4" stroke="rgba(74,48,22,.28)" stroke-width="1" fill="none" stroke-linecap="round"/><ellipse cx="9" cy="8.2" rx="1" ry="1.7" fill="rgba(255,255,255,.42)"/></symbol>
+<symbol id="zif-curd" viewBox="0 0 24 24"><path d="M4 12h16c0 4.4-3.6 8-8 8s-8-3.6-8-8z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M8 12c0-2.2 1.8-4 4-4s4 1.8 4 4z" fill="#fff" stroke="rgba(74,48,22,.18)" stroke-width=".9" stroke-linejoin="round"/></symbol>
+<symbol id="zif-cheese" viewBox="0 0 24 24"><path d="M4 18V13l15-4c.6 2 1 4.5 1 9H4z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M4 13l15-4" stroke="rgba(74,48,22,.22)" stroke-width="1" fill="none"/><g fill="rgba(74,48,22,.25)"><circle cx="9" cy="16" r="1.1"/><circle cx="14" cy="15.5" r="1"/><circle cx="16.5" cy="13" r=".8"/></g></symbol>
+<symbol id="zif-butter" viewBox="0 0 24 24"><path d="M4 14l4-3h9a2 2 0 012 2v3a2 2 0 01-2 2H6a2 2 0 01-2-2z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M4 14l4-3M8 11v8" stroke="rgba(74,48,22,.22)" stroke-width="1" fill="none"/></symbol>
+<symbol id="zif-buttermilk" viewBox="0 0 24 24"><path d="M8 6h8l-.6 13c-.07 1.1-1 2-2.1 2h-2.6c-1.1 0-2-.9-2.1-2z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M8.3 9c1.5-.8 2.7.8 4.2 0s3.2.6 3.2.6" stroke="rgba(74,48,22,.25)" stroke-width="1" fill="none" stroke-linecap="round"/><g fill="rgba(255,255,255,.5)"><circle cx="10" cy="7.5" r=".5"/><circle cx="13" cy="7.2" r=".5"/></g></symbol>
+<symbol id="zif-egg" viewBox="0 0 24 24"><ellipse cx="12" cy="13.5" rx="6" ry="8" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1"/><circle cx="12" cy="14.5" r="2.7" fill="#f4b740"/></symbol>
+<symbol id="zif-almond" viewBox="0 0 24 24"><path d="M12 3.5c3.8 1.9 5.9 5.6 5.9 9.4 0 3.7-2.3 6.7-5.9 7.8-3.6-1.1-5.9-4.1-5.9-7.8 0-3.8 2.1-7.5 5.9-9.4z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M12 5.5v13.5" stroke="rgba(74,48,22,.3)" stroke-width=".9" fill="none"/></symbol>
+<symbol id="zif-walnut" viewBox="0 0 24 24"><path d="M12 3.4c4.4 0 7.4 3.6 7.4 8.1 0 5-3.4 9-7.4 9s-7.4-4-7.4-9c0-4.5 3-8.1 7.4-8.1z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M12 4.1v15.8" stroke="rgba(74,48,22,.3)" stroke-width="1" fill="none"/><g stroke="rgba(74,48,22,.3)" stroke-width=".9" fill="none" stroke-linecap="round"><path d="M9.4 6.6c-2 2.6-2.1 7.2.3 10.8M14.6 6.6c2 2.6 2.1 7.2-.3 10.8M10.7 9.2c-1 1.6-.8 4.2.6 6.2M13.3 9.2c1 1.6.8 4.2-.6 6.2"/></g></symbol>
+<symbol id="zif-cashew" viewBox="0 0 24 24"><path d="M15.5 4.5c-1.2 0-2 .8-2.2 1.9-.9 1.7-2.6 2.7-2.6 4.8 0 1.7-1.5 2.6-3 2.8-1.4.2-2.7 1.2-2.7 2.8 0 1.6 1.3 2.9 2.9 2.9 3.6 0 6.5-2.9 6.5-6.5 0-1.6-.6-2.4-.6-3.4 0-1.3 1-2 1-3.3 0-1.5-1-2.7-2.8-2.7z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/></symbol>
+<symbol id="zif-pistachio" viewBox="0 0 24 24"><path d="M12 4c-3.5 1.6-5.5 5-5.5 8.6 0 3.5 2.2 6.4 5.5 7.4 3.3-1 5.5-3.9 5.5-7.4C17.5 9 15.5 5.6 12 4z" fill="#cfe0a0" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M12 4c-3 1.4-4.8 4.3-5.3 7.4 3.5.5 7.1.5 10.6 0C16.8 8.3 15 5.4 12 4z" fill="currentColor"/><path d="M8 13l3 2 2-2 3 1.6" stroke="rgba(0,0,0,.16)" stroke-width=".8" fill="none"/></symbol>
+<symbol id="zif-cumin" viewBox="0 0 24 24"><g fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width=".6"><path d="M8 7c1.5 1 2 3 1.5 5.5" stroke-width="1.6" stroke-linecap="round" fill="none"/><path d="M12 6c1.2 1.2 1.5 3.3.8 5.8" stroke-width="1.6" stroke-linecap="round" fill="none"/><path d="M16 7.5c1 1.3 1 3.4 0 5.7" stroke-width="1.6" stroke-linecap="round" fill="none"/><path d="M9.5 14c1.5 1 2 3 1.5 5" stroke-width="1.6" stroke-linecap="round" fill="none"/><path d="M14 13.5c1.2 1.2 1.3 3.3.6 5.3" stroke-width="1.6" stroke-linecap="round" fill="none"/></g></symbol>
+<symbol id="zif-pumpkinseed" viewBox="0 0 24 24"><g fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"><path d="M10 6.5c-2 1.5-3 4-3 6.5 0 2 1.3 3.5 3 3.5s3-1.5 3-3.5c0-2.5-1-5-3-6.5z" transform="rotate(-15 10 11.5)"/><path d="M15 9c-2 1.5-3 4-3 6.5 0 2 1.3 3.5 3 3.5s3-1.5 3-3.5c0-2.5-1-5-3-6.5z" transform="rotate(12 15 14)"/></g></symbol>
+<symbol id="zif-chia" viewBox="0 0 24 24"><g fill="currentColor"><ellipse cx="8" cy="9" rx="1.3" ry="1"/><ellipse cx="12" cy="8" rx="1.3" ry="1" transform="rotate(20 12 8)"/><ellipse cx="15.5" cy="10" rx="1.3" ry="1"/><ellipse cx="9.5" cy="12" rx="1.3" ry="1" transform="rotate(-15 9.5 12)"/><ellipse cx="13" cy="11.5" rx="1.3" ry="1"/><ellipse cx="11" cy="15" rx="1.3" ry="1" transform="rotate(15 11 15)"/><ellipse cx="14.5" cy="14.5" rx="1.3" ry="1"/></g></symbol>
+<symbol id="zif-flaxseed" viewBox="0 0 24 24"><g fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width=".7"><path d="M7 11c2-1.5 5-1.5 7 0-2 1.5-5 1.5-7 0z"/><path d="M11 14c2-1.5 5-1.5 7 0-2 1.5-5 1.5-7 0z"/><path d="M9 8c1.8-1.3 4.2-1.3 6 0-1.8 1.3-4.2 1.3-6 0z"/></g></symbol>
+<symbol id="zif-sesame" viewBox="0 0 24 24"><g fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width=".55"><ellipse cx="8.5" cy="10" rx="1.6" ry="1"/><ellipse cx="12" cy="9" rx="1.6" ry="1"/><ellipse cx="15.5" cy="10.5" rx="1.6" ry="1"/><ellipse cx="10" cy="13" rx="1.6" ry="1"/><ellipse cx="13.5" cy="12.5" rx="1.6" ry="1"/><ellipse cx="11.5" cy="15.5" rx="1.6" ry="1"/></g></symbol>
+<symbol id="zif-fish" viewBox="0 0 24 24"><path d="M3 12c3-4.2 8-5.2 12-5.2-1 1.6-1 3.6 0 5.2 1 1.6 1 3.6 0 5.2-4 0-9-1-12-5.2z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M15 6.8l5-2v14.4l-5-2" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><circle cx="6.3" cy="10.8" r="1" fill="#fff"/><circle cx="6.3" cy="10.8" r=".45" fill="rgba(74,48,22,.7)"/><path d="M9 12h4" stroke="rgba(255,255,255,.45)" stroke-width="1" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zif-chicken" viewBox="0 0 24 24"><path d="M15.5 4.5a5 5 0 00-7.2 6.8l.6.7-3.4 3.4a2 2 0 102.8 2.8l3.4-3.4.7.6a5 5 0 003.1-10.9z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M6.2 15.5l-1.6 1.6M8 17.3l-1.6 1.6" stroke="#fff" stroke-width="1.6" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zif-tofu" viewBox="0 0 24 24"><path d="M12 3.5l7.5 3.8v9L12 20l-7.5-3.7v-9z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M4.5 7.3L12 11l7.5-3.7M12 11v9" stroke="rgba(74,48,22,.22)" stroke-width="1" fill="none" stroke-linejoin="round"/></symbol>
+<symbol id="zif-prawn" viewBox="0 0 24 24"><path d="M16 6c-4 0-7 3-7 7 0 3 2 5 5 5h2c.6 0 1-.5 1-1s-.4-1-1-1h-2c-1.6 0-3-1.3-3-3 0-2.5 2-4.5 5-4.5.6 0 1-.5 1-1s-.4-1-1-1z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M16 6c1-.5 2-.3 2.5.5M9.5 16l-2 2M11 18l-1.5 1.8" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linecap="round" fill="none"/><circle cx="16" cy="8.5" r=".7" fill="rgba(0,0,0,.5)"/></symbol>
+<symbol id="zif-mutton" viewBox="0 0 24 24"><ellipse cx="13.5" cy="12" rx="6" ry="5.4" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" transform="rotate(-22 13.5 12)"/><path d="M11 14.5l-6 5.5" stroke="#f1ead8" stroke-width="3.2" stroke-linecap="round"/><circle cx="5.2" cy="19.6" r="1.7" fill="#f1ead8" stroke="rgba(74,48,22,.22)" stroke-width=".8"/><circle cx="6.6" cy="18.2" r="1.5" fill="#f1ead8" stroke="rgba(74,48,22,.22)" stroke-width=".8"/><ellipse cx="12" cy="10" rx="1.6" ry="1" fill="rgba(255,255,255,.3)" transform="rotate(-22 12 10)"/></symbol>
+<symbol id="zif-jaggery" viewBox="0 0 24 24"><path d="M4.6 14.2l1.3-4.4 4.2-2.1 4.7.3 3.4 2.9-.6 5-4.4 2.7-6 .2z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M5.9 9.8l4.4 1.9 4.5-1.6M10.3 11.7l-.5 7.2" stroke="rgba(74,48,22,.28)" stroke-width=".8" fill="none"/><path d="M17.4 17.2l2 .6-.5 1.9-1.9-.5z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width=".8" stroke-linejoin="round"/><g fill="rgba(74,48,22,.32)"><circle cx="8.4" cy="13.4" r=".4"/><circle cx="12" cy="14.2" r=".4"/><circle cx="13.8" cy="12.6" r=".4"/><circle cx="10.2" cy="15.4" r=".4"/></g></symbol>
+<symbol id="zif-honey" viewBox="0 0 24 24"><path d="M7 5h10v2l-1.5 1.5v3L17 14v4a2 2 0 01-2 2H9a2 2 0 01-2-2v-4l1.5-2.5v-3L7 7z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M9 15h6" stroke="rgba(74,48,22,.25)" stroke-width="1" fill="none"/></symbol>
+<symbol id="zif-oil" viewBox="0 0 24 24"><path d="M9 4.5h6v2.5l3 2v8.5a2 2 0 01-2 2H8a2 2 0 01-2-2V9l3-2z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M11 4.5h2V3h-2z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M6.2 12h11.6" stroke="rgba(74,48,22,.25)" stroke-width="1" fill="none"/><path d="M11 15c0 1 1.5 1.2 1.5 2.6" stroke="rgba(255,255,255,.5)" stroke-width="1" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zif-turmeric" viewBox="0 0 24 24"><path d="M6.5 12c-1-.3-1.4-1.4-.8-2.3.5-.7 1.4-.8 2.1-.4.2-1.1 1.2-1.8 2.3-1.5.5-1 1.7-1.3 2.6-.6.8-.6 1.9-.4 2.4.5.9-.1 1.6.5 1.6 1.4 0 .8-.5 1.4-1.3 1.5.3 1-.3 2.1-1.3 2.3-.4 1-1.6 1.5-2.5 1-.7.7-1.9.6-2.5-.2-.9.2-1.8-.4-1.9-1.3-.9 0-1.5-.9-1.2-1.7z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><g stroke="rgba(74,48,22,.22)" stroke-width=".5" fill="none" opacity=".5"><path d="M9 11c.8.6 1.2 1.8 1 3M13 10.5c-.3 1.1.2 2.4 1 3"/></g></symbol>
+<symbol id="zif-blackpepper" viewBox="0 0 24 24"><g fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width=".8"><circle cx="9" cy="10" r="2.4"/><circle cx="14" cy="9.5" r="2.4"/><circle cx="11.5" cy="13.6" r="2.4"/><circle cx="15.6" cy="13.6" r="2.4"/></g><g stroke="rgba(0,0,0,.3)" stroke-width=".5" fill="none"><path d="M8 9c.5.8 1.5 1 2 .5M13 8.8c.5.8 1.5 1 2 .5"/></g></symbol>
+<symbol id="zif-cinnamon" viewBox="0 0 24 24"><rect x="8" y="4" width="8" height="16" rx="3" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" transform="rotate(12 12 12)"/><g stroke="rgba(0,0,0,.2)" stroke-width=".8" fill="none" transform="rotate(12 12 12)"><path d="M11 4.5v15M14 4v15.5"/></g></symbol>
+<symbol id="zif-cardamom" viewBox="0 0 24 24"><path d="M12 4c-2.5 0-4 2.5-4 6s1.5 10 4 10 4-6.5 4-10-1.5-6-4-6z" fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"/><path d="M12 5v14" stroke="rgba(74,48,22,.22)" stroke-width=".7" opacity=".5" fill="none"/><path d="M12 4c0-1 .6-1.6 1.5-1.8" stroke="#7a5a36" stroke-width="1.2" stroke-linecap="round" fill="none"/></symbol>
+<symbol id="zif-coriander" viewBox="0 0 24 24"><g fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width=".6"><path d="M9 7.5c-1.5 0-2.5 1-2.5 2.5 1.5 0 2.5-1 2.5-2.5z"/><path d="M12 6c-1.5 0-2.5 1-2.5 2.5 1.5 0 2.5-1 2.5-2.5z"/><path d="M15 7.5c-1.5 0-2.5 1-2.5 2.5 1.5 0 2.5-1 2.5-2.5z"/><path d="M10.5 10c-1.5 0-2.5 1-2.5 2.5 1.5 0 2.5-1 2.5-2.5z"/><path d="M13.5 10c-1.5 0-2.5 1-2.5 2.5 1.5 0 2.5-1 2.5-2.5z"/></g><g stroke="currentColor" stroke-width="1" stroke-linecap="round" fill="none"><path d="M9 8l1.3 11.5M12 6.5l0 13M15 8l-1.3 11.5"/></g></symbol>
+<symbol id="zif-mint" viewBox="0 0 24 24"><g fill="currentColor" stroke="rgba(74,48,22,.22)" stroke-width="1" stroke-linejoin="round"><path d="M11 5c-3 1-5 4-4.3 7.5C9.2 12 11.2 9.3 11 5z"/><path d="M13 7c3 1 4.5 4 3.7 7.5C13.5 13.7 12.6 10.6 13 7z"/></g><g stroke="rgba(255,255,255,.5)" stroke-width=".8" fill="none"><path d="M10 6.5c-1.5 1.5-2.5 3.5-2.6 5.2M14 8.5c1.3 1.3 2 3.1 2 4.7"/></g><path d="M12 13.5v6" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" fill="none"/></symbol></svg>
+<div class="sc-wrap">
+  <div class="sc-banner"><strong>Generated view — do not hand-edit.</strong> Rebuilt every build by <code>split/build-surface-catalog.mjs</code> from the live <code>split/styles.css</code> + sprite. This is the <strong>design surface</strong>: to build a new surface, add its exemplar to the <code>SURFACES</code> array in the generator first, review it here rendered (this is what ships — same stylesheet), get sign-off, then wire the feature with these exact classes. Edit exemplars in the generator, never this file.</div>
+
+  <div class="sc-h1">Surface Catalog</div>
+  <p class="sc-sub">Every canonical SproutLab surface, rendered with the live tokens in light + dark. The visual contract that prevents post-build surprises.</p>
+
+  <div class="sc-toolbar">
+    <span class="sc-zlabel">Zoom</span>
+    <button class="sc-zbtn active" data-zoom="default">Default</button>
+    <button class="sc-zbtn" data-zoom="med">Medium</button>
+    <button class="sc-zbtn" data-zoom="high">Large</button>
+  </div>
+
+  <table class="sc-rm"><tbody><tr class="sc-rm-live"><td>Heroes</td><td><span class="sc-badge sc-badge-live">live</span></td><td>Ziva Score + per-tab domain heroes</td></tr><tr class="sc-rm-next"><td>Cards</td><td><span class="sc-badge sc-badge-next">next</span></td><td>action / info / stat cards</td></tr><tr class="sc-rm-planned"><td>Chips &amp; pills</td><td><span class="sc-badge sc-badge-planned">planned</span></td><td>domain chips, food chips, status pills</td></tr><tr class="sc-rm-planned"><td>Inputs &amp; steppers</td><td><span class="sc-badge sc-badge-planned">planned</span></td><td>text/date/time inputs, qty steppers, intake pills</td></tr><tr class="sc-rm-planned"><td>Composer rails &amp; lists</td><td><span class="sc-badge sc-badge-planned">planned</span></td><td>L1–L4 rails, 48px item rows — where the white-bg + Diet-tab prediction-visibility regressions get settled</td></tr><tr class="sc-rm-planned"><td>Toasts &amp; overlays</td><td><span class="sc-badge sc-badge-planned">planned</span></td><td>undo toast, post-save flash, bottom sheets, score popup</td></tr><tr class="sc-rm-planned"><td>Interactions</td><td><span class="sc-badge sc-badge-planned">planned</span></td><td>save-on-action, burst + undo choreography, blur-dismiss</td></tr></tbody></table>
+
+  <h2 style="font-family:'Fraunces',serif;font-size:24px;color:var(--text,#3a2e2e);margin:10px 0 0;">Heroes</h2>
+  <section class="sc-surface" id="hero-ziva">
+    <h3>Ziva Score hero (Home)</h3>
+    <p class="sc-surface-note">The home front-door hero — composite score ring + per-domain pills. <code>.ziva-score-hero.zs-score-{label}</code>. Tap a domain pill to jump to that tab; tap the ring for the score popup.</p>
+    
+    <div class="sc-specimen">
+      <div class="sc-specimen-label">Strong week</div>
+      <div class="sc-render-row">
+        <div class="sc-panel"><span class="sc-mode">Light</span><div class="sc-stage"><div class="ziva-score-hero zs-score-great">
+    <div class="zs-ring">
+      <div class="zs-number">84</div>
+      <div class="zs-label">Ziva Score</div>
+      <div class="zs-trend">↑ +4 vs last week</div>
+    </div>
+    <div class="zs-domains"><div class="zs-domain-pill zsd-great">
+      <div class="zsd-icon"><svg class="zi" aria-hidden="true"><use href="#zi-moon"/></svg></div>
+      <div class="zsd-text"><div class="zsd-score">79</div><div class="zsd-label">Sleep</div></div>
+    </div><div class="zs-domain-pill zsd-great">
+      <div class="zsd-icon"><svg class="zi" aria-hidden="true"><use href="#zi-bowl"/></svg></div>
+      <div class="zsd-text"><div class="zsd-score">88</div><div class="zsd-label">Diet</div></div>
+    </div><div class="zs-domain-pill zsd-good">
+      <div class="zsd-icon"><svg class="zi" aria-hidden="true"><use href="#zi-diaper"/></svg></div>
+      <div class="zsd-text"><div class="zsd-score">72</div><div class="zsd-label">Poop</div></div>
+    </div><div class="zs-domain-pill zsd-excellent">
+      <div class="zsd-icon"><svg class="zi" aria-hidden="true"><use href="#zi-medical"/></svg></div>
+      <div class="zsd-text"><div class="zsd-score">95</div><div class="zsd-label">Medical</div></div>
+    </div><div class="zs-domain-pill zsd-good">
+      <div class="zsd-icon"><svg class="zi" aria-hidden="true"><use href="#zi-trophy"/></svg></div>
+      <div class="zsd-text"><div class="zsd-score">66</div><div class="zsd-label">Milestones</div></div>
+    </div></div>
+  </div></div></div>
+        <div class="sc-panel" data-theme="dark"><span class="sc-mode">Dark</span><div class="sc-stage"><div class="ziva-score-hero zs-score-great">
+    <div class="zs-ring">
+      <div class="zs-number">84</div>
+      <div class="zs-label">Ziva Score</div>
+      <div class="zs-trend">↑ +4 vs last week</div>
+    </div>
+    <div class="zs-domains"><div class="zs-domain-pill zsd-great">
+      <div class="zsd-icon"><svg class="zi" aria-hidden="true"><use href="#zi-moon"/></svg></div>
+      <div class="zsd-text"><div class="zsd-score">79</div><div class="zsd-label">Sleep</div></div>
+    </div><div class="zs-domain-pill zsd-great">
+      <div class="zsd-icon"><svg class="zi" aria-hidden="true"><use href="#zi-bowl"/></svg></div>
+      <div class="zsd-text"><div class="zsd-score">88</div><div class="zsd-label">Diet</div></div>
+    </div><div class="zs-domain-pill zsd-good">
+      <div class="zsd-icon"><svg class="zi" aria-hidden="true"><use href="#zi-diaper"/></svg></div>
+      <div class="zsd-text"><div class="zsd-score">72</div><div class="zsd-label">Poop</div></div>
+    </div><div class="zs-domain-pill zsd-excellent">
+      <div class="zsd-icon"><svg class="zi" aria-hidden="true"><use href="#zi-medical"/></svg></div>
+      <div class="zsd-text"><div class="zsd-score">95</div><div class="zsd-label">Medical</div></div>
+    </div><div class="zs-domain-pill zsd-good">
+      <div class="zsd-icon"><svg class="zi" aria-hidden="true"><use href="#zi-trophy"/></svg></div>
+      <div class="zsd-text"><div class="zsd-score">66</div><div class="zsd-label">Milestones</div></div>
+    </div></div>
+  </div></div></div>
+      </div>
+      <details class="sc-markup"><summary>Canonical markup</summary><pre><code>&lt;div class="ziva-score-hero zs-score-great"&gt;
+    &lt;div class="zs-ring"&gt;
+      &lt;div class="zs-number"&gt;84&lt;/div&gt;
+      &lt;div class="zs-label"&gt;Ziva Score&lt;/div&gt;
+      &lt;div class="zs-trend"&gt;↑ +4 vs last week&lt;/div&gt;
+    &lt;/div&gt;
+    &lt;div class="zs-domains"&gt;&lt;div class="zs-domain-pill zsd-great"&gt;
+      &lt;div class="zsd-icon"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-moon"/&gt;&lt;/svg&gt;&lt;/div&gt;
+      &lt;div class="zsd-text"&gt;&lt;div class="zsd-score"&gt;79&lt;/div&gt;&lt;div class="zsd-label"&gt;Sleep&lt;/div&gt;&lt;/div&gt;
+    &lt;/div&gt;&lt;div class="zs-domain-pill zsd-great"&gt;
+      &lt;div class="zsd-icon"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-bowl"/&gt;&lt;/svg&gt;&lt;/div&gt;
+      &lt;div class="zsd-text"&gt;&lt;div class="zsd-score"&gt;88&lt;/div&gt;&lt;div class="zsd-label"&gt;Diet&lt;/div&gt;&lt;/div&gt;
+    &lt;/div&gt;&lt;div class="zs-domain-pill zsd-good"&gt;
+      &lt;div class="zsd-icon"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-diaper"/&gt;&lt;/svg&gt;&lt;/div&gt;
+      &lt;div class="zsd-text"&gt;&lt;div class="zsd-score"&gt;72&lt;/div&gt;&lt;div class="zsd-label"&gt;Poop&lt;/div&gt;&lt;/div&gt;
+    &lt;/div&gt;&lt;div class="zs-domain-pill zsd-excellent"&gt;
+      &lt;div class="zsd-icon"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-medical"/&gt;&lt;/svg&gt;&lt;/div&gt;
+      &lt;div class="zsd-text"&gt;&lt;div class="zsd-score"&gt;95&lt;/div&gt;&lt;div class="zsd-label"&gt;Medical&lt;/div&gt;&lt;/div&gt;
+    &lt;/div&gt;&lt;div class="zs-domain-pill zsd-good"&gt;
+      &lt;div class="zsd-icon"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-trophy"/&gt;&lt;/svg&gt;&lt;/div&gt;
+      &lt;div class="zsd-text"&gt;&lt;div class="zsd-score"&gt;66&lt;/div&gt;&lt;div class="zsd-label"&gt;Milestones&lt;/div&gt;&lt;/div&gt;
+    &lt;/div&gt;&lt;/div&gt;
+  &lt;/div&gt;</code></pre></details>
+    </div>
+    <div class="sc-specimen">
+      <div class="sc-specimen-label">Needs attention + a not-yet-tracked domain</div>
+      <div class="sc-render-row">
+        <div class="sc-panel"><span class="sc-mode">Light</span><div class="sc-stage"><div class="ziva-score-hero zs-score-fair">
+    <div class="zs-ring">
+      <div class="zs-number">52</div>
+      <div class="zs-label">Ziva Score</div>
+      <div class="zs-trend">→ stable</div>
+    </div>
+    <div class="zs-domains"><div class="zs-domain-pill zsd-fair">
+      <div class="zsd-icon"><svg class="zi" aria-hidden="true"><use href="#zi-moon"/></svg></div>
+      <div class="zsd-text"><div class="zsd-score">48</div><div class="zsd-label">Sleep</div></div>
+    </div><div class="zs-domain-pill zsd-good">
+      <div class="zsd-icon"><svg class="zi" aria-hidden="true"><use href="#zi-bowl"/></svg></div>
+      <div class="zsd-text"><div class="zsd-score">61</div><div class="zsd-label">Diet</div></div>
+    </div><div class="zs-domain-pill zsd-attention">
+      <div class="zsd-icon"><svg class="zi" aria-hidden="true"><use href="#zi-diaper"/></svg></div>
+      <div class="zsd-text"><div class="zsd-score">40</div><div class="zsd-label">Poop</div></div>
+    </div><div class="zs-domain-pill">
+      <div class="zsd-icon"><svg class="zi" aria-hidden="true"><use href="#zi-medical"/></svg></div>
+      <div class="zsd-text"><div class="zsd-score">—</div><div class="zsd-label">Medical</div></div>
+    </div><div class="zs-domain-pill zsd-fair">
+      <div class="zsd-icon"><svg class="zi" aria-hidden="true"><use href="#zi-trophy"/></svg></div>
+      <div class="zsd-text"><div class="zsd-score">55</div><div class="zsd-label">Milestones</div></div>
+    </div></div>
+  </div></div></div>
+        <div class="sc-panel" data-theme="dark"><span class="sc-mode">Dark</span><div class="sc-stage"><div class="ziva-score-hero zs-score-fair">
+    <div class="zs-ring">
+      <div class="zs-number">52</div>
+      <div class="zs-label">Ziva Score</div>
+      <div class="zs-trend">→ stable</div>
+    </div>
+    <div class="zs-domains"><div class="zs-domain-pill zsd-fair">
+      <div class="zsd-icon"><svg class="zi" aria-hidden="true"><use href="#zi-moon"/></svg></div>
+      <div class="zsd-text"><div class="zsd-score">48</div><div class="zsd-label">Sleep</div></div>
+    </div><div class="zs-domain-pill zsd-good">
+      <div class="zsd-icon"><svg class="zi" aria-hidden="true"><use href="#zi-bowl"/></svg></div>
+      <div class="zsd-text"><div class="zsd-score">61</div><div class="zsd-label">Diet</div></div>
+    </div><div class="zs-domain-pill zsd-attention">
+      <div class="zsd-icon"><svg class="zi" aria-hidden="true"><use href="#zi-diaper"/></svg></div>
+      <div class="zsd-text"><div class="zsd-score">40</div><div class="zsd-label">Poop</div></div>
+    </div><div class="zs-domain-pill">
+      <div class="zsd-icon"><svg class="zi" aria-hidden="true"><use href="#zi-medical"/></svg></div>
+      <div class="zsd-text"><div class="zsd-score">—</div><div class="zsd-label">Medical</div></div>
+    </div><div class="zs-domain-pill zsd-fair">
+      <div class="zsd-icon"><svg class="zi" aria-hidden="true"><use href="#zi-trophy"/></svg></div>
+      <div class="zsd-text"><div class="zsd-score">55</div><div class="zsd-label">Milestones</div></div>
+    </div></div>
+  </div></div></div>
+      </div>
+      <details class="sc-markup"><summary>Canonical markup</summary><pre><code>&lt;div class="ziva-score-hero zs-score-fair"&gt;
+    &lt;div class="zs-ring"&gt;
+      &lt;div class="zs-number"&gt;52&lt;/div&gt;
+      &lt;div class="zs-label"&gt;Ziva Score&lt;/div&gt;
+      &lt;div class="zs-trend"&gt;→ stable&lt;/div&gt;
+    &lt;/div&gt;
+    &lt;div class="zs-domains"&gt;&lt;div class="zs-domain-pill zsd-fair"&gt;
+      &lt;div class="zsd-icon"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-moon"/&gt;&lt;/svg&gt;&lt;/div&gt;
+      &lt;div class="zsd-text"&gt;&lt;div class="zsd-score"&gt;48&lt;/div&gt;&lt;div class="zsd-label"&gt;Sleep&lt;/div&gt;&lt;/div&gt;
+    &lt;/div&gt;&lt;div class="zs-domain-pill zsd-good"&gt;
+      &lt;div class="zsd-icon"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-bowl"/&gt;&lt;/svg&gt;&lt;/div&gt;
+      &lt;div class="zsd-text"&gt;&lt;div class="zsd-score"&gt;61&lt;/div&gt;&lt;div class="zsd-label"&gt;Diet&lt;/div&gt;&lt;/div&gt;
+    &lt;/div&gt;&lt;div class="zs-domain-pill zsd-attention"&gt;
+      &lt;div class="zsd-icon"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-diaper"/&gt;&lt;/svg&gt;&lt;/div&gt;
+      &lt;div class="zsd-text"&gt;&lt;div class="zsd-score"&gt;40&lt;/div&gt;&lt;div class="zsd-label"&gt;Poop&lt;/div&gt;&lt;/div&gt;
+    &lt;/div&gt;&lt;div class="zs-domain-pill"&gt;
+      &lt;div class="zsd-icon"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-medical"/&gt;&lt;/svg&gt;&lt;/div&gt;
+      &lt;div class="zsd-text"&gt;&lt;div class="zsd-score"&gt;—&lt;/div&gt;&lt;div class="zsd-label"&gt;Medical&lt;/div&gt;&lt;/div&gt;
+    &lt;/div&gt;&lt;div class="zs-domain-pill zsd-fair"&gt;
+      &lt;div class="zsd-icon"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-trophy"/&gt;&lt;/svg&gt;&lt;/div&gt;
+      &lt;div class="zsd-text"&gt;&lt;div class="zsd-score"&gt;55&lt;/div&gt;&lt;div class="zsd-label"&gt;Milestones&lt;/div&gt;&lt;/div&gt;
+    &lt;/div&gt;&lt;/div&gt;
+  &lt;/div&gt;</code></pre></details>
+    </div>
+  </section>
+<section class="sc-surface" id="hero-domain">
+    <h3>Domain Score hero (per-tab)</h3>
+    <p class="sc-surface-note">Per-tab score hero — ring + component-pill breakdown. <code>.domain-score-hero.dsh-{domain}</code>, ring tinted by band via <code>.dsh-ring-{label}</code>, component bars <code>.dcb-{high|mid|low}</code>. One per tab (diet/sleep/poop/medical/milestones).</p>
+    
+    <div class="sc-specimen">
+      <div class="sc-specimen-label">Diet · Great (88)</div>
+      <div class="sc-render-row">
+        <div class="sc-panel"><span class="sc-mode">Light</span><div class="sc-stage"><div class="domain-score-hero dsh-diet">
+    <div class="dsh-top">
+      <div class="dsh-ring dsh-ring-great">
+        <div class="dsh-number">88</div>
+        <div class="dsh-label">Diet</div>
+        <div class="dsh-emoji"><svg class="zi" aria-hidden="true"><use href="#zi-check"/></svg></div>
+      </div>
+      <div class="dsh-info">
+        <div class="dsh-domain-name"><svg class="zi" aria-hidden="true"><use href="#zi-check"/></svg> Great</div>
+        <div class="dsh-domain-sublabel">Based on meals, variety, groups &amp; nutrients · 24% of Ziva Score</div>
+      </div>
+    </div>
+    <div class="dsh-components"><div class="dsh-comp-pill dcp-high">
+      <div class="dcp-bar dcb-high">92</div>
+      <div class="dcp-text">
+        <div class="dcp-name">Meals logged <span class="dcp-weight">40%</span></div>
+        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-bowl"/></svg> 3 of 3 today</div>
+      </div>
+    </div><div class="dsh-comp-pill dcp-high">
+      <div class="dcp-bar dcb-high">78</div>
+      <div class="dcp-text">
+        <div class="dcp-name">Variety <span class="dcp-weight">30%</span></div>
+        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-rainbow"/></svg> 5 food groups</div>
+      </div>
+    </div><div class="dsh-comp-pill dcp-high">
+      <div class="dcp-bar dcb-high">84</div>
+      <div class="dcp-text">
+        <div class="dcp-name">Nutrients <span class="dcp-weight">30%</span></div>
+        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-drop"/></svg> iron + Vit C paired</div>
+      </div>
+    </div></div>
+  </div></div></div>
+        <div class="sc-panel" data-theme="dark"><span class="sc-mode">Dark</span><div class="sc-stage"><div class="domain-score-hero dsh-diet">
+    <div class="dsh-top">
+      <div class="dsh-ring dsh-ring-great">
+        <div class="dsh-number">88</div>
+        <div class="dsh-label">Diet</div>
+        <div class="dsh-emoji"><svg class="zi" aria-hidden="true"><use href="#zi-check"/></svg></div>
+      </div>
+      <div class="dsh-info">
+        <div class="dsh-domain-name"><svg class="zi" aria-hidden="true"><use href="#zi-check"/></svg> Great</div>
+        <div class="dsh-domain-sublabel">Based on meals, variety, groups &amp; nutrients · 24% of Ziva Score</div>
+      </div>
+    </div>
+    <div class="dsh-components"><div class="dsh-comp-pill dcp-high">
+      <div class="dcp-bar dcb-high">92</div>
+      <div class="dcp-text">
+        <div class="dcp-name">Meals logged <span class="dcp-weight">40%</span></div>
+        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-bowl"/></svg> 3 of 3 today</div>
+      </div>
+    </div><div class="dsh-comp-pill dcp-high">
+      <div class="dcp-bar dcb-high">78</div>
+      <div class="dcp-text">
+        <div class="dcp-name">Variety <span class="dcp-weight">30%</span></div>
+        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-rainbow"/></svg> 5 food groups</div>
+      </div>
+    </div><div class="dsh-comp-pill dcp-high">
+      <div class="dcp-bar dcb-high">84</div>
+      <div class="dcp-text">
+        <div class="dcp-name">Nutrients <span class="dcp-weight">30%</span></div>
+        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-drop"/></svg> iron + Vit C paired</div>
+      </div>
+    </div></div>
+  </div></div></div>
+      </div>
+      <details class="sc-markup"><summary>Canonical markup</summary><pre><code>&lt;div class="domain-score-hero dsh-diet"&gt;
+    &lt;div class="dsh-top"&gt;
+      &lt;div class="dsh-ring dsh-ring-great"&gt;
+        &lt;div class="dsh-number"&gt;88&lt;/div&gt;
+        &lt;div class="dsh-label"&gt;Diet&lt;/div&gt;
+        &lt;div class="dsh-emoji"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-check"/&gt;&lt;/svg&gt;&lt;/div&gt;
+      &lt;/div&gt;
+      &lt;div class="dsh-info"&gt;
+        &lt;div class="dsh-domain-name"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-check"/&gt;&lt;/svg&gt; Great&lt;/div&gt;
+        &lt;div class="dsh-domain-sublabel"&gt;Based on meals, variety, groups &amp;amp; nutrients · 24% of Ziva Score&lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;
+    &lt;div class="dsh-components"&gt;&lt;div class="dsh-comp-pill dcp-high"&gt;
+      &lt;div class="dcp-bar dcb-high"&gt;92&lt;/div&gt;
+      &lt;div class="dcp-text"&gt;
+        &lt;div class="dcp-name"&gt;Meals logged &lt;span class="dcp-weight"&gt;40%&lt;/span&gt;&lt;/div&gt;
+        &lt;div class="dcp-detail"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-bowl"/&gt;&lt;/svg&gt; 3 of 3 today&lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;&lt;div class="dsh-comp-pill dcp-high"&gt;
+      &lt;div class="dcp-bar dcb-high"&gt;78&lt;/div&gt;
+      &lt;div class="dcp-text"&gt;
+        &lt;div class="dcp-name"&gt;Variety &lt;span class="dcp-weight"&gt;30%&lt;/span&gt;&lt;/div&gt;
+        &lt;div class="dcp-detail"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-rainbow"/&gt;&lt;/svg&gt; 5 food groups&lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;&lt;div class="dsh-comp-pill dcp-high"&gt;
+      &lt;div class="dcp-bar dcb-high"&gt;84&lt;/div&gt;
+      &lt;div class="dcp-text"&gt;
+        &lt;div class="dcp-name"&gt;Nutrients &lt;span class="dcp-weight"&gt;30%&lt;/span&gt;&lt;/div&gt;
+        &lt;div class="dcp-detail"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-drop"/&gt;&lt;/svg&gt; iron + Vit C paired&lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;&lt;/div&gt;
+  &lt;/div&gt;</code></pre></details>
+    </div>
+    <div class="sc-specimen">
+      <div class="sc-specimen-label">Sleep · Fair (55)</div>
+      <div class="sc-render-row">
+        <div class="sc-panel"><span class="sc-mode">Light</span><div class="sc-stage"><div class="domain-score-hero dsh-sleep">
+    <div class="dsh-top">
+      <div class="dsh-ring dsh-ring-fair">
+        <div class="dsh-number">55</div>
+        <div class="dsh-label">Sleep</div>
+        <div class="dsh-emoji"><svg class="zi" aria-hidden="true"><use href="#zi-target"/></svg></div>
+      </div>
+      <div class="dsh-info">
+        <div class="dsh-domain-name"><svg class="zi" aria-hidden="true"><use href="#zi-target"/></svg> Fair</div>
+        <div class="dsh-domain-sublabel">Based on duration, wake-ups, bedtime &amp; naps · 22% of Ziva Score</div>
+      </div>
+    </div>
+    <div class="dsh-components"><div class="dsh-comp-pill dcp-mid">
+      <div class="dcp-bar dcb-mid">62</div>
+      <div class="dcp-text">
+        <div class="dcp-name">Duration <span class="dcp-weight">40%</span></div>
+        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-moon"/></svg> 10.5h last night</div>
+      </div>
+    </div><div class="dsh-comp-pill dcp-mid">
+      <div class="dcp-bar dcb-mid">45</div>
+      <div class="dcp-text">
+        <div class="dcp-name">Wake-ups <span class="dcp-weight">30%</span></div>
+        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-zzz"/></svg> 3 wake-ups</div>
+      </div>
+    </div><div class="dsh-comp-pill dcp-low">
+      <div class="dcp-bar dcb-low">38</div>
+      <div class="dcp-text">
+        <div class="dcp-name">Naps <span class="dcp-weight">30%</span></div>
+        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-sun"/></svg> 1 of 2 expected</div>
+      </div>
+    </div></div>
+  </div></div></div>
+        <div class="sc-panel" data-theme="dark"><span class="sc-mode">Dark</span><div class="sc-stage"><div class="domain-score-hero dsh-sleep">
+    <div class="dsh-top">
+      <div class="dsh-ring dsh-ring-fair">
+        <div class="dsh-number">55</div>
+        <div class="dsh-label">Sleep</div>
+        <div class="dsh-emoji"><svg class="zi" aria-hidden="true"><use href="#zi-target"/></svg></div>
+      </div>
+      <div class="dsh-info">
+        <div class="dsh-domain-name"><svg class="zi" aria-hidden="true"><use href="#zi-target"/></svg> Fair</div>
+        <div class="dsh-domain-sublabel">Based on duration, wake-ups, bedtime &amp; naps · 22% of Ziva Score</div>
+      </div>
+    </div>
+    <div class="dsh-components"><div class="dsh-comp-pill dcp-mid">
+      <div class="dcp-bar dcb-mid">62</div>
+      <div class="dcp-text">
+        <div class="dcp-name">Duration <span class="dcp-weight">40%</span></div>
+        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-moon"/></svg> 10.5h last night</div>
+      </div>
+    </div><div class="dsh-comp-pill dcp-mid">
+      <div class="dcp-bar dcb-mid">45</div>
+      <div class="dcp-text">
+        <div class="dcp-name">Wake-ups <span class="dcp-weight">30%</span></div>
+        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-zzz"/></svg> 3 wake-ups</div>
+      </div>
+    </div><div class="dsh-comp-pill dcp-low">
+      <div class="dcp-bar dcb-low">38</div>
+      <div class="dcp-text">
+        <div class="dcp-name">Naps <span class="dcp-weight">30%</span></div>
+        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-sun"/></svg> 1 of 2 expected</div>
+      </div>
+    </div></div>
+  </div></div></div>
+      </div>
+      <details class="sc-markup"><summary>Canonical markup</summary><pre><code>&lt;div class="domain-score-hero dsh-sleep"&gt;
+    &lt;div class="dsh-top"&gt;
+      &lt;div class="dsh-ring dsh-ring-fair"&gt;
+        &lt;div class="dsh-number"&gt;55&lt;/div&gt;
+        &lt;div class="dsh-label"&gt;Sleep&lt;/div&gt;
+        &lt;div class="dsh-emoji"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-target"/&gt;&lt;/svg&gt;&lt;/div&gt;
+      &lt;/div&gt;
+      &lt;div class="dsh-info"&gt;
+        &lt;div class="dsh-domain-name"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-target"/&gt;&lt;/svg&gt; Fair&lt;/div&gt;
+        &lt;div class="dsh-domain-sublabel"&gt;Based on duration, wake-ups, bedtime &amp;amp; naps · 22% of Ziva Score&lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;
+    &lt;div class="dsh-components"&gt;&lt;div class="dsh-comp-pill dcp-mid"&gt;
+      &lt;div class="dcp-bar dcb-mid"&gt;62&lt;/div&gt;
+      &lt;div class="dcp-text"&gt;
+        &lt;div class="dcp-name"&gt;Duration &lt;span class="dcp-weight"&gt;40%&lt;/span&gt;&lt;/div&gt;
+        &lt;div class="dcp-detail"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-moon"/&gt;&lt;/svg&gt; 10.5h last night&lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;&lt;div class="dsh-comp-pill dcp-mid"&gt;
+      &lt;div class="dcp-bar dcb-mid"&gt;45&lt;/div&gt;
+      &lt;div class="dcp-text"&gt;
+        &lt;div class="dcp-name"&gt;Wake-ups &lt;span class="dcp-weight"&gt;30%&lt;/span&gt;&lt;/div&gt;
+        &lt;div class="dcp-detail"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-zzz"/&gt;&lt;/svg&gt; 3 wake-ups&lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;&lt;div class="dsh-comp-pill dcp-low"&gt;
+      &lt;div class="dcp-bar dcb-low"&gt;38&lt;/div&gt;
+      &lt;div class="dcp-text"&gt;
+        &lt;div class="dcp-name"&gt;Naps &lt;span class="dcp-weight"&gt;30%&lt;/span&gt;&lt;/div&gt;
+        &lt;div class="dcp-detail"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-sun"/&gt;&lt;/svg&gt; 1 of 2 expected&lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;&lt;/div&gt;
+  &lt;/div&gt;</code></pre></details>
+    </div>
+    <div class="sc-specimen">
+      <div class="sc-specimen-label">Medical · Excellent (95)</div>
+      <div class="sc-render-row">
+        <div class="sc-panel"><span class="sc-mode">Light</span><div class="sc-stage"><div class="domain-score-hero dsh-medical">
+    <div class="dsh-top">
+      <div class="dsh-ring dsh-ring-excellent">
+        <div class="dsh-number">95</div>
+        <div class="dsh-label">Medical</div>
+        <div class="dsh-emoji"><svg class="zi" aria-hidden="true"><use href="#zi-sparkle"/></svg></div>
+      </div>
+      <div class="dsh-info">
+        <div class="dsh-domain-name"><svg class="zi" aria-hidden="true"><use href="#zi-sparkle"/></svg> Excellent</div>
+        <div class="dsh-domain-sublabel">Based on vaccines, supplements, growth &amp; checkups · 18% of Ziva Score</div>
+      </div>
+    </div>
+    <div class="dsh-components"><div class="dsh-comp-pill dcp-high">
+      <div class="dcp-bar dcb-high">100</div>
+      <div class="dcp-text">
+        <div class="dcp-name">Vaccines <span class="dcp-weight">35%</span></div>
+        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-shield"/></svg> on schedule</div>
+      </div>
+    </div><div class="dsh-comp-pill dcp-high">
+      <div class="dcp-bar dcb-high">90</div>
+      <div class="dcp-text">
+        <div class="dcp-name">Supplements <span class="dcp-weight">30%</span></div>
+        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-drop"/></svg> Vit D3 today</div>
+      </div>
+    </div><div class="dsh-comp-pill dcp-high">
+      <div class="dcp-bar dcb-high">94</div>
+      <div class="dcp-text">
+        <div class="dcp-name">Growth <span class="dcp-weight">35%</span></div>
+        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-ruler"/></svg> 50th percentile</div>
+      </div>
+    </div></div>
+  </div></div></div>
+        <div class="sc-panel" data-theme="dark"><span class="sc-mode">Dark</span><div class="sc-stage"><div class="domain-score-hero dsh-medical">
+    <div class="dsh-top">
+      <div class="dsh-ring dsh-ring-excellent">
+        <div class="dsh-number">95</div>
+        <div class="dsh-label">Medical</div>
+        <div class="dsh-emoji"><svg class="zi" aria-hidden="true"><use href="#zi-sparkle"/></svg></div>
+      </div>
+      <div class="dsh-info">
+        <div class="dsh-domain-name"><svg class="zi" aria-hidden="true"><use href="#zi-sparkle"/></svg> Excellent</div>
+        <div class="dsh-domain-sublabel">Based on vaccines, supplements, growth &amp; checkups · 18% of Ziva Score</div>
+      </div>
+    </div>
+    <div class="dsh-components"><div class="dsh-comp-pill dcp-high">
+      <div class="dcp-bar dcb-high">100</div>
+      <div class="dcp-text">
+        <div class="dcp-name">Vaccines <span class="dcp-weight">35%</span></div>
+        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-shield"/></svg> on schedule</div>
+      </div>
+    </div><div class="dsh-comp-pill dcp-high">
+      <div class="dcp-bar dcb-high">90</div>
+      <div class="dcp-text">
+        <div class="dcp-name">Supplements <span class="dcp-weight">30%</span></div>
+        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-drop"/></svg> Vit D3 today</div>
+      </div>
+    </div><div class="dsh-comp-pill dcp-high">
+      <div class="dcp-bar dcb-high">94</div>
+      <div class="dcp-text">
+        <div class="dcp-name">Growth <span class="dcp-weight">35%</span></div>
+        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-ruler"/></svg> 50th percentile</div>
+      </div>
+    </div></div>
+  </div></div></div>
+      </div>
+      <details class="sc-markup"><summary>Canonical markup</summary><pre><code>&lt;div class="domain-score-hero dsh-medical"&gt;
+    &lt;div class="dsh-top"&gt;
+      &lt;div class="dsh-ring dsh-ring-excellent"&gt;
+        &lt;div class="dsh-number"&gt;95&lt;/div&gt;
+        &lt;div class="dsh-label"&gt;Medical&lt;/div&gt;
+        &lt;div class="dsh-emoji"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-sparkle"/&gt;&lt;/svg&gt;&lt;/div&gt;
+      &lt;/div&gt;
+      &lt;div class="dsh-info"&gt;
+        &lt;div class="dsh-domain-name"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-sparkle"/&gt;&lt;/svg&gt; Excellent&lt;/div&gt;
+        &lt;div class="dsh-domain-sublabel"&gt;Based on vaccines, supplements, growth &amp;amp; checkups · 18% of Ziva Score&lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;
+    &lt;div class="dsh-components"&gt;&lt;div class="dsh-comp-pill dcp-high"&gt;
+      &lt;div class="dcp-bar dcb-high"&gt;100&lt;/div&gt;
+      &lt;div class="dcp-text"&gt;
+        &lt;div class="dcp-name"&gt;Vaccines &lt;span class="dcp-weight"&gt;35%&lt;/span&gt;&lt;/div&gt;
+        &lt;div class="dcp-detail"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-shield"/&gt;&lt;/svg&gt; on schedule&lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;&lt;div class="dsh-comp-pill dcp-high"&gt;
+      &lt;div class="dcp-bar dcb-high"&gt;90&lt;/div&gt;
+      &lt;div class="dcp-text"&gt;
+        &lt;div class="dcp-name"&gt;Supplements &lt;span class="dcp-weight"&gt;30%&lt;/span&gt;&lt;/div&gt;
+        &lt;div class="dcp-detail"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-drop"/&gt;&lt;/svg&gt; Vit D3 today&lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;&lt;div class="dsh-comp-pill dcp-high"&gt;
+      &lt;div class="dcp-bar dcb-high"&gt;94&lt;/div&gt;
+      &lt;div class="dcp-text"&gt;
+        &lt;div class="dcp-name"&gt;Growth &lt;span class="dcp-weight"&gt;35%&lt;/span&gt;&lt;/div&gt;
+        &lt;div class="dcp-detail"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-ruler"/&gt;&lt;/svg&gt; 50th percentile&lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;&lt;/div&gt;
+  &lt;/div&gt;</code></pre></details>
+    </div>
+  </section>
+</div>
+<script>
+  document.querySelectorAll('.sc-zbtn').forEach(function(b){
+    b.addEventListener('click', function(){
+      document.documentElement.dataset.zoom = b.dataset.zoom;
+      document.querySelectorAll('.sc-zbtn').forEach(function(x){ x.classList.toggle('active', x===b); });
+    });
+  });
+</script>
+</body>
+</html>

--- a/docs/SURFACE_CATALOG.html
+++ b/docs/SURFACE_CATALOG.html
@@ -6429,6 +6429,38 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
 .dsh-medical .dsh-comp-pill { background:linear-gradient(135deg, var(--warm), rgba(242,168,184,0.10)); border-color:rgba(242,168,184,0.3); }
 .dsh-milestones .dsh-comp-pill { background:linear-gradient(135deg, var(--warm), rgba(201,184,232,0.10)); border-color:rgba(201,184,232,0.3); }
 
+/* ═══════════════════════════════════════════════════════════════
+   Hero polish (Surface Catalog, design floor §Tint System).
+   The Home Ziva-Score hero (.ziva-score-hero) carries NO card-hero shell, so
+   it was flat — give it the signature rainbow FADE (rose→peach→sage→lavender,
+   §Tint "home rainbow"), as a directional fade over --card-bg (not a flat
+   fill), hue-swapped deep in dark (Law 1). The per-tab domain heroes already
+   carry their .card.card-hero.hero-{domain} gradient + ::before stripe, so
+   they are NOT re-washed here (a second wash would muddy — §Tint Law 2).
+   ═══════════════════════════════════════════════════════════════ */
+.ziva-score-hero {
+  border-bottom:none;
+  border-radius:var(--r-xl);
+  padding:var(--sp-12) var(--sp-14);
+  background-color:var(--card-bg);
+  background-image:linear-gradient(135deg, rgba(242,168,184,0.12), rgba(250,212,180,0.08) 35%, rgba(181,213,197,0.08) 65%, rgba(201,184,232,0.14));
+  background-repeat:no-repeat;
+}
+[data-theme="dark"] .ziva-score-hero {
+  background-color:var(--surface);
+  background-image:linear-gradient(135deg, rgba(158,62,82,0.20), rgba(138,101,32,0.10) 35%, rgba(58,112,96,0.10) 65%, rgba(110,94,154,0.20));
+}
+
+/* Text in full + reflow at medium/large zoom (HR-5/HR-11 — no truncation,
+   wraps; the rigid grids relax so longer detail/label text never clips). */
+.dsh-domain-name, .dsh-domain-sublabel, .dcp-name, .dcp-detail, .zsd-label, .zsd-score { overflow-wrap:break-word; }
+.dsh-components { grid-template-columns:minmax(0,1fr) minmax(0,1fr); }
+:root[data-zoom="high"] .dsh-components { grid-template-columns:1fr; }
+:root[data-zoom="med"]  .zs-domains,
+:root[data-zoom="high"] .zs-domains { grid-template-columns:repeat(4, 1fr); }
+:root[data-zoom="med"]  .zs-domain-pill,
+:root[data-zoom="high"] .zs-domain-pill { grid-column:span 2 !important; }
+
 /* ── Domain-tinted card backgrounds per track tab ── */
 #tab-diet .card { background:linear-gradient(135deg, var(--warm), rgba(181,213,197,0.10)); }
 #tab-sleep .card { background:linear-gradient(135deg, var(--warm), rgba(155,168,216,0.10)); }
@@ -12293,7 +12325,7 @@ body { padding:0; margin:0; }
   <h2 style="font-family:'Fraunces',serif;font-size:24px;color:var(--text,#3a2e2e);margin:10px 0 0;">Heroes</h2>
   <section class="sc-surface" id="hero-ziva">
     <h3>Ziva Score hero (Home)</h3>
-    <p class="sc-surface-note">The home front-door hero — composite score ring + per-domain pills. <code>.ziva-score-hero.zs-score-{label}</code>. Tap a domain pill to jump to that tab; tap the ring for the score popup.</p>
+    <p class="sc-surface-note">The home front-door hero — composite score ring + per-domain pills. <code>.ziva-score-hero.zs-score-{label}</code>. Carries the signature rainbow FADE (rose→peach→sage→lavender) over <code>--card-bg</code>, hue-swapped in dark. Domain pills reflow 2-per-row at medium/large zoom. Tap a pill to jump to that tab; tap the ring for the score popup.</p>
     
     <div class="sc-specimen">
       <div class="sc-specimen-label">Strong week</div>
@@ -12446,12 +12478,12 @@ body { padding:0; margin:0; }
   </section>
 <section class="sc-surface" id="hero-domain">
     <h3>Domain Score hero (per-tab)</h3>
-    <p class="sc-surface-note">Per-tab score hero — ring + component-pill breakdown. <code>.domain-score-hero.dsh-{domain}</code>, ring tinted by band via <code>.dsh-ring-{label}</code>, component bars <code>.dcb-{high|mid|low}</code>. One per tab (diet/sleep/poop/medical/milestones).</p>
+    <p class="sc-surface-note">Per-tab score hero. Rendered inside its real <code>.card.card-hero.hero-{domain}</code> shell (the floor’s two-domain semantic gradient + the 5px <code>::before</code> accent stripe) wrapping <code>.domain-score-hero.dsh-{domain}</code>. The RING carries the score-band polarity (<code>.dsh-ring-{label}</code>), the card-hero gradient carries domain identity — the two never compete (§Polarity Collision). Component bars <code>.dcb-{high|mid|low}</code>. One per tab (diet/sleep/poop/medical/milestones).</p>
     
     <div class="sc-specimen">
       <div class="sc-specimen-label">Diet · Great (88)</div>
       <div class="sc-render-row">
-        <div class="sc-panel"><span class="sc-mode">Light</span><div class="sc-stage"><div class="domain-score-hero dsh-diet">
+        <div class="sc-panel"><span class="sc-mode">Light</span><div class="sc-stage"><div class="card card-hero hero-diet"><div class="domain-score-hero dsh-diet">
     <div class="dsh-top">
       <div class="dsh-ring dsh-ring-great">
         <div class="dsh-number">88</div>
@@ -12479,11 +12511,11 @@ body { padding:0; margin:0; }
       <div class="dcp-bar dcb-high">84</div>
       <div class="dcp-text">
         <div class="dcp-name">Nutrients <span class="dcp-weight">30%</span></div>
-        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-drop"/></svg> iron + Vit C paired</div>
+        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-drop"/></svg> iron + Vitamin C paired this morning — great for absorption</div>
       </div>
     </div></div>
-  </div></div></div>
-        <div class="sc-panel" data-theme="dark"><span class="sc-mode">Dark</span><div class="sc-stage"><div class="domain-score-hero dsh-diet">
+  </div></div></div></div>
+        <div class="sc-panel" data-theme="dark"><span class="sc-mode">Dark</span><div class="sc-stage"><div class="card card-hero hero-diet"><div class="domain-score-hero dsh-diet">
     <div class="dsh-top">
       <div class="dsh-ring dsh-ring-great">
         <div class="dsh-number">88</div>
@@ -12511,12 +12543,12 @@ body { padding:0; margin:0; }
       <div class="dcp-bar dcb-high">84</div>
       <div class="dcp-text">
         <div class="dcp-name">Nutrients <span class="dcp-weight">30%</span></div>
-        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-drop"/></svg> iron + Vit C paired</div>
+        <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-drop"/></svg> iron + Vitamin C paired this morning — great for absorption</div>
       </div>
     </div></div>
-  </div></div></div>
+  </div></div></div></div>
       </div>
-      <details class="sc-markup"><summary>Canonical markup</summary><pre><code>&lt;div class="domain-score-hero dsh-diet"&gt;
+      <details class="sc-markup"><summary>Canonical markup</summary><pre><code>&lt;div class="card card-hero hero-diet"&gt;&lt;div class="domain-score-hero dsh-diet"&gt;
     &lt;div class="dsh-top"&gt;
       &lt;div class="dsh-ring dsh-ring-great"&gt;
         &lt;div class="dsh-number"&gt;88&lt;/div&gt;
@@ -12544,15 +12576,15 @@ body { padding:0; margin:0; }
       &lt;div class="dcp-bar dcb-high"&gt;84&lt;/div&gt;
       &lt;div class="dcp-text"&gt;
         &lt;div class="dcp-name"&gt;Nutrients &lt;span class="dcp-weight"&gt;30%&lt;/span&gt;&lt;/div&gt;
-        &lt;div class="dcp-detail"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-drop"/&gt;&lt;/svg&gt; iron + Vit C paired&lt;/div&gt;
+        &lt;div class="dcp-detail"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-drop"/&gt;&lt;/svg&gt; iron + Vitamin C paired this morning — great for absorption&lt;/div&gt;
       &lt;/div&gt;
     &lt;/div&gt;&lt;/div&gt;
-  &lt;/div&gt;</code></pre></details>
+  &lt;/div&gt;&lt;/div&gt;</code></pre></details>
     </div>
     <div class="sc-specimen">
       <div class="sc-specimen-label">Sleep · Fair (55)</div>
       <div class="sc-render-row">
-        <div class="sc-panel"><span class="sc-mode">Light</span><div class="sc-stage"><div class="domain-score-hero dsh-sleep">
+        <div class="sc-panel"><span class="sc-mode">Light</span><div class="sc-stage"><div class="card card-hero hero-sleep"><div class="domain-score-hero dsh-sleep">
     <div class="dsh-top">
       <div class="dsh-ring dsh-ring-fair">
         <div class="dsh-number">55</div>
@@ -12583,8 +12615,8 @@ body { padding:0; margin:0; }
         <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-sun"/></svg> 1 of 2 expected</div>
       </div>
     </div></div>
-  </div></div></div>
-        <div class="sc-panel" data-theme="dark"><span class="sc-mode">Dark</span><div class="sc-stage"><div class="domain-score-hero dsh-sleep">
+  </div></div></div></div>
+        <div class="sc-panel" data-theme="dark"><span class="sc-mode">Dark</span><div class="sc-stage"><div class="card card-hero hero-sleep"><div class="domain-score-hero dsh-sleep">
     <div class="dsh-top">
       <div class="dsh-ring dsh-ring-fair">
         <div class="dsh-number">55</div>
@@ -12615,9 +12647,9 @@ body { padding:0; margin:0; }
         <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-sun"/></svg> 1 of 2 expected</div>
       </div>
     </div></div>
-  </div></div></div>
+  </div></div></div></div>
       </div>
-      <details class="sc-markup"><summary>Canonical markup</summary><pre><code>&lt;div class="domain-score-hero dsh-sleep"&gt;
+      <details class="sc-markup"><summary>Canonical markup</summary><pre><code>&lt;div class="card card-hero hero-sleep"&gt;&lt;div class="domain-score-hero dsh-sleep"&gt;
     &lt;div class="dsh-top"&gt;
       &lt;div class="dsh-ring dsh-ring-fair"&gt;
         &lt;div class="dsh-number"&gt;55&lt;/div&gt;
@@ -12648,12 +12680,12 @@ body { padding:0; margin:0; }
         &lt;div class="dcp-detail"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-sun"/&gt;&lt;/svg&gt; 1 of 2 expected&lt;/div&gt;
       &lt;/div&gt;
     &lt;/div&gt;&lt;/div&gt;
-  &lt;/div&gt;</code></pre></details>
+  &lt;/div&gt;&lt;/div&gt;</code></pre></details>
     </div>
     <div class="sc-specimen">
       <div class="sc-specimen-label">Medical · Excellent (95)</div>
       <div class="sc-render-row">
-        <div class="sc-panel"><span class="sc-mode">Light</span><div class="sc-stage"><div class="domain-score-hero dsh-medical">
+        <div class="sc-panel"><span class="sc-mode">Light</span><div class="sc-stage"><div class="card card-hero hero-medical"><div class="domain-score-hero dsh-medical">
     <div class="dsh-top">
       <div class="dsh-ring dsh-ring-excellent">
         <div class="dsh-number">95</div>
@@ -12684,8 +12716,8 @@ body { padding:0; margin:0; }
         <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-ruler"/></svg> 50th percentile</div>
       </div>
     </div></div>
-  </div></div></div>
-        <div class="sc-panel" data-theme="dark"><span class="sc-mode">Dark</span><div class="sc-stage"><div class="domain-score-hero dsh-medical">
+  </div></div></div></div>
+        <div class="sc-panel" data-theme="dark"><span class="sc-mode">Dark</span><div class="sc-stage"><div class="card card-hero hero-medical"><div class="domain-score-hero dsh-medical">
     <div class="dsh-top">
       <div class="dsh-ring dsh-ring-excellent">
         <div class="dsh-number">95</div>
@@ -12716,9 +12748,9 @@ body { padding:0; margin:0; }
         <div class="dcp-detail"><svg class="zi" aria-hidden="true"><use href="#zi-ruler"/></svg> 50th percentile</div>
       </div>
     </div></div>
-  </div></div></div>
+  </div></div></div></div>
       </div>
-      <details class="sc-markup"><summary>Canonical markup</summary><pre><code>&lt;div class="domain-score-hero dsh-medical"&gt;
+      <details class="sc-markup"><summary>Canonical markup</summary><pre><code>&lt;div class="card card-hero hero-medical"&gt;&lt;div class="domain-score-hero dsh-medical"&gt;
     &lt;div class="dsh-top"&gt;
       &lt;div class="dsh-ring dsh-ring-excellent"&gt;
         &lt;div class="dsh-number"&gt;95&lt;/div&gt;
@@ -12749,7 +12781,7 @@ body { padding:0; margin:0; }
         &lt;div class="dcp-detail"&gt;&lt;svg class="zi" aria-hidden="true"&gt;&lt;use href="#zi-ruler"/&gt;&lt;/svg&gt; 50th percentile&lt;/div&gt;
       &lt;/div&gt;
     &lt;/div&gt;&lt;/div&gt;
-  &lt;/div&gt;</code></pre></details>
+  &lt;/div&gt;&lt;/div&gt;</code></pre></details>
     </div>
   </section>
 </div>

--- a/index.html
+++ b/index.html
@@ -6426,6 +6426,38 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
 .dsh-medical .dsh-comp-pill { background:linear-gradient(135deg, var(--warm), rgba(242,168,184,0.10)); border-color:rgba(242,168,184,0.3); }
 .dsh-milestones .dsh-comp-pill { background:linear-gradient(135deg, var(--warm), rgba(201,184,232,0.10)); border-color:rgba(201,184,232,0.3); }
 
+/* ═══════════════════════════════════════════════════════════════
+   Hero polish (Surface Catalog, design floor §Tint System).
+   The Home Ziva-Score hero (.ziva-score-hero) carries NO card-hero shell, so
+   it was flat — give it the signature rainbow FADE (rose→peach→sage→lavender,
+   §Tint "home rainbow"), as a directional fade over --card-bg (not a flat
+   fill), hue-swapped deep in dark (Law 1). The per-tab domain heroes already
+   carry their .card.card-hero.hero-{domain} gradient + ::before stripe, so
+   they are NOT re-washed here (a second wash would muddy — §Tint Law 2).
+   ═══════════════════════════════════════════════════════════════ */
+.ziva-score-hero {
+  border-bottom:none;
+  border-radius:var(--r-xl);
+  padding:var(--sp-12) var(--sp-14);
+  background-color:var(--card-bg);
+  background-image:linear-gradient(135deg, rgba(242,168,184,0.12), rgba(250,212,180,0.08) 35%, rgba(181,213,197,0.08) 65%, rgba(201,184,232,0.14));
+  background-repeat:no-repeat;
+}
+[data-theme="dark"] .ziva-score-hero {
+  background-color:var(--surface);
+  background-image:linear-gradient(135deg, rgba(158,62,82,0.20), rgba(138,101,32,0.10) 35%, rgba(58,112,96,0.10) 65%, rgba(110,94,154,0.20));
+}
+
+/* Text in full + reflow at medium/large zoom (HR-5/HR-11 — no truncation,
+   wraps; the rigid grids relax so longer detail/label text never clips). */
+.dsh-domain-name, .dsh-domain-sublabel, .dcp-name, .dcp-detail, .zsd-label, .zsd-score { overflow-wrap:break-word; }
+.dsh-components { grid-template-columns:minmax(0,1fr) minmax(0,1fr); }
+:root[data-zoom="high"] .dsh-components { grid-template-columns:1fr; }
+:root[data-zoom="med"]  .zs-domains,
+:root[data-zoom="high"] .zs-domains { grid-template-columns:repeat(4, 1fr); }
+:root[data-zoom="med"]  .zs-domain-pill,
+:root[data-zoom="high"] .zs-domain-pill { grid-column:span 2 !important; }
+
 /* ── Domain-tinted card backgrounds per track tab ── */
 #tab-diet .card { background:linear-gradient(135deg, var(--warm), rgba(181,213,197,0.10)); }
 #tab-sleep .card { background:linear-gradient(135deg, var(--warm), rgba(155,168,216,0.10)); }
@@ -47100,12 +47132,15 @@ function renderDomainHero(domainKey) {
     if (c.isTrend) return; // Trends line not shown in overview pills
     const barClass = c.score >= 70 ? 'dcb-high' : c.score >= 40 ? 'dcb-mid' : 'dcb-low';
     const pillClass = c.score >= 70 ? 'dcp-high' : c.score >= 40 ? 'dcp-mid' : 'dcp-low';
-    const shortDetail = c.detail && c.detail.length > 28 ? c.detail.substring(0, 26) + '…' : (c.detail || '');
+    // HR-5 — show the detail IN FULL and let it wrap (no '…' truncation); the
+    // .dcp-detail rule wraps, and the components grid reflows to 1 column at
+    // large zoom so longer detail text never clips.
+    const detail = c.detail || '';
     html += `<div class="dsh-comp-pill ${pillClass}" data-action="openScorePopup" data-arg="${domainKey}">
       <div class="dcp-bar ${barClass}">${c.score}</div>
       <div class="dcp-text">
         <div class="dcp-name">${c.name} <span class="dcp-weight">${c.weight}</span></div>
-        <div class="dcp-detail">${c.icon ? c.icon + ' ' : ''}${escHtml(shortDetail)}</div>
+        <div class="dcp-detail">${c.icon ? c.icon + ' ' : ''}${escHtml(detail)}</div>
       </div>
     </div>`;
   });

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.15-12",
+  "version": "2026.06.15-13",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Ziva's Dashboard",
   "short_name": "Ziva's Dashboard",
   "description": "Baby tracker and nutrition dashboard for Ziva",
-  "version": "2026.06.15-13",
+  "version": "2026.06.15-14",
   "start_url": "./index.html",
   "display": "standalone",
   "background_color": "#fdf0f3",

--- a/split/build-surface-catalog.mjs
+++ b/split/build-surface-catalog.mjs
@@ -59,7 +59,7 @@ function domainHero({ key, word, sub, weight, score, comps }) {
       </div>
     </div>`;
   }).join('');
-  return `<div class="domain-score-hero dsh-${key}">
+  return `<div class="card card-hero hero-${key}"><div class="domain-score-hero dsh-${key}">
     <div class="dsh-top">
       <div class="dsh-ring dsh-ring-${lb.label}">
         <div class="dsh-number">${score}</div>
@@ -72,7 +72,7 @@ function domainHero({ key, word, sub, weight, score, comps }) {
       </div>
     </div>
     <div class="dsh-components">${pills}</div>
-  </div>`;
+  </div></div>`;
 }
 
 function homeHero({ score, trend, domains }) {
@@ -98,7 +98,7 @@ const SURFACES = [
   {
     id: 'hero-ziva',
     title: 'Ziva Score hero (Home)',
-    note: 'The home front-door hero — composite score ring + per-domain pills. `.ziva-score-hero.zs-score-{label}`. Tap a domain pill to jump to that tab; tap the ring for the score popup.',
+    note: 'The home front-door hero — composite score ring + per-domain pills. `.ziva-score-hero.zs-score-{label}`. Carries the signature rainbow FADE (rose→peach→sage→lavender) over `--card-bg`, hue-swapped in dark. Domain pills reflow 2-per-row at medium/large zoom. Tap a pill to jump to that tab; tap the ring for the score popup.',
     exemplars: [
       { label: 'Strong week', html: homeHero({ score: 84, trend: '↑ +4 vs last week', domains: [
         { key: 'sleep', icon: 'moon', label: 'Sleep', score: 79 },
@@ -119,14 +119,14 @@ const SURFACES = [
   {
     id: 'hero-domain',
     title: 'Domain Score hero (per-tab)',
-    note: 'Per-tab score hero — ring + component-pill breakdown. `.domain-score-hero.dsh-{domain}`, ring tinted by band via `.dsh-ring-{label}`, component bars `.dcb-{high|mid|low}`. One per tab (diet/sleep/poop/medical/milestones).',
+    note: 'Per-tab score hero. Rendered inside its real `.card.card-hero.hero-{domain}` shell (the floor’s two-domain semantic gradient + the 5px `::before` accent stripe) wrapping `.domain-score-hero.dsh-{domain}`. The RING carries the score-band polarity (`.dsh-ring-{label}`), the card-hero gradient carries domain identity — the two never compete (§Polarity Collision). Component bars `.dcb-{high|mid|low}`. One per tab (diet/sleep/poop/medical/milestones).',
     exemplars: [
       { label: 'Diet · Great (88)', html: domainHero({
         key: 'diet', word: 'Diet', sub: 'Based on meals, variety, groups & nutrients', weight: '24%', score: 88,
         comps: [
           { name: 'Meals logged', weight: '40%', score: 92, icon: 'bowl', detail: '3 of 3 today' },
           { name: 'Variety', weight: '30%', score: 78, icon: 'rainbow', detail: '5 food groups' },
-          { name: 'Nutrients', weight: '30%', score: 84, icon: 'drop', detail: 'iron + Vit C paired' },
+          { name: 'Nutrients', weight: '30%', score: 84, icon: 'drop', detail: 'iron + Vitamin C paired this morning — great for absorption' },
         ] }) },
       { label: 'Sleep · Fair (55)', html: domainHero({
         key: 'sleep', word: 'Sleep', sub: 'Based on duration, wake-ups, bedtime & naps', weight: '22%', score: 55,

--- a/split/build-surface-catalog.mjs
+++ b/split/build-surface-catalog.mjs
@@ -1,0 +1,261 @@
+// docs/SURFACE_CATALOG.html generator — the living Surface Catalog.
+//
+// SproutLab's visual contract. A build-time, can't-drift gallery that renders
+// every canonical surface type using the REAL styles.css tokens + the REAL zi
+// sprite, in light AND dark, with a zoom toggle. It is BOTH documentation and
+// the design surface: to build a new surface you add its exemplar HERE first,
+// review it rendered (this is exactly what will ship — same stylesheet), get
+// Architect sign-off, THEN wire the feature using these exact classes/tokens.
+// That closes the "post-build surprise" gap structurally — what you approve is
+// what ships, because the catalog and the app read the same CSS.
+//
+// NEVER hand-edit docs/SURFACE_CATALOG.html — it is regenerated every build
+// from this script + the live styles.css/template.html. Edit the exemplars in
+// this file (the SURFACES array) instead.
+//
+// Cascade roadmap (built in visual-weight order): heroes → cards → chips/pills
+// → inputs/steppers → composer rails/lists → toasts/overlays → interactions.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, '..');
+const CSS = readFileSync(join(ROOT, 'split', 'styles.css'), 'utf8');
+const TEMPLATE = readFileSync(join(ROOT, 'split', 'template.html'), 'utf8');
+const OUT = join(ROOT, 'docs', 'SURFACE_CATALOG.html');
+
+const esc = s => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+// ── Inline the live zi/zif sprites (the hidden <svg> symbol blocks at the
+// top of template.html) so every zi() icon resolves exactly as in the app. ──
+const sprites = (TEMPLATE.match(/<svg[^>]*display:\s*none[\s\S]*?<\/svg>/g) || []).join('\n');
+
+// zi(name) → the same <svg><use> string the app emits (HR-7).
+const zi = name => `<svg class="zi" aria-hidden="true"><use href="#zi-${name}"/></svg>`;
+
+// Score → label/emoji, mirroring core.js SCORE_LABELS so hero ring states are faithful.
+function scoreLabel(s) {
+  if (s >= 90) return { label: 'excellent', emoji: 'sparkle', text: 'Excellent' };
+  if (s >= 75) return { label: 'great',     emoji: 'check',   text: 'Great' };
+  if (s >= 60) return { label: 'good',      emoji: 'check',   text: 'Good' };
+  if (s >= 45) return { label: 'fair',      emoji: 'target',  text: 'Fair' };
+  return            { label: 'attention',  emoji: 'warn',    text: 'Needs attention' };
+}
+const band = s => (s >= 70 ? 'high' : s >= 40 ? 'mid' : 'low');
+
+// ── Hero exemplars (faithful to renderDomainHero / renderHeroScore markup) ──
+
+function domainHero({ key, word, sub, weight, score, comps }) {
+  const lb = scoreLabel(score);
+  const pills = comps.map(c => {
+    const b = band(c.score);
+    return `<div class="dsh-comp-pill dcp-${b}">
+      <div class="dcp-bar dcb-${b}">${c.score}</div>
+      <div class="dcp-text">
+        <div class="dcp-name">${esc(c.name)} <span class="dcp-weight">${esc(c.weight)}</span></div>
+        <div class="dcp-detail">${c.icon ? zi(c.icon) + ' ' : ''}${esc(c.detail)}</div>
+      </div>
+    </div>`;
+  }).join('');
+  return `<div class="domain-score-hero dsh-${key}">
+    <div class="dsh-top">
+      <div class="dsh-ring dsh-ring-${lb.label}">
+        <div class="dsh-number">${score}</div>
+        <div class="dsh-label">${esc(word)}</div>
+        <div class="dsh-emoji">${zi(lb.emoji)}</div>
+      </div>
+      <div class="dsh-info">
+        <div class="dsh-domain-name">${zi(lb.emoji)} ${esc(lb.text)}</div>
+        <div class="dsh-domain-sublabel">${esc(sub)} · ${esc(weight)} of Ziva Score</div>
+      </div>
+    </div>
+    <div class="dsh-components">${pills}</div>
+  </div>`;
+}
+
+function homeHero({ score, trend, domains }) {
+  const dpills = domains.map(d => {
+    const lvl = d.score === null ? '' : ' zsd-' + scoreLabel(d.score).label;
+    return `<div class="zs-domain-pill${lvl}">
+      <div class="zsd-icon">${zi(d.icon)}</div>
+      <div class="zsd-text"><div class="zsd-score">${d.score === null ? '—' : d.score}</div><div class="zsd-label">${esc(d.label)}</div></div>
+    </div>`;
+  }).join('');
+  return `<div class="ziva-score-hero zs-score-${scoreLabel(score).label}">
+    <div class="zs-ring">
+      <div class="zs-number">${score}</div>
+      <div class="zs-label">Ziva Score</div>
+      <div class="zs-trend">${esc(trend)}</div>
+    </div>
+    <div class="zs-domains">${dpills}</div>
+  </div>`;
+}
+
+// Each surface: { id, title, note, exemplars: [{label, html}] }.
+const SURFACES = [
+  {
+    id: 'hero-ziva',
+    title: 'Ziva Score hero (Home)',
+    note: 'The home front-door hero — composite score ring + per-domain pills. `.ziva-score-hero.zs-score-{label}`. Tap a domain pill to jump to that tab; tap the ring for the score popup.',
+    exemplars: [
+      { label: 'Strong week', html: homeHero({ score: 84, trend: '↑ +4 vs last week', domains: [
+        { key: 'sleep', icon: 'moon', label: 'Sleep', score: 79 },
+        { key: 'diet', icon: 'bowl', label: 'Diet', score: 88 },
+        { key: 'poop', icon: 'diaper', label: 'Poop', score: 72 },
+        { key: 'medical', icon: 'medical', label: 'Medical', score: 95 },
+        { key: 'milestones', icon: 'trophy', label: 'Milestones', score: 66 },
+      ] }) },
+      { label: 'Needs attention + a not-yet-tracked domain', html: homeHero({ score: 52, trend: '→ stable', domains: [
+        { key: 'sleep', icon: 'moon', label: 'Sleep', score: 48 },
+        { key: 'diet', icon: 'bowl', label: 'Diet', score: 61 },
+        { key: 'poop', icon: 'diaper', label: 'Poop', score: 40 },
+        { key: 'medical', icon: 'medical', label: 'Medical', score: null },
+        { key: 'milestones', icon: 'trophy', label: 'Milestones', score: 55 },
+      ] }) },
+    ],
+  },
+  {
+    id: 'hero-domain',
+    title: 'Domain Score hero (per-tab)',
+    note: 'Per-tab score hero — ring + component-pill breakdown. `.domain-score-hero.dsh-{domain}`, ring tinted by band via `.dsh-ring-{label}`, component bars `.dcb-{high|mid|low}`. One per tab (diet/sleep/poop/medical/milestones).',
+    exemplars: [
+      { label: 'Diet · Great (88)', html: domainHero({
+        key: 'diet', word: 'Diet', sub: 'Based on meals, variety, groups & nutrients', weight: '24%', score: 88,
+        comps: [
+          { name: 'Meals logged', weight: '40%', score: 92, icon: 'bowl', detail: '3 of 3 today' },
+          { name: 'Variety', weight: '30%', score: 78, icon: 'rainbow', detail: '5 food groups' },
+          { name: 'Nutrients', weight: '30%', score: 84, icon: 'drop', detail: 'iron + Vit C paired' },
+        ] }) },
+      { label: 'Sleep · Fair (55)', html: domainHero({
+        key: 'sleep', word: 'Sleep', sub: 'Based on duration, wake-ups, bedtime & naps', weight: '22%', score: 55,
+        comps: [
+          { name: 'Duration', weight: '40%', score: 62, icon: 'moon', detail: '10.5h last night' },
+          { name: 'Wake-ups', weight: '30%', score: 45, icon: 'zzz', detail: '3 wake-ups' },
+          { name: 'Naps', weight: '30%', score: 38, icon: 'sun', detail: '1 of 2 expected' },
+        ] }) },
+      { label: 'Medical · Excellent (95)', html: domainHero({
+        key: 'medical', word: 'Medical', sub: 'Based on vaccines, supplements, growth & checkups', weight: '18%', score: 95,
+        comps: [
+          { name: 'Vaccines', weight: '35%', score: 100, icon: 'shield', detail: 'on schedule' },
+          { name: 'Supplements', weight: '30%', score: 90, icon: 'drop', detail: 'Vit D3 today' },
+          { name: 'Growth', weight: '35%', score: 94, icon: 'ruler', detail: '50th percentile' },
+        ] }) },
+    ],
+  },
+];
+
+// ── Page assembly ──
+function specimen(s) {
+  const panels = s.exemplars.map(ex => `
+    <div class="sc-specimen">
+      <div class="sc-specimen-label">${esc(ex.label)}</div>
+      <div class="sc-render-row">
+        <div class="sc-panel"><span class="sc-mode">Light</span><div class="sc-stage">${ex.html}</div></div>
+        <div class="sc-panel" data-theme="dark"><span class="sc-mode">Dark</span><div class="sc-stage">${ex.html}</div></div>
+      </div>
+      <details class="sc-markup"><summary>Canonical markup</summary><pre><code>${esc(ex.html.trim())}</code></pre></details>
+    </div>`).join('');
+  return `<section class="sc-surface" id="${s.id}">
+    <h3>${esc(s.title)}</h3>
+    <p class="sc-surface-note">${s.note.replace(/`([^`]+)`/g, (m, c) => '<code>' + esc(c) + '</code>')}</p>
+    ${panels}
+  </section>`;
+}
+
+const ROADMAP = [
+  ['Heroes', 'live', 'Ziva Score + per-tab domain heroes'],
+  ['Cards', 'next', 'action / info / stat cards'],
+  ['Chips & pills', 'planned', 'domain chips, food chips, status pills'],
+  ['Inputs & steppers', 'planned', 'text/date/time inputs, qty steppers, intake pills'],
+  ['Composer rails & lists', 'planned', 'L1–L4 rails, 48px item rows — where the white-bg + Diet-tab prediction-visibility regressions get settled'],
+  ['Toasts & overlays', 'planned', 'undo toast, post-save flash, bottom sheets, score popup'],
+  ['Interactions', 'planned', 'save-on-action, burst + undo choreography, blur-dismiss'],
+];
+
+const heroSection = SURFACES.map(specimen).join('\n');
+const roadmapRows = ROADMAP.map(([name, state, desc]) =>
+  `<tr class="sc-rm-${state}"><td>${esc(name)}</td><td><span class="sc-badge sc-badge-${state}">${state}</span></td><td>${esc(desc)}</td></tr>`).join('');
+
+const html = `<!DOCTYPE html>
+<html lang="en" data-zoom="default">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SproutLab — Surface Catalog</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&family=Nunito:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+/* ── the LIVE app stylesheet (inlined; do not edit here — edit split/styles.css) ── */
+${CSS}
+</style>
+<style>
+/* ── catalog chrome (sc-* only; never collides with app classes) ── */
+body { padding:0; margin:0; }
+.sc-wrap { max-width:1100px; margin:0 auto; padding:var(--sp-24, 24px) var(--sp-16, 16px) 80px; }
+.sc-banner { background:var(--amber-light, #f7ecd6); border:1.5px solid var(--amber, #e8b86d); border-radius:14px; padding:14px 18px; margin-bottom:24px; font-size:14px; line-height:1.5; color:var(--text, #3a2e2e); }
+.sc-h1 { font-family:'Fraunces',serif; font-size:30px; font-weight:700; color:var(--text, #3a2e2e); margin:8px 0 4px; }
+.sc-sub { color:var(--mid, #8a7a72); font-size:15px; margin:0 0 8px; }
+.sc-toolbar { display:flex; gap:8px; align-items:center; flex-wrap:wrap; margin:18px 0 8px; }
+.sc-toolbar .sc-zlabel { font-size:12px; text-transform:uppercase; letter-spacing:.08em; color:var(--mid,#8a7a72); font-weight:700; }
+.sc-zbtn { font-family:'Nunito',sans-serif; font-size:13px; font-weight:700; padding:6px 12px; border-radius:999px; border:1.5px solid var(--border-subtle,#e8ddd5); background:var(--surface,#fff); color:var(--mid,#8a7a72); cursor:pointer; }
+.sc-zbtn.active { background:var(--tc-rose,#c2607a); color:#fff; border-color:var(--tc-rose,#c2607a); }
+.sc-rm { width:100%; border-collapse:collapse; margin:8px 0 28px; font-size:14px; }
+.sc-rm td { padding:8px 10px; border-bottom:1px solid var(--border-subtle,#eee); }
+.sc-badge { font-size:11px; font-weight:700; text-transform:uppercase; letter-spacing:.06em; padding:2px 9px; border-radius:999px; }
+.sc-badge-live { background:var(--sage,#b5d5c5); color:#1a4a32; }
+.sc-badge-next { background:var(--amber,#e8b86d); color:#5a3e10; }
+.sc-badge-planned { background:var(--border-subtle,#eee); color:var(--mid,#8a7a72); }
+.sc-rm-live td:first-child { font-weight:800; }
+.sc-surface { margin:0 0 40px; }
+.sc-surface > h3 { font-family:'Fraunces',serif; font-size:21px; font-weight:600; color:var(--text,#3a2e2e); margin:30px 0 4px; padding-top:14px; border-top:2px solid var(--border-subtle,#eee); }
+.sc-surface-note { color:var(--mid,#8a7a72); font-size:14px; line-height:1.5; margin:0 0 14px; }
+.sc-surface-note code, .sc-markup code { font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:.86em; background:var(--warm,#f3ece6); padding:1px 5px; border-radius:5px; }
+.sc-specimen { margin:0 0 22px; }
+.sc-specimen-label { font-size:13px; font-weight:700; color:var(--mid,#8a7a72); margin:0 0 8px; }
+.sc-render-row { display:grid; grid-template-columns:1fr 1fr; gap:14px; }
+@media (max-width:720px){ .sc-render-row { grid-template-columns:1fr; } }
+.sc-panel { position:relative; border-radius:16px; padding:30px 18px 18px; background:var(--cream,#fffaf7); border:1px solid var(--border-subtle,#e8ddd5); overflow:visible; }
+.sc-panel[data-theme="dark"] { background:var(--cream); border-color:#3a2e3e; }
+.sc-mode { position:absolute; top:8px; left:12px; font-size:10px; font-weight:800; text-transform:uppercase; letter-spacing:.1em; color:var(--light,#b0a098); }
+.sc-stage { /* the live surface renders here, on its real token background */ }
+.sc-markup { margin-top:10px; }
+.sc-markup summary { font-size:12px; font-weight:700; color:var(--mid,#8a7a72); cursor:pointer; }
+.sc-markup pre { background:var(--warm,#f6f0ea); border:1px solid var(--border-subtle,#e8ddd5); border-radius:10px; padding:12px; overflow:auto; font-size:11.5px; line-height:1.45; margin:8px 0 0; }
+[data-theme="dark"] .sc-markup pre { background:#221c28; border-color:#3a2e3e; }
+</style>
+</head>
+<body>
+${sprites}
+<div class="sc-wrap">
+  <div class="sc-banner"><strong>Generated view — do not hand-edit.</strong> Rebuilt every build by <code>split/build-surface-catalog.mjs</code> from the live <code>split/styles.css</code> + sprite. This is the <strong>design surface</strong>: to build a new surface, add its exemplar to the <code>SURFACES</code> array in the generator first, review it here rendered (this is what ships — same stylesheet), get sign-off, then wire the feature with these exact classes. Edit exemplars in the generator, never this file.</div>
+
+  <div class="sc-h1">Surface Catalog</div>
+  <p class="sc-sub">Every canonical SproutLab surface, rendered with the live tokens in light + dark. The visual contract that prevents post-build surprises.</p>
+
+  <div class="sc-toolbar">
+    <span class="sc-zlabel">Zoom</span>
+    <button class="sc-zbtn active" data-zoom="default">Default</button>
+    <button class="sc-zbtn" data-zoom="med">Medium</button>
+    <button class="sc-zbtn" data-zoom="high">Large</button>
+  </div>
+
+  <table class="sc-rm"><tbody>${roadmapRows}</tbody></table>
+
+  <h2 style="font-family:'Fraunces',serif;font-size:24px;color:var(--text,#3a2e2e);margin:10px 0 0;">Heroes</h2>
+  ${heroSection}
+</div>
+<script>
+  document.querySelectorAll('.sc-zbtn').forEach(function(b){
+    b.addEventListener('click', function(){
+      document.documentElement.dataset.zoom = b.dataset.zoom;
+      document.querySelectorAll('.sc-zbtn').forEach(function(x){ x.classList.toggle('active', x===b); });
+    });
+  });
+</script>
+</body>
+</html>`;
+
+writeFileSync(OUT, html);
+console.error('Surface Catalog generated: docs/SURFACE_CATALOG.html (' + (html.length / 1024).toFixed(0) + 'KB; heroes section)');

--- a/split/build.sh
+++ b/split/build.sh
@@ -189,6 +189,11 @@ node build-doc-views.mjs >&2
 # Icon reference: a visual gallery of every zi-/zif- symbol in the sprite, auto-generated from
 # template.html so the icon count/list can never drift from the actual sprite.
 node build-icon-reference.mjs >&2
+# Surface Catalog: the living visual contract — every canonical surface type
+# rendered with the live styles.css tokens + sprite, light + dark + zoom. Both
+# documentation and the design surface (add a surface's exemplar to the
+# generator, review rendered, sign off, THEN wire it). Rebuilt each build.
+node build-surface-catalog.mjs >&2
 cat <<'HEAD'
 <!DOCTYPE html>
 <html lang="en">

--- a/split/diet.js
+++ b/split/diet.js
@@ -6484,12 +6484,15 @@ function renderDomainHero(domainKey) {
     if (c.isTrend) return; // Trends line not shown in overview pills
     const barClass = c.score >= 70 ? 'dcb-high' : c.score >= 40 ? 'dcb-mid' : 'dcb-low';
     const pillClass = c.score >= 70 ? 'dcp-high' : c.score >= 40 ? 'dcp-mid' : 'dcp-low';
-    const shortDetail = c.detail && c.detail.length > 28 ? c.detail.substring(0, 26) + '…' : (c.detail || '');
+    // HR-5 — show the detail IN FULL and let it wrap (no '…' truncation); the
+    // .dcp-detail rule wraps, and the components grid reflows to 1 column at
+    // large zoom so longer detail text never clips.
+    const detail = c.detail || '';
     html += `<div class="dsh-comp-pill ${pillClass}" data-action="openScorePopup" data-arg="${domainKey}">
       <div class="dcp-bar ${barClass}">${c.score}</div>
       <div class="dcp-text">
         <div class="dcp-name">${c.name} <span class="dcp-weight">${c.weight}</span></div>
-        <div class="dcp-detail">${c.icon ? c.icon + ' ' : ''}${escHtml(shortDetail)}</div>
+        <div class="dcp-detail">${c.icon ? c.icon + ' ' : ''}${escHtml(detail)}</div>
       </div>
     </div>`;
   });

--- a/split/styles.css
+++ b/split/styles.css
@@ -6419,6 +6419,38 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
 .dsh-medical .dsh-comp-pill { background:linear-gradient(135deg, var(--warm), rgba(242,168,184,0.10)); border-color:rgba(242,168,184,0.3); }
 .dsh-milestones .dsh-comp-pill { background:linear-gradient(135deg, var(--warm), rgba(201,184,232,0.10)); border-color:rgba(201,184,232,0.3); }
 
+/* ═══════════════════════════════════════════════════════════════
+   Hero polish (Surface Catalog, design floor §Tint System).
+   The Home Ziva-Score hero (.ziva-score-hero) carries NO card-hero shell, so
+   it was flat — give it the signature rainbow FADE (rose→peach→sage→lavender,
+   §Tint "home rainbow"), as a directional fade over --card-bg (not a flat
+   fill), hue-swapped deep in dark (Law 1). The per-tab domain heroes already
+   carry their .card.card-hero.hero-{domain} gradient + ::before stripe, so
+   they are NOT re-washed here (a second wash would muddy — §Tint Law 2).
+   ═══════════════════════════════════════════════════════════════ */
+.ziva-score-hero {
+  border-bottom:none;
+  border-radius:var(--r-xl);
+  padding:var(--sp-12) var(--sp-14);
+  background-color:var(--card-bg);
+  background-image:linear-gradient(135deg, rgba(242,168,184,0.12), rgba(250,212,180,0.08) 35%, rgba(181,213,197,0.08) 65%, rgba(201,184,232,0.14));
+  background-repeat:no-repeat;
+}
+[data-theme="dark"] .ziva-score-hero {
+  background-color:var(--surface);
+  background-image:linear-gradient(135deg, rgba(158,62,82,0.20), rgba(138,101,32,0.10) 35%, rgba(58,112,96,0.10) 65%, rgba(110,94,154,0.20));
+}
+
+/* Text in full + reflow at medium/large zoom (HR-5/HR-11 — no truncation,
+   wraps; the rigid grids relax so longer detail/label text never clips). */
+.dsh-domain-name, .dsh-domain-sublabel, .dcp-name, .dcp-detail, .zsd-label, .zsd-score { overflow-wrap:break-word; }
+.dsh-components { grid-template-columns:minmax(0,1fr) minmax(0,1fr); }
+:root[data-zoom="high"] .dsh-components { grid-template-columns:1fr; }
+:root[data-zoom="med"]  .zs-domains,
+:root[data-zoom="high"] .zs-domains { grid-template-columns:repeat(4, 1fr); }
+:root[data-zoom="med"]  .zs-domain-pill,
+:root[data-zoom="high"] .zs-domain-pill { grid-column:span 2 !important; }
+
 /* ── Domain-tinted card backgrounds per track tab ── */
 #tab-diet .card { background:linear-gradient(135deg, var(--warm), rgba(181,213,197,0.10)); }
 #tab-sleep .card { background:linear-gradient(135deg, var(--warm), rgba(155,168,216,0.10)); }

--- a/sproutlab.html
+++ b/sproutlab.html
@@ -6426,6 +6426,38 @@ body.essential-mode[data-theme] .hero-avatar-bg { opacity:0.06; }
 .dsh-medical .dsh-comp-pill { background:linear-gradient(135deg, var(--warm), rgba(242,168,184,0.10)); border-color:rgba(242,168,184,0.3); }
 .dsh-milestones .dsh-comp-pill { background:linear-gradient(135deg, var(--warm), rgba(201,184,232,0.10)); border-color:rgba(201,184,232,0.3); }
 
+/* ═══════════════════════════════════════════════════════════════
+   Hero polish (Surface Catalog, design floor §Tint System).
+   The Home Ziva-Score hero (.ziva-score-hero) carries NO card-hero shell, so
+   it was flat — give it the signature rainbow FADE (rose→peach→sage→lavender,
+   §Tint "home rainbow"), as a directional fade over --card-bg (not a flat
+   fill), hue-swapped deep in dark (Law 1). The per-tab domain heroes already
+   carry their .card.card-hero.hero-{domain} gradient + ::before stripe, so
+   they are NOT re-washed here (a second wash would muddy — §Tint Law 2).
+   ═══════════════════════════════════════════════════════════════ */
+.ziva-score-hero {
+  border-bottom:none;
+  border-radius:var(--r-xl);
+  padding:var(--sp-12) var(--sp-14);
+  background-color:var(--card-bg);
+  background-image:linear-gradient(135deg, rgba(242,168,184,0.12), rgba(250,212,180,0.08) 35%, rgba(181,213,197,0.08) 65%, rgba(201,184,232,0.14));
+  background-repeat:no-repeat;
+}
+[data-theme="dark"] .ziva-score-hero {
+  background-color:var(--surface);
+  background-image:linear-gradient(135deg, rgba(158,62,82,0.20), rgba(138,101,32,0.10) 35%, rgba(58,112,96,0.10) 65%, rgba(110,94,154,0.20));
+}
+
+/* Text in full + reflow at medium/large zoom (HR-5/HR-11 — no truncation,
+   wraps; the rigid grids relax so longer detail/label text never clips). */
+.dsh-domain-name, .dsh-domain-sublabel, .dcp-name, .dcp-detail, .zsd-label, .zsd-score { overflow-wrap:break-word; }
+.dsh-components { grid-template-columns:minmax(0,1fr) minmax(0,1fr); }
+:root[data-zoom="high"] .dsh-components { grid-template-columns:1fr; }
+:root[data-zoom="med"]  .zs-domains,
+:root[data-zoom="high"] .zs-domains { grid-template-columns:repeat(4, 1fr); }
+:root[data-zoom="med"]  .zs-domain-pill,
+:root[data-zoom="high"] .zs-domain-pill { grid-column:span 2 !important; }
+
 /* ── Domain-tinted card backgrounds per track tab ── */
 #tab-diet .card { background:linear-gradient(135deg, var(--warm), rgba(181,213,197,0.10)); }
 #tab-sleep .card { background:linear-gradient(135deg, var(--warm), rgba(155,168,216,0.10)); }
@@ -47100,12 +47132,15 @@ function renderDomainHero(domainKey) {
     if (c.isTrend) return; // Trends line not shown in overview pills
     const barClass = c.score >= 70 ? 'dcb-high' : c.score >= 40 ? 'dcb-mid' : 'dcb-low';
     const pillClass = c.score >= 70 ? 'dcp-high' : c.score >= 40 ? 'dcp-mid' : 'dcp-low';
-    const shortDetail = c.detail && c.detail.length > 28 ? c.detail.substring(0, 26) + '…' : (c.detail || '');
+    // HR-5 — show the detail IN FULL and let it wrap (no '…' truncation); the
+    // .dcp-detail rule wraps, and the components grid reflows to 1 column at
+    // large zoom so longer detail text never clips.
+    const detail = c.detail || '';
     html += `<div class="dsh-comp-pill ${pillClass}" data-action="openScorePopup" data-arg="${domainKey}">
       <div class="dcp-bar ${barClass}">${c.score}</div>
       <div class="dcp-text">
         <div class="dcp-name">${c.name} <span class="dcp-weight">${c.weight}</span></div>
-        <div class="dcp-detail">${c.icon ? c.icon + ' ' : ''}${escHtml(shortDetail)}</div>
+        <div class="dcp-detail">${c.icon ? c.icon + ' ' : ''}${escHtml(detail)}</div>
       </div>
     </div>`;
   });


### PR DESCRIPTION
## Surface Catalog — the no-surprise visual contract

A build-time, can't-drift gallery (`docs/SURFACE_CATALOG.html`) that renders every canonical SproutLab surface using the **live** `styles.css` tokens + the real `zi` sprite, in **light + dark** side-by-side, with a **zoom toggle**. Same proven pattern as `ICON_REFERENCE` / `PROVINCE_MAP` / the `/doc-render` views.

**Why:** F-6a shipped two post-build surprises (white inner panels; Diet-tab prediction collapsed). This is the structural fix — the catalog is **both documentation and the design surface**: a new surface gets its exemplar added to the generator *first*, reviewed rendered (this is exactly what ships — same stylesheet), signed off, *then* wired with those exact classes.

### This PR (heroes section)
- `split/build-surface-catalog.mjs` — generator, wired into `build.sh` beside the other reference views; inlines the live CSS + sprite; faithful exemplars of:
  - **Ziva Score hero** (Home front-door) — strong-week + needs-attention variants.
  - **Domain Score heroes** (per-tab) — Diet/Sleep/Medical across the ring-state spectrum.
- Cascade roadmap table seeds the rest: **cards → chips/pills → inputs/steppers → composer rails/lists → toasts/overlays → interactions**. The *composer rails/lists* entry is where the F-6a **white-bg + Diet-tab prediction-visibility** regressions get settled with sign-off.

### Workflow established
1. Add/adjust a surface exemplar in the generator's `SURFACES` array.
2. `pnpm build` → review `docs/SURFACE_CATALOG.html` rendered.
3. Architect signs off on tokens/layout.
4. Wire the feature using the approved classes — no surprise.

Draft until you've reviewed the heroes rendering and confirmed the mechanism + cascade order.

https://claude.ai/code/session_01WW9oAawuTqufzkzTdJ32JB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WW9oAawuTqufzkzTdJ32JB)_